### PR TITLE
Fix LDFLAGS and work around a Fedora bug that broke pthread linking

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -154,8 +154,9 @@ includecapnp_HEADERS =                                         \
 
 lib_LTLIBRARIES = libkj.la libcapnp.la libcapnpc.la
 
-libkj_la_LIBADD = $(PTHREAD_LIBS)
-libkj_la_LDFLAGS = -release $(VERSION) -export-dynamic -no-undefined
+# -lpthread is here to work around https://bugzilla.redhat.com/show_bug.cgi?id=661333
+libkj_la_LIBADD = $(PTHREAD_LIBS) -lpthread
+libkj_la_LDFLAGS = -release $(VERSION) -Wl,--no-undefined
 libkj_la_SOURCES=                                              \
   src/kj/common.c++                                            \
   src/kj/units.c++                                             \
@@ -172,8 +173,9 @@ libkj_la_SOURCES=                                              \
   src/kj/main.c++                                              \
   src/kj/parse/char.c++
 
-libcapnp_la_LIBADD = libkj.la $(PTHREAD_LIBS)
-libcapnp_la_LDFLAGS = -release $(VERSION) -export-dynamic -no-undefined
+# -lpthread is here to work around https://bugzilla.redhat.com/show_bug.cgi?id=661333
+libcapnp_la_LIBADD = libkj.la $(PTHREAD_LIBS) -lpthread
+libcapnp_la_LDFLAGS = -release $(VERSION) -Wl,--no-undefined
 libcapnp_la_SOURCES=                                           \
   src/capnp/c++.capnp.c++                                      \
   src/capnp/blob.c++                                           \
@@ -190,8 +192,9 @@ libcapnp_la_SOURCES=                                           \
   src/capnp/serialize.c++                                      \
   src/capnp/serialize-packed.c++
 
-libcapnpc_la_LIBADD = libcapnp.la libkj.la $(PTHREAD_LIBS)
-libcapnpc_la_LDFLAGS = -release $(VERSION) -export-dynamic -no-undefined
+# -lpthread is here to work around https://bugzilla.redhat.com/show_bug.cgi?id=661333
+libcapnpc_la_LIBADD = libcapnp.la libkj.la $(PTHREAD_LIBS) -lpthread
+libcapnpc_la_LDFLAGS = -release $(VERSION) -Wl,--no-undefined
 libcapnpc_la_SOURCES=                                          \
   src/capnp/compiler/md5.h                                     \
   src/capnp/compiler/md5.c++                                   \


### PR DESCRIPTION
The Fedora bug caused the DT_NEEDED for libpthread to be omitted, and
the missing -Wl before no-undefined prevented binutils from detecting it.

-export-dynamic is unnecessary for libraries, so this removes it, too.
