### PR TITLE
Fix md5.c++ to work on non x86 systems

### DIFF
--- a/c++/src/capnp/compiler/md5.c++
+++ b/c++/src/capnp/compiler/md5.c++
@@ -81,13 +81,13 @@ namespace compiler {
   SET(n)
 #else
 #define SET(n) \
-  (ctx->block[(n)] = \
+  (ctx.block[(n)] = \
   (MD5_u32plus)ptr[(n) * 4] | \
   ((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
   ((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
   ((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
 #define GET(n) \
-  (ctx->block[(n)])
+  (ctx.block[(n)])
 #endif
 
 /*


### PR DESCRIPTION
ctx is not a pointer but was being used with the arrow operator on non-x86 systems
