### PR TITLE
capnp plugin: missing comment for union tag on groups.

### DIFF
--- a/c++/src/capnp/compiler/capnpc-capnp.c++
+++ b/c++/src/capnp/compiler/capnpc-capnp.c++
@@ -391,7 +391,7 @@ private:
             indent, field.getName(),
             " :group", genAnnotations(field.getAnnotations(), scope), " {",
             field.hasDiscriminantValue()
-                ? kj::strTree(", union tag = ", field.getDiscriminantValue()) : kj::strTree(),
+                ? kj::strTree("  # union tag = ", field.getDiscriminantValue()) : kj::strTree(),
             "\n",
             genStructFields(group, indent.next()),
             indent, "}\n");


### PR DESCRIPTION
Fixes this:

```
  union {  # tag bits [96, 112)
    file @6 :Void;  # bits[0, 0), union tag = 0
    struct :group {, union tag = 1      <<<=== parse error here
      dataWordCount @7 :UInt16;  # bits[112, 128)
```

N.b.
The parser also complained that the file was missing a Id attribute after bailing on this parse error (in a different schema, but the same kind of error), but in fact it did have one.

I've made no attempt at addressing that issue:

```
test/test.capnp:7:24: error: Parse error.
test/test.capnp:1:1: error: File does not declare an ID.  I've generated one for you.  Add this line to your file: @0xee8d1a7adfba730e;
```
