### PR TITLE
add missing includes

### DIFF
--- a/c++/src/capnp/benchmark/common.h
+++ b/c++/src/capnp/benchmark/common.h
@@ -37,6 +37,8 @@
 #include <stdexcept>
 #include <stdio.h>
 #include <string.h>
+#include <string>
+#include <vector>
 
 namespace capnp {
 namespace benchmark {


### PR DESCRIPTION
Without these, clang++ and llvmg++ fail to compile the benchmark for me.
