### PR TITLE
remove superfluous null terminator

### DIFF
--- a/c++/src/capnp/benchmark/capnproto-catrank.c++
+++ b/c++/src/capnp/benchmark/capnproto-catrank.c++
@@ -56,10 +56,11 @@ public:
       int urlSize = fastRand(100);
 
       static const char URL_PREFIX[] = "http://example.com/";
-      auto url = result.initUrl(urlSize + sizeof(URL_PREFIX));
+      size_t urlPrefixLength = strlen(URL_PREFIX);
+      auto url = result.initUrl(urlSize + urlPrefixLength);
 
       strcpy(url.begin(), URL_PREFIX);
-      char* pos = url.begin() + strlen(URL_PREFIX);
+      char* pos = url.begin() + urlPrefixLength;
       for (int j = 0; j < urlSize; j++) {
         *pos++ = 'a' + fastRand(26);
       }


### PR DESCRIPTION
`sizeof(URL_PREFIX)` counts the null terminator, so `result.initUrl(urlSize + sizeof(URL_PREFIX))` allocates one more byte than is needed.

By coincidence, making this change does _not_ actually lower the byte throughput in this benchmark case, because of the way the modular arithmetic works out during the pseudorandom number generation.
