### PR TITLE
Fixes for getting emscripten to build

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -35,7 +35,7 @@
 
 #if !KJ_NO_RTTI
 #include <typeinfo>
-#if __GNUC__
+#if __GNUC__ && !EMSCRIPTEN
 #include <cxxabi.h>
 #include <stdlib.h>
 #endif
@@ -419,7 +419,7 @@ _::PromiseNode* Event::getInnerForTrace() {
 }
 
 #if !KJ_NO_RTTI
-#if __GNUC__
+#if __GNUC__ && !EMSCRIPTEN
 static kj::String demangleTypeName(const char* name) {
   int status;
   char* buf = abi::__cxa_demangle(name, nullptr, nullptr, &status);

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -28,6 +28,11 @@
 #ifndef KJ_COMMON_H_
 #define KJ_COMMON_H_
 
+#if EMSCRIPTEN
+  #define __atomic_store_n(ptr, val, memmodel) (*ptr) = val
+  #define __atomic_load_n(ptr, memmodel) (*ptr)
+#endif
+
 #ifndef KJ_NO_COMPILER_CHECK
 #if __cplusplus < 201103L && !__CDT_PARSER__
   #error "This code requires C++11. Either your compiler does not support it or it is not enabled."
@@ -1100,5 +1105,6 @@ _::Deferred<Decay<Func>> defer(Func&& func) {
 // Run the given code when the function exits, whether by return or exception.
 
 }  // namespace kj
+
 
 #endif  // KJ_COMMON_H_

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1106,5 +1106,4 @@ _::Deferred<Decay<Func>> defer(Func&& func) {
 
 }  // namespace kj
 
-
 #endif  // KJ_COMMON_H_

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -352,9 +352,16 @@ void throwRecoverableException(kj::Exception&& exception) {
 
 // =======================================================================================
 
+#if EMSCRIPTEN
+UnwindDetector::UnwindDetector() {}
+
+bool UnwindDetector::isUnwinding() const {
+  return false;
+}
+#else
+  #if __GNUC__
 namespace _ {  // private
 
-#if __GNUC__
 
 // Horrible -- but working -- hack:  We can dig into __cxa_get_globals() in order to extract the
 // count of uncaught exceptions.  This function is part of the C++ ABI implementation used on Linux,
@@ -391,9 +398,9 @@ uint uncaughtExceptionCount() {
   return __cxa_get_globals()->uncaughtExceptions;
 }
 
-#else
-#error "This needs to be ported to your compiler / C++ ABI."
-#endif
+  #else
+  #error "This needs to be ported to your compiler / C++ ABI."
+  #endif
 
 }  // namespace _ (private)
 
@@ -402,6 +409,8 @@ UnwindDetector::UnwindDetector(): uncaughtCount(_::uncaughtExceptionCount()) {}
 bool UnwindDetector::isUnwinding() const {
   return _::uncaughtExceptionCount() > uncaughtCount;
 }
+
+#endif
 
 void UnwindDetector::catchExceptionsAsSecondaryFaults(_::Runnable& runnable) const {
   // TODO(someday):  Attach the secondary exception to whatever primary exception is causing

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -31,6 +31,13 @@
 #include <limits.h>
 #endif
 
+#if EMSCRIPTEN
+#define pthread_rwlock_destroy(lock) 0
+#define pthread_rwlock_wrlock(lock) 0
+#define pthread_rwlock_rdlock(lock) 0
+#define pthread_rwlock_unlock(lock) 0
+#endif
+
 namespace kj {
 namespace _ {  // private
 


### PR DESCRIPTION
The changes to get emscripten working with Cap'n Proto are relatively small. The biggest change had to occur in exception.c++ because emscripten doesn't have __cxa_get_globals
