### PR TITLE
Fix bounds check passing for relative struct pointers with offsets that underflow

### DIFF
--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -295,7 +295,7 @@ inline SegmentReader::SegmentReader(Arena* arena, SegmentId id, kj::ArrayPtr<con
     : arena(arena), id(id), ptr(ptr), readLimiter(readLimiter) {}
 
 inline bool SegmentReader::containsInterval(const void* from, const void* to) {
-  return from >= this->ptr.begin() && to <= this->ptr.end() &&
+  return from >= this->ptr.begin() && to <= this->ptr.end() && from <= to &&
       readLimiter->canRead(
           intervalLength(reinterpret_cast<const byte*>(from),
                          reinterpret_cast<const byte*>(to)) / BYTES_PER_WORD,


### PR DESCRIPTION
Fixes segfaults (reads from unallocated memory) that can happen when using SegmentArrayMessageReader on invalid data.

This problem was identified by hosing down a capnproto-using server that takes flat-form messages as UDP datagrams with random data. Rarely, a datagram would come in whose first word appeared to be a struct pointer with a very large negative offset. The computation of the structure start address would then underflow. As WireHelpers::boundsCheck did not account for this possibility, the resulting pointer was be treated as valid and dereferenced during SegmentArrayMessageReader::getRoot().

It's not obvious that this is the only case where additional checking to handle overflow is necessary, but I haven't been able to produce any more crashes in my server after applying this fix.

Note: The 'capnp decode' debugging tool explicitly checks for negative offsets in root pointers, making this a little non-obvious to reproduce.
