### PR TITLE
Enable default move constructor for MallocMessageBuilder

### DIFF
--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -333,6 +333,8 @@ public:
   // firstSegment MUST be zero-initialized.  MallocMessageBuilder's destructor will write new zeros
   // over any space that was used so that it can be reused.
 
+  MallocMessageBuilder(MallocMessageBuilder && other) = default;
+
   KJ_DISALLOW_COPY(MallocMessageBuilder);
   virtual ~MallocMessageBuilder() noexcept(false);
 


### PR DESCRIPTION
I'm not completely certain the default move constructor is appropriate here, but some move constructor is certainly useful to have.
