### PR TITLE
Allow DynamicEnum fields to be set with int/uint

### DIFF
--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -522,7 +522,11 @@ void DynamicStruct::Builder::set(StructSchema::Field field, const DynamicValue::
           if (value.getType() == DynamicValue::TEXT) {
             // Convert from text.
             rawValue = enumSchema.getEnumerantByName(value.as<Text>()).getOrdinal();
-          } else {
+          }
+          else if (value.getType() == DynamicValue::INT || value.getType() == DynamicValue::UINT) {
+            rawValue = value.as<uint16_t>();
+          }
+          else {
             DynamicEnum enumValue = value.as<DynamicEnum>();
             KJ_REQUIRE(enumValue.getSchema() == enumSchema, "Value type mismatch.") {
               return;


### PR DESCRIPTION
I want to add the ability to use ints as enum types in pycapnp, and this change would make it much easier.
