### PR TITLE
Avoid including system gtest header of an incompatible version

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -331,7 +331,7 @@ BUILT_SOURCES = $(test_capnpc_outputs)
 check_PROGRAMS = capnp-test capnp-evolution-test
 capnp_test_LDADD = gtest/lib/libgtest.la gtest/lib/libgtest_main.la \
                    libcapnpc.la libcapnp-rpc.la libcapnp.la libkj-async.la libkj.la
-capnp_test_CPPFLAGS = -Igtest/include -I$(srcdir)/gtest/include
+capnp_test_CPPFLAGS = -I$(srcdir)/gtest/include
 capnp_test_SOURCES =                                           \
   src/kj/common-test.c++                                       \
   src/kj/memory-test.c++                                       \


### PR DESCRIPTION
With a gtest 1.7 on my system, the `make check` command reports a ton of undefined reference of `EqFailure`s. Obviously, the message types were changed from some internal string data structure to `std::string`. The current Makefile includes the system gtest headers, but does not link in its libraries.

Given that `make check` fails when the gtest directory is not there, including files under `$(srcdir)/gtest/include` doesn't break more things, and should be enough.
