### PR TITLE
Add timer functionality to the async IO framework.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ under the same BSD license terms as the rest of the library.
 
 Kenton Varda <temporal@gmail.com>: Primary Author
 Jason Choy <jjwchoy@gmail.com>: kj/threadlocal.h and other iOS tweaks
+Remy Blank <rblank@google.com> (contributions copyright Google Inc.)
 
 This file does not list people who maintain their own Cap'n Proto
 implementations as separate projects.  Those people are awesome too!  :)

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -27,6 +27,7 @@
 #include "async.h"
 #include "function.h"
 #include "thread.h"
+#include "time.h"
 
 namespace kj {
 
@@ -196,6 +197,9 @@ public:
   //
   // TODO(someday):  I'm not entirely comfortable with this interface.  It seems to be doing too
   //   much at once but I'm not sure how to cleanly break it down.
+
+  virtual Timer& getTimer() = 0;
+  // Returns a Timer interface for the underlying event loop.
 };
 
 class LowLevelAsyncIoProvider {
@@ -270,6 +274,9 @@ public:
   // have had `bind()` and `listen()` called on it, so it's ready for `accept()`.
   //
   // `flags` is a bitwise-OR of the values of the `Flags` enum.
+
+  virtual Timer& getTimer() = 0;
+  // Returns a Timer interface for the underlying event loop.
 };
 
 Own<AsyncIoProvider> newAsyncIoProvider(LowLevelAsyncIoProvider& lowLevel);

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -653,7 +653,7 @@ public:
 
   void wait() override { KJ_FAIL_ASSERT("Nothing to wait for."); }
   void poll() override {}
-  void setRunnable(bool runnable) {
+  void setRunnable(bool runnable) override {
     this->runnable = runnable;
     ++callCount;
   }

--- a/c++/src/kj/time.h
+++ b/c++/src/kj/time.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2014, Kenton Varda <temporal@gmail.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef KJ_TIME_H_
+#define KJ_TIME_H_
+
+#include "async.h"
+#include "units.h"
+#include <inttypes.h>
+
+namespace kj {
+namespace _ {  // private
+
+class MicrosecondLabel;
+
+}  // namespace _ (private)
+
+using Time = Quantity<int64_t, _::MicrosecondLabel>;
+// A time value, in microseconds.
+
+constexpr Time MICROSECOND = unit<Time>();
+constexpr Time MILLISECOND = 1000 * MICROSECOND;
+constexpr Time SECOND = 1000 * MILLISECOND;
+constexpr Time MINUTE = 60 * SECOND;
+constexpr Time HOUR = 60 * MINUTE;
+constexpr Time DAY = 24 * HOUR;
+
+class Timer {
+  // Interface to time and timer functionality. The underlying time unit comes from
+  // a steady clock, i.e. a clock that increments steadily and is independent of
+  // system (or wall) time.
+
+public:
+  virtual Time steadyTime() = 0;
+  // Returns the current value of a clock that moves steadily forward, independent of any
+  // changes in the wall clock. The value is updated every time the event loop waits,
+  // and is constant in-between waits.
+
+  virtual Promise<void> atSteadyTime(Time time) = 0;
+  // Schedules a timer that will trigger when the value returned by steadyTime() reaches
+  // the given time.
+
+  virtual Promise<void> atTimeFromNow(Time delay) = 0;
+  // Schedules a timer that will trigger after the given delay. The timer uses steadyTime()
+  // and is therefore immune to system clock updates.
+};
+
+}  // namespace kj
+
+#endif  // KJ_TIME_H_


### PR DESCRIPTION
This supersedes #73, and moves the timer processing into `UnixEventPort`. The times are still kept as a Quantity<int64_t>. Only "steady" timers are implemented for now, although the hooks for "wall" timers are already shown in TimeProvider.
