### PR TITLE
capnpc-capnp: keep list of extended interfaces.

### DIFF
--- a/c++/src/capnp/compiler/capnpc-capnp.c++
+++ b/c++/src/capnp/compiler/capnpc-capnp.c++
@@ -424,6 +424,17 @@ private:
     }
   }
 
+  kj::StringTree genExtends(InterfaceSchema interface) {
+    auto extends = interface.getProto().getInterface().getExtends();
+    if (extends.size() == 0)
+      return kj::strTree();
+    else
+      return kj::strTree(" extends(", kj::StringTree(
+          KJ_MAP(id, extends) {
+            return nodeName(schemaLoader.get(id), interface);
+          }, ", "), ")");
+  }
+
   kj::StringTree genDecl(Schema schema, Text::Reader name, uint64_t scopeId, Indent indent) {
     auto proto = schema.getProto();
     if (proto.getScopeId() != scopeId) {
@@ -466,6 +477,7 @@ private:
         auto interface = schema.asInterface();
         return kj::strTree(
             indent, "interface ", name, " @0x", kj::hex(proto.getId()),
+            genExtends(interface),
             genAnnotations(schema), " {\n",
             KJ_MAP(method, sortByCodeOrder(interface.getMethods())) {
               auto methodProto = method.getProto();


### PR DESCRIPTION
```
interface BasicCap @0xf329462caa09f38f {
  add @0 (a :Int64, b :Int64) -> (result :Int64);
}
interface OtherCap @0x9000899726987e7f {
  sqroot @0 (a :Int64, b :Int64) -> (root1 :Int64, root2 :Int64);
}
interface ThirdCap @0xfb84e23a9ca71e0e extends(BasicCap, OtherCap) {
  square @0 (a :Int64) -> (sq :Int64);
}
```

Without this patch, the `extends()` info for `ThirdCap` is missing in the output from `capnpc-capnp`.
