### PR TITLE
Allow direct access to the memory of a primitive list via. an ArrayPtr.

### DIFF
--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -627,6 +627,10 @@ public:
   // Reinterpret the list as a blob.  Throws an exception if the elements are not byte-sized.
 
   template <typename T>
+  KJ_ALWAYS_INLINE(kj::ArrayPtr<T> asPtr());
+  // Pointer to the list's data.  Throws an exception if T is not the same width as the list elements.
+
+  template <typename T>
   KJ_ALWAYS_INLINE(T getDataElement(ElementCount index));
   // Get the element of the given type at the given index.
 
@@ -684,6 +688,10 @@ public:
   Text::Reader asText();
   Data::Reader asData();
   // Reinterpret the list as a blob.  Throws an exception if the elements are not byte-sized.
+
+  template <typename T>
+  KJ_ALWAYS_INLINE(kj::ArrayPtr<const T> asPtr() const);
+  // Pointer to the list's data.  Throws an exception if T is not the same width as the list elements.
 
   template <typename T>
   KJ_ALWAYS_INLINE(T getDataElement(ElementCount index) const);
@@ -986,6 +994,12 @@ inline PointerReader StructReader::getPointerField(WirePointerCount ptrIndex) co
 inline ElementCount ListBuilder::size() const { return elementCount; }
 
 template <typename T>
+inline kj::ArrayPtr<T> ListBuilder::asPtr() {
+  KJ_IREQUIRE(sizeof(T) == step / BITS_PER_BYTE, "T must be the same width as the list elements");
+  return kj::ArrayPtr<T>(reinterpret_cast<T*>(ptr), size());
+}
+
+template <typename T>
 inline T ListBuilder::getDataElement(ElementCount index) {
   return reinterpret_cast<WireValue<T>*>(ptr + index * step / BITS_PER_BYTE)->get();
 
@@ -1048,6 +1062,12 @@ inline PointerBuilder ListBuilder::getPointerElement(ElementCount index) {
 // -------------------------------------------------------------------
 
 inline ElementCount ListReader::size() const { return elementCount; }
+
+template <typename T>
+inline kj::ArrayPtr<const T> ListReader::asPtr() const {
+  KJ_IREQUIRE(sizeof(T) == step / BITS_PER_BYTE, "T must be the same width as the list elements");
+  return kj::ArrayPtr<const T>(reinterpret_cast<const T*>(ptr), size());
+}
 
 template <typename T>
 inline T ListReader::getDataElement(ElementCount index) const {

--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -119,6 +119,8 @@ struct List<T, Kind::PRIMITIVE> {
     inline Iterator begin() const { return Iterator(this, 0); }
     inline Iterator end() const { return Iterator(this, size()); }
 
+    inline kj::ArrayPtr<const T> asPtr() const { return reader.template asPtr<T>(); }
+
   private:
     _::ListReader reader;
     template <typename U, Kind K>
@@ -159,6 +161,8 @@ struct List<T, Kind::PRIMITIVE> {
     typedef _::IndexingIterator<Builder, T> Iterator;
     inline Iterator begin() { return Iterator(this, 0); }
     inline Iterator end() { return Iterator(this, size()); }
+
+    inline kj::ArrayPtr<T> asPtr() { return builder.template asPtr<T>(); }
 
   private:
     _::ListBuilder builder;


### PR DESCRIPTION
Adds an `asPtr()` method to `capnp::List::Reader`/`Builder` that returns a `kj::ArrayPtr` to the underlying memory.

This makes it a little easier to perform operations on blocks of list elements, and you can pass the list to functions/store it in classes without introducing a dependency on capnp (or copying the elements).
