### PR TITLE
rpc.capnp: replace "newly" with "previously"

### DIFF
--- a/c++/src/capnp/rpc.capnp
+++ b/c++/src/capnp/rpc.capnp
@@ -870,7 +870,7 @@ struct CapDescriptor {
     # Hopefully this is unusual.
 
     senderHosted @1 :ExportId;
-    # A capability newly exported by the sender.  This is the ID of the new capability in the
+    # A capability previously exported by the sender.  This is the ID of the new capability in the
     # sender's export table (receiver's import table).
 
     senderPromise @2 :ExportId;


### PR DESCRIPTION
Nitpicking..

As it may not have been exported recently, "newly" doesn't feel right in this context.
Switched to "previously", which is also used in the context of a describing a `receiverHosted` cap.
