### PR TITLE
Close #94: obsolete comment in rpc.capnp

### DIFF
--- a/c++/src/capnp/rpc.capnp
+++ b/c++/src/capnp/rpc.capnp
@@ -420,21 +420,19 @@ struct Finish {
   # Message type sent from the caller to the callee to indicate:
   # 1) The questionId will no longer be used in any messages sent by the callee (no further
   #    pipelined requests).
-  # 2) Any capabilities in the results other than the ones listed below should be implicitly
-  #    released.
-  # 3) If the call has not returned yet, the caller no longer cares about the result.  If nothing
-  #    else cares about the result either (e.g. there are to other outstanding calls pipelined on
+  # 2) If the call has not returned yet, the caller no longer cares about the result.  If nothing
+  #    else cares about the result either (e.g. there are no other outstanding calls pipelined on
   #    the result of this one) then the callee may wish to immediately cancel the operation and
   #    send back a Return message with "canceled" set.  However, implementations are not required
   #    to support premature cancellation -- instead, the implementation may wait until the call
   #    actually completes and send a normal `Return` message.
   #
-  # TODO(someday):  Should we separate (1) and (2)?  It would be possible and useful to notify the
-  #   server that it doesn't need to keep around the response to service pipeline requests even
-  #   though the caller still wants to receive it / hasn't yet finished processing it.  It could
-  #   also be useful to notify the server that it need not marshal the results because the caller
-  #   doesn't want them anyway, even if the caller is still sending pipelined calls, although this
-  #   seems less useful (just saving some bytes on the wire).
+  # TODO(someday): Should we separate (1) and implicitly releasing result capabilities?  It would be
+  #   possible and useful to notify the server that it doesn't need to keep around the response to
+  #   service pipeline requests even though the caller still wants to receive it / hasn't yet
+  #   finished processing it.  It could also be useful to notify the server that it need not marshal
+  #   the results because the caller doesn't want them anyway, even if the caller is still sending
+  #   pipelined calls, although this seems less useful (just saving some bytes on the wire).
 
   questionId @0 :QuestionId;
   # ID of the call whose result is to be released.


### PR DESCRIPTION
And a minor `to` -> `no` change.
