### PR TITLE
Add configured includedir as a default import path

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -33,7 +33,7 @@ clean-local:
 	  cd gtest && $(MAKE) $(AM_MAKEFLAGS) clean; \
 	fi
 
-AM_CXXFLAGS = -I$(srcdir)/src -I$(builddir)/src $(PTHREAD_CFLAGS)
+AM_CXXFLAGS = -I$(srcdir)/src -I$(builddir)/src -DCAPNP_INCLUDE_DIR='"$(includedir)"' $(PTHREAD_CFLAGS)
 
 AM_LDFLAGS = $(PTHREAD_CFLAGS)
 

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -281,6 +281,9 @@ public:
     if (addStandardImportPaths) {
       loader.addImportPath(kj::heapString("/usr/local/include"));
       loader.addImportPath(kj::heapString("/usr/include"));
+#ifdef CAPNP_INCLUDE_DIR
+      loader.addImportPath(kj::heapString(CAPNP_INCLUDE_DIR));
+#endif
       addStandardImportPaths = false;
     }
 


### PR DESCRIPTION
Protected by an ifdef to avoid tripping up non-autotools builds
