### PR TITLE
Move construction/assignment operator for kj::Arena.

### DIFF
--- a/c++/src/kj/arena-test.c++
+++ b/c++/src/kj/arena-test.c++
@@ -286,6 +286,23 @@ TEST(Arena, Constructor) {
   EXPECT_EQ("foo", arena.allocate<StringPtr>("foo", 3));
 }
 
+TEST(Arena, Move) {
+  Arena arena;
+  EXPECT_EQ(1u, arena.allocate<uint64_t>(1));
+
+  Arena arena_move(kj::mv(arena));
+  EXPECT_EQ(2u, arena_move.allocate<uint64_t>(2));
+  EXPECT_EQ(3u, arena.allocate<uint64_t>(3));
+
+  Arena assigned;
+  EXPECT_EQ(4u, assigned.allocate<uint64_t>(4));
+
+  assigned = kj::mv(arena_move);
+  EXPECT_EQ(5u, assigned.allocate<uint64_t>(5));
+
+  // Nothing should go wrong (e.g., double-free or leak) when the three Arenas are destroyed
+}
+
 TEST(Arena, Strings) {
   Arena arena;
 

--- a/c++/src/kj/arena.c++
+++ b/c++/src/kj/arena.c++
@@ -41,6 +41,32 @@ Arena::Arena(ArrayPtr<byte> scratch)
   }
 }
 
+Arena::Arena(Arena&& other) noexcept
+    : nextChunkSize(other.nextChunkSize),
+      chunkList(other.chunkList),
+      objectList(other.objectList),
+      currentChunk(other.currentChunk) {
+  other.nextChunkSize = sizeof(ChunkHeader);
+  other.chunkList = other.currentChunk = nullptr;
+  other.objectList = nullptr;
+}
+
+Arena& Arena::operator=(Arena&& other) noexcept(false) {
+  if (this != &other) {
+    cleanup();
+
+    nextChunkSize = other.nextChunkSize;
+    chunkList = other.chunkList;
+    objectList = other.objectList;
+    currentChunk = other.currentChunk;
+
+    other.nextChunkSize = sizeof(ChunkHeader);
+    other.chunkList = other.currentChunk = nullptr;
+    other.objectList = nullptr;
+  }
+  return *this;
+}
+
 Arena::~Arena() noexcept(false) {
   // Run cleanup() explicitly, but if it throws an exception, make sure to run it again as part of
   // unwind.  The second call will not throw because destructors are required to guard against

--- a/c++/src/kj/arena.h
+++ b/c++/src/kj/arena.h
@@ -46,6 +46,9 @@ public:
   explicit Arena(ArrayPtr<byte> scratch);
   // Allocates from the given scratch space first, only resorting to the heap when it runs out.
 
+  Arena(Arena&& other) noexcept;
+  Arena& operator=(Arena&& other) noexcept(false);
+
   KJ_DISALLOW_COPY(Arena);
   ~Arena() noexcept(false);
 


### PR DESCRIPTION
It seems to me like this is a reasonable thing for an `Arena` to support.
