### PR TITLE
Replace AC_PROG_LIBTOOL with LT_INIT in configure.ac

### DIFF
--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -28,7 +28,7 @@ AC_PROG_CXX
 AC_LANG([C++])
 AX_CXX_COMPILE_STDCXX_11
 ACX_PTHREAD
-AC_PROG_LIBTOOL
+LT_INIT
 
 AS_IF([test "$external_capnp" != "no"], [
 	AS_IF([test "x$CAPNP" = "x"], [CAPNP="capnp"], [with_capnp=yes])


### PR DESCRIPTION
AC_PROG_LIBTOOL is a deprecated name for older versions of LT_INIT.[1]
1. http://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
