### PR TITLE
Reduce noise with GCC / Clang -Wunused-parameter.

### DIFF
--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -850,6 +850,7 @@ inline bool StructBuilder::hasDataField(ElementCount offset) {
 
 template <>
 inline bool StructBuilder::hasDataField<Void>(ElementCount offset) {
+  (void)offset;
   return false;
 }
 
@@ -869,6 +870,7 @@ inline bool StructBuilder::getDataField<bool>(ElementCount offset) {
 
 template <>
 inline Void StructBuilder::getDataField<Void>(ElementCount offset) {
+  (void)offset;
   return VOID;
 }
 
@@ -906,7 +908,9 @@ inline void StructBuilder::setDataField<bool>(ElementCount offset, bool value) {
 }
 
 template <>
-inline void StructBuilder::setDataField<Void>(ElementCount offset, Void value) {}
+inline void StructBuilder::setDataField<Void>(ElementCount offset, Void value) {
+  (void)offset, (void)value;
+}
 
 template <typename T>
 inline void StructBuilder::setDataField(ElementCount offset, kj::NoInfer<T> value, Mask<T> m) {
@@ -932,6 +936,7 @@ inline bool StructReader::hasDataField(ElementCount offset) const {
 
 template <>
 inline bool StructReader::hasDataField<Void>(ElementCount offset) const {
+  (void)offset;
   return false;
 }
 
@@ -961,6 +966,7 @@ inline bool StructReader::getDataField<bool>(ElementCount offset) const {
 
 template <>
 inline Void StructReader::getDataField<Void>(ElementCount offset) const {
+  (void)offset;
   return VOID;
 }
 
@@ -1005,6 +1011,7 @@ inline bool ListBuilder::getDataElement<bool>(ElementCount index) {
 
 template <>
 inline Void ListBuilder::getDataElement<Void>(ElementCount index) {
+  (void)index;
   return VOID;
 }
 
@@ -1036,7 +1043,9 @@ inline void ListBuilder::setDataElement<bool>(ElementCount index, bool value) {
 }
 
 template <>
-inline void ListBuilder::setDataElement<Void>(ElementCount index, Void value) {}
+inline void ListBuilder::setDataElement<Void>(ElementCount index, Void value) {
+  (void)index, (void)value;
+}
 
 inline PointerBuilder ListBuilder::getPointerElement(ElementCount index) {
   return PointerBuilder(segment,
@@ -1062,6 +1071,7 @@ inline bool ListReader::getDataElement<bool>(ElementCount index) const {
 
 template <>
 inline Void ListReader::getDataElement<Void>(ElementCount index) const {
+  (void)index;
   return VOID;
 }
 

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -85,7 +85,7 @@ class NullDisposer: public Disposer {
 public:
   static const NullDisposer instance;
 
-  void disposeImpl(void* pointer) const override {}
+  void disposeImpl(void* pointer) const override { (void)pointer; }
 };
 
 // =======================================================================================

--- a/c++/src/kj/string-tree.h
+++ b/c++/src/kj/string-tree.h
@@ -85,13 +85,13 @@ private:
 
   template <typename T>
   static inline size_t flatSize(const T& t) { return t.size(); }
-  static inline size_t flatSize(String&& s) { return 0; }
-  static inline size_t flatSize(StringTree&& s) { return 0; }
+  static inline size_t flatSize(String&& s) { (void)s; return 0; }
+  static inline size_t flatSize(StringTree&& s) { (void)s; return 0; }
 
   template <typename T>
-  static inline size_t branchCount(const T& t) { return 0; }
-  static inline size_t branchCount(String&& s) { return 1; }
-  static inline size_t branchCount(StringTree&& s) { return 1; }
+  static inline size_t branchCount(const T& t) { (void)t; return 0; }
+  static inline size_t branchCount(String&& s) { (void)s; return 1; }
+  static inline size_t branchCount(StringTree&& s) { (void)s; return 1; }
 
   template <typename... Params>
   friend StringTree strTree(Params&&... params);
@@ -162,6 +162,7 @@ void StringTree::visit(Func&& func) const {
 }
 
 inline void StringTree::fill(char* pos, size_t branchIndex) {
+  (void)pos, (void)branchIndex;
   KJ_IREQUIRE(pos == text.end() && branchIndex == branches.size(),
               kj::str(text.end() - pos, ' ', branches.size() - branchIndex).cStr());
 }


### PR DESCRIPTION
With these changes, the inclusion of the .capnp.h file generated from a relatively simple capnp file (containing multiple unsigned integers, an enumerated type, Text, Data) which I made for testing purposes doesn't trigger a bunch of -Wunused-parameter warnings anymore for me. I can focus on warnings in my own code :)

I chose to cast the unused parameters to void because I know that doing so is more portable than both self-assignment (GCC / Clang -Winit-self is designed to trigger warnings about it) and of course **attribute**((unused)).
