### PR TITLE
Remove '-d' flag from call to atos(1)

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -83,7 +83,7 @@ String getStackSymbols(ArrayPtr<void* const> trace) {
 #elif __APPLE__
   // The Mac OS X equivalent of addr2line is atos.
   // (Internally, it uses the private CoreSymbolication.framework library.)
-  p = popen(str("atos -p ", getpid(), ' ', strArray(trace, " ")).cStr(), "r");
+  p = popen(str("xcrun atos -p ", getpid(), ' ', strArray(trace, " ")).cStr(), "r");
 #endif
 
   if (p == nullptr) {


### PR DESCRIPTION
atos(1) doesn't actually have a '-d' flag, but its accidental inclusion was innocuous until OS X 10.10. Now it's a hard-error.
