### PR TITLE
fix copy-paste bug in TestRpc_TailCall: add missing assertion

### DIFF
--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -607,7 +607,7 @@ TEST(Rpc, TailCall) {
 
   auto response = promise.wait(context.waitScope);
   EXPECT_EQ(456, response.getI());
-  EXPECT_EQ(456, response.getI());
+  EXPECT_EQ("from TestTailCaller", response.getT());
 
   auto dependentCall1 = promise.getC().getCallSequenceRequest().send();
 


### PR DESCRIPTION
Hi Kenton! Happened across this while kicking the tires on a Go capnp implementation I've been toying with in my copious free time.
