### PR TITLE
Fix `CAPNP_LITE` build

### DIFF
--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -473,20 +473,19 @@ inline constexpr uint sizeInWords() {
 #define CAPNP_DEFINE_ENUM(type, id) \
     constexpr uint64_t EnumInfo<type>::typeId
 
-#define CAPNP_DECLARE_STRUCT_HEADER(id, dataWordSize, pointerCount, preferredElementEncoding) \
+#define CAPNP_DECLARE_STRUCT_HEADER(id, dataWordSize, pointerCount) \
     struct _capnpPrivate { \
       struct IsStruct; \
       static constexpr uint64_t typeId = 0x##id; \
       static constexpr ::capnp::_::StructSize structSize = ::capnp::_::StructSize( \
-          dataWordSize * ::capnp::WORDS, pointerCount * ::capnp::POINTERS, \
-          ::capnp::_::FieldSize::preferredElementEncoding); \
+          dataWordSize * ::capnp::WORDS, pointerCount * ::capnp::POINTERS); \
       static inline ::capnp::word const* encodedSchema() { return ::capnp::schemas::bp_##id; }
-#define CAPNP_DECLARE_STRUCT(id, dataWordSize, pointerCount, preferredElementEncoding) \
-    CAPNP_DECLARE_STRUCT_HEADER(id, dataWordSize, pointerCount, preferredElementEncoding) \
+#define CAPNP_DECLARE_STRUCT(id, dataWordSize, pointerCount) \
+    CAPNP_DECLARE_STRUCT_HEADER(id, dataWordSize, pointerCount) \
     }
-#define CAPNP_DECLARE_TEMPLATE_STRUCT(id, dataWordSize, pointerCount, preferredElementEncoding, \
+#define CAPNP_DECLARE_TEMPLATE_STRUCT(id, dataWordSize, pointerCount, \
                                       ...) \
-    CAPNP_DECLARE_STRUCT_HEADER(id, dataWordSize, pointerCount, preferredElementEncoding) \
+    CAPNP_DECLARE_STRUCT_HEADER(id, dataWordSize, pointerCount) \
     }
 #define CAPNP_DEFINE_STRUCT(type, templates, id) \
     templates constexpr uint64_t type::_capnpPrivate::typeId; \


### PR DESCRIPTION
Building with `--disable-reflection` fails when compiling `schema.capnp.c++`:

```
libtool: compile:  g++ -std=gnu++11 -DHAVE_CONFIG_H -I. -I./src -I./src -DCAPNP_INCLUDE_DIR=\"/usr/local/include\" -D_THREAD_SAFE -DCAPNP_LITE -O2 -DNDEBUG -D_THREAD_SAFE -MT src/capnp/schema.capnp.lo -MD -MP -MF src/capnp/.deps/schema.capnp.Tpo -c src/capnp/schema.capnp.c++  -fno-common -DPIC -o src/capnp/.libs/schema.capnp.o
In file included from src/capnp/schema.capnp.c++:4:
src/capnp/schema.capnp.h:90:46: error: too few arguments provided to function-like macro invocation
  CAPNP_DECLARE_STRUCT(e682ab4cf923a417, 5, 6);
                                             ^
./src/capnp/generated-header-support.h:484:9: note: macro 'CAPNP_DECLARE_STRUCT' defined here
#define CAPNP_DECLARE_STRUCT(id, dataWordSize, pointerCount, preferredElementEncoding) \
        ^
In file included from src/capnp/schema.capnp.c++:4:
src/capnp/schema.capnp.h:90:3: error: C++ requires a type specifier for all declarations
  CAPNP_DECLARE_STRUCT(e682ab4cf923a417, 5, 6);
  ^~~~~~~~~~~~~~~~~~~~
[...]
```

It looks like the changes in [b469079] weren't applied to both sides of the `#if CAPNP_LITE`
conditional.
