### PR TITLE
Ensure CAPNP_LITE is always defined to 0 when not used

### DIFF
--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -43,6 +43,10 @@ namespace capnp {
 // MSVC only supports "lite" mode for now, due to missing C++11 features.
 #endif
 
+#ifndef CAPNP_LITE
+#define CAPNP_LITE 0
+#endif
+
 typedef unsigned int uint;
 
 struct Void {


### PR DESCRIPTION
With `-Wundef`, Clang (and probably GCC, too) raises a warning on the use of `#if !CAPNP_LITE` in the generated sources for schemas:

```
warning: 'CAPNP_LITE' is not defined, evaluates to 0 [-Wundef]
#if !CAPNP_LITE
     ^
```

Rather than switching to `#if !defined(CAPNP_LITE)` or `#if !defined(CAPNP_LITE) || !CAPNP_LITE`, this seems like the tidiest way to fix it.
