### PR TITLE
ENONET is not supported on OSX

### DIFF
--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -70,7 +70,9 @@ Exception::Type typeOfErrno(int error) {
     case ENETDOWN:
     case ENETRESET:
     case ENETUNREACH:
+#if ENONET
     case ENONET:
+#endif
     case EPIPE:
       return Exception::Type::DISCONNECTED;
 


### PR DESCRIPTION
Before making this change, I get this error:

```
../src/kj/debug.c++:73:10: error: use of undeclared identifier 'ENONET'
    case ENONET:
```
