### PR TITLE
Check for the definition of `_MSC_VER`, rather than its value.

### DIFF
--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1620,7 +1620,7 @@ private:
             "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(),
-                "#if !_MSC_VER\n"
+                "#ifndef _MSC_VER\n"
                 "// Excluded under MSVC because bugs may make it unable to compile this method.\n"),
             templateContext.allDecls(),
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
@@ -1812,7 +1812,7 @@ private:
         "// ", fullName, "\n"
         // TODO(msvc): MSVC doen't expect constexprs to have definitions. Remove #if once
         //   MSVC catches up on constexpr.
-        "#if !_MSC_VER\n",
+        "#ifndef _MSC_VER\n",
         templates, "constexpr uint16_t ", fullName, "::_capnpPrivate::dataWordSize;\n",
         templates, "constexpr uint16_t ", fullName, "::_capnpPrivate::pointerCount;\n"
         "#endif\n",
@@ -2266,7 +2266,7 @@ private:
           scope.size() == 0 ? kj::strTree() : kj::strTree(
               // TODO(msvc): MSVC doesn't like definitions of constexprs, but other compilers and
               //   the standard require them.
-              "#if !_MSC_VER\n"
+              "#ifndef _MSC_VER\n"
               "constexpr ", typeName_, ' ', scope, upperCase, ";\n"
               "#endif\n")
         };

--- a/c++/src/capnp/compiler/grammar.capnp.c++
+++ b/c++/src/capnp/compiler/grammar.capnp.c++
@@ -2704,7 +2704,7 @@ namespace capnp {
 namespace compiler {
 
 // LocatedText
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t LocatedText::_capnpPrivate::dataWordSize;
 constexpr uint16_t LocatedText::_capnpPrivate::pointerCount;
 #endif
@@ -2715,7 +2715,7 @@ constexpr ::capnp::_::RawBrandedSchema const* LocatedText::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // LocatedInteger
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t LocatedInteger::_capnpPrivate::dataWordSize;
 constexpr uint16_t LocatedInteger::_capnpPrivate::pointerCount;
 #endif
@@ -2726,7 +2726,7 @@ constexpr ::capnp::_::RawBrandedSchema const* LocatedInteger::_capnpPrivate::bra
 #endif  // !CAPNP_LITE
 
 // LocatedFloat
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t LocatedFloat::_capnpPrivate::dataWordSize;
 constexpr uint16_t LocatedFloat::_capnpPrivate::pointerCount;
 #endif
@@ -2737,7 +2737,7 @@ constexpr ::capnp::_::RawBrandedSchema const* LocatedFloat::_capnpPrivate::brand
 #endif  // !CAPNP_LITE
 
 // Expression
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Expression::_capnpPrivate::dataWordSize;
 constexpr uint16_t Expression::_capnpPrivate::pointerCount;
 #endif
@@ -2748,7 +2748,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Expression::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Expression::Param
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Expression::Param::_capnpPrivate::dataWordSize;
 constexpr uint16_t Expression::Param::_capnpPrivate::pointerCount;
 #endif
@@ -2759,7 +2759,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Expression::Param::_capnpPrivate::
 #endif  // !CAPNP_LITE
 
 // Expression::Application
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Expression::Application::_capnpPrivate::dataWordSize;
 constexpr uint16_t Expression::Application::_capnpPrivate::pointerCount;
 #endif
@@ -2770,7 +2770,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Expression::Application::_capnpPri
 #endif  // !CAPNP_LITE
 
 // Expression::Member
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Expression::Member::_capnpPrivate::dataWordSize;
 constexpr uint16_t Expression::Member::_capnpPrivate::pointerCount;
 #endif
@@ -2781,7 +2781,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Expression::Member::_capnpPrivate:
 #endif  // !CAPNP_LITE
 
 // Declaration
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::_capnpPrivate::pointerCount;
 #endif
@@ -2792,7 +2792,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Declaration::BrandParameter
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::BrandParameter::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::BrandParameter::_capnpPrivate::pointerCount;
 #endif
@@ -2803,7 +2803,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::BrandParameter::_capn
 #endif  // !CAPNP_LITE
 
 // Declaration::AnnotationApplication
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::AnnotationApplication::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::AnnotationApplication::_capnpPrivate::pointerCount;
 #endif
@@ -2814,7 +2814,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::AnnotationApplication
 #endif  // !CAPNP_LITE
 
 // Declaration::AnnotationApplication::Value
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::AnnotationApplication::Value::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::AnnotationApplication::Value::_capnpPrivate::pointerCount;
 #endif
@@ -2825,7 +2825,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::AnnotationApplication
 #endif  // !CAPNP_LITE
 
 // Declaration::ParamList
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::ParamList::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::ParamList::_capnpPrivate::pointerCount;
 #endif
@@ -2836,7 +2836,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::ParamList::_capnpPriv
 #endif  // !CAPNP_LITE
 
 // Declaration::Param
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Param::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Param::_capnpPrivate::pointerCount;
 #endif
@@ -2847,7 +2847,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Param::_capnpPrivate:
 #endif  // !CAPNP_LITE
 
 // Declaration::Param::DefaultValue
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Param::DefaultValue::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Param::DefaultValue::_capnpPrivate::pointerCount;
 #endif
@@ -2858,7 +2858,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Param::DefaultValue::
 #endif  // !CAPNP_LITE
 
 // Declaration::Id
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Id::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Id::_capnpPrivate::pointerCount;
 #endif
@@ -2869,7 +2869,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Id::_capnpPrivate::br
 #endif  // !CAPNP_LITE
 
 // Declaration::Using
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Using::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Using::_capnpPrivate::pointerCount;
 #endif
@@ -2880,7 +2880,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Using::_capnpPrivate:
 #endif  // !CAPNP_LITE
 
 // Declaration::Const
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Const::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Const::_capnpPrivate::pointerCount;
 #endif
@@ -2891,7 +2891,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Const::_capnpPrivate:
 #endif  // !CAPNP_LITE
 
 // Declaration::Field
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Field::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Field::_capnpPrivate::pointerCount;
 #endif
@@ -2902,7 +2902,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Field::_capnpPrivate:
 #endif  // !CAPNP_LITE
 
 // Declaration::Field::DefaultValue
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Field::DefaultValue::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Field::DefaultValue::_capnpPrivate::pointerCount;
 #endif
@@ -2913,7 +2913,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Field::DefaultValue::
 #endif  // !CAPNP_LITE
 
 // Declaration::Interface
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Interface::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Interface::_capnpPrivate::pointerCount;
 #endif
@@ -2924,7 +2924,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Interface::_capnpPriv
 #endif  // !CAPNP_LITE
 
 // Declaration::Method
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Method::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Method::_capnpPrivate::pointerCount;
 #endif
@@ -2935,7 +2935,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Method::_capnpPrivate
 #endif  // !CAPNP_LITE
 
 // Declaration::Method::Results
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Method::Results::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Method::Results::_capnpPrivate::pointerCount;
 #endif
@@ -2946,7 +2946,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Method::Results::_cap
 #endif  // !CAPNP_LITE
 
 // Declaration::Annotation
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Declaration::Annotation::_capnpPrivate::dataWordSize;
 constexpr uint16_t Declaration::Annotation::_capnpPrivate::pointerCount;
 #endif
@@ -2957,7 +2957,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Declaration::Annotation::_capnpPri
 #endif  // !CAPNP_LITE
 
 // ParsedFile
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t ParsedFile::_capnpPrivate::dataWordSize;
 constexpr uint16_t ParsedFile::_capnpPrivate::pointerCount;
 #endif

--- a/c++/src/capnp/compiler/lexer.capnp.c++
+++ b/c++/src/capnp/compiler/lexer.capnp.c++
@@ -463,7 +463,7 @@ namespace capnp {
 namespace compiler {
 
 // Token
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Token::_capnpPrivate::dataWordSize;
 constexpr uint16_t Token::_capnpPrivate::pointerCount;
 #endif
@@ -474,7 +474,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Token::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Statement
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Statement::_capnpPrivate::dataWordSize;
 constexpr uint16_t Statement::_capnpPrivate::pointerCount;
 #endif
@@ -485,7 +485,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Statement::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // LexedTokens
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t LexedTokens::_capnpPrivate::dataWordSize;
 constexpr uint16_t LexedTokens::_capnpPrivate::pointerCount;
 #endif
@@ -496,7 +496,7 @@ constexpr ::capnp::_::RawBrandedSchema const* LexedTokens::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // LexedStatements
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t LexedStatements::_capnpPrivate::dataWordSize;
 constexpr uint16_t LexedStatements::_capnpPrivate::pointerCount;
 #endif

--- a/c++/src/capnp/persistent.capnp.h
+++ b/c++/src/capnp/persistent.capnp.h
@@ -649,7 +649,7 @@ inline typename  ::capnp::Persistent<SturdyRef>::Client& Persistent<SturdyRef>::
 
 #endif  // !CAPNP_LITE
 // Persistent<SturdyRef>::SaveParams
-#if !_MSC_VER
+#ifndef _MSC_VER
 template <typename SturdyRef>
 constexpr uint16_t Persistent<SturdyRef>::SaveParams::_capnpPrivate::dataWordSize;
 template <typename SturdyRef>
@@ -729,7 +729,7 @@ inline ::capnp::Orphan<SturdyRef> Persistent<SturdyRef>::SaveResults::Builder::d
 }
 
 // Persistent<SturdyRef>::SaveResults
-#if !_MSC_VER
+#ifndef _MSC_VER
 template <typename SturdyRef>
 constexpr uint16_t Persistent<SturdyRef>::SaveResults::_capnpPrivate::dataWordSize;
 template <typename SturdyRef>
@@ -949,7 +949,7 @@ inline ::capnp::Orphan<typename  ::capnp::Persistent<InternalRef>::SaveParams> R
 }
 
 // RealmGateway<InternalRef, ExternalRef>::ImportParams
-#if !_MSC_VER
+#ifndef _MSC_VER
 template <typename InternalRef, typename ExternalRef>
 constexpr uint16_t RealmGateway<InternalRef, ExternalRef>::ImportParams::_capnpPrivate::dataWordSize;
 template <typename InternalRef, typename ExternalRef>
@@ -1076,7 +1076,7 @@ inline ::capnp::Orphan<typename  ::capnp::Persistent<ExternalRef>::SaveParams> R
 }
 
 // RealmGateway<InternalRef, ExternalRef>::ExportParams
-#if !_MSC_VER
+#ifndef _MSC_VER
 template <typename InternalRef, typename ExternalRef>
 constexpr uint16_t RealmGateway<InternalRef, ExternalRef>::ExportParams::_capnpPrivate::dataWordSize;
 template <typename InternalRef, typename ExternalRef>

--- a/c++/src/capnp/rpc-twoparty.capnp.c++
+++ b/c++/src/capnp/rpc-twoparty.capnp.c++
@@ -351,7 +351,7 @@ namespace rpc {
 namespace twoparty {
 
 // VatId
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t VatId::_capnpPrivate::dataWordSize;
 constexpr uint16_t VatId::_capnpPrivate::pointerCount;
 #endif
@@ -362,7 +362,7 @@ constexpr ::capnp::_::RawBrandedSchema const* VatId::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // ProvisionId
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t ProvisionId::_capnpPrivate::dataWordSize;
 constexpr uint16_t ProvisionId::_capnpPrivate::pointerCount;
 #endif
@@ -373,7 +373,7 @@ constexpr ::capnp::_::RawBrandedSchema const* ProvisionId::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // RecipientId
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t RecipientId::_capnpPrivate::dataWordSize;
 constexpr uint16_t RecipientId::_capnpPrivate::pointerCount;
 #endif
@@ -384,7 +384,7 @@ constexpr ::capnp::_::RawBrandedSchema const* RecipientId::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // ThirdPartyCapId
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t ThirdPartyCapId::_capnpPrivate::dataWordSize;
 constexpr uint16_t ThirdPartyCapId::_capnpPrivate::pointerCount;
 #endif
@@ -395,7 +395,7 @@ constexpr ::capnp::_::RawBrandedSchema const* ThirdPartyCapId::_capnpPrivate::br
 #endif  // !CAPNP_LITE
 
 // JoinKeyPart
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t JoinKeyPart::_capnpPrivate::dataWordSize;
 constexpr uint16_t JoinKeyPart::_capnpPrivate::pointerCount;
 #endif
@@ -406,7 +406,7 @@ constexpr ::capnp::_::RawBrandedSchema const* JoinKeyPart::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // JoinResult
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t JoinResult::_capnpPrivate::dataWordSize;
 constexpr uint16_t JoinResult::_capnpPrivate::pointerCount;
 #endif

--- a/c++/src/capnp/rpc.capnp.c++
+++ b/c++/src/capnp/rpc.capnp.c++
@@ -1890,7 +1890,7 @@ namespace capnp {
 namespace rpc {
 
 // Message
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Message::_capnpPrivate::dataWordSize;
 constexpr uint16_t Message::_capnpPrivate::pointerCount;
 #endif
@@ -1901,7 +1901,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Message::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Bootstrap
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Bootstrap::_capnpPrivate::dataWordSize;
 constexpr uint16_t Bootstrap::_capnpPrivate::pointerCount;
 #endif
@@ -1912,7 +1912,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Bootstrap::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Call
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Call::_capnpPrivate::dataWordSize;
 constexpr uint16_t Call::_capnpPrivate::pointerCount;
 #endif
@@ -1923,7 +1923,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Call::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Call::SendResultsTo
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Call::SendResultsTo::_capnpPrivate::dataWordSize;
 constexpr uint16_t Call::SendResultsTo::_capnpPrivate::pointerCount;
 #endif
@@ -1934,7 +1934,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Call::SendResultsTo::_capnpPrivate
 #endif  // !CAPNP_LITE
 
 // Return
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Return::_capnpPrivate::dataWordSize;
 constexpr uint16_t Return::_capnpPrivate::pointerCount;
 #endif
@@ -1945,7 +1945,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Return::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Finish
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Finish::_capnpPrivate::dataWordSize;
 constexpr uint16_t Finish::_capnpPrivate::pointerCount;
 #endif
@@ -1956,7 +1956,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Finish::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Resolve
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Resolve::_capnpPrivate::dataWordSize;
 constexpr uint16_t Resolve::_capnpPrivate::pointerCount;
 #endif
@@ -1967,7 +1967,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Resolve::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Release
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Release::_capnpPrivate::dataWordSize;
 constexpr uint16_t Release::_capnpPrivate::pointerCount;
 #endif
@@ -1978,7 +1978,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Release::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Disembargo
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Disembargo::_capnpPrivate::dataWordSize;
 constexpr uint16_t Disembargo::_capnpPrivate::pointerCount;
 #endif
@@ -1989,7 +1989,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Disembargo::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Disembargo::Context
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Disembargo::Context::_capnpPrivate::dataWordSize;
 constexpr uint16_t Disembargo::Context::_capnpPrivate::pointerCount;
 #endif
@@ -2000,7 +2000,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Disembargo::Context::_capnpPrivate
 #endif  // !CAPNP_LITE
 
 // Provide
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Provide::_capnpPrivate::dataWordSize;
 constexpr uint16_t Provide::_capnpPrivate::pointerCount;
 #endif
@@ -2011,7 +2011,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Provide::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Accept
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Accept::_capnpPrivate::dataWordSize;
 constexpr uint16_t Accept::_capnpPrivate::pointerCount;
 #endif
@@ -2022,7 +2022,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Accept::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Join
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Join::_capnpPrivate::dataWordSize;
 constexpr uint16_t Join::_capnpPrivate::pointerCount;
 #endif
@@ -2033,7 +2033,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Join::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // MessageTarget
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t MessageTarget::_capnpPrivate::dataWordSize;
 constexpr uint16_t MessageTarget::_capnpPrivate::pointerCount;
 #endif
@@ -2044,7 +2044,7 @@ constexpr ::capnp::_::RawBrandedSchema const* MessageTarget::_capnpPrivate::bran
 #endif  // !CAPNP_LITE
 
 // Payload
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Payload::_capnpPrivate::dataWordSize;
 constexpr uint16_t Payload::_capnpPrivate::pointerCount;
 #endif
@@ -2055,7 +2055,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Payload::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // CapDescriptor
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t CapDescriptor::_capnpPrivate::dataWordSize;
 constexpr uint16_t CapDescriptor::_capnpPrivate::pointerCount;
 #endif
@@ -2066,7 +2066,7 @@ constexpr ::capnp::_::RawBrandedSchema const* CapDescriptor::_capnpPrivate::bran
 #endif  // !CAPNP_LITE
 
 // PromisedAnswer
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t PromisedAnswer::_capnpPrivate::dataWordSize;
 constexpr uint16_t PromisedAnswer::_capnpPrivate::pointerCount;
 #endif
@@ -2077,7 +2077,7 @@ constexpr ::capnp::_::RawBrandedSchema const* PromisedAnswer::_capnpPrivate::bra
 #endif  // !CAPNP_LITE
 
 // PromisedAnswer::Op
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t PromisedAnswer::Op::_capnpPrivate::dataWordSize;
 constexpr uint16_t PromisedAnswer::Op::_capnpPrivate::pointerCount;
 #endif
@@ -2088,7 +2088,7 @@ constexpr ::capnp::_::RawBrandedSchema const* PromisedAnswer::Op::_capnpPrivate:
 #endif  // !CAPNP_LITE
 
 // ThirdPartyCapDescriptor
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t ThirdPartyCapDescriptor::_capnpPrivate::dataWordSize;
 constexpr uint16_t ThirdPartyCapDescriptor::_capnpPrivate::pointerCount;
 #endif
@@ -2099,7 +2099,7 @@ constexpr ::capnp::_::RawBrandedSchema const* ThirdPartyCapDescriptor::_capnpPri
 #endif  // !CAPNP_LITE
 
 // Exception
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Exception::_capnpPrivate::dataWordSize;
 constexpr uint16_t Exception::_capnpPrivate::pointerCount;
 #endif

--- a/c++/src/capnp/schema.capnp.c++
+++ b/c++/src/capnp/schema.capnp.c++
@@ -3222,7 +3222,7 @@ namespace capnp {
 namespace schema {
 
 // Node
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::_capnpPrivate::pointerCount;
 #endif
@@ -3233,7 +3233,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Node::Parameter
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::Parameter::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::Parameter::_capnpPrivate::pointerCount;
 #endif
@@ -3244,7 +3244,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::Parameter::_capnpPrivate::br
 #endif  // !CAPNP_LITE
 
 // Node::NestedNode
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::NestedNode::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::NestedNode::_capnpPrivate::pointerCount;
 #endif
@@ -3255,7 +3255,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::NestedNode::_capnpPrivate::b
 #endif  // !CAPNP_LITE
 
 // Node::Struct
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::Struct::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::Struct::_capnpPrivate::pointerCount;
 #endif
@@ -3266,7 +3266,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::Struct::_capnpPrivate::brand
 #endif  // !CAPNP_LITE
 
 // Node::Enum
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::Enum::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::Enum::_capnpPrivate::pointerCount;
 #endif
@@ -3277,7 +3277,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::Enum::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Node::Interface
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::Interface::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::Interface::_capnpPrivate::pointerCount;
 #endif
@@ -3288,7 +3288,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::Interface::_capnpPrivate::br
 #endif  // !CAPNP_LITE
 
 // Node::Const
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::Const::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::Const::_capnpPrivate::pointerCount;
 #endif
@@ -3299,7 +3299,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::Const::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Node::Annotation
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Node::Annotation::_capnpPrivate::dataWordSize;
 constexpr uint16_t Node::Annotation::_capnpPrivate::pointerCount;
 #endif
@@ -3310,7 +3310,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Node::Annotation::_capnpPrivate::b
 #endif  // !CAPNP_LITE
 
 // Field
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Field::_capnpPrivate::dataWordSize;
 constexpr uint16_t Field::_capnpPrivate::pointerCount;
 #endif
@@ -3320,11 +3320,11 @@ constexpr ::capnp::_::RawSchema const* Field::_capnpPrivate::schema;
 constexpr ::capnp::_::RawBrandedSchema const* Field::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr  ::uint16_t Field::NO_DISCRIMINANT;
 #endif
 // Field::Slot
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Field::Slot::_capnpPrivate::dataWordSize;
 constexpr uint16_t Field::Slot::_capnpPrivate::pointerCount;
 #endif
@@ -3335,7 +3335,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Field::Slot::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Field::Group
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Field::Group::_capnpPrivate::dataWordSize;
 constexpr uint16_t Field::Group::_capnpPrivate::pointerCount;
 #endif
@@ -3346,7 +3346,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Field::Group::_capnpPrivate::brand
 #endif  // !CAPNP_LITE
 
 // Field::Ordinal
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Field::Ordinal::_capnpPrivate::dataWordSize;
 constexpr uint16_t Field::Ordinal::_capnpPrivate::pointerCount;
 #endif
@@ -3357,7 +3357,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Field::Ordinal::_capnpPrivate::bra
 #endif  // !CAPNP_LITE
 
 // Enumerant
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Enumerant::_capnpPrivate::dataWordSize;
 constexpr uint16_t Enumerant::_capnpPrivate::pointerCount;
 #endif
@@ -3368,7 +3368,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Enumerant::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Superclass
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Superclass::_capnpPrivate::dataWordSize;
 constexpr uint16_t Superclass::_capnpPrivate::pointerCount;
 #endif
@@ -3379,7 +3379,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Superclass::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Method
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Method::_capnpPrivate::dataWordSize;
 constexpr uint16_t Method::_capnpPrivate::pointerCount;
 #endif
@@ -3390,7 +3390,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Method::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Type
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::_capnpPrivate::pointerCount;
 #endif
@@ -3401,7 +3401,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Type::List
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::List::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::List::_capnpPrivate::pointerCount;
 #endif
@@ -3412,7 +3412,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::List::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Type::Enum
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::Enum::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::Enum::_capnpPrivate::pointerCount;
 #endif
@@ -3423,7 +3423,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::Enum::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Type::Struct
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::Struct::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::Struct::_capnpPrivate::pointerCount;
 #endif
@@ -3434,7 +3434,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::Struct::_capnpPrivate::brand
 #endif  // !CAPNP_LITE
 
 // Type::Interface
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::Interface::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::Interface::_capnpPrivate::pointerCount;
 #endif
@@ -3445,7 +3445,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::Interface::_capnpPrivate::br
 #endif  // !CAPNP_LITE
 
 // Type::AnyPointer
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::AnyPointer::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::AnyPointer::_capnpPrivate::pointerCount;
 #endif
@@ -3456,7 +3456,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::AnyPointer::_capnpPrivate::b
 #endif  // !CAPNP_LITE
 
 // Type::AnyPointer::Parameter
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::AnyPointer::Parameter::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::AnyPointer::Parameter::_capnpPrivate::pointerCount;
 #endif
@@ -3467,7 +3467,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::AnyPointer::Parameter::_capn
 #endif  // !CAPNP_LITE
 
 // Type::AnyPointer::ImplicitMethodParameter
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Type::AnyPointer::ImplicitMethodParameter::_capnpPrivate::dataWordSize;
 constexpr uint16_t Type::AnyPointer::ImplicitMethodParameter::_capnpPrivate::pointerCount;
 #endif
@@ -3478,7 +3478,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Type::AnyPointer::ImplicitMethodPa
 #endif  // !CAPNP_LITE
 
 // Brand
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Brand::_capnpPrivate::dataWordSize;
 constexpr uint16_t Brand::_capnpPrivate::pointerCount;
 #endif
@@ -3489,7 +3489,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Brand::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Brand::Scope
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Brand::Scope::_capnpPrivate::dataWordSize;
 constexpr uint16_t Brand::Scope::_capnpPrivate::pointerCount;
 #endif
@@ -3500,7 +3500,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Brand::Scope::_capnpPrivate::brand
 #endif  // !CAPNP_LITE
 
 // Brand::Binding
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Brand::Binding::_capnpPrivate::dataWordSize;
 constexpr uint16_t Brand::Binding::_capnpPrivate::pointerCount;
 #endif
@@ -3511,7 +3511,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Brand::Binding::_capnpPrivate::bra
 #endif  // !CAPNP_LITE
 
 // Value
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Value::_capnpPrivate::dataWordSize;
 constexpr uint16_t Value::_capnpPrivate::pointerCount;
 #endif
@@ -3522,7 +3522,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Value::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // Annotation
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t Annotation::_capnpPrivate::dataWordSize;
 constexpr uint16_t Annotation::_capnpPrivate::pointerCount;
 #endif
@@ -3533,7 +3533,7 @@ constexpr ::capnp::_::RawBrandedSchema const* Annotation::_capnpPrivate::brand;
 #endif  // !CAPNP_LITE
 
 // CodeGeneratorRequest
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t CodeGeneratorRequest::_capnpPrivate::dataWordSize;
 constexpr uint16_t CodeGeneratorRequest::_capnpPrivate::pointerCount;
 #endif
@@ -3544,7 +3544,7 @@ constexpr ::capnp::_::RawBrandedSchema const* CodeGeneratorRequest::_capnpPrivat
 #endif  // !CAPNP_LITE
 
 // CodeGeneratorRequest::RequestedFile
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t CodeGeneratorRequest::RequestedFile::_capnpPrivate::dataWordSize;
 constexpr uint16_t CodeGeneratorRequest::RequestedFile::_capnpPrivate::pointerCount;
 #endif
@@ -3555,7 +3555,7 @@ constexpr ::capnp::_::RawBrandedSchema const* CodeGeneratorRequest::RequestedFil
 #endif  // !CAPNP_LITE
 
 // CodeGeneratorRequest::RequestedFile::Import
-#if !_MSC_VER
+#ifndef _MSC_VER
 constexpr uint16_t CodeGeneratorRequest::RequestedFile::Import::_capnpPrivate::dataWordSize;
 constexpr uint16_t CodeGeneratorRequest::RequestedFile::Import::_capnpPrivate::pointerCount;
 #endif


### PR DESCRIPTION
Similar to #139, this changes how `_MSC_VER` is tested in generated code. 
