### PR TITLE
Wait for writeable, rather than readable, socket on connect.

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -191,7 +191,7 @@ public:
 
     if (pollResult == 0) {
       // Not ready yet. We can safely use the edge-triggered observer.
-      return observer.whenBecomesReadable();
+      return observer.whenBecomesWritable();
     } else {
       // Ready now.
       return kj::READY_NOW;


### PR DESCRIPTION
On our system, this change is necessary to be able to establish remote connections.  Local connections finish so quickly that the first poll() call returns 0, so whenBecomesReadable() is never called.
