### PR TITLE
Add versioning to the libraries in the CMake build

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -64,6 +64,8 @@ target_include_directories(capnp INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
   $<INSTALL_INTERFACE:include>
 )
+# Ensure the library has a version set to match autotools build
+set_target_properties(capnp PROPERTIES VERSION ${VERSION})
 install(TARGETS capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${capnp_headers} ${capnp_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
 
@@ -97,6 +99,8 @@ if(NOT CAPNP_LITE)
   add_library(capnp-rpc ${capnp-rpc_sources})
   add_library(CapnProto::capnp-rpc ALIAS capnp-rpc)
   target_link_libraries(capnp-rpc PUBLIC capnp kj-async kj)
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(capnp-rpc PROPERTIES VERSION ${VERSION})
   install(TARGETS capnp-rpc ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${capnp-rpc_headers} ${capnp-rpc_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
 endif()
@@ -118,6 +122,8 @@ if(NOT CAPNP_LITE)
   add_library(capnp-json ${capnp-json_sources})
   add_library(CapnProto::capnp-json ALIAS capnp-json)
   target_link_libraries(capnp-json PUBLIC capnp kj-async kj)
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(capnp-json PROPERTIES VERSION ${VERSION})
   install(TARGETS capnp-json ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${capnp-json_headers} ${capnp-json_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp/compat")
 endif()
@@ -139,6 +145,8 @@ set(capnpc_sources
 if(NOT CAPNP_LITE)
   add_library(capnpc ${capnpc_sources})
   target_link_libraries(capnpc PUBLIC capnp kj)
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(capnpc PROPERTIES VERSION ${VERSION})
   install(TARGETS capnpc ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${capnpc_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
 endif()

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -74,6 +74,8 @@ target_include_directories(kj INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
   $<INSTALL_INTERFACE:include>
 )
+# Ensure the library has a version set to match autotools build
+set_target_properties(kj PROPERTIES VERSION ${VERSION})
 install(TARGETS kj ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${kj_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
 install(FILES ${kj-parse_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/parse")
@@ -91,6 +93,8 @@ set(kj-test-compat_headers
 add_library(kj-test ${kj-test_sources})
 add_library(CapnProto::kj-test ALIAS kj-test)
 target_link_libraries(kj-test PUBLIC kj)
+# Ensure the library has a version set to match autotools build
+set_target_properties(kj-test PROPERTIES VERSION ${VERSION})
 install(TARGETS kj-test ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${kj-test_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
 install(FILES ${kj-test-compat_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
@@ -123,6 +127,8 @@ if(NOT CAPNP_LITE)
   elseif(WIN32)
     target_link_libraries(kj-async PUBLIC ws2_32)
   endif()
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(kj-async PROPERTIES VERSION ${VERSION})
   install(TARGETS kj-async ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${kj-async_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
 endif()
@@ -141,6 +147,8 @@ if(NOT CAPNP_LITE)
   add_library(kj-http ${kj-http_sources})
   add_library(CapnProto::kj-http ALIAS kj-http)
   target_link_libraries(kj-http PUBLIC kj-async kj)
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(kj-http PROPERTIES VERSION ${VERSION})
   install(TARGETS kj-http ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${kj-http_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
 endif()


### PR DESCRIPTION
The Autotools and CMake builds are almost the same, except for
the libraries not being generated as versioned libraries in CMake.

Fixing this lets Linux CMake builds be on the same level as Autotools ones.