### PR TITLE
Add cmake_minimum_required to root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,2 @@
+cmake_minimum_required(VERSION 3.1)
 add_subdirectory(c++)


### PR DESCRIPTION
There was already a minimum version specified in the actual CMakeLists file in the C++ directory, but since the parent file does not have it you get a warning if you build in the idiomatic cmake fashion:

```bash
mkdir build
cd build
cmake .. # <---- warning here because no minimum version specified
```

I used 3.1 as min version because that is the same as specified in child file.