### PR TITLE
Remove references to C# implementation in docs

### DIFF
--- a/doc/_posts/2014-06-17-capnproto-flatbuffers-sbe.md
+++ b/doc/_posts/2014-06-17-capnproto-flatbuffers-sbe.md
@@ -42,7 +42,7 @@ Note: For features which are properties of the implementation rather than the pr
 <tr><td>Pointers take space on wire?</td><td class="pass">no</td><td class="fail">yes</td><td class="pass">no</td><td class="fail">yes</td></tr>
 <tr><td>C++</td><td class="pass">yes</td><td class="pass">yes (C++11)*</td><td class="pass">yes</td><td class="pass">yes</td></tr>
 <tr><td>Java</td><td class="pass">yes</td><td class="pass">yes*</td><td class="pass">yes</td><td class="pass">yes</td></tr>
-<tr><td>C#</td><td class="pass">yes</td><td class="pass">yes*</td><td class="pass">yes</td><td class="pass">yes*</td></tr>
+<tr><td>C#</td><td class="pass">yes</td><td class="fail">no</td><td class="pass">yes</td><td class="pass">yes*</td></tr>
 <tr><td>Go</td><td class="pass">yes</td><td class="pass">yes</td><td class="fail">no</td><td class="pass">yes*</td></tr>
 <tr><td>Other languages</td><td class="pass">lots!</td><td class="warn">6+ others*</td><td class="fail">no</td><td class="fail">no</td></tr>
 <tr><td>Authors' preferred use case</td><td>distributed<br>computing</td><td><a href="https://sandstorm.io">platforms /<br>sandboxing</a></td><td>financial<br>trading</td><td>games</td></tr>

--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -23,7 +23,6 @@ project's documentation for details.
 ##### Serialization only
 
 * [C](https://github.com/opensourcerouting/c-capnproto) by [OpenSourceRouting](https://www.opensourcerouting.org/) / [@eqvinox](https://github.com/eqvinox) (originally by [@jmckaskill](https://github.com/jmckaskill))
-* [C#](https://github.com/mgravell/capnproto-net) by [@mgravell](https://github.com/mgravell)
 * [D](https://github.com/capnproto/capnproto-dlang) by [@ThomasBrixLarsen](https://github.com/ThomasBrixLarsen)
 * [Go](https://github.com/glycerine/go-capnproto) by [@glycerine](https://github.com/glycerine) (originally by [@jmckaskill](https://github.com/jmckaskill))
 * [Java](https://github.com/capnproto/capnproto-java/) by [@dwrensha](https://github.com/dwrensha)


### PR DESCRIPTION
capnproto-net is dead and has vanished from github. This removes references to it to prevent confusion.