### PR TITLE
Fix link errors with -fsanitize=vptr

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -61,10 +61,6 @@ ClientHook::ClientHook() {
   setGlobalBrokenCapFactoryForLayoutCpp(brokenCapFactory);
 }
 
-void* ClientHook::getLocalServer(_::CapabilityServerSetBase& capServerSet) {
-  return nullptr;
-}
-
 // =======================================================================================
 
 Capability::Client::Client(decltype(nullptr))

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -55,6 +55,10 @@ void setGlobalBrokenCapFactoryForLayoutCpp(BrokenCapFactory& factory) {
 const uint ClientHook::NULL_CAPABILITY_BRAND = 0;
 // Defined here rather than capability.c++ so that we can safely call isNull() in this file.
 
+void* ClientHook::getLocalServer(_::CapabilityServerSetBase& capServerSet) {
+  return nullptr;
+}
+
 namespace _ {  // private
 
 #endif  // !CAPNP_LITE

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -56,6 +56,7 @@ const uint ClientHook::NULL_CAPABILITY_BRAND = 0;
 // Defined here rather than capability.c++ so that we can safely call isNull() in this file.
 
 void* ClientHook::getLocalServer(_::CapabilityServerSetBase& capServerSet) {
+  // Defined here rather than capability.c++ because otherwise building with -fsanitize=vptr fails.
   return nullptr;
 }
 


### PR DESCRIPTION
When building on gcc 5.4.0 with -fsanitize=vptr (enabled by -fsanitize=undefined) linking libcapnp.a fails in layout.c++.o with `undefined reference to `typeinfo for capnp::ClientHook'.

This is because `ClientHook::NULL_CAPABILITY_BRAND` is defined in layout.c++ and fsanitize=vptr makes that definition depend in some way on the vtable. Simplest workaround is to drag the vtable in as well by defining the first virtual function. Fortunately in this case this is `ClientHook::getLocalServer(_::CapabilityServerSetBase&)` which has a trivial implementation and does not drag in any other symbols.

Note https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64670