### PR TITLE
cmake: do not install header miniposix.h

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -41,7 +41,6 @@ set(kj_headers
   exception.h
   debug.h
   arena.h
-  miniposix.h
   io.h
   tuple.h
   one-of.h


### PR DESCRIPTION
synchrozines behavior with autoconf build

https://github.com/capnproto/capnproto/issues/515