### PR TITLE
Align CMake-built shared library filenames, sonames, and rpaths with autotools build

### DIFF
--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -43,6 +43,67 @@ if(BUILD_TESTING)
   add_custom_target(check "${CMAKE_CTEST_COMMAND}" -V)
 endif()  # BUILD_TESTING
 
+# CMake support functions ======================================================
+
+function(kj_add_library target)
+  # Wrapper around `add_library()` to implement certain boilerplate practices:
+  #
+  #   1. The project version is appended to the library's output name (if it's a shared library).
+  #   2. The library gets an ALIAS target in the CapnProto:: namespace.
+  #   3. The library is install()ed using the value of INSTALL_TARGETS_DEFAULT_ARGS as arguments.
+  #   4. The installed library is copied to a convenience library without the name mangling from
+  #      (1) (if it's a shared library).
+  #
+  # You should use this function as you would `add_library()`.
+  #
+  # DETAILS
+  #
+  # The Cap'n Proto C++ ABI stability policy assumes no two versions are ABI-compatible. To prevent
+  # accidental dynamic linkage to an ABI-incompatible version of the library, the project version
+  # (-dev metadata and all) is appended to the library target's output name. For example, target
+  # `kj` produces a library whose filename and soname are `libkj-0.7-dev.so`. Additionally, the
+  # autotools build produces a `libkj.so` convenience file (but with the full soname).
+  #
+  # The autotools build implements this name mangling with `libtool -release`. The CMake build can
+  # emulate its behavior by manually setting the OUTPUT_NAME property. Copying the file to a
+  # filename without the version appendage is accomplished with a technique I learned from reading
+  # the Xerces-C++ project's CMakeLists.txt, by Roger Leigh:
+  # http://svn.apache.org/viewvc/xerces/c/trunk/src/CMakeLists.txt?revision=1800911&view=markup#l1269
+
+  add_library(${target} ${ARGN})
+  # Forward all arguments directly to add_library.
+
+  add_library(CapnProto::${target} ALIAS ${target})
+
+  install(TARGETS ${target} ${INSTALL_TARGETS_DEFAULT_ARGS})
+  # This install line must precede the shared library copy script install line below to ensure the
+  # library is installed before the script is executed.
+
+  get_target_property(target_type ${target} TYPE)
+  if(target_type STREQUAL "SHARED_LIBRARY")
+    # The autotools build only mangles shared library names.
+    set_target_properties(${target}
+        PROPERTIES
+          OUTPUT_NAME ${target}-${VERSION}
+          INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
+          # The autotools build sets the rpath this way on all libraries with dependencies
+    )
+    # Mangle shared library output names the same way the autotools build does.
+
+    file(GENERATE
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/install-${target}-copy.cmake"
+        CONTENT "execute_process(COMMAND ${CMAKE_COMMAND} -E copy \
+\"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/$<TARGET_FILE_NAME:${target}>\" \
+\"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${target}${CMAKE_SHARED_LIBRARY_SUFFIX}\")")
+    # This says: copy the installed target filename to lib${target}.so.
+
+    install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/install-${target}-copy.cmake")
+    # We have to create a script file because we can't use generator expressions inside
+    # install(CODE). This is a requested feature of CMake:
+    #   https://gitlab.kitware.com/cmake/cmake/issues/15785
+  endif()
+endfunction()
+
 # kj ===========================================================================
 
 add_subdirectory(kj)

--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -56,17 +56,14 @@ set(capnp_schemas
   c++.capnp
   schema.capnp
 )
-add_library(capnp ${capnp_sources})
-add_library(CapnProto::capnp ALIAS capnp)
+
+kj_add_library(capnp ${capnp_sources})
 target_link_libraries(capnp PUBLIC kj)
 #make sure external consumers don't need to manually set the include dirs
 target_include_directories(capnp INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
   $<INSTALL_INTERFACE:include>
 )
-# Ensure the library has a version set to match autotools build
-set_target_properties(capnp PROPERTIES VERSION ${VERSION})
-install(TARGETS capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${capnp_headers} ${capnp_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
 
 set(capnp-rpc_sources
@@ -96,12 +93,8 @@ set(capnp-rpc_schemas
   persistent.capnp
 )
 if(NOT CAPNP_LITE)
-  add_library(capnp-rpc ${capnp-rpc_sources})
-  add_library(CapnProto::capnp-rpc ALIAS capnp-rpc)
+  kj_add_library(capnp-rpc ${capnp-rpc_sources})
   target_link_libraries(capnp-rpc PUBLIC capnp kj-async kj)
-  # Ensure the library has a version set to match autotools build
-  set_target_properties(capnp-rpc PROPERTIES VERSION ${VERSION})
-  install(TARGETS capnp-rpc ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${capnp-rpc_headers} ${capnp-rpc_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
 endif()
 
@@ -119,12 +112,8 @@ set(capnp-json_schemas
   compat/json.capnp
 )
 if(NOT CAPNP_LITE)
-  add_library(capnp-json ${capnp-json_sources})
-  add_library(CapnProto::capnp-json ALIAS capnp-json)
+  kj_add_library(capnp-json ${capnp-json_sources})
   target_link_libraries(capnp-json PUBLIC capnp kj-async kj)
-  # Ensure the library has a version set to match autotools build
-  set_target_properties(capnp-json PROPERTIES VERSION ${VERSION})
-  install(TARGETS capnp-json ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${capnp-json_headers} ${capnp-json_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp/compat")
 endif()
 
@@ -143,11 +132,8 @@ set(capnpc_sources
   serialize-text.c++
 )
 if(NOT CAPNP_LITE)
-  add_library(capnpc ${capnpc_sources})
+  kj_add_library(capnpc ${capnpc_sources})
   target_link_libraries(capnpc PUBLIC capnp kj)
-  # Ensure the library has a version set to match autotools build
-  set_target_properties(capnpc PROPERTIES VERSION ${VERSION})
-  install(TARGETS capnpc ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${capnpc_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
 endif()
 

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -58,8 +58,7 @@ set(kj-parse_headers
 set(kj-std_headers
   std/iostream.h
 )
-add_library(kj ${kj_sources})
-add_library(CapnProto::kj ALIAS kj)
+kj_add_library(kj ${kj_sources})
 target_compile_features(kj PUBLIC cxx_constexpr)
 # Requiring the cxx_std_11 metafeature would be preferable, but that doesn't exist until CMake 3.8.
 
@@ -73,9 +72,6 @@ target_include_directories(kj INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
   $<INSTALL_INTERFACE:include>
 )
-# Ensure the library has a version set to match autotools build
-set_target_properties(kj PROPERTIES VERSION ${VERSION})
-install(TARGETS kj ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${kj_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
 install(FILES ${kj-parse_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/parse")
 install(FILES ${kj-std_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/std")
@@ -89,12 +85,8 @@ set(kj-test_headers
 set(kj-test-compat_headers
   compat/gtest.h
 )
-add_library(kj-test ${kj-test_sources})
-add_library(CapnProto::kj-test ALIAS kj-test)
+kj_add_library(kj-test ${kj-test_sources})
 target_link_libraries(kj-test PUBLIC kj)
-# Ensure the library has a version set to match autotools build
-set_target_properties(kj-test PROPERTIES VERSION ${VERSION})
-install(TARGETS kj-test ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${kj-test_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
 install(FILES ${kj-test-compat_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
 
@@ -117,8 +109,7 @@ set(kj-async_headers
   time.h
 )
 if(NOT CAPNP_LITE)
-  add_library(kj-async ${kj-async_sources})
-  add_library(CapnProto::kj-async ALIAS kj-async)
+  kj_add_library(kj-async ${kj-async_sources})
   target_link_libraries(kj-async PUBLIC kj)
   if(UNIX)
     # external clients of this library need to link to pthreads
@@ -126,9 +117,6 @@ if(NOT CAPNP_LITE)
   elseif(WIN32)
     target_link_libraries(kj-async PUBLIC ws2_32)
   endif()
-  # Ensure the library has a version set to match autotools build
-  set_target_properties(kj-async PROPERTIES VERSION ${VERSION})
-  install(TARGETS kj-async ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${kj-async_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
 endif()
 
@@ -143,12 +131,8 @@ set(kj-http_headers
   compat/http.h
 )
 if(NOT CAPNP_LITE)
-  add_library(kj-http ${kj-http_sources})
-  add_library(CapnProto::kj-http ALIAS kj-http)
+  kj_add_library(kj-http ${kj-http_sources})
   target_link_libraries(kj-http PUBLIC kj-async kj)
-  # Ensure the library has a version set to match autotools build
-  set_target_properties(kj-http PROPERTIES VERSION ${VERSION})
-  install(TARGETS kj-http ${INSTALL_TARGETS_DEFAULT_ARGS})
   install(FILES ${kj-http_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
 endif()
 


### PR DESCRIPTION
@kentonv This branch improves the CMake build by installing shared library files which match the autotools build in terms of filename, soname, and rpath (as reported by `readelf -d`). Here are a few gists showing the listing of all `.so` files installed by autotools and CMake on my Ubuntu 16.04 virtual machine, as well as their dynamic headers:

1. [autotools-built .so files](https://gist.github.com/harrishancock/b17f148f823406ce994267c902f88bec)
2. [CMake-built .so files (master branch)](https://gist.github.com/harrishancock/5a121fb4094c4ddd52f97630b4a19ca3)
3. [CMake-built .so files (this branch)](https://gist.github.com/harrishancock/e85015377016dd7fa22852dfda5c59a3)

Note that the first and third listings are now nearly identical.

While writing this branch, I realized I have a question. For every library target `foo`, the autotools build installs `libfoo-version.so` and `libfoo.so` with identical contents. I would have expected `libfoo.so` to be a symlink, rather than a copy. CMake can emulate either behavior, but I was wondering if the copy was intentional?

And a few more notes:

- I haven't been able to verify the results on Mac. @pqu would you be able to help with that?

- @Conan-Kudo I'd appreciate your opinion on this branch, too, since it rewrites your work.

- The `kj_add_library()` (`capnp_add_library()`?) function could be factored differently. For instance, it could be called `kj_install_library()` and deal solely will name-version mangling and installing. I threw in the `add_library()` calls because they were so clearly boilerplate, though I'm a bit wary of custom target functions like that. I'm open to opinions.