### PR TITLE
initialize null builder's sizes.

### DIFF
--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -498,7 +498,9 @@ private:
 
 class StructBuilder: public kj::DisallowConstCopy {
 public:
-  inline StructBuilder(): segment(nullptr), capTable(nullptr), data(nullptr), pointers(nullptr) {}
+  inline StructBuilder()
+      : segment(nullptr), capTable(nullptr), data(nullptr), pointers(nullptr),
+	    dataSize(0), pointerCount(0) {}
 
   inline word* getLocation() { return reinterpret_cast<word*>(data); }
   // Get the object's location.  Only valid for independently-allocated objects (i.e. not list


### PR DESCRIPTION
So they are not random junk numbers and we can safely cast the builder to reader and read the content.