### PR TITLE
RPC: Support abstract unix socket addresses on Linux

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -102,6 +102,9 @@ TEST(AsyncIo, AddressParsing) {
 
 #if !_WIN32
   EXPECT_EQ("unix:foo/bar/baz", tryParse(w, network, "unix:foo/bar/baz"));
+#if __linux__
+  EXPECT_EQ("unix-abstract:foo/bar/baz", tryParse(w, network, "unix-abstract:foo/bar/baz"));
+#endif
 #endif
 
   // We can parse services by name...

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -102,9 +102,7 @@ TEST(AsyncIo, AddressParsing) {
 
 #if !_WIN32
   EXPECT_EQ("unix:foo/bar/baz", tryParse(w, network, "unix:foo/bar/baz"));
-#if __linux__
   EXPECT_EQ("unix-abstract:foo/bar/baz", tryParse(w, network, "unix-abstract:foo/bar/baz"));
-#endif
 #endif
 
   // We can parse services by name...

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -491,7 +491,9 @@ public:
                  "Unix domain socket address is too long.", str);
       result.addr.unixDomain.sun_family = AF_UNIX;
       result.addr.unixDomain.sun_path[0] = '\0';
-      memcpy(result.addr.unixDomain.sun_path + 1, path.cStr(), path.size());
+      // although not strictly required by Linux, also copy the trailing
+      // NULL terminator so that we can safely read it back in toString
+      memcpy(result.addr.unixDomain.sun_path + 1, path.cStr(), path.size() + 1);
       result.addrlen = offsetof(struct sockaddr_un, sun_path) + path.size() + 1;
       auto array = kj::heapArrayBuilder<SocketAddress>(1);
       array.add(result);

--- a/doc/cxxrpc.md
+++ b/doc/cxxrpc.md
@@ -390,7 +390,8 @@ int main(int argc, const char* argv[]) {
 {% endhighlight %}
 
 Note that for the connect address, Cap'n Proto supports DNS host names as well as IPv4 and IPv6
-addresses.  Additionally, a Unix domain socket can be specified as `unix:` followed by a path name.
+addresses.  Additionally, a Unix domain socket can be specified as `unix:` followed by a path name,
+and an abstract Unix domain socket can be specified as `unix-abstract:` followed by an identifier.
 
 For a more complete example, see the
 [calculator client sample](https://github.com/sandstorm-io/capnproto/tree/master/c++/samples/calculator-client.c++).
@@ -429,7 +430,8 @@ int main(int argc, const char* argv[]) {
 Note that for the bind address, Cap'n Proto supports DNS host names as well as IPv4 and IPv6
 addresses.  The special address `*` can be used to bind to the same port on all local IPv4 and
 IPv6 interfaces.  Additionally, a Unix domain socket can be specified as `unix:` followed by a
-path name.
+path name, and an abstract Unix domain socket can be specified as `unix-abstract:` followed by
+an identifier.
 
 For a more complete example, see the
 [calculator server sample](https://github.com/sandstorm-io/capnproto/tree/master/c++/samples/calculator-server.c++).


### PR DESCRIPTION
Since `kj::StringPtr` supports embedded `NULL`s, copy its entire data buffer to the `sockaddr_un` structure instead of using `strcpy`.

On Linux, this allows the use of the abstract socket namespace, where the first character in the path is `\0`