### PR TITLE
buffers passed to PackedOutputStream::write() must be word-aligned

### DIFF
--- a/c++/src/capnp/serialize-packed.c++
+++ b/c++/src/capnp/serialize-packed.c++
@@ -351,7 +351,8 @@ void PackedOutputStream::write(const void* src, size_t size) {
       // An all-zero word is followed by a count of consecutive zero words (not including the
       // first one).
 
-      // We can check a whole word at a time.
+      // We can check a whole word at a time. (Here is where we use the assumption that
+      // `src` is word-aligned.)
       const uint64_t* inWord = reinterpret_cast<const uint64_t*>(in);
 
       // The count must fit it 1 byte, so limit to 255 words.

--- a/c++/src/capnp/serialize-packed.h
+++ b/c++/src/capnp/serialize-packed.h
@@ -50,6 +50,7 @@ private:
 };
 
 class PackedOutputStream: public kj::OutputStream {
+  // An output stream that packs data. Buffers passed to `write()` must be word-aligned.
 public:
   explicit PackedOutputStream(kj::BufferedOutputStream& inner);
   KJ_DISALLOW_COPY(PackedOutputStream);


### PR DESCRIPTION
Fixes an error in the test suite that was reported by ubsan, and adds documentation about `PackedOutputStream`'s alignment assumptions.

As far as I can tell, the error cannot occur through normal usage of `serialize_package::write_message()`.
