### PR TITLE
Implement TLS option to verify client certificates.

### DIFF
--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -473,6 +473,7 @@ private:
 
 TlsContext::Options::Options()
     : useSystemTrustStore(true),
+      verifyClients(false),
       minVersion(TlsVersion::TLS_1_0),
       cipherList("ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS") {}
 // Cipher list is Mozilla's "intermediate" list, except with classic DH removed since we don't
@@ -514,6 +515,10 @@ TlsContext::TlsContext(Options options) {
         throwOpensslError();
       }
     }
+  }
+
+  if (options.verifyClients) {
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
   }
 
   // honor options.minVersion

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -58,6 +58,13 @@ public:
     bool useSystemTrustStore;
     // Whether or not to trust the system's default trust store. Default: true.
 
+    bool verifyClients;
+    // If true, when acting as a server, require the client to present a certificate. The
+    // certificate must be signed by one of the trusted CAs, otherwise the client will be rejected.
+    // (Typically you should set `useSystemTrustStore` false when using this flag, and specify
+    // your specific trusted CAs in `trustedCertificates`.)
+    // Default: false
+
     kj::ArrayPtr<const TlsCertificate> trustedCertificates;
     // Additional certificates which should be trusted. Default: none.
 


### PR DESCRIPTION
Use case for me is Cloudflare's "Authenticated Origin Pulls", in which Cloudflare authenticates itself to the origin server using client certificates. Thus the origin server can ensure that it only accepts traffic through Cloudflare, without resorting to IP whitelists.