### PR TITLE
Extend kj::Network interface for easy SSRF protection

### DIFF
--- a/c++/src/kj/async-io-internal.h
+++ b/c++/src/kj/async-io-internal.h
@@ -28,9 +28,18 @@
 #include <stdint.h>
 
 struct sockaddr;
+struct sockaddr_un;
 
 namespace kj {
 namespace _ {  // private
+
+// =======================================================================================
+
+#if !_WIN32
+kj::ArrayPtr<const char> safeUnixPath(const struct sockaddr_un* addr, uint addrlen);
+// sockaddr_un::sun_path is not required to have a NUL terminator! Thus to be safe unix address
+// paths MUST be read using this function.
+#endif
 
 class CidrRange {
 public:
@@ -64,10 +73,8 @@ public:
   NetworkFilter(ArrayPtr<const StringPtr> allow, ArrayPtr<const StringPtr> deny,
                 NetworkFilter& next);
 
-  bool shouldAllow(const struct sockaddr* addr) const;
-  bool shouldAllowParse(const struct sockaddr* addr) const;
-
   bool shouldAllow(const struct sockaddr* addr, uint addrlen) override;
+  bool shouldAllowParse(const struct sockaddr* addr, uint addrlen);
 
 private:
   Vector<CidrRange> allowCidrs;

--- a/c++/src/kj/async-io-internal.h
+++ b/c++/src/kj/async-io-internal.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2017 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef KJ_ASYNC_IO_INTERNAL_H_
+#define KJ_ASYNC_IO_INTERNAL_H_
+
+#include "string.h"
+#include "vector.h"
+#include "async-io.h"
+#include <stdint.h>
+
+struct sockaddr;
+
+namespace kj {
+namespace _ {  // private
+
+class CidrRange {
+public:
+  CidrRange(StringPtr pattern);
+
+  static CidrRange inet4(ArrayPtr<const byte> bits, uint bitCount);
+  static CidrRange inet6(ArrayPtr<const uint16_t> prefix, ArrayPtr<const uint16_t> suffix,
+                         uint bitCount);
+  // Zeros are inserted between `prefix` and `suffix` to extend the address to 128 bits.
+
+  uint getSpecificity() const { return bitCount; }
+
+  bool matches(const struct sockaddr* addr) const;
+  bool matchesFamily(int family) const;
+
+  String toString() const;
+
+private:
+  int family;
+  byte bits[16];
+  uint bitCount;    // how many bits in `bits` need to match
+
+  CidrRange(int family, ArrayPtr<const byte> bits, uint bitCount);
+
+  void zeroIrrelevantBits();
+};
+
+class NetworkFilter: public LowLevelAsyncIoProvider::NetworkFilter {
+public:
+  NetworkFilter();
+  NetworkFilter(ArrayPtr<const StringPtr> allow, ArrayPtr<const StringPtr> deny,
+                NetworkFilter& next);
+
+  bool shouldAllow(const struct sockaddr* addr) const;
+  bool shouldAllowParse(const struct sockaddr* addr) const;
+
+  bool shouldAllow(const struct sockaddr* addr, uint addrlen) override;
+
+private:
+  Vector<CidrRange> allowCidrs;
+  Vector<CidrRange> denyCidrs;
+  bool allowUnix;
+  bool allowAbstractUnix;
+
+  kj::Maybe<NetworkFilter&> next;
+};
+
+}  // namespace _ (private)
+}  // namespace kj
+
+#endif // KJ_ASYNC_IO_INTERNAL_H_

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -19,17 +19,27 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if _WIN32
+// Request Vista-level APIs.
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+#endif
+
 #include "async-io.h"
+#include "async-io-internal.h"
 #include "debug.h"
 #include <kj/compat/gtest.h>
 #include <sys/types.h>
 #if _WIN32
 #include <ws2tcpip.h>
 #include "windows-sanity.h"
+#define inet_pton InetPtonA
+#define inet_ntop InetNtopA
 #else
 #include <netdb.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <arpa/inet.h>
 #endif
 
 namespace kj {
@@ -411,6 +421,153 @@ TEST(AsyncIo, AbstractUnixSocket) {
 }
 
 #endif  // __linux__
+
+KJ_TEST("CIDR parsing") {
+  KJ_EXPECT(_::CidrRange("1.2.3.4/16").toString() == "1.2.0.0/16");
+  KJ_EXPECT(_::CidrRange("1.2.255.4/18").toString() == "1.2.192.0/18");
+  KJ_EXPECT(_::CidrRange("1234::abcd:ffff:ffff/98").toString() == "1234::abcd:c000:0/98");
+
+  KJ_EXPECT(_::CidrRange::inet4({1,2,255,4}, 18).toString() == "1.2.192.0/18");
+  KJ_EXPECT(_::CidrRange::inet6({0x1234, 0x5678}, {0xabcd, 0xffff, 0xffff}, 98).toString() ==
+            "1234:5678::abcd:c000:0/98");
+
+  union {
+    struct sockaddr addr;
+    struct sockaddr_in addr4;
+    struct sockaddr_in6 addr6;
+  };
+  memset(&addr6, 0, sizeof(addr6));
+
+  {
+    addr4.sin_family = AF_INET;
+    addr4.sin_addr.s_addr = htonl(0x0102dfff);
+    KJ_EXPECT(_::CidrRange("1.2.255.255/18").matches(&addr));
+    KJ_EXPECT(!_::CidrRange("1.2.255.255/19").matches(&addr));
+    KJ_EXPECT(_::CidrRange("1.2.0.0/16").matches(&addr));
+    KJ_EXPECT(!_::CidrRange("1.3.0.0/16").matches(&addr));
+    KJ_EXPECT(_::CidrRange("1.2.223.255/32").matches(&addr));
+    KJ_EXPECT(_::CidrRange("0.0.0.0/0").matches(&addr));
+    KJ_EXPECT(!_::CidrRange("::/0").matches(&addr));
+  }
+
+  {
+    addr4.sin_family = AF_INET6;
+    byte bytes[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    memcpy(addr6.sin6_addr.s6_addr, bytes, 16);
+    KJ_EXPECT(_::CidrRange("0102:03ff::/24").matches(&addr));
+    KJ_EXPECT(!_::CidrRange("0102:02ff::/24").matches(&addr));
+    KJ_EXPECT(_::CidrRange("0102:02ff::/23").matches(&addr));
+    KJ_EXPECT(_::CidrRange("0102:0304:0506:0708:090a:0b0c:0d0e:0f10/128").matches(&addr));
+    KJ_EXPECT(_::CidrRange("::/0").matches(&addr));
+    KJ_EXPECT(!_::CidrRange("0.0.0.0/0").matches(&addr));
+  }
+
+  {
+    addr4.sin_family = AF_INET6;
+    inet_pton(AF_INET6, "::ffff:1.2.223.255", &addr6.sin6_addr);
+    KJ_EXPECT(_::CidrRange("1.2.255.255/18").matches(&addr));
+    KJ_EXPECT(!_::CidrRange("1.2.255.255/19").matches(&addr));
+    KJ_EXPECT(_::CidrRange("1.2.0.0/16").matches(&addr));
+    KJ_EXPECT(!_::CidrRange("1.3.0.0/16").matches(&addr));
+    KJ_EXPECT(_::CidrRange("1.2.223.255/32").matches(&addr));
+    KJ_EXPECT(_::CidrRange("0.0.0.0/0").matches(&addr));
+    KJ_EXPECT(_::CidrRange("::/0").matches(&addr));
+  }
+}
+
+bool allowed4(const _::NetworkFilter& filter, StringPtr addrStr) {
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  inet_pton(AF_INET, addrStr.cStr(), &addr.sin_addr);
+  return filter.shouldAllow(reinterpret_cast<struct sockaddr*>(&addr));
+}
+
+bool allowed6(const _::NetworkFilter& filter, StringPtr addrStr) {
+  struct sockaddr_in6 addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin6_family = AF_INET6;
+  inet_pton(AF_INET6, addrStr.cStr(), &addr.sin6_addr);
+  return filter.shouldAllow(reinterpret_cast<struct sockaddr*>(&addr));
+}
+
+KJ_TEST("NetworkFilter") {
+  _::NetworkFilter base;
+
+  KJ_EXPECT(allowed4(base, "8.8.8.8"));
+  KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+
+  {
+    _::NetworkFilter filter({"public"}, {}, base);
+
+    KJ_EXPECT(allowed4(filter, "8.8.8.8"));
+    KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+
+    KJ_EXPECT(!allowed4(filter, "192.168.0.1"));
+    KJ_EXPECT(!allowed4(filter, "10.1.2.3"));
+    KJ_EXPECT(!allowed4(filter, "127.0.0.1"));
+    KJ_EXPECT(!allowed4(filter, "0.0.0.0"));
+
+    KJ_EXPECT(allowed6(filter, "2400:cb00:2048:1::c629:d7a2"));
+    KJ_EXPECT(!allowed6(filter, "fc00::1234"));
+    KJ_EXPECT(!allowed6(filter, "::1"));
+    KJ_EXPECT(!allowed6(filter, "::"));
+  }
+
+  {
+    _::NetworkFilter filter({"private"}, {"local"}, base);
+
+    KJ_EXPECT(!allowed4(filter, "8.8.8.8"));
+    KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+
+    KJ_EXPECT(allowed4(filter, "192.168.0.1"));
+    KJ_EXPECT(allowed4(filter, "10.1.2.3"));
+    KJ_EXPECT(!allowed4(filter, "127.0.0.1"));
+    KJ_EXPECT(!allowed4(filter, "0.0.0.0"));
+
+    KJ_EXPECT(!allowed6(filter, "2400:cb00:2048:1::c629:d7a2"));
+    KJ_EXPECT(allowed6(filter, "fc00::1234"));
+    KJ_EXPECT(!allowed6(filter, "::1"));
+    KJ_EXPECT(!allowed6(filter, "::"));
+  }
+
+  {
+    _::NetworkFilter filter({"1.0.0.0/8", "1.2.3.0/24"}, {"1.2.0.0/16", "1.2.3.4/32"}, base);
+
+    KJ_EXPECT(!allowed4(filter, "8.8.8.8"));
+    KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+
+    KJ_EXPECT(allowed4(filter, "1.0.0.1"));
+    KJ_EXPECT(!allowed4(filter, "1.2.2.1"));
+    KJ_EXPECT(allowed4(filter, "1.2.3.1"));
+    KJ_EXPECT(!allowed4(filter, "1.2.3.4"));
+  }
+}
+
+KJ_TEST("Network::restrictPeers()") {
+  auto ioContext = setupAsyncIo();
+  auto& w = ioContext.waitScope;
+  auto& network = ioContext.provider->getNetwork();
+  auto restrictedNetwork = network.restrictPeers({"public"});
+
+  KJ_EXPECT(tryParse(w, *restrictedNetwork, "8.8.8.8") == "8.8.8.8:0");
+  KJ_EXPECT_THROW_MESSAGE("restrictPeers", tryParse(w, *restrictedNetwork, "unix:/foo"));
+
+  auto addr = restrictedNetwork->parseAddress("127.0.0.1").wait(w);
+
+  auto listener = addr->listen();
+  auto acceptTask = listener->accept()
+      .then([](kj::Own<kj::AsyncIoStream>) {
+    KJ_FAIL_EXPECT("should not have received connection");
+  }).eagerlyEvaluate(nullptr);
+
+  KJ_EXPECT_THROW_MESSAGE("restrictPeers", addr->connect().wait(w));
+
+  // We can connect to the listener but the connection will be immediately closed.
+  auto addr2 = network.parseAddress("127.0.0.1", listener->getPort()).wait(w);
+  auto conn = addr2->connect().wait(w);
+  KJ_EXPECT(conn->readAllText().wait(w) == "");
+}
 
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -501,7 +501,7 @@ KJ_TEST("NetworkFilter") {
     _::NetworkFilter filter({"public"}, {}, base);
 
     KJ_EXPECT(allowed4(filter, "8.8.8.8"));
-    KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+    KJ_EXPECT(!allowed4(filter, "240.1.2.3"));
 
     KJ_EXPECT(!allowed4(filter, "192.168.0.1"));
     KJ_EXPECT(!allowed4(filter, "10.1.2.3"));
@@ -518,7 +518,7 @@ KJ_TEST("NetworkFilter") {
     _::NetworkFilter filter({"private"}, {"local"}, base);
 
     KJ_EXPECT(!allowed4(filter, "8.8.8.8"));
-    KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+    KJ_EXPECT(!allowed4(filter, "240.1.2.3"));
 
     KJ_EXPECT(allowed4(filter, "192.168.0.1"));
     KJ_EXPECT(allowed4(filter, "10.1.2.3"));
@@ -535,7 +535,7 @@ KJ_TEST("NetworkFilter") {
     _::NetworkFilter filter({"1.0.0.0/8", "1.2.3.0/24"}, {"1.2.0.0/16", "1.2.3.4/32"}, base);
 
     KJ_EXPECT(!allowed4(filter, "8.8.8.8"));
-    KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+    KJ_EXPECT(!allowed4(filter, "240.1.2.3"));
 
     KJ_EXPECT(allowed4(filter, "1.0.0.1"));
     KJ_EXPECT(!allowed4(filter, "1.2.2.1"));

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -475,20 +475,20 @@ KJ_TEST("CIDR parsing") {
   }
 }
 
-bool allowed4(const _::NetworkFilter& filter, StringPtr addrStr) {
+bool allowed4(_::NetworkFilter& filter, StringPtr addrStr) {
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   inet_pton(AF_INET, addrStr.cStr(), &addr.sin_addr);
-  return filter.shouldAllow(reinterpret_cast<struct sockaddr*>(&addr));
+  return filter.shouldAllow(reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr));
 }
 
-bool allowed6(const _::NetworkFilter& filter, StringPtr addrStr) {
+bool allowed6(_::NetworkFilter& filter, StringPtr addrStr) {
   struct sockaddr_in6 addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin6_family = AF_INET6;
   inet_pton(AF_INET6, addrStr.cStr(), &addr.sin6_addr);
-  return filter.shouldAllow(reinterpret_cast<struct sockaddr*>(&addr));
+  return filter.shouldAllow(reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr));
 }
 
 KJ_TEST("NetworkFilter") {

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -551,7 +551,9 @@ KJ_TEST("Network::restrictPeers()") {
   auto restrictedNetwork = network.restrictPeers({"public"});
 
   KJ_EXPECT(tryParse(w, *restrictedNetwork, "8.8.8.8") == "8.8.8.8:0");
+#if !_WIN32
   KJ_EXPECT_THROW_MESSAGE("restrictPeers", tryParse(w, *restrictedNetwork, "unix:/foo"));
+#endif
 
   auto addr = restrictedNetwork->parseAddress("127.0.0.1").wait(w);
 

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -23,6 +23,7 @@
 // For Win32 implementation, see async-io-win32.c++.
 
 #include "async-io.h"
+#include "async-io-internal.h"
 #include "async-unix.h"
 #include "debug.h"
 #include "thread.h"
@@ -461,11 +462,12 @@ public:
   }
 
   static Promise<Array<SocketAddress>> lookupHost(
-      LowLevelAsyncIoProvider& lowLevel, kj::String host, kj::String service, uint portHint);
+      LowLevelAsyncIoProvider& lowLevel, kj::String host, kj::String service, uint portHint,
+      _::NetworkFilter& filter);
   // Perform a DNS lookup.
 
   static Promise<Array<SocketAddress>> parse(
-      LowLevelAsyncIoProvider& lowLevel, StringPtr str, uint portHint) {
+      LowLevelAsyncIoProvider& lowLevel, StringPtr str, uint portHint, _::NetworkFilter& filter) {
     // TODO(someday):  Allow commas in `str`.
 
     SocketAddress result;
@@ -480,6 +482,12 @@ public:
       result.addr.unixDomain.sun_family = AF_UNIX;
       strcpy(result.addr.unixDomain.sun_path, path.cStr());
       result.addrlen = offsetof(struct sockaddr_un, sun_path) + path.size() + 1;
+
+      if (!result.parseAllowedBy(filter)) {
+        KJ_FAIL_REQUIRE("unix sockets blocked by restrictPeers()");
+        return Array<SocketAddress>();
+      }
+
       auto array = kj::heapArrayBuilder<SocketAddress>(1);
       array.add(result);
       return array.finish();
@@ -495,6 +503,12 @@ public:
       // NULL terminator so that we can safely read it back in toString
       memcpy(result.addr.unixDomain.sun_path + 1, path.cStr(), path.size() + 1);
       result.addrlen = offsetof(struct sockaddr_un, sun_path) + path.size() + 1;
+
+      if (!result.parseAllowedBy(filter)) {
+        KJ_FAIL_REQUIRE("abstract unix sockets blocked by restrictPeers()");
+        return Array<SocketAddress>();
+      }
+
       auto array = kj::heapArrayBuilder<SocketAddress>(1);
       array.add(result);
       return array.finish();
@@ -547,7 +561,8 @@ public:
       port = strtoul(portText->cStr(), &endptr, 0);
       if (portText->size() == 0 || *endptr != '\0') {
         // Not a number.  Maybe it's a service name.  Fall back to DNS.
-        return lookupHost(lowLevel, kj::heapString(addrPart), kj::heapString(*portText), portHint);
+        return lookupHost(lowLevel, kj::heapString(addrPart), kj::heapString(*portText), portHint,
+                          filter);
       }
       KJ_REQUIRE(port < 65536, "Port number too large.");
     } else {
@@ -569,6 +584,7 @@ public:
       result.addr.inet6.sin6_family = AF_INET6;
       result.addr.inet6.sin6_port = htons(port);
 #endif
+
       auto array = kj::heapArrayBuilder<SocketAddress>(1);
       array.add(result);
       return array.finish();
@@ -597,13 +613,18 @@ public:
     switch (inet_pton(af, buffer, addrTarget)) {
       case 1: {
         // success.
+        if (!result.parseAllowedBy(filter)) {
+          KJ_FAIL_REQUIRE("address family blocked by restrictPeers()");
+          return Array<SocketAddress>();
+        }
+
         auto array = kj::heapArrayBuilder<SocketAddress>(1);
         array.add(result);
         return array.finish();
       }
       case 0:
         // It's apparently not a simple address...  fall back to DNS.
-        return lookupHost(lowLevel, kj::heapString(addrPart), nullptr, port);
+        return lookupHost(lowLevel, kj::heapString(addrPart), nullptr, port, filter);
       default:
         KJ_FAIL_SYSCALL("inet_pton", errno, af, addrPart);
     }
@@ -614,6 +635,14 @@ public:
     result.addrlen = sizeof(addr);
     KJ_SYSCALL(getsockname(sockfd, &result.addr.generic, &result.addrlen));
     return result;
+  }
+
+  bool allowedBy(LowLevelAsyncIoProvider::NetworkFilter& filter) {
+    return filter.shouldAllow(&addr.generic, addrlen);
+  }
+
+  bool parseAllowedBy(const _::NetworkFilter& filter) {
+    return filter.shouldAllowParse(&addr.generic);
   }
 
 private:
@@ -640,8 +669,9 @@ class SocketAddress::LookupReader {
   // getaddrinfo.
 
 public:
-  LookupReader(kj::Own<Thread>&& thread, kj::Own<AsyncInputStream>&& input)
-      : thread(kj::mv(thread)), input(kj::mv(input)) {}
+  LookupReader(kj::Own<Thread>&& thread, kj::Own<AsyncInputStream>&& input,
+               _::NetworkFilter& filter)
+      : thread(kj::mv(thread)), input(kj::mv(input)), filter(filter) {}
 
   ~LookupReader() {
     if (thread) thread->detach();
@@ -654,7 +684,7 @@ public:
         thread = nullptr;
         // getaddrinfo()'s docs seem to say it will never return an empty list, but let's check
         // anyway.
-        KJ_REQUIRE(addresses.size() > 0, "DNS lookup returned no addresses.") { break; }
+        KJ_REQUIRE(addresses.size() > 0, "DNS lookup returned no permitted addresses.") { break; }
         return addresses.releaseAsArray();
       } else {
         // getaddrinfo() can return multiple copies of the same address for several reasons.
@@ -667,7 +697,9 @@ public:
         //
         // So we instead resort to de-duping results.
         if (alreadySeen.insert(current).second) {
-          addresses.add(current);
+          if (current.parseAllowedBy(filter)) {
+            addresses.add(current);
+          }
         }
         return read();
       }
@@ -677,6 +709,7 @@ public:
 private:
   kj::Own<Thread> thread;
   kj::Own<AsyncInputStream> input;
+  _::NetworkFilter& filter;
   SocketAddress current;
   kj::Vector<SocketAddress> addresses;
   std::set<SocketAddress> alreadySeen;
@@ -688,7 +721,8 @@ struct SocketAddress::LookupParams {
 };
 
 Promise<Array<SocketAddress>> SocketAddress::lookupHost(
-    LowLevelAsyncIoProvider& lowLevel, kj::String host, kj::String service, uint portHint) {
+    LowLevelAsyncIoProvider& lowLevel, kj::String host, kj::String service, uint portHint,
+    _::NetworkFilter& filter) {
   // This shitty function spawns a thread to run getaddrinfo().  Unfortunately, getaddrinfo() is
   // the only cross-platform DNS API and it is blocking.
   //
@@ -773,7 +807,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
     }
   }));
 
-  auto reader = heap<LookupReader>(kj::mv(thread), kj::mv(input));
+  auto reader = heap<LookupReader>(kj::mv(thread), kj::mv(input), filter);
   return reader->read().attach(kj::mv(reader));
 }
 
@@ -781,22 +815,33 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
 
 class FdConnectionReceiver final: public ConnectionReceiver, public OwnedFileDescriptor {
 public:
-  FdConnectionReceiver(UnixEventPort& eventPort, int fd, uint flags)
-      : OwnedFileDescriptor(fd, flags), eventPort(eventPort),
+  FdConnectionReceiver(UnixEventPort& eventPort, int fd,
+                       LowLevelAsyncIoProvider::NetworkFilter& filter, uint flags)
+      : OwnedFileDescriptor(fd, flags), eventPort(eventPort), filter(filter),
         observer(eventPort, fd, UnixEventPort::FdObserver::OBSERVE_READ) {}
 
   Promise<Own<AsyncIoStream>> accept() override {
     int newFd;
 
+    struct sockaddr_storage addr;
+    socklen_t addrlen = sizeof(addr);
+
   retry:
 #if __linux__ && !__BIONIC__
-    newFd = ::accept4(fd, nullptr, nullptr, SOCK_NONBLOCK | SOCK_CLOEXEC);
+    newFd = ::accept4(fd, reinterpret_cast<struct sockaddr*>(&addr), &addrlen,
+                      SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
-    newFd = ::accept(fd, nullptr, nullptr);
+    newFd = ::accept(fd, reinterpret_cast<struct sockaddr*>(&addr), &addrlen);
 #endif
 
     if (newFd >= 0) {
-      return Own<AsyncIoStream>(heap<AsyncStreamFd>(eventPort, newFd, NEW_FD_FLAGS));
+      if (!filter.shouldAllow(reinterpret_cast<struct sockaddr*>(&addr), addrlen)) {
+        // Drop disallowed address.
+        close(newFd);
+        return accept();
+      } else {
+        return Own<AsyncIoStream>(heap<AsyncStreamFd>(eventPort, newFd, NEW_FD_FLAGS));
+      }
     } else {
       int error = errno;
 
@@ -849,13 +894,15 @@ public:
 
 public:
   UnixEventPort& eventPort;
+  LowLevelAsyncIoProvider::NetworkFilter& filter;
   UnixEventPort::FdObserver observer;
 };
 
 class DatagramPortImpl final: public DatagramPort, public OwnedFileDescriptor {
 public:
-  DatagramPortImpl(LowLevelAsyncIoProvider& lowLevel, UnixEventPort& eventPort, int fd, uint flags)
-      : OwnedFileDescriptor(fd, flags), lowLevel(lowLevel), eventPort(eventPort),
+  DatagramPortImpl(LowLevelAsyncIoProvider& lowLevel, UnixEventPort& eventPort, int fd,
+                   LowLevelAsyncIoProvider::NetworkFilter& filter, uint flags)
+      : OwnedFileDescriptor(fd, flags), lowLevel(lowLevel), eventPort(eventPort), filter(filter),
         observer(eventPort, fd, UnixEventPort::FdObserver::OBSERVE_READ |
                                 UnixEventPort::FdObserver::OBSERVE_WRITE) {}
 
@@ -883,6 +930,7 @@ public:
 public:
   LowLevelAsyncIoProvider& lowLevel;
   UnixEventPort& eventPort;
+  LowLevelAsyncIoProvider::NetworkFilter& filter;
   UnixEventPort::FdObserver observer;
 };
 
@@ -935,11 +983,13 @@ public:
       return kj::mv(stream);
     }));
   }
-  Own<ConnectionReceiver> wrapListenSocketFd(int fd, uint flags = 0) override {
-    return heap<FdConnectionReceiver>(eventPort, fd, flags);
+  Own<ConnectionReceiver> wrapListenSocketFd(
+      int fd, NetworkFilter& filter, uint flags = 0) override {
+    return heap<FdConnectionReceiver>(eventPort, fd, filter, flags);
   }
-  Own<DatagramPort> wrapDatagramSocketFd(int fd, uint flags = 0) override {
-    return heap<DatagramPortImpl>(*this, eventPort, fd, flags);
+  Own<DatagramPort> wrapDatagramSocketFd(
+      int fd, NetworkFilter& filter, uint flags = 0) override {
+    return heap<DatagramPortImpl>(*this, eventPort, fd, filter, flags);
   }
 
   Timer& getTimer() override { return eventPort.getTimer(); }
@@ -956,12 +1006,14 @@ private:
 
 class NetworkAddressImpl final: public NetworkAddress {
 public:
-  NetworkAddressImpl(LowLevelAsyncIoProvider& lowLevel, Array<SocketAddress> addrs)
-      : lowLevel(lowLevel), addrs(kj::mv(addrs)) {}
+  NetworkAddressImpl(LowLevelAsyncIoProvider& lowLevel,
+                     LowLevelAsyncIoProvider::NetworkFilter& filter,
+                     Array<SocketAddress> addrs)
+      : lowLevel(lowLevel), filter(filter), addrs(kj::mv(addrs)) {}
 
   Promise<Own<AsyncIoStream>> connect() override {
     auto addrsCopy = heapArray(addrs.asPtr());
-    auto promise = connectImpl(lowLevel, addrsCopy);
+    auto promise = connectImpl(lowLevel, filter, addrsCopy);
     return promise.attach(kj::mv(addrsCopy));
   }
 
@@ -988,7 +1040,7 @@ public:
       KJ_SYSCALL(::listen(fd, SOMAXCONN));
     }
 
-    return lowLevel.wrapListenSocketFd(fd, NEW_FD_FLAGS);
+    return lowLevel.wrapListenSocketFd(fd, filter, NEW_FD_FLAGS);
   }
 
   Own<DatagramPort> bindDatagramPort() override {
@@ -1011,11 +1063,11 @@ public:
       addrs[0].bind(fd);
     }
 
-    return lowLevel.wrapDatagramSocketFd(fd, NEW_FD_FLAGS);
+    return lowLevel.wrapDatagramSocketFd(fd, filter, NEW_FD_FLAGS);
   }
 
   Own<NetworkAddress> clone() override {
-    return kj::heap<NetworkAddressImpl>(lowLevel, kj::heapArray(addrs.asPtr()));
+    return kj::heap<NetworkAddressImpl>(lowLevel, filter, kj::heapArray(addrs.asPtr()));
   }
 
   String toString() override {
@@ -1029,26 +1081,33 @@ public:
 
 private:
   LowLevelAsyncIoProvider& lowLevel;
+  LowLevelAsyncIoProvider::NetworkFilter& filter;
   Array<SocketAddress> addrs;
   uint counter = 0;
 
   static Promise<Own<AsyncIoStream>> connectImpl(
-      LowLevelAsyncIoProvider& lowLevel, ArrayPtr<SocketAddress> addrs) {
+      LowLevelAsyncIoProvider& lowLevel,
+      LowLevelAsyncIoProvider::NetworkFilter& filter,
+      ArrayPtr<SocketAddress> addrs) {
     KJ_ASSERT(addrs.size() > 0);
 
     int fd = addrs[0].socket(SOCK_STREAM);
 
-    return kj::evalNow([&]() {
-      return lowLevel.wrapConnectingSocketFd(
-          fd, addrs[0].getRaw(), addrs[0].getRawSize(), NEW_FD_FLAGS);
+    return kj::evalNow([&]() -> Promise<Own<AsyncIoStream>> {
+      if (!addrs[0].allowedBy(filter)) {
+        return KJ_EXCEPTION(FAILED, "connect() blocked by restrictPeers()");
+      } else {
+        return lowLevel.wrapConnectingSocketFd(
+            fd, addrs[0].getRaw(), addrs[0].getRawSize(), NEW_FD_FLAGS);
+      }
     }).then([](Own<AsyncIoStream>&& stream) -> Promise<Own<AsyncIoStream>> {
       // Success, pass along.
       return kj::mv(stream);
-    }, [&lowLevel,addrs](Exception&& exception) mutable -> Promise<Own<AsyncIoStream>> {
+    }, [&lowLevel,&filter,addrs](Exception&& exception) mutable -> Promise<Own<AsyncIoStream>> {
       // Connect failed.
       if (addrs.size() > 1) {
         // Try the next address instead.
-        return connectImpl(lowLevel, addrs.slice(1, addrs.size()));
+        return connectImpl(lowLevel, filter, addrs.slice(1, addrs.size()));
       } else {
         // No more addresses to try, so propagate the exception.
         return kj::mv(exception);
@@ -1060,25 +1119,35 @@ private:
 class SocketNetwork final: public Network {
 public:
   explicit SocketNetwork(LowLevelAsyncIoProvider& lowLevel): lowLevel(lowLevel) {}
+  explicit SocketNetwork(SocketNetwork& parent,
+                         kj::ArrayPtr<const kj::StringPtr> allow,
+                         kj::ArrayPtr<const kj::StringPtr> deny)
+      : lowLevel(parent.lowLevel), filter(allow, deny, parent.filter) {}
 
   Promise<Own<NetworkAddress>> parseAddress(StringPtr addr, uint portHint = 0) override {
-    auto& lowLevelCopy = lowLevel;
-    return evalLater(mvCapture(heapString(addr),
-        [&lowLevelCopy,portHint](String&& addr) {
-      return SocketAddress::parse(lowLevelCopy, addr, portHint);
-    })).then([&lowLevelCopy](Array<SocketAddress> addresses) -> Own<NetworkAddress> {
-      return heap<NetworkAddressImpl>(lowLevelCopy, kj::mv(addresses));
+    return evalLater(mvCapture(heapString(addr), [this,portHint](String&& addr) {
+      return SocketAddress::parse(lowLevel, addr, portHint, filter);
+    })).then([this](Array<SocketAddress> addresses) -> Own<NetworkAddress> {
+      return heap<NetworkAddressImpl>(lowLevel, filter, kj::mv(addresses));
     });
   }
 
   Own<NetworkAddress> getSockaddr(const void* sockaddr, uint len) override {
     auto array = kj::heapArrayBuilder<SocketAddress>(1);
     array.add(SocketAddress(sockaddr, len));
-    return Own<NetworkAddress>(heap<NetworkAddressImpl>(lowLevel, array.finish()));
+    KJ_REQUIRE(array[0].allowedBy(filter), "address blocked by restrictPeers()") { break; }
+    return Own<NetworkAddress>(heap<NetworkAddressImpl>(lowLevel, filter, array.finish()));
+  }
+
+  Own<Network> restrictPeers(
+      kj::ArrayPtr<const kj::StringPtr> allow,
+      kj::ArrayPtr<const kj::StringPtr> deny = nullptr) override {
+    return heap<SocketNetwork>(*this, allow, deny);
   }
 
 private:
   LowLevelAsyncIoProvider& lowLevel;
+  _::NetworkFilter filter;
 };
 
 // =======================================================================================
@@ -1189,10 +1258,16 @@ public:
         return receive();
       });
     } else {
+      if (!port.filter.shouldAllow(reinterpret_cast<const struct sockaddr*>(msg.msg_name),
+                                   msg.msg_namelen)) {
+        // Ignore message from disallowed source.
+        return receive();
+      }
+
       receivedSize = n;
       contentTruncated = msg.msg_flags & MSG_TRUNC;
 
-      source.emplace(port.lowLevel, msg.msg_name, msg.msg_namelen);
+      source.emplace(port.lowLevel, port.filter, msg.msg_name, msg.msg_namelen);
 
       ancillaryList.resize(0);
       ancillaryTruncated = msg.msg_flags & MSG_CTRUNC;
@@ -1250,9 +1325,10 @@ private:
   bool ancillaryTruncated = false;
 
   struct StoredAddress {
-    StoredAddress(LowLevelAsyncIoProvider& lowLevel, const void* sockaddr, uint length)
+    StoredAddress(LowLevelAsyncIoProvider& lowLevel, LowLevelAsyncIoProvider::NetworkFilter& filter,
+                  const void* sockaddr, uint length)
         : raw(sockaddr, length),
-          abstract(lowLevel, Array<SocketAddress>(&raw, 1, NullArrayDisposer::instance)) {}
+          abstract(lowLevel, filter, Array<SocketAddress>(&raw, 1, NullArrayDisposer::instance)) {}
 
     SocketAddress raw;
     NetworkAddressImpl abstract;

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -450,10 +450,11 @@ public:
         return str('[', buffer, "]:", ntohs(addr.inet6.sin6_port));
       }
       case AF_UNIX: {
-        if (addr.unixDomain.sun_path[0] == '\0') {
-          return str("unix-abstract:", addr.unixDomain.sun_path + 1);
+        auto path = _::safeUnixPath(&addr.unixDomain, addrlen);
+        if (path.size() > 0 && path[0] == '\0') {
+          return str("unix-abstract:", path.slice(1, path.size()));
         } else {
-          return str("unix:", addr.unixDomain.sun_path);
+          return str("unix:", path);
         }
       }
       default:
@@ -641,8 +642,8 @@ public:
     return filter.shouldAllow(&addr.generic, addrlen);
   }
 
-  bool parseAllowedBy(const _::NetworkFilter& filter) {
-    return filter.shouldAllowParse(&addr.generic);
+  bool parseAllowedBy(_::NetworkFilter& filter) {
+    return filter.shouldAllowParse(&addr.generic, addrlen);
   }
 
 private:

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -654,7 +654,7 @@ public:
   }
 
   bool parseAllowedBy(const _::NetworkFilter& filter) {
-    return filter.shouldAllowParse(&addr.generic);
+    return filter.shouldAllowParse(&addr.generic, addrlen);
   }
 
   static SocketAddress getWildcardForFamily(int family) {

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -359,7 +359,10 @@ ArrayPtr<const CidrRange> localCidrs() {
     "0.0.0.0/32"_kj,
     "::/128"_kj,
   };
-  return result;
+
+  // TODO(cleanup): A bug in GCC 4.8, fixed in 4.9, prevents result from implicitly
+  //   casting to our return type.
+  return kj::arrayPtr(result, kj::size(result));
 }
 
 ArrayPtr<const CidrRange> privateCidrs() {
@@ -373,7 +376,10 @@ ArrayPtr<const CidrRange> privateCidrs() {
     "fc00::/7"_kj,              // RFC4193 unique private network
     "fe80::/10"_kj,             // RFC4291 "link local" (auto-configured LAN in absence of DHCP)
   };
-  return result;
+
+  // TODO(cleanup): A bug in GCC 4.8, fixed in 4.9, prevents result from implicitly
+  //   casting to our return type.
+  return kj::arrayPtr(result, kj::size(result));
 }
 
 ArrayPtr<const CidrRange> reservedCidrs() {
@@ -386,7 +392,10 @@ ArrayPtr<const CidrRange> reservedCidrs() {
     "2001::/23"_kj,             // RFC2928 reserved for special protocols
     "ff00::/8"_kj,              // RFC4291 multicast
   };
-  return result;
+
+  // TODO(cleanup): A bug in GCC 4.8, fixed in 4.9, prevents result from implicitly
+  //   casting to our return type.
+  return kj::arrayPtr(result, kj::size(result));
 }
 
 ArrayPtr<const CidrRange> exampleAddresses() {
@@ -396,7 +405,10 @@ ArrayPtr<const CidrRange> exampleAddresses() {
     "203.0.113.0/24"_kj,        // RFC5737 "example address" block 3 -- like example.com for IPs
     "2001:db8::/32"_kj,         // RFC3849 "example address" block -- like example.com for IPs
   };
-  return result;
+
+  // TODO(cleanup): A bug in GCC 4.8, fixed in 4.9, prevents result from implicitly
+  //   casting to our return type.
+  return kj::arrayPtr(result, kj::size(result));
 }
 
 NetworkFilter::NetworkFilter()

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -19,15 +19,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if _WIN32
+// Request Vista-level APIs.
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+#endif
+
 #include "async-io.h"
 #include "async-io-internal.h"
 #include "debug.h"
 #include "vector.h"
 
 #if _WIN32
-// Request Vista-level APIs.
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #include <ws2tcpip.h>
@@ -205,7 +208,8 @@ void DatagramPort::setsockopt(int level, int option, const void* value, uint len
 Own<DatagramPort> NetworkAddress::bindDatagramPort() {
   KJ_UNIMPLEMENTED("Datagram sockets not implemented.");
 }
-Own<DatagramPort> LowLevelAsyncIoProvider::wrapDatagramSocketFd(Fd fd, uint flags) {
+Own<DatagramPort> LowLevelAsyncIoProvider::wrapDatagramSocketFd(
+    Fd fd, LowLevelAsyncIoProvider::NetworkFilter& filter, uint flags) {
   KJ_UNIMPLEMENTED("Datagram sockets not implemented.");
 }
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -268,7 +268,7 @@ CidrRange::CidrRange(int family, ArrayPtr<const byte> bits, uint bitCount)
   KJ_REQUIRE(bits.size() * 8 >= bitCount);
   size_t byteCount = (bitCount + 7) / 8;
   memcpy(this->bits, bits.begin(), byteCount);
-  memset(this->bits + byteCount, 0, sizeof(bits) - byteCount);
+  memset(this->bits + byteCount, 0, sizeof(this->bits) - byteCount);
 
   zeroIrrelevantBits();
 }
@@ -486,7 +486,7 @@ NetworkFilter::NetworkFilter(ArrayPtr<const StringPtr> allow, ArrayPtr<const Str
 }
 
 bool NetworkFilter::shouldAllow(const struct sockaddr* addr, uint addrlen) {
-  KJ_REQUIRE(addrlen > sizeof(addr->sa_family));
+  KJ_REQUIRE(addrlen >= sizeof(addr->sa_family));
 
 #if !_WIN32
   if (addr->sa_family == AF_UNIX) {

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -469,12 +469,12 @@ NetworkFilter::NetworkFilter(ArrayPtr<const StringPtr> allow, ArrayPtr<const Str
     if (rule == "local") {
       denyCidrs.addAll(localCidrs());
     } else if (rule == "network") {
-      KJ_FAIL_REQUIRE("don't deny 'network', allow 'local' isntead");
+      KJ_FAIL_REQUIRE("don't deny 'network', allow 'local' instead");
     } else if (rule == "private") {
       denyCidrs.addAll(privateCidrs());
     } else if (rule == "public") {
       // Tricky: What if we allow 'network' and deny 'public'?
-      KJ_FAIL_REQUIRE("don't deny 'public', allow 'private' isntead");
+      KJ_FAIL_REQUIRE("don't deny 'public', allow 'private' instead");
     } else if (rule == "unix") {
       allowUnix = false;
     } else if (rule == "unix-abstract") {

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -323,7 +323,7 @@ public:
   virtual Own<Network> restrictPeers(
       kj::ArrayPtr<const kj::StringPtr> allow,
       kj::ArrayPtr<const kj::StringPtr> deny = nullptr) KJ_WARN_UNUSED_RESULT = 0;
-  // Constructs a new Network instance wrappingc this one which restricts which peer addresses are
+  // Constructs a new Network instance wrapping this one which restricts which peer addresses are
   // permitted (both for outgoing and incoming connections).
   //
   // Communication will be allowed only with peers whose addresses match one of the patterns

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -319,6 +319,67 @@ public:
 
   virtual Own<NetworkAddress> getSockaddr(const void* sockaddr, uint len) = 0;
   // Construct a network address from a legacy struct sockaddr.
+
+  virtual Own<Network> restrictPeers(
+      kj::ArrayPtr<const kj::StringPtr> allow,
+      kj::ArrayPtr<const kj::StringPtr> deny = nullptr) KJ_WARN_UNUSED_RESULT = 0;
+  // Constructs a new Network instance wrappingc this one which restricts which peer addresses are
+  // permitted (both for outgoing and incoming connections).
+  //
+  // Communication will be allowed only with peers whose addresses match one of the patterns
+  // specified in the `allow` array. If a `deny` array is specified, then any address which matches
+  // a pattern in `deny` and *does not* match any more-specific pattern in `allow` will also be
+  // denied.
+  //
+  // The syntax of address patterns depends on the network, except that three special patterns are
+  // defined for all networks:
+  // - "private": Matches network addresses that are reserved by standards for private networks,
+  //   such as "10.0.0.0/8" or "192.168.0.0/16". This is a superset of "local".
+  // - "public": Opposite of "private".
+  // - "local": Matches network addresses that are defined by standards to only be accessible from
+  //   the local machine, such as "127.0.0.0/8" or Unix domain addresses.
+  // - "network": Opposite of "local".
+  //
+  // For the standard KJ network implementation, the following patterns are also recognized:
+  // - Network blocks specified in CIDR notation (ipv4 and ipv6), such as "192.0.2.0/24" or
+  //   "2001:db8::/32".
+  // - "unix" to match all Unix domain addresses. (In the future, we may support specifying a
+  //   glob.)
+  // - "unix-abstract" to match Linux's "abstract unix domain" addresses. (In the future, we may
+  //   support specifying a glob.)
+  //
+  // Network restrictions apply *after* DNS resolution (otherwise they'd be useless).
+  //
+  // It is legal to parseAddress() a restricted address. An exception won't be thrown until
+  // connect() is called.
+  //
+  // It's possible to listen() on a restricted address. However, connections will only be accepted
+  // from non-restricted addresses; others will be dropped. If a particular listen address has no
+  // valid peers (e.g. because it's a unix socket address and unix sockets are not allowed) then
+  // listen() may throw (or may simply never receive any connections).
+  //
+  // Examples:
+  //
+  //     auto restricted = network->restrictPeers({"public"});
+  //
+  // Allows connections only to/from public internet addresses. Use this when connecting to an
+  // address specified by a third party that is not trusted and is not themselves already on your
+  // private network.
+  //
+  //     auto restricted = network->restrictPeers({"private"});
+  //
+  // Allows connections only to/from the private network. Use this on the server side to reject
+  // connections from the public internet.
+  //
+  //     auto restricted = network->restrictPeers({"192.0.2.0/24"}, {"192.0.2.3/32"});
+  //
+  // Allows connections only to/from 192.0.2.*, except 192.0.2.3 which is blocked.
+  //
+  //     auto restricted = network->restrictPeers({"10.0.0.0/8", "10.1.2.3/32"}, {"10.1.2.0/24"});
+  //
+  // Allows connections to/from 10.*.*.*, with the exception of 10.1.2.* (which is denied), with an
+  // exception to the exception of 10.1.2.3 (which is allowed, because it is matched by an allow
+  // rule that is more specific than the deny rule).
 };
 
 // =======================================================================================
@@ -470,13 +531,21 @@ public:
   //
   // `flags` is a bitwise-OR of the values of the `Flags` enum.
 
-  virtual Own<ConnectionReceiver> wrapListenSocketFd(Fd fd, uint flags = 0) = 0;
+  class NetworkFilter {
+  public:
+    virtual bool shouldAllow(const struct sockaddr* addr, uint addrlen) = 0;
+    // Returns true if incoming connections or datagrams from the given peer should be accepted.
+    // If false, they will be dropped. This is used to implement kj::Network::restrictPeers().
+  };
+
+  virtual Own<ConnectionReceiver> wrapListenSocketFd(
+      Fd fd, NetworkFilter& filter, uint flags = 0) = 0;
   // Create an AsyncIoStream wrapping a listen socket file descriptor.  This socket should already
   // have had `bind()` and `listen()` called on it, so it's ready for `accept()`.
   //
   // `flags` is a bitwise-OR of the values of the `Flags` enum.
 
-  virtual Own<DatagramPort> wrapDatagramSocketFd(Fd fd, uint flags = 0);
+  virtual Own<DatagramPort> wrapDatagramSocketFd(Fd fd, NetworkFilter& filter, uint flags = 0);
 
   virtual Timer& getTimer() = 0;
   // Returns a `Timer` based on real time.  Time does not pass while event handlers are running --

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1280,7 +1280,7 @@ public:
     return ArrayPtr<const T>(ptr, size_);
   }
 
-  inline size_t size() const { return size_; }
+  inline constexpr size_t size() const { return size_; }
   inline const T& operator[](size_t index) const {
     KJ_IREQUIRE(index < size_, "Out-of-bounds ArrayPtr access.");
     return ptr[index];
@@ -1294,8 +1294,8 @@ public:
   inline T* end() { return ptr + size_; }
   inline T& front() { return *ptr; }
   inline T& back() { return *(ptr + size_ - 1); }
-  inline const T* begin() const { return ptr; }
-  inline const T* end() const { return ptr + size_; }
+  inline constexpr const T* begin() const { return ptr; }
+  inline constexpr const T* end() const { return ptr + size_; }
   inline const T& front() const { return *ptr; }
   inline const T& back() const { return *(ptr + size_ - 1); }
 

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -173,6 +173,18 @@ TEST(String, ToString) {
 }
 #endif
 
+KJ_TEST("string literals with _kj suffix") {
+  static constexpr StringPtr FOO = "foo"_kj;
+  KJ_EXPECT(FOO == "foo", FOO);
+  KJ_EXPECT(FOO[3] == 0);
+
+  KJ_EXPECT("foo\0bar"_kj == StringPtr("foo\0bar", 7));
+
+  static constexpr ArrayPtr<const char> ARR = "foo"_kj;
+  KJ_EXPECT(ARR.size() == 3);
+  KJ_EXPECT(kj::str(ARR) == "foo");
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj


### PR DESCRIPTION
This is an important security feature for many applications which is really difficult to implement on top of the KJ interfaces prior to this change.