### PR TITLE
Add AsyncCapabilityStream, an abstraction of unix sockets SCM_RIGHTS FD passing.

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -245,6 +245,40 @@ CapabilityPipe AsyncIoProvider::newCapabilityPipe() {
   KJ_UNIMPLEMENTED("Capability pipes not implemented.");
 }
 
+Own<AsyncInputStream> LowLevelAsyncIoProvider::wrapInputFd(OwnFd fd, uint flags) {
+  return wrapInputFd(reinterpret_cast<Fd>(fd.release()), flags | TAKE_OWNERSHIP);
+}
+Own<AsyncOutputStream> LowLevelAsyncIoProvider::wrapOutputFd(OwnFd fd, uint flags) {
+  return wrapOutputFd(reinterpret_cast<Fd>(fd.release()), flags | TAKE_OWNERSHIP);
+}
+Own<AsyncIoStream> LowLevelAsyncIoProvider::wrapSocketFd(OwnFd fd, uint flags) {
+  return wrapSocketFd(reinterpret_cast<Fd>(fd.release()), flags | TAKE_OWNERSHIP);
+}
+#if !_WIN32
+Own<AsyncCapabilityStream> LowLevelAsyncIoProvider::wrapUnixSocketFd(OwnFd fd, uint flags) {
+  return wrapUnixSocketFd(reinterpret_cast<Fd>(fd.release()), flags | TAKE_OWNERSHIP);
+}
+#endif
+Promise<Own<AsyncIoStream>> LowLevelAsyncIoProvider::wrapConnectingSocketFd(
+    OwnFd fd, const struct sockaddr* addr, uint addrlen, uint flags) {
+  return wrapConnectingSocketFd(reinterpret_cast<Fd>(fd.release()), addr, addrlen,
+                                flags | TAKE_OWNERSHIP);
+}
+Own<ConnectionReceiver> LowLevelAsyncIoProvider::wrapListenSocketFd(
+    OwnFd fd, NetworkFilter& filter, uint flags) {
+  return wrapListenSocketFd(reinterpret_cast<Fd>(fd.release()), filter, flags | TAKE_OWNERSHIP);
+}
+Own<ConnectionReceiver> LowLevelAsyncIoProvider::wrapListenSocketFd(OwnFd fd, uint flags) {
+  return wrapListenSocketFd(reinterpret_cast<Fd>(fd.release()), flags | TAKE_OWNERSHIP);
+}
+Own<DatagramPort> LowLevelAsyncIoProvider::wrapDatagramSocketFd(
+    OwnFd fd, NetworkFilter& filter, uint flags) {
+  return wrapDatagramSocketFd(reinterpret_cast<Fd>(fd.release()), filter, flags | TAKE_OWNERSHIP);
+}
+Own<DatagramPort> LowLevelAsyncIoProvider::wrapDatagramSocketFd(OwnFd fd, uint flags) {
+  return wrapDatagramSocketFd(reinterpret_cast<Fd>(fd.release()), flags | TAKE_OWNERSHIP);
+}
+
 namespace {
 
 class DummyNetworkFilter: public kj::LowLevelAsyncIoProvider::NetworkFilter {

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -29,6 +29,7 @@
 #include "async-io-internal.h"
 #include "debug.h"
 #include "vector.h"
+#include "io.h"
 
 #if _WIN32
 #include <winsock2.h>
@@ -181,6 +182,34 @@ Maybe<Promise<uint64_t>> AsyncOutputStream::tryPumpFrom(
   return nullptr;
 }
 
+Promise<Own<AsyncCapabilityStream>> AsyncCapabilityStream::receiveStream() {
+  return tryReceiveStream()
+      .then([](Maybe<Own<AsyncCapabilityStream>>&& result)
+            -> Promise<Own<AsyncCapabilityStream>> {
+    KJ_IF_MAYBE(r, result) {
+      return kj::mv(*r);
+    } else {
+      return KJ_EXCEPTION(FAILED, "EOF when expecting to receive capability");
+    }
+  });
+}
+
+Promise<AutoCloseFd> AsyncCapabilityStream::receiveFd() {
+  return tryReceiveFd().then([](Maybe<AutoCloseFd>&& result) -> Promise<AutoCloseFd> {
+    KJ_IF_MAYBE(r, result) {
+      return kj::mv(*r);
+    } else {
+      return KJ_EXCEPTION(FAILED, "EOF when expecting to receive capability");
+    }
+  });
+}
+Promise<Maybe<AutoCloseFd>> AsyncCapabilityStream::tryReceiveFd() {
+  return KJ_EXCEPTION(UNIMPLEMENTED, "this stream cannot receive file descriptors");
+}
+Promise<void> AsyncCapabilityStream::sendFd(int fd) {
+  return KJ_EXCEPTION(UNIMPLEMENTED, "this stream cannot send file descriptors");
+}
+
 void AsyncIoStream::getsockopt(int level, int option, void* value, uint* length) {
   KJ_UNIMPLEMENTED("Not a socket.");
 }
@@ -212,6 +241,9 @@ Own<DatagramPort> LowLevelAsyncIoProvider::wrapDatagramSocketFd(
     Fd fd, LowLevelAsyncIoProvider::NetworkFilter& filter, uint flags) {
   KJ_UNIMPLEMENTED("Datagram sockets not implemented.");
 }
+CapabilityPipe AsyncIoProvider::newCapabilityPipe() {
+  KJ_UNIMPLEMENTED("Capability pipes not implemented.");
+}
 
 namespace {
 
@@ -225,6 +257,39 @@ public:
 LowLevelAsyncIoProvider::NetworkFilter& LowLevelAsyncIoProvider::NetworkFilter::getAllAllowed() {
   static DummyNetworkFilter result;
   return result;
+}
+
+// =======================================================================================
+// Convenience adapters.
+
+Promise<Own<AsyncIoStream>> CapabilityStreamConnectionReceiver::accept() {
+  return inner.receiveStream()
+      .then([](Own<AsyncCapabilityStream>&& stream) -> Own<AsyncIoStream> {
+    return kj::mv(stream);
+  });
+}
+
+uint CapabilityStreamConnectionReceiver::getPort() {
+  return 0;
+}
+
+Promise<Own<AsyncIoStream>> CapabilityStreamNetworkAddress::connect() {
+  auto pipe = provider.newCapabilityPipe();
+  auto result = kj::mv(pipe.ends[0]);
+  return inner.sendStream(kj::mv(pipe.ends[1]))
+      .then(kj::mvCapture(result, [](Own<AsyncIoStream>&& result) {
+    return kj::mv(result);
+  }));
+}
+Own<ConnectionReceiver> CapabilityStreamNetworkAddress::listen() {
+  return kj::heap<CapabilityStreamConnectionReceiver>(inner);
+}
+
+Own<NetworkAddress> CapabilityStreamNetworkAddress::clone() {
+  KJ_UNIMPLEMENTED("can't clone CapabilityStreamNetworkAddress");
+}
+String CapabilityStreamNetworkAddress::toString() {
+  return kj::str("<CapabilityStreamNetworkAddress>");
 }
 
 // =======================================================================================

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -683,7 +683,7 @@ AsyncIoContext setupAsyncIo();
 // =======================================================================================
 // Convenience adapters.
 
-class CapabilityStreamConnectionReceiver: public ConnectionReceiver {
+class CapabilityStreamConnectionReceiver final: public ConnectionReceiver {
   // Trivial wrapper which allows an AsyncCapabilityStream to act as a ConnectionReceiver. accept()
   // calls receiveStream().
 
@@ -698,7 +698,7 @@ private:
   AsyncCapabilityStream& inner;
 };
 
-class CapabilityStreamNetworkAddress: public NetworkAddress {
+class CapabilityStreamNetworkAddress final: public NetworkAddress {
   // Trivial wrapper which allows an AsyncCapabilityStream to act as a NetworkAddress.
   //
   // connect() is implemented by calling provider.newCapabilityPipe(), sending one end over the

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -37,11 +37,12 @@ namespace kj {
 
 #if _WIN32
 class Win32EventPort;
+class AutoCloseHandle;
 #else
 class UnixEventPort;
-class AutoCloseFd;
 #endif
 
+class AutoCloseFd;
 class NetworkAddress;
 class AsyncOutputStream;
 class AsyncIoStream;

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -283,6 +283,13 @@ public:
   inline bool operator==(decltype(nullptr)) { return fd < 0; }
   inline bool operator!=(decltype(nullptr)) { return fd >= 0; }
 
+  inline int release() {
+    // Release ownership of an FD. Not recommended.
+    int result = fd;
+    fd = -1;
+    return result;
+  }
+
 private:
   int fd;
   UnwindDetector unwindDetector;
@@ -375,6 +382,13 @@ public:
 
   inline bool operator==(decltype(nullptr)) { return handle != (void*)-1; }
   inline bool operator!=(decltype(nullptr)) { return handle == (void*)-1; }
+
+  inline void* release() {
+    // Release ownership of an FD. Not recommended.
+    void* result = handle;
+    handle = (void*)-1;
+    return result;
+  }
 
 private:
   void* handle;  // -1 (aka INVALID_HANDLE_VALUE) if not valid.


### PR DESCRIPTION
This allows a lot of nice design patterns, and might later the the basis for capnp 3-party handoff within a machine.

(This is not needed for anything we're working on right now, but it was a fun thing to build.)