### PR TITLE
Avoid MSVC workaround in parse/common.h for clang.

### DIFF
--- a/c++/src/kj/common.c++
+++ b/c++/src/kj/common.c++
@@ -49,7 +49,7 @@ void unreachable() {
 
 }  // namespace _ (private)
 
-#if _MSC_VER
+#if _MSC_VER && !__clang__
 
 float nan() { return std::numeric_limits<float>::quiet_NaN(); }
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -166,7 +166,7 @@ typedef unsigned char byte;
 #define KJ_NOINLINE __attribute__((noinline))
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !__clang__
 #define KJ_NORETURN(prototype) __declspec(noreturn) prototype
 #define KJ_UNUSED
 #define KJ_WARN_UNUSED_RESULT
@@ -635,7 +635,7 @@ struct ThrowOverflow {
   void operator()() const;
 };
 
-#if __GNUC__
+#if __GNUC__ || __clang__
 inline constexpr float inf() { return __builtin_huge_valf(); }
 inline constexpr float nan() { return __builtin_nanf(""); }
 

--- a/c++/src/kj/parse/common.h
+++ b/c++/src/kj/parse/common.h
@@ -45,7 +45,7 @@
 #include "../array.h"
 #include "../tuple.h"
 #include "../vector.h"
-#if _MSC_VER
+#if _MSC_VER && !__clang__
 #include <type_traits>  // result_of_t
 #endif
 
@@ -104,7 +104,7 @@ template <typename T> struct OutputType_;
 template <typename T> struct OutputType_<Maybe<T>> { typedef T Type; };
 template <typename Parser, typename Input>
 using OutputType = typename OutputType_<
-#if _MSC_VER
+#if _MSC_VER && !__clang__
     std::result_of_t<Parser(Input)>
     // The instance<T&>() based version below results in:
     //   C2064: term does not evaluate to a function taking 1 arguments
@@ -162,7 +162,7 @@ private:
   };
   template <typename ParserImpl>
   struct WrapperImplInstance {
-#if _MSC_VER
+#if _MSC_VER && !__clang__
     // TODO(msvc): MSVC currently fails to initialize vtable pointers for constexpr values so
     //   we have to make this just const instead.
     static const WrapperImpl<ParserImpl> instance;
@@ -177,7 +177,7 @@ private:
 
 template <typename Input, typename Output>
 template <typename ParserImpl>
-#if _MSC_VER
+#if _MSC_VER && !__clang__
 const typename ParserRef<Input, Output>::template WrapperImpl<ParserImpl>
 ParserRef<Input, Output>::WrapperImplInstance<ParserImpl>::instance = WrapperImpl<ParserImpl>();
 #else
@@ -332,7 +332,7 @@ public:
 
   template <typename Input>
   auto operator()(Input& input) const
-#ifndef _MSC_VER
+#if !_MSC_VER || __clang__
       -> Maybe<decltype(tuple(
           instance<OutputType<FirstSubParser, Input>>(),
           instance<OutputType<SubParsers, Input>>()...))>
@@ -343,7 +343,7 @@ public:
 
   template <typename Input, typename... InitialParams>
   auto parseNext(Input& input, InitialParams&&... initialParams) const
-#ifndef _MSC_VER
+#if !_MSC_VER || __clang__
       -> Maybe<decltype(tuple(
           kj::fwd<InitialParams>(initialParams)...,
           instance<OutputType<FirstSubParser, Input>>(),


### PR DESCRIPTION
Fixes capnproto/capnproto#559