### PR TITLE
Allow KJ_SWITCH_ONEOF to work on const variables

### DIFF
--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -133,6 +133,22 @@ TEST(OneOf, Switch) {
       }
     }
   }
+
+  {
+    // At one time this failed to compile.
+    const auto& constVar = var;
+    KJ_SWITCH_ONEOF(constVar) {
+      KJ_CASE_ONEOF(i, int) {
+        KJ_FAIL_ASSERT("expected char*, got int", i);
+      }
+      KJ_CASE_ONEOF(s, const char*) {
+        KJ_EXPECT(kj::StringPtr(s) == "foo");
+      }
+      KJ_CASE_ONEOF(n, float) {
+        KJ_FAIL_ASSERT("expected char*, got float", n);
+      }
+    }
+  }
 }
 
 }  // namespace kj

--- a/c++/src/kj/one-of.h
+++ b/c++/src/kj/one-of.h
@@ -128,7 +128,7 @@ public:
 
   typedef _::Variants<sizeof...(Variants)> Tag;
 
-  Tag which() {
+  Tag which() const {
     KJ_IREQUIRE(tag != 0, "Can't KJ_SWITCH_ONEOF() on uninitialized value.");
     return static_cast<Tag>(tag - 1);
   }


### PR DESCRIPTION
This change allows:

```c++
const OneOf<Foo, Bar> var = ...;
KJ_SWITCH_ONEOF(var) {
  // ...
}
```