### PR TITLE
Removed mgravell C# implementation from list

### DIFF
--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -24,7 +24,6 @@ project's documentation for details.
 ##### Serialization only
 
 * [C](https://github.com/opensourcerouting/c-capnproto) by [OpenSourceRouting](https://www.opensourcerouting.org/) / [@eqvinox](https://github.com/eqvinox) (originally by [@jmckaskill](https://github.com/jmckaskill))
-* [C#](https://github.com/mgravell/capnproto-net) by [@mgravell](https://github.com/mgravell)
 * [D](https://github.com/capnproto/capnproto-dlang) by [@ThomasBrixLarsen](https://github.com/ThomasBrixLarsen)
 * [Go](https://github.com/glycerine/go-capnproto) by [@glycerine](https://github.com/glycerine) (originally by [@jmckaskill](https://github.com/jmckaskill))
 * [Java](https://github.com/capnproto/capnproto-java/) by [@dwrensha](https://github.com/dwrensha)


### PR DESCRIPTION
mgravell has deleted the branch.
https://github.com/mgravell/capnproto-net

Maybe, but I didn't judge it:
https://github.com/ThomasBrixLarsen/capnproto-dotnet