### PR TITLE
Variable-length arrays must have positive bound.

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -261,7 +261,7 @@ KJ_NORETURN(void unreachable());
 #define KJ_STACK_ARRAY(type, name, size, minStack, maxStack) \
   size_t name##_size = (size); \
   bool name##_isOnStack = name##_size <= (maxStack); \
-  type name##_stack[name##_isOnStack ? size : 0]; \
+  type name##_stack[kj::max(1, name##_isOnStack ? name##_size : 0)]; \
   ::kj::Array<type> name##_heap = name##_isOnStack ? \
       nullptr : kj::heapArray<type>(name##_size); \
   ::kj::ArrayPtr<type> name = name##_isOnStack ? \


### PR DESCRIPTION
>  If the size is an expression that is not an integer constant expression [...], each time it is evaluated it shall have a value greater than zero.

Detected by -fsanitize=vla-bound