### PR TITLE
Don't read past the end of the base64 decode out buffer.

### DIFF
--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -269,9 +269,21 @@ KJ_TEST("C escape encoding/decoding") {
 
 KJ_TEST("base64 encoding/decoding") {
   {
+    auto encoded = encodeBase64(StringPtr("").asBytes(), false);
+    KJ_EXPECT(encoded == "", encoded, encoded.size());
+    KJ_EXPECT(heapString(decodeBase64(encoded.asArray()).asChars()) == "");
+  }
+
+  {
     auto encoded = encodeBase64(StringPtr("foo").asBytes(), false);
     KJ_EXPECT(encoded == "Zm9v", encoded, encoded.size());
     KJ_EXPECT(heapString(decodeBase64(encoded.asArray()).asChars()) == "foo");
+  }
+
+  {
+    auto encoded = encodeBase64(StringPtr("quux").asBytes(), false);
+    KJ_EXPECT(encoded == "cXV1eA==", encoded, encoded.size());
+    KJ_EXPECT(heapString(decodeBase64(encoded.asArray()).asChars()) == "quux");
   }
 
   {

--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -697,7 +697,7 @@ int base64_decode_block(const char* code_in, const int length_in,
       do {
         if (codechar == code_in+length_in) {
           state_in->step = step_a;
-          state_in->plainchar = *plainchar;
+          state_in->plainchar = '\0';
           return plainchar - plaintext_out;
         }
         fragment = (char)base64_decode_value(*codechar++);


### PR DESCRIPTION
If we finish decoding in step_a state, there is no current output character, so reading *plainchar will either be an uninitialized read or (if the output buffer is minimally sized) a past-the-end read.

Detected by -fsanitize=address.