### PR TITLE
Include <wincrypt.h> directly for WIN32_LEAN_AND_MEAN

### DIFF
--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -31,6 +31,7 @@
 #include <fcntl.h>
 
 #if _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <wincrypt.h>
 #undef VOID

--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -32,6 +32,7 @@
 
 #if _WIN32
 #include <windows.h>
+#include <wincrypt.h>
 #undef VOID
 #endif
 


### PR DESCRIPTION
Visual Studio 2017 (14.11.25503, 19.11.25508.2) needs `#include <wincrypt.h>` for CryptGenRandom etc.