### PR TITLE
Revert "avoid passing invalid reference to Array<T> constructor"

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -450,17 +450,11 @@ public:
     // check might catch bugs.  Probably people should use Vector if they want to build arrays
     // without knowing the final size in advance.
     KJ_IREQUIRE(pos == endPtr, "ArrayBuilder::finish() called prematurely.");
-    const ptrdiff_t size = pos - ptr;
-    T* start = reinterpret_cast<T*>(ptr);
+    Array<T> result(reinterpret_cast<T*>(ptr), pos - ptr, *disposer);
     ptr = nullptr;
     pos = nullptr;
     endPtr = nullptr;
-    if (size == 0) {
-      // `disposer` possibly does not point to anything, so don't pass `*disposer` to `Array`.
-      return Array<T>();
-    } else {
-      return Array<T>(start, size, *disposer);
-    }
+    return result;
   }
 
   inline bool isFull() const {


### PR DESCRIPTION
Reverts capnproto/capnproto#549

Introduced memory leak because zero-sized arrays are often allocated on the heap and they need to be deleted too.