### PR TITLE
Add missing headers to unbreak the build on FreeBSD/Clang.

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -39,7 +39,9 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #endif
 
 namespace kj {

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -41,6 +41,7 @@
 #else
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <sys/un.h>
 #endif
 


### PR DESCRIPTION
Howdy @kentonv,
I'm currently porting `mozilla/rr` to FreeBSD and it depends on captnproto, so I decided to fix the build there :)

cc: @sfwhittaker/@espindola