### PR TITLE
Make decodeBase64() report errors

### DIFF
--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -271,17 +271,43 @@ KJ_TEST("base64 encoding/decoding") {
   {
     auto encoded = encodeBase64(StringPtr("foo").asBytes(), false);
     KJ_EXPECT(encoded == "Zm9v", encoded, encoded.size());
-    KJ_EXPECT(heapString(decodeBase64(encoded.asArray()).asChars()) == "foo");
+    auto decoded = decodeBase64(encoded.asArray());
+    KJ_EXPECT(!decoded.hadErrors);
+    KJ_EXPECT(heapString(decoded.asChars()) == "foo");
   }
 
   {
     auto encoded = encodeBase64(StringPtr("corge").asBytes(), false);
     KJ_EXPECT(encoded == "Y29yZ2U=", encoded);
-    KJ_EXPECT(heapString(decodeBase64(encoded.asArray()).asChars()) == "corge");
+    auto decoded = decodeBase64(encoded.asArray());
+    KJ_EXPECT(!decoded.hadErrors);
+    KJ_EXPECT(heapString(decoded.asChars()) == "corge");
   }
 
-  KJ_EXPECT(heapString(decodeBase64("Y29yZ2U").asChars()) == "corge");
-  KJ_EXPECT(heapString(decodeBase64("Y\n29y Z@2U=\n").asChars()) == "corge");
+  {
+    auto decoded = decodeBase64("Y29yZ2U");
+    KJ_EXPECT(!decoded.hadErrors);
+    KJ_EXPECT(heapString(decoded.asChars()) == "corge");
+  }
+
+  {
+    auto decoded = decodeBase64("Y\n29y Z@2U=\n");
+    KJ_EXPECT(decoded.hadErrors);  // @-sign is invalid base64 input.
+    KJ_EXPECT(heapString(decoded.asChars()) == "corge");
+  }
+
+  {
+    auto decoded = decodeBase64("Y\n29y Z2U=\n");
+    KJ_EXPECT(!decoded.hadErrors);
+    KJ_EXPECT(heapString(decoded.asChars()) == "corge");
+  }
+
+  // Too much padding.
+  KJ_EXPECT(decodeBase64("Y29yZ2U==").hadErrors);
+  KJ_EXPECT(decodeBase64("Y29yZ===").hadErrors);
+
+  // Non-terminal padding.
+  KJ_EXPECT(decodeBase64("ab=c").hadErrors);
 
   {
     auto encoded = encodeBase64(StringPtr("corge").asBytes(), true);

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -97,9 +97,9 @@ String encodeBase64(ArrayPtr<const byte> bytes, bool breakLines = false);
 // Encode the given bytes as base64 text. If `breakLines` is true, line breaks will be inserted
 // into the output every 72 characters (e.g. for encoding e-mail bodies).
 
-Array<byte> decodeBase64(ArrayPtr<const char> text);
-// Decode base64 text. Non-base64 characters are ignored and padding characters are not requried;
-// as such, this function never fails.
+EncodingResult<Array<byte>> decodeBase64(ArrayPtr<const char> text);
+// Decode base64 text. This function reports errors required by the WHATWG HTML/Infra specs: see
+// https://html.spec.whatwg.org/multipage/webappapis.html#atob for details.
 
 // =======================================================================================
 // inline implementation details
@@ -200,7 +200,7 @@ inline EncodingResult<String> decodeCEscape(const char (&text)[s]) {
   return decodeCEscape(arrayPtr(text, s-1));
 }
 template <size_t s>
-Array<byte> decodeBase64(const char (&text)[s]) {
+EncodingResult<Array<byte>> decodeBase64(const char (&text)[s]) {
   return decodeBase64(arrayPtr(text, s - 1));
 }
 


### PR DESCRIPTION
This change modifies decodeBase64() to report errors as required by the WHATWG HTML spec's atob() JavaScript function. Notably, it reports errors for non-whitespace characters outside of the valid base64 character range ([+/0-9A-Za-z=]), and performs sanity checks on padding and input length (as calculated after removing whitespace).

I took care to keep the algorithm single-pass, and to support streaming via multiple calls of base64_decode_block(), though we don't currently expose that functionality.