### PR TITLE
Add support for Own<void>.

### DIFF
--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -212,12 +212,12 @@ TEST(Memory, OwnVoid) {
     // On most (all?) C++ ABIs, the second base class in a multiply-inherited class is offset from
     // the beginning of the object (assuming the first base class has non-zero size). We use this
     // fact here to verify that then casting to Own<void> does in fact result in a pointer that
-    // points to the start of the overall object, not the base class. We assert that the pointers
+    // points to the start of the overall object, not the base class. We expect that the pointers
     // are different here to prove that the test below is non-trivial.
     //
-    // If there is some other ABI where these pointers are the same, and thus this assert fails,
-    // then it's no problem to #ifdef out the assert on that platform.
-    KJ_ASSERT(static_cast<void*>(baseAddr) != static_cast<void*>(addr));
+    // If there is some other ABI where these pointers are the same, and thus this expectation
+    // fails, then it's no problem to #ifdef out the expectation on that platform.
+    KJ_EXPECT(static_cast<void*>(baseAddr) != static_cast<void*>(addr));
 
     Own<void> voidPtr = kj::mv(basePtr);
     KJ_EXPECT(voidPtr.get() == static_cast<void*>(addr));

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -228,6 +228,59 @@ TEST(Memory, OwnVoid) {
   }
 }
 
+TEST(Memory, OwnConstVoid) {
+  {
+    Own<StaticType> ptr = heap<StaticType>({123});
+    StaticType* addr = ptr.get();
+    Own<const void> voidPtr = kj::mv(ptr);
+    KJ_EXPECT(voidPtr.get() == implicitCast<void*>(addr));
+  }
+
+  {
+    Own<DynamicType1> ptr = heap<DynamicType1>(123);
+    DynamicType1* addr = ptr.get();
+    Own<const void> voidPtr = kj::mv(ptr);
+    KJ_EXPECT(voidPtr.get() == implicitCast<void*>(addr));
+  }
+
+  {
+    bool destructorCalled = false;
+    Own<DerivedDynamic> ptr = heap<DerivedDynamic>(123, 456, destructorCalled);
+    DerivedDynamic* addr = ptr.get();
+    Own<const void> voidPtr = kj::mv(ptr);
+    KJ_EXPECT(voidPtr.get() == implicitCast<void*>(addr));
+
+    KJ_EXPECT(!destructorCalled);
+    voidPtr = nullptr;
+    KJ_EXPECT(destructorCalled);
+  }
+
+  {
+    bool destructorCalled = false;
+    Own<DerivedDynamic> ptr = heap<DerivedDynamic>(123, 456, destructorCalled);
+    DerivedDynamic* addr = ptr.get();
+    Own<DynamicType2> basePtr = kj::mv(ptr);
+    DynamicType2* baseAddr = basePtr.get();
+
+    // On most (all?) C++ ABIs, the second base class in a multiply-inherited class is offset from
+    // the beginning of the object (assuming the first base class has non-zero size). We use this
+    // fact here to verify that then casting to Own<void> does in fact result in a pointer that
+    // points to the start of the overall object, not the base class. We expect that the pointers
+    // are different here to prove that the test below is non-trivial.
+    //
+    // If there is some other ABI where these pointers are the same, and thus this expectation
+    // fails, then it's no problem to #ifdef out the expectation on that platform.
+    KJ_EXPECT(static_cast<void*>(baseAddr) != static_cast<void*>(addr));
+
+    Own<const void> voidPtr = kj::mv(basePtr);
+    KJ_EXPECT(voidPtr.get() == static_cast<void*>(addr));
+
+    KJ_EXPECT(!destructorCalled);
+    voidPtr = nullptr;
+    KJ_EXPECT(destructorCalled);
+  }
+}
+
 // TODO(test):  More tests.
 
 }  // namespace

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -136,6 +136,12 @@ TEST(Memory, AttachNested) {
   KJ_EXPECT(destroyed3 == 3, destroyed3);
 }
 
+#if __GNUG__
+// We don't actually illegally invoke any non-virtual destructors but it's hard to write this test
+// without triggering this warning, so ignore it.
+#pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
+#endif
+
 struct StaticType {
   int i;
 };

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -73,7 +73,7 @@ void* castToVoid(T* ptr) {
 }
 
 template <typename T>
-void* castToConstVoid(T* ptr) {
+const void* castToConstVoid(T* ptr) {
   return CastToVoid_<T>::applyConst(ptr);
 }
 


### PR DESCRIPTION
Any `Own<T>` can be converted to `Own<void>` (or `Own<const void>`). The main purpose of this is to give someone a way to invoke an object's disposer without them having to know anything about the type.