### PR TITLE
Change capnp compiler to use KJ filesystem API.

### DIFF
--- a/c++/src/capnp/compiler/capnp-test.sh
+++ b/c++/src/capnp/compiler/capnp-test.sh
@@ -109,5 +109,5 @@ test_eval 'TestListDefaults.lists.int32ListList[2][0]' 12341234
 
 test "x`$CAPNP eval $SCHEMA -ojson globalPrintableStruct | tr -d '\r'`" = "x{\"someText\": \"foo\"}" || fail eval json "globalPrintableStruct == {someText = \"foo\"}"
 
-$CAPNP compile --src-prefix="$PREFIX" -ofoo $TESTDATA/errors.capnp.nobuild 2>&1 | sed -e "s,^.*/errors[.]capnp[.]nobuild,file,g" | tr -d '\r' |
+$CAPNP compile --src-prefix="$PREFIX" -ofoo $TESTDATA/errors.capnp.nobuild 2>&1 | sed -e "s,^.*errors[.]capnp[.]nobuild:,file:,g" | tr -d '\r' |
     cmp $TESTDATA/errors.txt - || fail error output

--- a/c++/src/capnp/compiler/capnp-test.sh
+++ b/c++/src/capnp/compiler/capnp-test.sh
@@ -40,6 +40,13 @@ fi
 SCHEMA=`dirname "$0"`/../test.capnp
 TESTDATA=`dirname "$0"`/../testdata
 
+SUFFIX=${TESTDATA#*/src/}
+PREFIX=${TESTDATA%${SUFFIX}}
+
+if [ "$PREFIX" = "" ]; then
+  PREFIX=.
+fi
+
 # ========================================================================================
 # convert
 
@@ -102,5 +109,5 @@ test_eval 'TestListDefaults.lists.int32ListList[2][0]' 12341234
 
 test "x`$CAPNP eval $SCHEMA -ojson globalPrintableStruct | tr -d '\r'`" = "x{\"someText\": \"foo\"}" || fail eval json "globalPrintableStruct == {someText = \"foo\"}"
 
-$CAPNP compile -ofoo $TESTDATA/errors.capnp.nobuild 2>&1 | sed -e "s,^.*/errors[.]capnp[.]nobuild,file,g" | tr -d '\r' |
+$CAPNP compile --src-prefix="$PREFIX" -ofoo $TESTDATA/errors.capnp.nobuild 2>&1 | sed -e "s,^.*/errors[.]capnp[.]nobuild,file,g" | tr -d '\r' |
     cmp $TESTDATA/errors.txt - || fail error output

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -421,7 +421,7 @@ public:
       if (stat(dir.cStr(), &stats) < 0 || !S_ISDIR(stats.st_mode)) {
         return "output location is inaccessible or is not a directory";
       }
-      outputs.add(OutputDirective { plugin, disk->getCurrentPath().eval(dir) });
+      outputs.add(OutputDirective { plugin, disk->getCurrentPath().evalNative(dir) });
     } else {
       outputs.add(OutputDirective { spec.asArray(), nullptr });
     }

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -1716,7 +1716,7 @@ public:
 public:
   // =====================================================================================
 
-  void addError(kj::ReadableDirectory& directory, kj::PathPtr path,
+  void addError(const kj::ReadableDirectory& directory, kj::PathPtr path,
                 SourcePos start, SourcePos end,
                 kj::StringPtr message) override {
     auto file = getDisplayName(directory, path);
@@ -1761,7 +1761,7 @@ private:
 
   struct SourceDirectory {
     kj::Path path;
-    kj::Own<kj::ReadableDirectory> dir;
+    kj::Own<const kj::ReadableDirectory> dir;
     bool isSourcePrefix;
   };
 
@@ -1770,7 +1770,7 @@ private:
   //
   // Use via getSourceDirectory().
 
-  std::map<kj::ReadableDirectory*, kj::String> dirPrefixes;
+  std::map<const kj::ReadableDirectory*, kj::String> dirPrefixes;
   // For each open directory object, maps to a path prefix to add when displaying this path in
   // error messages. This keeps track of the original directory name as given by the user, before
   // canonicalization.
@@ -1813,7 +1813,7 @@ private:
 
   bool hadErrors_ = false;
 
-  kj::Maybe<kj::ReadableDirectory&> getSourceDirectory(
+  kj::Maybe<const kj::ReadableDirectory&> getSourceDirectory(
       kj::StringPtr pathStr, bool isSourcePrefix) {
     auto cwd = disk->getCurrentPath();
     auto path = cwd.evalNative(pathStr);
@@ -1837,7 +1837,7 @@ private:
       auto& result = disk->getCurrent();
       if (isSourcePrefix) {
         kj::PathPtr key = path;
-        kj::Own<kj::ReadableDirectory> fakeOwn(&result, kj::NullDisposer::instance);
+        kj::Own<const kj::ReadableDirectory> fakeOwn(&result, kj::NullDisposer::instance);
         KJ_ASSERT(sourceDirectories.insert(std::make_pair(key,
             SourceDirectory { kj::mv(path), kj::mv(fakeOwn), isSourcePrefix })).second);
       }
@@ -1863,7 +1863,7 @@ private:
   }
 
   struct DirPathPair {
-    kj::ReadableDirectory& dir;
+    const kj::ReadableDirectory& dir;
     kj::Path path;
   };
 
@@ -1906,7 +1906,7 @@ private:
     }
   }
 
-  kj::String getDisplayName(kj::ReadableDirectory& dir, kj::PathPtr path) {
+  kj::String getDisplayName(const kj::ReadableDirectory& dir, kj::PathPtr path) {
     auto iter = dirPrefixes.find(&dir);
     if (iter != dirPrefixes.end()) {
       return kj::str(iter->second, path.toNativeString());

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -1806,6 +1806,8 @@ private:
 
     KJ_DISALLOW_COPY(OutputDirective);
     OutputDirective(OutputDirective&&) = default;
+    OutputDirective(kj::ArrayPtr<const char> name, kj::Maybe<kj::Path> dir)
+        : name(name), dir(kj::mv(dir)) {}
   };
   kj::Vector<OutputDirective> outputs;
 

--- a/c++/src/capnp/compiler/error-reporter.h
+++ b/c++/src/capnp/compiler/error-reporter.h
@@ -69,7 +69,7 @@ public:
     uint column;
   };
 
-  virtual void addError(kj::ReadableDirectory& directory, kj::PathPtr path,
+  virtual void addError(const kj::ReadableDirectory& directory, kj::PathPtr path,
                         SourcePos start, SourcePos end,
                         kj::StringPtr message) = 0;
   // Report an error at the given location in the given file.

--- a/c++/src/capnp/compiler/error-reporter.h
+++ b/c++/src/capnp/compiler/error-reporter.h
@@ -30,6 +30,7 @@
 #include <kj/string.h>
 #include <kj/exception.h>
 #include <kj/vector.h>
+#include <kj/filesystem.h>
 
 namespace capnp {
 namespace compiler {
@@ -68,7 +69,8 @@ public:
     uint column;
   };
 
-  virtual void addError(kj::StringPtr file, SourcePos start, SourcePos end,
+  virtual void addError(kj::ReadableDirectory& directory, kj::PathPtr path,
+                        SourcePos start, SourcePos end,
                         kj::StringPtr message) = 0;
   // Report an error at the given location in the given file.
 

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -27,10 +27,100 @@
 #include <kj/debug.h>
 #include <kj/io.h>
 #include <capnp/message.h>
-#include <map>
+#include <unordered_map>
 
 namespace capnp {
 namespace compiler {
+
+namespace {
+
+struct FileKey {
+  // Key type for the modules map. We need to implement some complicated heuristics to detect when
+  // two files are actually the same underlying file on disk, in order to handle the case where
+  // people have mapped the same file into multiple locations in the import tree, whether by
+  // passing overlapping import paths, weird symlinks, or whatever.
+  //
+  // This is probably over-engineered.
+
+  kj::ReadableDirectory& baseDir;
+  kj::PathPtr path;
+  kj::ReadableFile* file;  // should be Maybe<ReadableFile&> but annoying const-copy issues come up.
+  uint64_t hashCode;
+  uint64_t size;
+  kj::Date lastModified;
+
+  FileKey(kj::ReadableDirectory& baseDir, kj::PathPtr path)
+      : baseDir(baseDir), path(path), file(nullptr),
+        hashCode(0), size(0), lastModified(kj::UNIX_EPOCH) {}
+  FileKey(kj::ReadableDirectory& baseDir, kj::PathPtr path, kj::ReadableFile& file)
+      : FileKey(baseDir, path, file, file.stat()) {}
+
+  FileKey(kj::ReadableDirectory& baseDir, kj::PathPtr path, kj::ReadableFile& file,
+          kj::FsNode::Metadata meta)
+      : baseDir(baseDir), path(path), file(&file),
+        hashCode(meta.hashCode), size(meta.size), lastModified(meta.lastModified) {}
+
+  bool operator==(const FileKey& other) const {
+    // Allow matching on baseDir and path without a file.
+    if (&baseDir == &other.baseDir && path == other.path) return true;
+    if (file == nullptr || other.file == nullptr) return false;
+
+    // Try comparing various file metadata to rule out obvious differences.
+    if (hashCode != other.hashCode) return false;
+    if (size != other.size || lastModified != other.lastModified) return false;
+    if (path.size() > 0 && other.path.size() > 0 &&
+        path[path.size() - 1] != other.path[other.path.size() - 1]) {
+      // Names differ, so probably not the same file.
+      return false;
+    }
+
+    // Same file hash, but different paths, but same size and modification date. This could be a
+    // case of two different import paths overlapping and containing the same file. We'll need to
+    // check the content.
+    auto mapping1 = file->mmap(0, size);
+    auto mapping2 = other.file->mmap(0, size);
+    if (memcmp(mapping1.begin(), mapping2.begin(), size) != 0) return false;
+
+    if (path == other.path) {
+      // Exactly the same content was mapped at exactly the same path relative to two different
+      // import directories. This can only really happen if this was one of the files passed on
+      // the command line, but its --src-prefix is not also an import path, but some other
+      // directory containing the same file was given as an import path. Whatever, we'll ignore
+      // this.
+      return true;
+    }
+
+    // Exactly the same content!
+    static bool warned = false;
+    if (!warned) {
+      KJ_LOG(WARNING,
+          "Found exactly the same source file mapped at two different paths. This suggests "
+          "that your -I and --src-prefix flags are overlapping or inconsistent. Remember, these "
+          "flags should only specify directories that are logical 'roots' of the source tree. "
+          "It should never be the case that one of the import directories contains another one of "
+          "them.",
+          path, other.path);
+      warned = true;
+    }
+
+    return true;
+  }
+};
+
+struct FileKeyHash {
+  size_t operator()(const FileKey& key) const {
+    if (sizeof(size_t) < sizeof(key.hashCode)) {
+      // 32-bit system, do more mixing
+      return (key.hashCode >> 32) * 31 + static_cast<size_t>(key.hashCode) +
+          key.size * 103 + (key.lastModified - kj::UNIX_EPOCH) / kj::MILLISECONDS * 73;
+    } else {
+      return key.hashCode + key.size * 103 +
+          (key.lastModified - kj::UNIX_EPOCH) / kj::NANOSECONDS * 73;
+    }
+  }
+};
+
+};
 
 class ModuleLoader::Impl {
 public:
@@ -50,14 +140,14 @@ public:
 private:
   GlobalErrorReporter& errorReporter;
   kj::Vector<kj::ReadableDirectory*> searchPath;
-  std::map<std::pair<kj::ReadableDirectory*, kj::PathPtr>, kj::Own<Module>> modules;
+  std::unordered_map<FileKey, kj::Own<Module>, FileKeyHash> modules;
 };
 
 class ModuleLoader::ModuleImpl final: public Module {
 public:
   ModuleImpl(ModuleLoader::Impl& loader, kj::Own<kj::ReadableFile> file,
-             kj::ReadableDirectory& sourceDir, kj::PathPtr path)
-      : loader(loader), file(kj::mv(file)), sourceDir(sourceDir), path(path.clone()),
+             kj::ReadableDirectory& sourceDir, kj::Path pathParam)
+      : loader(loader), file(kj::mv(file)), sourceDir(sourceDir), path(kj::mv(pathParam)),
         sourceNameStr(path.toString()) {
     KJ_REQUIRE(path.size() > 0);
   }
@@ -128,17 +218,24 @@ private:
 
 kj::Maybe<Module&> ModuleLoader::Impl::loadModule(
     kj::ReadableDirectory& dir, kj::PathPtr path) {
-  auto iter = modules.find(std::make_pair(&dir, path));
+  auto iter = modules.find(FileKey(dir, path));
   if (iter != modules.end()) {
     // Return existing file.
     return *iter->second;
   }
 
   KJ_IF_MAYBE(file, dir.tryOpenFile(path)) {
-    auto module = kj::heap<ModuleImpl>(*this, kj::mv(*file), dir, path);
+    auto pathCopy = path.clone();
+    auto key = FileKey(dir, pathCopy, **file);
+    auto module = kj::heap<ModuleImpl>(*this, kj::mv(*file), dir, kj::mv(pathCopy));
     auto& result = *module;
-    modules.insert(std::make_pair(std::make_pair(&dir, result.getPath()), kj::mv(module)));
-    return result;
+    auto insertResult = modules.insert(std::make_pair(key, kj::mv(module)));
+    if (insertResult.second) {
+      return result;
+    } else {
+      // Now that we have the file open, we noticed a collision. Return the old file.
+      return *insertResult.first->second;
+    }
   } else {
     // No such file.
     return nullptr;

--- a/c++/src/capnp/compiler/module-loader.h
+++ b/c++/src/capnp/compiler/module-loader.h
@@ -45,10 +45,10 @@ public:
 
   ~ModuleLoader() noexcept(false);
 
-  void addImportPath(kj::ReadableDirectory& dir);
+  void addImportPath(const kj::ReadableDirectory& dir);
   // Add a directory to the list of paths that is searched for imports that start with a '/'.
 
-  kj::Maybe<Module&> loadModule(kj::ReadableDirectory& dir, kj::PathPtr path);
+  kj::Maybe<Module&> loadModule(const kj::ReadableDirectory& dir, kj::PathPtr path);
   // Tries to load a module with the given path inside the given directory. Returns nullptr if the
   // file doesn't exist.
 

--- a/c++/src/capnp/compiler/module-loader.h
+++ b/c++/src/capnp/compiler/module-loader.h
@@ -31,6 +31,7 @@
 #include <kj/memory.h>
 #include <kj/array.h>
 #include <kj/string.h>
+#include <kj/filesystem.h>
 
 namespace capnp {
 namespace compiler {
@@ -44,13 +45,12 @@ public:
 
   ~ModuleLoader() noexcept(false);
 
-  void addImportPath(kj::String path);
+  void addImportPath(kj::ReadableDirectory& dir);
   // Add a directory to the list of paths that is searched for imports that start with a '/'.
 
-  kj::Maybe<Module&> loadModule(kj::StringPtr localName, kj::StringPtr sourceName);
-  // Tries to load the module with the given filename.  `localName` is the path to the file on
-  // disk (as you'd pass to open(2)), and `sourceName` is the canonical name it should be given
-  // in the schema (this is used e.g. to decide output file locations).  Often, these are the same.
+  kj::Maybe<Module&> loadModule(kj::ReadableDirectory& dir, kj::PathPtr path);
+  // Tries to load a module with the given path inside the given directory. Returns nullptr if the
+  // file doesn't exist.
 
 private:
   class Impl;

--- a/c++/src/capnp/schema-parser-test.c++
+++ b/c++/src/capnp/schema-parser-test.c++
@@ -30,26 +30,22 @@
 namespace capnp {
 namespace {
 
-class FakeFileReader final: public SchemaFile::FileReader {
+class FakeFileReader final: public kj::Filesystem {
 public:
   void add(kj::StringPtr name, kj::StringPtr content) {
-    files[name] = content;
+    root->openFile(cwd.eval(name), kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT)
+        ->writeAll(content);
   }
 
-  bool exists(kj::StringPtr path) const override {
-    return files.count(path) > 0;
-  }
-
-  kj::Array<const char> read(kj::StringPtr path) const override {
-    auto iter = files.find(path);
-    KJ_ASSERT(iter != files.end(), "FakeFileReader has no such file.", path);
-    auto result = kj::heapArray<char>(iter->second.size());
-    memcpy(result.begin(), iter->second.begin(), iter->second.size());
-    return kj::mv(result);
-  }
+  kj::Directory& getRoot() override { return *root; }
+  kj::Directory& getCurrent() override { return *current; }
+  kj::PathPtr getCurrentPath() override { return cwd; }
 
 private:
-  std::map<kj::StringPtr, kj::StringPtr> files;
+  kj::Own<kj::Directory> root = kj::newInMemoryDirectory(kj::nullClock());
+  kj::Path cwd = kj::Path({"path", "to", "current", "dir"});
+  kj::Own<kj::Directory> current = root->openSubdir(cwd,
+      kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT);
 };
 
 static uint64_t getFieldTypeFileId(StructSchema::Field field) {
@@ -59,8 +55,9 @@ static uint64_t getFieldTypeFileId(StructSchema::Field field) {
 }
 
 TEST(SchemaParser, Basic) {
-  SchemaParser parser;
   FakeFileReader reader;
+  SchemaParser parser;
+  parser.setDiskFilesystem(reader);
 
   reader.add("src/foo/bar.capnp",
       "@0x8123456789abcdef;\n"
@@ -90,8 +87,8 @@ TEST(SchemaParser, Basic) {
     "/usr/include", "/usr/local/include", "/opt/include"
   };
 
-  ParsedSchema barSchema = parser.parseFile(SchemaFile::newDiskFile(
-      "foo2/bar2.capnp", "src/foo/bar.capnp", importPath, reader));
+  ParsedSchema barSchema = parser.parseDiskFile(
+      "foo2/bar2.capnp", "src/foo/bar.capnp", importPath);
 
   auto barProto = barSchema.getProto();
   EXPECT_EQ(0x8123456789abcdefull, barProto.getId());
@@ -109,25 +106,25 @@ TEST(SchemaParser, Basic) {
   EXPECT_EQ("garply", barFields[3].getProto().getName());
   EXPECT_EQ(0x856789abcdef1234ull, getFieldTypeFileId(barFields[3]));
 
-  auto bazSchema = parser.parseFile(SchemaFile::newDiskFile(
+  auto bazSchema = parser.parseDiskFile(
       "not/used/because/already/loaded",
-      "src/foo/baz.capnp", importPath, reader));
+      "src/foo/baz.capnp", importPath);
   EXPECT_EQ(0x823456789abcdef1ull, bazSchema.getProto().getId());
   EXPECT_EQ("foo2/baz.capnp", bazSchema.getProto().getDisplayName());
   auto bazStruct = bazSchema.getNested("Baz").asStruct();
   EXPECT_EQ(bazStruct, barStruct.getDependency(bazStruct.getProto().getId()));
 
-  auto corgeSchema = parser.parseFile(SchemaFile::newDiskFile(
+  auto corgeSchema = parser.parseDiskFile(
       "not/used/because/already/loaded",
-      "src/qux/corge.capnp", importPath, reader));
+      "src/qux/corge.capnp", importPath);
   EXPECT_EQ(0x83456789abcdef12ull, corgeSchema.getProto().getId());
   EXPECT_EQ("qux/corge.capnp", corgeSchema.getProto().getDisplayName());
   auto corgeStruct = corgeSchema.getNested("Corge").asStruct();
   EXPECT_EQ(corgeStruct, barStruct.getDependency(corgeStruct.getProto().getId()));
 
-  auto graultSchema = parser.parseFile(SchemaFile::newDiskFile(
+  auto graultSchema = parser.parseDiskFile(
       "not/used/because/already/loaded",
-      "/usr/include/grault.capnp", importPath, reader));
+      "/usr/include/grault.capnp", importPath);
   EXPECT_EQ(0x8456789abcdef123ull, graultSchema.getProto().getId());
   EXPECT_EQ("grault.capnp", graultSchema.getProto().getDisplayName());
   auto graultStruct = graultSchema.getNested("Grault").asStruct();
@@ -135,9 +132,9 @@ TEST(SchemaParser, Basic) {
 
   // Try importing the other grault.capnp directly.  It'll get the display name we specify since
   // it wasn't imported before.
-  auto wrongGraultSchema = parser.parseFile(SchemaFile::newDiskFile(
+  auto wrongGraultSchema = parser.parseDiskFile(
       "weird/display/name.capnp",
-      "/opt/include/grault.capnp", importPath, reader));
+      "/opt/include/grault.capnp", importPath);
   EXPECT_EQ(0x8000000000000001ull, wrongGraultSchema.getProto().getId());
   EXPECT_EQ("weird/display/name.capnp", wrongGraultSchema.getProto().getDisplayName());
 }
@@ -147,8 +144,9 @@ TEST(SchemaParser, Constants) {
   // constants are not actually accessible from the generated code API, so the only way to ever
   // get a ConstSchema is by parsing it.
 
-  SchemaParser parser;
   FakeFileReader reader;
+  SchemaParser parser;
+  parser.setDiskFilesystem(reader);
 
   reader.add("const.capnp",
       "@0x8123456789abcdef;\n"
@@ -164,8 +162,8 @@ TEST(SchemaParser, Constants) {
       "  value @0 :T;\n"
       "}\n");
 
-  ParsedSchema fileSchema = parser.parseFile(SchemaFile::newDiskFile(
-      "const.capnp", "const.capnp", nullptr, reader));
+  ParsedSchema fileSchema = parser.parseDiskFile(
+      "const.capnp", "const.capnp", nullptr);
 
   EXPECT_EQ(1234, fileSchema.getNested("uint32Const").asConst().as<uint32_t>());
 
@@ -198,8 +196,9 @@ void expectSourceInfo(schema::Node::SourceInfo::Reader sourceInfo,
 }
 
 TEST(SchemaParser, SourceInfo) {
-  SchemaParser parser;
   FakeFileReader reader;
+  SchemaParser parser;
+  parser.setDiskFilesystem(reader);
 
   reader.add("foo.capnp",
       "@0x84a2c6051e1061ed;\n"
@@ -234,8 +233,8 @@ TEST(SchemaParser, SourceInfo) {
       "struct Thud @0xcca9972702b730b4 {}\n"
       "# post-comment\n");
 
-  ParsedSchema file = parser.parseFile(SchemaFile::newDiskFile(
-      "foo.capnp", "foo.capnp", nullptr, reader));
+  ParsedSchema file = parser.parseDiskFile(
+      "foo.capnp", "foo.capnp", nullptr);
   ParsedSchema foo = file.getNested("Foo");
 
   expectSourceInfo(file.getSourceInfo(), 0x84a2c6051e1061edull, "file doc comment\n", {});

--- a/c++/src/capnp/schema-parser-test.c++
+++ b/c++/src/capnp/schema-parser-test.c++
@@ -43,14 +43,14 @@ public:
         ->writeAll(content);
   }
 
-  kj::Directory& getRoot() override { return *root; }
-  kj::Directory& getCurrent() override { return *current; }
-  kj::PathPtr getCurrentPath() override { return cwd; }
+  const kj::Directory& getRoot() const override { return *root; }
+  const kj::Directory& getCurrent() const override { return *current; }
+  kj::PathPtr getCurrentPath() const override { return cwd; }
 
 private:
-  kj::Own<kj::Directory> root = kj::newInMemoryDirectory(kj::nullClock());
+  kj::Own<const kj::Directory> root = kj::newInMemoryDirectory(kj::nullClock());
   kj::Path cwd = kj::Path({}).evalNative(ABS("path/to/current/dir"));
-  kj::Own<kj::Directory> current = root->openSubdir(cwd,
+  kj::Own<const kj::Directory> current = root->openSubdir(cwd,
       kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT);
 };
 

--- a/c++/src/capnp/schema-parser-test.c++
+++ b/c++/src/capnp/schema-parser-test.c++
@@ -49,7 +49,7 @@ public:
 
 private:
   kj::Own<kj::Directory> root = kj::newInMemoryDirectory(kj::nullClock());
-  kj::Path cwd = kj::Path::parse(ABS("path/to/current/dir"));
+  kj::Path cwd = kj::Path({}).evalNative(ABS("path/to/current/dir"));
   kj::Own<kj::Directory> current = root->openSubdir(cwd,
       kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT);
 };

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -31,17 +31,7 @@
 #include <kj/vector.h>
 #include <kj/debug.h>
 #include <kj/io.h>
-#include <kj/miniposix.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <errno.h>
-
-#if _WIN32
-#include <windows.h>
-#else
-#include <sys/mman.h>
-#endif
+#include <map>
 
 namespace capnp {
 
@@ -171,20 +161,128 @@ struct SchemaFileEq {
 
 }  // namespace
 
+struct SchemaParser::DiskFileCompat {
+  // Stuff we only create if parseDiskFile() is ever called, in order to translate that call into
+  // KJ filesystem API calls.
+
+  kj::Own<kj::Filesystem> ownFs;
+  kj::Filesystem& fs;
+
+  struct ImportDir {
+    kj::String pathStr;
+    kj::Path path;
+    kj::Own<kj::ReadableDirectory> dir;
+  };
+  std::map<kj::StringPtr, ImportDir> cachedImportDirs;
+
+  std::map<std::pair<const kj::StringPtr*, size_t>, kj::Array<kj::ReadableDirectory*>>
+      cachedImportPaths;
+
+  DiskFileCompat(): ownFs(kj::newDiskFilesystem()), fs(*ownFs) {}
+  DiskFileCompat(kj::Filesystem& fs): fs(fs) {}
+};
+
 struct SchemaParser::Impl {
   typedef std::unordered_map<
       const SchemaFile*, kj::Own<ModuleImpl>, SchemaFileHash, SchemaFileEq> FileMap;
   kj::MutexGuarded<FileMap> fileMap;
   compiler::Compiler compiler;
+
+  kj::MutexGuarded<kj::Maybe<DiskFileCompat>> compat;
 };
 
 SchemaParser::SchemaParser(): impl(kj::heap<Impl>()) {}
 SchemaParser::~SchemaParser() noexcept(false) {}
 
+ParsedSchema SchemaParser::parseFromDirectory(
+    kj::ReadableDirectory& baseDir, kj::Path path,
+    kj::ArrayPtr<kj::ReadableDirectory* const> importPath) const {
+  return parseFile(SchemaFile::newFromDirectory(baseDir, kj::mv(path), importPath));
+}
+
 ParsedSchema SchemaParser::parseDiskFile(
     kj::StringPtr displayName, kj::StringPtr diskPath,
     kj::ArrayPtr<const kj::StringPtr> importPath) const {
-  return parseFile(SchemaFile::newDiskFile(displayName, diskPath, importPath));
+  auto lock = impl->compat.lockExclusive();
+  DiskFileCompat* compat;
+  KJ_IF_MAYBE(c, *lock) {
+    compat = c;
+  } else {
+    compat = &lock->emplace();
+  }
+
+  auto& root = compat->fs.getRoot();
+  auto cwd = compat->fs.getCurrentPath();
+
+  kj::ReadableDirectory* baseDir = &root;
+  kj::Path path = cwd.evalNative(diskPath);
+
+  kj::ArrayPtr<kj::ReadableDirectory* const> translatedImportPath = nullptr;
+
+  if (importPath.size() > 0) {
+    auto importPathKey = std::make_pair(importPath.begin(), importPath.size());
+    auto& slot = compat->cachedImportPaths[importPathKey];
+
+    if (slot == nullptr) {
+      slot = KJ_MAP(path, importPath) -> kj::ReadableDirectory* {
+        auto iter = compat->cachedImportDirs.find(path);
+        if (iter != compat->cachedImportDirs.end()) {
+          return iter->second.dir;
+        }
+
+        auto parsed = cwd.evalNative(path);
+        kj::Own<kj::ReadableDirectory> dir;
+        KJ_IF_MAYBE(d, root.tryOpenSubdir(parsed)) {
+          dir = kj::mv(*d);
+        } else {
+          // Ignore paths that don't exist.
+          dir = kj::newInMemoryDirectory(kj::nullClock());
+        }
+
+        kj::ReadableDirectory* result = dir;
+
+        kj::StringPtr pathRef = path;
+        KJ_ASSERT(compat->cachedImportDirs.insert(std::make_pair(pathRef,
+            DiskFileCompat::ImportDir { kj::str(path), kj::mv(parsed), kj::mv(dir) })).second);
+
+        return result;
+      };
+    }
+
+    translatedImportPath = slot;
+
+    // Check if `path` appears to be inside any of the import path directories. If so, adjust
+    // to be relative to that directory rather than absolute.
+    kj::Maybe<DiskFileCompat::ImportDir&> matchedImportDir;
+    size_t bestMatchLength = 0;
+    for (auto importDir: importPath) {
+      auto iter = compat->cachedImportDirs.find(importDir);
+      KJ_ASSERT(iter != compat->cachedImportDirs.end());
+
+      if (path.startsWith(iter->second.path)) {
+        // Looks like we're trying to load a file from inside this import path. Treat the import
+        // path as the base directory.
+        if (iter->second.path.size() > bestMatchLength) {
+          bestMatchLength = iter->second.path.size();
+          matchedImportDir = iter->second;
+        }
+      }
+    }
+
+    KJ_IF_MAYBE(match, matchedImportDir) {
+      baseDir = match->dir;
+      path = path.slice(match->path.size(), path.size()).clone();
+    }
+  }
+
+  return parseFile(SchemaFile::newFromDirectory(
+      *baseDir, kj::mv(path), translatedImportPath, kj::str(displayName)));
+}
+
+void SchemaParser::setDiskFilesystem(kj::Filesystem& fs) {
+  auto lock = impl->compat.lockExclusive();
+  KJ_REQUIRE(*lock == nullptr, "already called parseDiskFile() or setDiskFilesystem()");
+  lock->emplace(fs);
 }
 
 ParsedSchema SchemaParser::parseFile(kj::Own<SchemaFile>&& file) const {
@@ -234,226 +332,63 @@ schema::Node::SourceInfo::Reader ParsedSchema::getSourceInfo() const {
   return KJ_ASSERT_NONNULL(parser->getSourceInfo(*this));
 }
 
-// =======================================================================================
-
-namespace {
-
-class MmapDisposer: public kj::ArrayDisposer {
-protected:
-  void disposeImpl(void* firstElement, size_t elementSize, size_t elementCount,
-                   size_t capacity, void (*destroyElement)(void*)) const {
-#if _WIN32
-    KJ_ASSERT(UnmapViewOfFile(firstElement));
-#else
-    munmap(firstElement, elementSize * elementCount);
-#endif
-  }
-};
-
-KJ_CONSTEXPR(static const) MmapDisposer mmapDisposer = MmapDisposer();
-
-static char* canonicalizePath(char* path) {
-  // Taken from some old C code of mine.
-
-  // Preconditions:
-  // - path has already been determined to be relative, perhaps because the pointer actually points
-  //   into the middle of some larger path string, in which case it must point to the character
-  //   immediately after a '/'.
-
-  // Invariants:
-  // - src points to the beginning of a path component.
-  // - dst points to the location where the path component should end up, if it is not special.
-  // - src == path or src[-1] == '/'.
-  // - dst == path or dst[-1] == '/'.
-
-  char* src = path;
-  char* dst = path;
-  char* locked = dst;  // dst cannot backtrack past this
-  char* partEnd;
-  bool hasMore;
-
-  for (;;) {
-    while (*src == '/') {
-      // Skip duplicate slash.
-      ++src;
-    }
-
-    partEnd = strchr(src, '/');
-    hasMore = partEnd != NULL;
-    if (hasMore) {
-      *partEnd = '\0';
-    } else {
-      partEnd = src + strlen(src);
-    }
-
-    if (strcmp(src, ".") == 0) {
-      // Skip it.
-    } else if (strcmp(src, "..") == 0) {
-      if (dst > locked) {
-        // Backtrack over last path component.
-        --dst;
-        while (dst > locked && dst[-1] != '/') --dst;
-      } else {
-        locked += 3;
-        goto copy;
-      }
-    } else {
-      // Copy if needed.
-    copy:
-      if (dst < src) {
-        memmove(dst, src, partEnd - src);
-        dst += partEnd - src;
-      } else {
-        dst = partEnd;
-      }
-      *dst++ = '/';
-    }
-
-    if (hasMore) {
-      src = partEnd + 1;
-    } else {
-      // Oops, we have to remove the trailing '/'.
-      if (dst == path) {
-        // Oops, there is no trailing '/'.  We have to return ".".
-        strcpy(path, ".");
-        return path + 1;
-      } else {
-        // Remove the trailing '/'.  Note that this means that opening the file will work even
-        // if it is not a directory, where normally it should fail on non-directories when a
-        // trailing '/' is present.  If this is a problem, we need to add some sort of special
-        // handling for this case where we stat() it separately to check if it is a directory,
-        // because Ekam findInput will not accept a trailing '/'.
-        --dst;
-        *dst = '\0';
-        return dst;
-      }
-    }
-  }
-}
-
-kj::String canonicalizePath(kj::StringPtr path) {
-  KJ_STACK_ARRAY(char, result, path.size() + 1, 128, 512);
-  strcpy(result.begin(), path.begin());
-
-  char* start = path.startsWith("/") ? result.begin() + 1 : result.begin();
-  char* end = canonicalizePath(start);
-  return kj::heapString(result.slice(0, end - result.begin()));
-}
-
-kj::String relativePath(kj::StringPtr base, kj::StringPtr add) {
-  if (add.size() > 0 && add[0] == '/') {
-    return kj::heapString(add);
-  }
-
-  const char* pos = base.end();
-  while (pos > base.begin() && pos[-1] != '/') {
-    --pos;
-  }
-
-  return kj::str(base.slice(0, pos - base.begin()), add);
-}
-
-kj::String joinPath(kj::StringPtr base, kj::StringPtr add) {
-  KJ_REQUIRE(!add.startsWith("/"));
-
-  return kj::str(base, '/', add);
-}
-
-}  // namespace
-
-const SchemaFile::DiskFileReader SchemaFile::DiskFileReader::instance =
-    SchemaFile::DiskFileReader();
-
-bool SchemaFile::DiskFileReader::exists(kj::StringPtr path) const {
-  return access(path.cStr(), F_OK) == 0;
-}
-
-kj::Array<const char> SchemaFile::DiskFileReader::read(kj::StringPtr path) const {
-  int fd;
-  // We already established that the file exists, so this should not fail.
-  KJ_SYSCALL(fd = open(path.cStr(), O_RDONLY), path);
-  kj::AutoCloseFd closer(fd);
-
-  struct stat stats;
-  KJ_SYSCALL(fstat(fd, &stats));
-
-  if (S_ISREG(stats.st_mode)) {
-    if (stats.st_size == 0) {
-      // mmap()ing zero bytes will fail.
-      return nullptr;
-    }
-
-    // Regular file.  Just mmap() it.
-#if _WIN32
-    HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
-    KJ_ASSERT(handle != INVALID_HANDLE_VALUE);
-    HANDLE mappingHandle = CreateFileMapping(
-        handle, NULL, PAGE_READONLY, 0, stats.st_size, NULL);
-    KJ_ASSERT(mappingHandle != INVALID_HANDLE_VALUE);
-    KJ_DEFER(KJ_ASSERT(CloseHandle(mappingHandle)));
-    const void* mapping = MapViewOfFile(mappingHandle, FILE_MAP_READ, 0, 0, stats.st_size);
-#else  // _WIN32
-    const void* mapping = mmap(NULL, stats.st_size, PROT_READ, MAP_SHARED, fd, 0);
-    if (mapping == MAP_FAILED) {
-      KJ_FAIL_SYSCALL("mmap", errno, path);
-    }
-#endif  // !_WIN32
-
-    return kj::Array<const char>(
-        reinterpret_cast<const char*>(mapping), stats.st_size, mmapDisposer);
-  } else {
-    // This could be a stream of some sort, like a pipe.  Fall back to read().
-    // TODO(cleanup):  This does a lot of copies.  Not sure I care.
-    kj::Vector<char> data(8192);
-
-    char buffer[4096];
-    for (;;) {
-      kj::miniposix::ssize_t n;
-      KJ_SYSCALL(n = ::read(fd, buffer, sizeof(buffer)));
-      if (n == 0) break;
-      data.addAll(buffer, buffer + n);
-    }
-
-    return data.releaseAsArray();
-  }
-}
-
 // -------------------------------------------------------------------
 
 class SchemaFile::DiskSchemaFile final: public SchemaFile {
 public:
-  DiskSchemaFile(const FileReader& fileReader, kj::String displayName,
-                 kj::String diskPath, kj::ArrayPtr<const kj::StringPtr> importPath)
-      : fileReader(fileReader),
-        displayName(kj::mv(displayName)),
-        diskPath(kj::mv(diskPath)),
-        importPath(importPath) {}
+  DiskSchemaFile(kj::ReadableDirectory& baseDir, kj::Path pathParam,
+                 kj::ArrayPtr<kj::ReadableDirectory* const> importPath,
+                 kj::Own<kj::ReadableFile> file,
+                 kj::Maybe<kj::String> displayNameOverride)
+      : baseDir(baseDir), path(kj::mv(pathParam)), importPath(importPath), file(kj::mv(file)) {
+    KJ_IF_MAYBE(dn, displayNameOverride) {
+      displayName = kj::mv(*dn);
+      displayNameOverridden = true;
+    } else {
+      displayName = path.toString();
+      displayNameOverridden = false;
+    }
+  }
 
   kj::StringPtr getDisplayName() const override {
     return displayName;
   }
 
   kj::Array<const char> readContent() const override {
-    return fileReader.read(diskPath);
+    auto lock = file.lockExclusive();
+    // TODO(soon): Should we say that KJ files must be thread-safe and mark all the methods const?
+    //   The disk-based implementations are already thread-safe. The in-memory implementations
+    //   are not thread-safe, in fact they are thread-hostile currently due to the non-threadsafe
+    //   refcounting.
+    return lock->get()->mmap(0, lock->get()->stat().size).releaseAsChars();
   }
 
-  kj::Maybe<kj::Own<SchemaFile>> import(kj::StringPtr path) const override {
-    if (path.startsWith("/")) {
+  kj::Maybe<kj::Own<SchemaFile>> import(kj::StringPtr target) const override {
+    if (target.startsWith("/")) {
+      auto parsed = kj::Path::parse(target.slice(1));
       for (auto candidate: importPath) {
-        kj::String newDiskPath = canonicalizePath(joinPath(candidate, path.slice(1)));
-        if (fileReader.exists(newDiskPath)) {
+        KJ_IF_MAYBE(newFile, candidate->tryOpenFile(parsed)) {
           return kj::implicitCast<kj::Own<SchemaFile>>(kj::heap<DiskSchemaFile>(
-              fileReader, canonicalizePath(path.slice(1)),
-              kj::mv(newDiskPath), importPath));
+              *candidate, kj::mv(parsed), importPath, kj::mv(*newFile), nullptr));
         }
       }
       return nullptr;
     } else {
-      kj::String newDiskPath = canonicalizePath(relativePath(diskPath, path));
-      if (fileReader.exists(newDiskPath)) {
+      auto parsed = path.parent().eval(target);
+
+      kj::Maybe<kj::String> displayNameOverride;
+      if (displayNameOverridden) {
+        // Try to create a consistent display name override for the imported file. This is for
+        // backwards-compatibility only -- display names are only overridden when using the
+        // deprecated parseDiskFile() interface.
+        kj::runCatchingExceptions([&]() {
+          displayNameOverride = kj::Path::parse(displayName).parent().eval(target).toString();
+        });
+      }
+
+      KJ_IF_MAYBE(newFile, baseDir.tryOpenFile(parsed)) {
         return kj::implicitCast<kj::Own<SchemaFile>>(kj::heap<DiskSchemaFile>(
-            fileReader, canonicalizePath(relativePath(displayName, path)),
-            kj::mv(newDiskPath), importPath));
+            baseDir, kj::mv(parsed), importPath, kj::mv(*newFile), kj::mv(displayNameOverride)));
       } else {
         return nullptr;
       }
@@ -461,40 +396,46 @@ public:
   }
 
   bool operator==(const SchemaFile& other) const override {
-    return diskPath == kj::downcast<const DiskSchemaFile>(other).diskPath;
+    auto& other2 = kj::downcast<const DiskSchemaFile>(other);
+    return &baseDir == &other2.baseDir && path == other2.path;
   }
   bool operator!=(const SchemaFile& other) const override {
-    return diskPath != kj::downcast<const DiskSchemaFile>(other).diskPath;
+    return !operator==(other);
   }
   size_t hashCode() const override {
     // djb hash with xor
     // TODO(someday):  Add hashing library to KJ.
-    size_t result = 5381;
-    for (char c: diskPath) {
-      result = (result * 33) ^ c;
+    size_t result = reinterpret_cast<uintptr_t>(&baseDir);
+    for (auto& part: path) {
+      for (char c: part) {
+        result = (result * 33) ^ c;
+      }
+      result = (result * 33) ^ '/';
     }
     return result;
   }
 
   void reportError(SourcePos start, SourcePos end, kj::StringPtr message) const override {
     kj::getExceptionCallback().onRecoverableException(kj::Exception(
-        kj::Exception::Type::FAILED, kj::heapString(diskPath), start.line,
+        kj::Exception::Type::FAILED, path.toString(), start.line,
         kj::heapString(message)));
   }
 
 private:
-  const FileReader& fileReader;
+  kj::ReadableDirectory& baseDir;
+  kj::Path path;
+  kj::ArrayPtr<kj::ReadableDirectory* const> importPath;
+  kj::MutexGuarded<kj::Own<kj::ReadableFile>> file;
   kj::String displayName;
-  kj::String diskPath;
-  kj::ArrayPtr<const kj::StringPtr> importPath;
+  bool displayNameOverridden;
 };
 
-kj::Own<SchemaFile> SchemaFile::newDiskFile(
-    kj::StringPtr displayName, kj::StringPtr diskPath,
-    kj::ArrayPtr<const kj::StringPtr> importPath,
-    const FileReader& fileReader) {
-  return kj::heap<DiskSchemaFile>(fileReader, canonicalizePath(displayName),
-                                  canonicalizePath(diskPath), importPath);
+kj::Own<SchemaFile> SchemaFile::newFromDirectory(
+    kj::ReadableDirectory& baseDir, kj::Path path,
+    kj::ArrayPtr<kj::ReadableDirectory* const> importPath,
+    kj::Maybe<kj::String> displayNameOverride) {
+  return kj::heap<DiskSchemaFile>(baseDir, kj::mv(path), importPath, baseDir.openFile(path),
+                                  kj::mv(displayNameOverride));
 }
 
 }  // namespace capnp

--- a/c++/src/capnp/schema-parser.h
+++ b/c++/src/capnp/schema-parser.h
@@ -44,8 +44,9 @@ public:
   SchemaParser();
   ~SchemaParser() noexcept(false);
 
-  ParsedSchema parseFromDirectory(kj::ReadableDirectory& baseDir, kj::Path path,
-                                  kj::ArrayPtr<kj::ReadableDirectory* const> importPath) const;
+  ParsedSchema parseFromDirectory(
+      const kj::ReadableDirectory& baseDir, kj::Path path,
+      kj::ArrayPtr<const kj::ReadableDirectory* const> importPath) const;
   // Parse a file from the KJ filesystem API.  Throws an exception if the file dosen't exist.
   //
   // `baseDir` and `path` are used together to resolve relative imports. `path` is the source
@@ -197,8 +198,8 @@ public:
   //   kj::ReadableDirectory, or using kj::newInMemoryDirectory().
 
   static kj::Own<SchemaFile> newFromDirectory(
-      kj::ReadableDirectory& baseDir, kj::Path path,
-      kj::ArrayPtr<kj::ReadableDirectory* const> importPath,
+      const kj::ReadableDirectory& baseDir, kj::Path path,
+      kj::ArrayPtr<const kj::ReadableDirectory* const> importPath,
       kj::Maybe<kj::String> displayNameOverride = nullptr);
   // Construct a SchemaFile representing a file in a kj::ReadableDirectory. This is used to
   // implement SchemaParser::parseFromDirectory(); see there for details.

--- a/c++/src/capnp/schema-parser.h
+++ b/c++/src/capnp/schema-parser.h
@@ -28,6 +28,7 @@
 
 #include "schema-loader.h"
 #include <kj/string.h>
+#include <kj/filesystem.h>
 
 namespace capnp {
 
@@ -43,31 +44,85 @@ public:
   SchemaParser();
   ~SchemaParser() noexcept(false);
 
-  ParsedSchema parseDiskFile(kj::StringPtr displayName, kj::StringPtr diskPath,
-                             kj::ArrayPtr<const kj::StringPtr> importPath) const;
-  // Parse a file located on disk.  Throws an exception if the file dosen't exist.
+  ParsedSchema parseFromDirectory(kj::ReadableDirectory& baseDir, kj::Path path,
+                                  kj::ArrayPtr<kj::ReadableDirectory* const> importPath) const;
+  // Parse a file from the KJ filesystem API.  Throws an exception if the file dosen't exist.
   //
-  // Parameters:
-  // * `displayName`:  The name that will appear in the file's schema node.  (If the file has
-  //   already been parsed, this will be ignored and the display name from the first time it was
-  //   parsed will be kept.)
-  // * `diskPath`:  The path to the file on disk.
-  // * `importPath`:  Directories to search when resolving absolute imports within this file
-  //   (imports that start with a `/`).  Must remain valid until the SchemaParser is destroyed.
-  //   (If the file has already been parsed, this will be ignored and the import path from the
-  //   first time it was parsed will be kept.)
+  // `baseDir` and `path` are used together to resolve relative imports. `path` is the source
+  // file's path within `baseDir`. Relative imports will be interpreted relative to `path` and
+  // will be opened using `baseDir`. Note that the KJ filesystem API prohibits "breaking out" of
+  // a directory using "..", so relative imports will be restricted to children of `baseDir`.
+  //
+  // `importPath` is used for absolute imports (imports that start with a '/'). Each directory in
+  // the array will be searched in order until a file is found.
+  //
+  // All `ReadableDirectory` objects must remain valid until the `SchemaParser` is destroyed. Also,
+  // the `importPath` array must remain valid. `path` will be copied; it need not remain valid.
   //
   // This method is a shortcut, equivalent to:
-  //     parser.parseFile(SchemaFile::newDiskFile(displayName, diskPath, importPath))`;
+  //     parser.parseFromDirectory(SchemaFile::newDiskFile(baseDir, path, importPath))`;
   //
   // This method throws an exception if any errors are encountered in the file or in anything the
   // file depends on.  Note that merely importing another file does not count as a dependency on
   // anything in the imported file -- only the imported types which are actually used are
   // "dependencies".
+  //
+  // Hint: Use kj::newDiskFilesystem() to initialize the KJ filesystem API. Usually you should do
+  //   this at a high level in your program, e.g. the main() function, and then pass down the
+  //   appropriate File/Directory objects to the components that need them. Example:
+  //
+  //     auto fs = kj::newDiskFilesystem();
+  //     SchemaParser parser;
+  //     auto schema = parser->parseFromDirectory(fs->getCurrent(),
+  //         kj::Path::parse("foo/bar.capnp"), nullptr);
+  //
+  // Hint: To use in-memory data rather than real disk, you can use kj::newInMemoryDirectory(),
+  //   write the files you want, then pass it to SchemaParser. Example:
+  //
+  //     auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  //     auto path = kj::Path::parse("foo/bar.capnp");
+  //     dir->openFile(path, kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT)
+  //        ->writeAll("struct Foo {}");
+  //     auto schema = parser->parseFromDirectory(*dir, path, nullptr);
+  //
+  // Hint: You can create an in-memory directory but then populate it with real files from disk,
+  //   in order to control what is visible while also avoiding reading files yourself or making
+  //   extra copies. Example:
+  //
+  //     auto fs = kj::newDiskFilesystem();
+  //     auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  //     auto fakePath = kj::Path::parse("foo/bar.capnp");
+  //     auto realPath = kj::Path::parse("path/to/some/file.capnp");
+  //     dir->transfer(fakePath, kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT,
+  //                   fs->getCurrent(), realPath, kj::TransferMode::LINK);
+  //     auto schema = parser->parseFromDirectory(*dir, fakePath, nullptr);
+  //
+  //   In this example, note that any imports in the file will fail, since the in-memory directory
+  //   you created contains no files except the specific one you linked in.
+
+  ParsedSchema parseDiskFile(kj::StringPtr displayName, kj::StringPtr diskPath,
+                             kj::ArrayPtr<const kj::StringPtr> importPath) const
+      CAPNP_DEPRECATED("Use parseFromDirectory() instead.");
+  // Creates a private kj::Filesystem and uses it to parse files from the real disk.
+  //
+  // DO NOT USE in new code. Use parseFromDirectory() instead.
+  //
+  // This API has a serious problem: the file can import and embed files located anywhere on disk
+  // using relative paths. Even if you specify no `importPath`, relative imports still work. By
+  // using `parseFromDirectory()`, you can arrange so that imports are only allowed within a
+  // particular directory, or even set up a dummy filesystem where other files are not visible.
+
+  void setDiskFilesystem(kj::Filesystem& fs)
+      CAPNP_DEPRECATED("Use parseFromDirectory() instead.");
+  // Call before calling parseDiskFile() to choose an alternative disk filesystem implementation.
+  // This exists mostly for testing purposes; new code should use parseFromDirectory() instead.
+  //
+  // If parseDiskFile() is called without having called setDiskFilesystem(), then
+  // kj::newDiskFilesystem() will be used instead.
 
   ParsedSchema parseFile(kj::Own<SchemaFile>&& file) const;
   // Advanced interface for parsing a file that may or may not be located in any global namespace.
-  // Most users will prefer `parseDiskFile()`.
+  // Most users will prefer `parseFromDirectory()`.
   //
   // If the file has already been parsed (that is, a SchemaFile that compares equal to this one
   // was parsed previously), the existing schema will be returned again.
@@ -90,6 +145,7 @@ public:
 
 private:
   struct Impl;
+  struct DiskFileCompat;
   class ModuleImpl;
   kj::Own<Impl> impl;
   mutable bool hadErrors = false;
@@ -135,44 +191,20 @@ class SchemaFile {
   // `SchemaFile::newDiskFile()`.
 
 public:
-  class FileReader {
-  public:
-    virtual bool exists(kj::StringPtr path) const = 0;
-    virtual kj::Array<const char> read(kj::StringPtr path) const = 0;
-  };
+  // Note: Cap'n Proto 0.6.x and below had classes FileReader and DiskFileReader and a method
+  //   newDiskFile() defined here. These were removed when SchemaParser was transitioned to use the
+  //   KJ filesystem API. You should be able to get the same effect by subclassing
+  //   kj::ReadableDirectory, or using kj::newInMemoryDirectory().
 
-  class DiskFileReader final: public FileReader {
-    // Implementation of FileReader that uses the local disk.  Files are read using mmap() if
-    // possible.
-
-  public:
-    static const DiskFileReader instance;
-
-    bool exists(kj::StringPtr path) const override;
-    kj::Array<const char> read(kj::StringPtr path) const override;
-  };
-
-  static kj::Own<SchemaFile> newDiskFile(
-      kj::StringPtr displayName, kj::StringPtr diskPath,
-      kj::ArrayPtr<const kj::StringPtr> importPath,
-      const FileReader& fileReader = DiskFileReader::instance);
-  // Construct a SchemaFile representing a file on disk (or located in the filesystem-like
-  // namespace represented by `fileReader`).
+  static kj::Own<SchemaFile> newFromDirectory(
+      kj::ReadableDirectory& baseDir, kj::Path path,
+      kj::ArrayPtr<kj::ReadableDirectory* const> importPath,
+      kj::Maybe<kj::String> displayNameOverride = nullptr);
+  // Construct a SchemaFile representing a file in a kj::ReadableDirectory. This is used to
+  // implement SchemaParser::parseFromDirectory(); see there for details.
   //
-  // Parameters:
-  // * `displayName`:  The name that will appear in the file's schema node.
-  // * `diskPath`:  The path to the file on disk.
-  // * `importPath`:  Directories to search when resolving absolute imports within this file
-  //   (imports that start with a `/`).  The array content must remain valid as long as the
-  //   SchemaFile exists (which is at least as long as the SchemaParser that parses it exists).
-  // * `fileReader`:  Allows you to use a filesystem other than the actual local disk.  Although,
-  //   if you find yourself using this, it may make more sense for you to implement SchemaFile
-  //   yourself.
-  //
-  // The SchemaFile compares equal to any other SchemaFile that has exactly the same disk path,
-  // after canonicalization.
-  //
-  // The SchemaFile will throw an exception if any errors are reported.
+  // The SchemaFile compares equal to any other SchemaFile that has exactly the same `baseDir`
+  // object (by identity) and `path` (by value).
 
   // -----------------------------------------------------------------
   // For more control, you can implement this interface.

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -310,10 +310,10 @@ KJ_TEST("DiskFile") {
     KJ_EXPECT(kj::str(writableMapping->get().slice(0, 6).asChars()) == "foobaz");
     KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "Foobaz");
 
-    writableMapping->get()[0] = 'D';
-    writableMapping->changed(writableMapping->get().slice(0, 1));
-    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "Doobaz");
-    KJ_EXPECT(kj::str(writableMapping->get().slice(0, 6).asChars()) == "Doobaz");
+    writableMapping->get()[1] = 'D';
+    writableMapping->changed(writableMapping->get().slice(1, 2));
+    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "fDobaz");
+    KJ_EXPECT(kj::str(writableMapping->get().slice(0, 6).asChars()) == "fDobaz");
     KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "Foobaz");
 
     file->write(0, StringPtr("qux").asBytes());

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -261,7 +261,7 @@ public:
 
   // OsHandle ------------------------------------------------------------------
 
-  AutoCloseFd clone() {
+  AutoCloseFd clone() const {
     int fd2;
 #ifdef F_DUPFD_CLOEXEC
     KJ_SYSCALL_HANDLE_ERRORS(fd2 = fcntl(fd, F_DUPFD_CLOEXEC, 3)) {
@@ -283,19 +283,19 @@ public:
     return result;
   }
 
-  int getFd() {
+  int getFd() const {
     return fd.get();
   }
 
   // FsNode --------------------------------------------------------------------
 
-  FsNode::Metadata stat() {
+  FsNode::Metadata stat() const {
     struct stat stats;
     KJ_SYSCALL(::fstat(fd, &stats));
     return statToMetadata(stats);
   }
 
-  void sync() {
+  void sync() const {
 #if __APPLE__
     // For whatever reason, fsync() on OSX only flushes kernel buffers. It does not flush hardware
     // disk buffers. This makes it not very useful. But OSX documents fcntl F_FULLFSYNC which does
@@ -306,7 +306,7 @@ public:
 #endif
   }
 
-  void datasync() {
+  void datasync() const {
     // The presence of the _POSIX_SYNCHRONIZED_IO define is supposed to tell us that fdatasync()
     // exists. But Apple defines this yet doesn't offer fdatasync(). Thanks, Apple.
 #if _POSIX_SYNCHRONIZED_IO && !__APPLE__
@@ -318,7 +318,7 @@ public:
 
   // ReadableFile --------------------------------------------------------------
 
-  size_t read(uint64_t offset, ArrayPtr<byte> buffer) {
+  size_t read(uint64_t offset, ArrayPtr<byte> buffer) const {
     // pread() probably never returns short reads unless it hits EOF. Unfortunately, though, per
     // spec we are not allowed to assume this.
 
@@ -334,7 +334,7 @@ public:
     return total;
   }
 
-  Array<const byte> mmap(uint64_t offset, uint64_t size) {
+  Array<const byte> mmap(uint64_t offset, uint64_t size) const {
     auto range = getMmapRange(offset, size);
     const void* mapping = ::mmap(NULL, range.size, PROT_READ, MAP_SHARED, fd, range.offset);
     if (mapping == MAP_FAILED) {
@@ -344,7 +344,7 @@ public:
                              size, mmapDisposer);
   }
 
-  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) {
+  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) const {
     auto range = getMmapRange(offset, size);
     void* mapping = ::mmap(NULL, range.size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, range.offset);
     if (mapping == MAP_FAILED) {
@@ -356,7 +356,7 @@ public:
 
   // File ----------------------------------------------------------------------
 
-  void write(uint64_t offset, ArrayPtr<const byte> data) {
+  void write(uint64_t offset, ArrayPtr<const byte> data) const {
     // pwrite() probably never returns short writes unless there's no space left on disk.
     // Unfortunately, though, per spec we are not allowed to assume this.
 
@@ -369,7 +369,7 @@ public:
     }
   }
 
-  void zero(uint64_t offset, uint64_t size)  {
+  void zero(uint64_t offset, uint64_t size) const {
 #ifdef FALLOC_FL_PUNCH_HOLE
     KJ_SYSCALL_HANDLE_ERRORS(
         fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, size)) {
@@ -426,7 +426,7 @@ public:
 #endif
   }
 
-  void truncate(uint64_t size)  {
+  void truncate(uint64_t size) const {
     KJ_SYSCALL(ftruncate(fd, size));
   }
 
@@ -434,11 +434,13 @@ public:
   public:
     WritableFileMappingImpl(Array<byte> bytes): bytes(kj::mv(bytes)) {}
 
-    ArrayPtr<byte> get() override {
-      return bytes;
+    ArrayPtr<byte> get() const override {
+      // const_cast OK because WritableFileMapping does indeed provide a writable view despite
+      // being const itself.
+      return arrayPtr(const_cast<byte*>(bytes.begin()), bytes.size());
     }
 
-    void changed(ArrayPtr<byte> slice) override {
+    void changed(ArrayPtr<byte> slice) const override {
       KJ_REQUIRE(slice.begin() >= bytes.begin() && slice.end() <= bytes.end(),
                  "byte range is not part of this mapping");
 
@@ -447,7 +449,7 @@ public:
       KJ_SYSCALL(msync(reinterpret_cast<void*>(range.offset), range.size, MS_ASYNC));
     }
 
-    void sync(ArrayPtr<byte> slice) override {
+    void sync(ArrayPtr<byte> slice) const override {
       KJ_REQUIRE(slice.begin() >= bytes.begin() && slice.end() <= bytes.end(),
                  "byte range is not part of this mapping");
 
@@ -460,7 +462,7 @@ public:
     Array<byte> bytes;
   };
 
-  Own<WritableFileMapping> mmapWritable(uint64_t offset, uint64_t size)  {
+  Own<const WritableFileMapping> mmapWritable(uint64_t offset, uint64_t size) const {
     auto range = getMmapRange(offset, size);
     void* mapping = ::mmap(NULL, range.size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, range.offset);
     if (mapping == MAP_FAILED) {
@@ -471,7 +473,7 @@ public:
     return heap<WritableFileMappingImpl>(kj::mv(array));
   }
 
-  size_t copyChunk(uint64_t offset, int fromFd, uint64_t fromOffset, uint64_t size) {
+  size_t copyChunk(uint64_t offset, int fromFd, uint64_t fromOffset, uint64_t size) const {
     // Copies a range of bytes from `fromFd` to this file in the most efficient way possible for
     // the OS. Only returns less than `size` if EOF. Does not account for holes.
 
@@ -510,7 +512,8 @@ public:
     return total;
   }
 
-  kj::Maybe<size_t> copy(uint64_t offset, ReadableFile& from, uint64_t fromOffset, uint64_t size) {
+  kj::Maybe<size_t> copy(uint64_t offset, const ReadableFile& from,
+                         uint64_t fromOffset, uint64_t size) const {
     KJ_IF_MAYBE(otherFd, from.getFd()) {
 #ifdef FICLONE
       if (offset == 0 && fromOffset == 0 && size == kj::maxValue && stat().size == 0) {
@@ -629,7 +632,7 @@ public:
   // ReadableDirectory ---------------------------------------------------------
 
   template <typename Func>
-  auto list(bool needTypes, Func&& func)
+  auto list(bool needTypes, Func&& func) const
       -> Array<Decay<decltype(func(instance<StringPtr>(), instance<FsNode::Type>()))>> {
     // Seek to start of directory.
     KJ_SYSCALL(lseek(fd, 0, SEEK_SET));
@@ -686,17 +689,17 @@ public:
     return result;
   }
 
-  Array<String> listNames() {
+  Array<String> listNames() const {
     return list(false, [](StringPtr name, FsNode::Type type) { return heapString(name); });
   }
 
-  Array<ReadableDirectory::Entry> listEntries() {
+  Array<ReadableDirectory::Entry> listEntries() const {
     return list(true, [](StringPtr name, FsNode::Type type) {
       return ReadableDirectory::Entry { type, heapString(name), };
     });
   }
 
-  bool exists(PathPtr path) {
+  bool exists(PathPtr path) const {
     KJ_SYSCALL_HANDLE_ERRORS(faccessat(fd, path.toString().cStr(), F_OK, 0)) {
       case ENOENT:
       case ENOTDIR:
@@ -707,7 +710,7 @@ public:
     return true;
   }
 
-  Maybe<FsNode::Metadata> tryLstat(PathPtr path) {
+  Maybe<FsNode::Metadata> tryLstat(PathPtr path) const {
     struct stat stats;
     KJ_SYSCALL_HANDLE_ERRORS(fstatat(fd, path.toString().cStr(), &stats, AT_SYMLINK_NOFOLLOW)) {
       case ENOENT:
@@ -719,7 +722,7 @@ public:
     return statToMetadata(stats);
   }
 
-  Maybe<Own<ReadableFile>> tryOpenFile(PathPtr path) {
+  Maybe<Own<const ReadableFile>> tryOpenFile(PathPtr path) const {
     int newFd;
     KJ_SYSCALL_HANDLE_ERRORS(newFd = openat(
         fd, path.toString().cStr(), O_RDONLY | MAYBE_O_CLOEXEC)) {
@@ -738,7 +741,7 @@ public:
     return newDiskReadableFile(kj::mv(result));
   }
 
-  Maybe<AutoCloseFd> tryOpenSubdirInternal(PathPtr path) {
+  Maybe<AutoCloseFd> tryOpenSubdirInternal(PathPtr path) const {
     int newFd;
     KJ_SYSCALL_HANDLE_ERRORS(newFd = openat(
         fd, path.toString().cStr(), O_RDONLY | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY)) {
@@ -764,11 +767,11 @@ public:
     return kj::mv(result);
   }
 
-  Maybe<Own<ReadableDirectory>> tryOpenSubdir(PathPtr path) {
+  Maybe<Own<const ReadableDirectory>> tryOpenSubdir(PathPtr path) const {
     return tryOpenSubdirInternal(path).map(newDiskReadableDirectory);
   }
 
-  Maybe<String> tryReadlink(PathPtr path) {
+  Maybe<String> tryReadlink(PathPtr path) const {
     size_t trySize = 256;
     for (;;) {
       KJ_STACK_ARRAY(char, buf, trySize, 256, 4096);
@@ -799,7 +802,7 @@ public:
 
   // Directory -----------------------------------------------------------------
 
-  bool tryMkdir(PathPtr path, WriteMode mode, bool noThrow) {
+  bool tryMkdir(PathPtr path, WriteMode mode, bool noThrow) const {
     // Internal function to make a directory.
 
     auto filename = path.toString();
@@ -849,7 +852,7 @@ public:
   }
 
   kj::Maybe<String> createNamedTemporary(
-      PathPtr finalName, WriteMode mode, Function<int(StringPtr)> tryCreate) {
+      PathPtr finalName, WriteMode mode, Function<int(StringPtr)> tryCreate) const {
     // Create a temporary file which will eventually replace `finalName`.
     //
     // Calls `tryCreate` to actually create the temporary, passing in the desired path. tryCreate()
@@ -895,7 +898,7 @@ public:
     return kj::mv(path);
   }
 
-  bool tryReplaceNode(PathPtr path, WriteMode mode, Function<int(StringPtr)> tryCreate) {
+  bool tryReplaceNode(PathPtr path, WriteMode mode, Function<int(StringPtr)> tryCreate) const {
     // Replaces the given path with an object created by calling tryCreate().
     //
     // tryCreate() must behave like a syscall which creates the node at the path passed to it,
@@ -959,7 +962,7 @@ public:
     }
   }
 
-  Maybe<AutoCloseFd> tryOpenFileInternal(PathPtr path, WriteMode mode, bool append) {
+  Maybe<AutoCloseFd> tryOpenFileInternal(PathPtr path, WriteMode mode, bool append) const {
     uint flags = O_RDWR | MAYBE_O_CLOEXEC;
     mode_t acl = 0666;
     if (has(mode, WriteMode::CREATE)) {
@@ -1037,7 +1040,7 @@ public:
   }
 
   bool tryCommitReplacement(StringPtr toPath, int fromDirFd, StringPtr fromPath, WriteMode mode,
-                            int* errorReason = nullptr) {
+                            int* errorReason = nullptr) const {
     if (has(mode, WriteMode::CREATE) && has(mode, WriteMode::MODIFY)) {
       // Always clobber. Try it.
       KJ_SYSCALL_HANDLE_ERRORS(renameat(fromDirFd, fromPath.cStr(), fd.get(), toPath.cStr())) {
@@ -1227,7 +1230,7 @@ public:
   template <typename T>
   class ReplacerImpl final: public Directory::Replacer<T> {
   public:
-    ReplacerImpl(Own<T>&& object, DiskHandle& handle,
+    ReplacerImpl(Own<const T>&& object, const DiskHandle& handle,
                  String&& tempPath, String&& path, WriteMode mode)
         : Directory::Replacer<T>(mode),
           object(kj::mv(object)), handle(handle),
@@ -1239,7 +1242,7 @@ public:
       }
     }
 
-    T& get() override {
+    const T& get() override {
       return *object;
     }
 
@@ -1250,8 +1253,8 @@ public:
     }
 
   private:
-    Own<T> object;
-    DiskHandle& handle;
+    Own<const T> object;
+    const DiskHandle& handle;
     String tempPath;
     String path;
     bool committed = false;  // true if *successfully* committed (in which case tempPath is gone)
@@ -1262,22 +1265,22 @@ public:
     // For recovery path when exceptions are disabled.
 
   public:
-    BrokenReplacer(Own<T> inner)
+    BrokenReplacer(Own<const T> inner)
         : Directory::Replacer<T>(WriteMode::CREATE | WriteMode::MODIFY),
           inner(kj::mv(inner)) {}
 
-    T& get() override { return *inner; }
+    const T& get() override { return *inner; }
     bool tryCommit() override { return false; }
 
   private:
-    Own<T> inner;
+    Own<const T> inner;
   };
 
-  Maybe<Own<File>> tryOpenFile(PathPtr path, WriteMode mode) {
+  Maybe<Own<const File>> tryOpenFile(PathPtr path, WriteMode mode) const {
     return tryOpenFileInternal(path, mode, false).map(newDiskFile);
   }
 
-  Own<Directory::Replacer<File>> replaceFile(PathPtr path, WriteMode mode) {
+  Own<Directory::Replacer<File>> replaceFile(PathPtr path, WriteMode mode) const {
     mode_t acl = 0666;
     if (has(mode, WriteMode::EXECUTABLE)) {
       acl = 0777;
@@ -1304,7 +1307,7 @@ public:
     }
   }
 
-  Own<File> createTemporary() {
+  Own<const File> createTemporary() const {
     int newFd_;
 
 #if __linux__ && defined(O_TMPFILE)
@@ -1345,11 +1348,11 @@ public:
     }
   }
 
-  Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) {
+  Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) const {
     return tryOpenFileInternal(path, mode, true).map(newDiskAppendableFile);
   }
 
-  Maybe<Own<Directory>> tryOpenSubdir(PathPtr path, WriteMode mode) {
+  Maybe<Own<const Directory>> tryOpenSubdir(PathPtr path, WriteMode mode) const {
     // Must create before open.
     if (has(mode, WriteMode::CREATE)) {
       if (!tryMkdir(path, mode, false)) return nullptr;
@@ -1358,7 +1361,7 @@ public:
     return tryOpenSubdirInternal(path).map(newDiskDirectory);
   }
 
-  Own<Directory::Replacer<Directory>> replaceSubdir(PathPtr path, WriteMode mode) {
+  Own<Directory::Replacer<Directory>> replaceSubdir(PathPtr path, WriteMode mode) const {
     mode_t acl = has(mode, WriteMode::PRIVATE) ? 0700 : 0777;
 
     KJ_IF_MAYBE(temp, createNamedTemporary(path, mode,
@@ -1385,15 +1388,15 @@ public:
     }
   }
 
-  bool trySymlink(PathPtr linkpath, StringPtr content, WriteMode mode) {
+  bool trySymlink(PathPtr linkpath, StringPtr content, WriteMode mode) const {
     return tryReplaceNode(linkpath, mode, [&](StringPtr candidatePath) {
       return symlinkat(content.cStr(), fd, candidatePath.cStr());
     });
   }
 
   bool tryTransfer(PathPtr toPath, WriteMode toMode,
-                   Directory& fromDirectory, PathPtr fromPath,
-                   TransferMode mode, Directory& self) {
+                   const Directory& fromDirectory, PathPtr fromPath,
+                   TransferMode mode, const Directory& self) const {
     KJ_REQUIRE(toPath.size() > 0, "can't replace self") { return false; }
 
     if (mode == TransferMode::LINK) {
@@ -1444,7 +1447,7 @@ public:
     return self.Directory::tryTransfer(toPath, toMode, fromDirectory, fromPath, mode);
   }
 
-  bool tryRemove(PathPtr path) {
+  bool tryRemove(PathPtr path) const {
     return rmrf(fd, path.toString());
   }
 
@@ -1452,16 +1455,16 @@ protected:
   AutoCloseFd fd;
 };
 
-#define FSNODE_METHODS(classname)                             \
-  Maybe<int> getFd() override { return DiskHandle::getFd(); } \
-                                                              \
-  Own<FsNode> cloneFsNode() override {                        \
-    return heap<classname>(DiskHandle::clone());              \
-  }                                                           \
-                                                              \
-  Metadata stat() override { return DiskHandle::stat(); }     \
-  void sync() override { DiskHandle::sync(); }                \
-  void datasync() override { DiskHandle::datasync(); }
+#define FSNODE_METHODS(classname)                                   \
+  Maybe<int> getFd() const override { return DiskHandle::getFd(); } \
+                                                                    \
+  Own<const FsNode> cloneFsNode() const override {                  \
+    return heap<classname>(DiskHandle::clone());                    \
+  }                                                                 \
+                                                                    \
+  Metadata stat() const override { return DiskHandle::stat(); }     \
+  void sync() const override { DiskHandle::sync(); }                \
+  void datasync() const override { DiskHandle::datasync(); }
 
 class DiskReadableFile final: public ReadableFile, public DiskHandle {
 public:
@@ -1469,13 +1472,13 @@ public:
 
   FSNODE_METHODS(DiskReadableFile);
 
-  size_t read(uint64_t offset, ArrayPtr<byte> buffer) override {
+  size_t read(uint64_t offset, ArrayPtr<byte> buffer) const override {
     return DiskHandle::read(offset, buffer);
   }
-  Array<const byte> mmap(uint64_t offset, uint64_t size) override {
+  Array<const byte> mmap(uint64_t offset, uint64_t size) const override {
     return DiskHandle::mmap(offset, size);
   }
-  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) override {
+  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) const override {
     return DiskHandle::mmapPrivate(offset, size);
   }
 };
@@ -1488,7 +1491,9 @@ public:
 
   FSNODE_METHODS(DiskAppendableFile);
 
-  void write(const void* buffer, size_t size) override { FdOutputStream::write(buffer, size); }
+  void write(const void* buffer, size_t size) override {
+    FdOutputStream::write(buffer, size);
+  }
   void write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
     FdOutputStream::write(pieces);
   }
@@ -1500,29 +1505,30 @@ public:
 
   FSNODE_METHODS(DiskFile);
 
-  size_t read(uint64_t offset, ArrayPtr<byte> buffer) override {
+  size_t read(uint64_t offset, ArrayPtr<byte> buffer) const override {
     return DiskHandle::read(offset, buffer);
   }
-  Array<const byte> mmap(uint64_t offset, uint64_t size) override {
+  Array<const byte> mmap(uint64_t offset, uint64_t size) const override {
     return DiskHandle::mmap(offset, size);
   }
-  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) override {
+  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) const override {
     return DiskHandle::mmapPrivate(offset, size);
   }
 
-  void write(uint64_t offset, ArrayPtr<const byte> data) override {
+  void write(uint64_t offset, ArrayPtr<const byte> data) const override {
     DiskHandle::write(offset, data);
   }
-  void zero(uint64_t offset, uint64_t size) override {
+  void zero(uint64_t offset, uint64_t size) const override {
     DiskHandle::zero(offset, size);
   }
-  void truncate(uint64_t size) override {
+  void truncate(uint64_t size) const override {
     DiskHandle::truncate(size);
   }
-  Own<WritableFileMapping> mmapWritable(uint64_t offset, uint64_t size) override {
+  Own<const WritableFileMapping> mmapWritable(uint64_t offset, uint64_t size) const override {
     return DiskHandle::mmapWritable(offset, size);
   }
-  size_t copy(uint64_t offset, ReadableFile& from, uint64_t fromOffset, uint64_t size) override {
+  size_t copy(uint64_t offset, const ReadableFile& from,
+              uint64_t fromOffset, uint64_t size) const override {
     KJ_IF_MAYBE(result, DiskHandle::copy(offset, from, fromOffset, size)) {
       return *result;
     } else {
@@ -1537,17 +1543,19 @@ public:
 
   FSNODE_METHODS(DiskReadableDirectory);
 
-  Array<String> listNames() override { return DiskHandle::listNames(); }
-  Array<Entry> listEntries() override { return DiskHandle::listEntries(); }
-  bool exists(PathPtr path) override { return DiskHandle::exists(path); }
-  Maybe<FsNode::Metadata> tryLstat(PathPtr path) override { return DiskHandle::tryLstat(path); }
-  Maybe<Own<ReadableFile>> tryOpenFile(PathPtr path) override {
+  Array<String> listNames() const override { return DiskHandle::listNames(); }
+  Array<Entry> listEntries() const override { return DiskHandle::listEntries(); }
+  bool exists(PathPtr path) const override { return DiskHandle::exists(path); }
+  Maybe<FsNode::Metadata> tryLstat(PathPtr path) const override {
+    return DiskHandle::tryLstat(path);
+  }
+  Maybe<Own<const ReadableFile>> tryOpenFile(PathPtr path) const override {
     return DiskHandle::tryOpenFile(path);
   }
-  Maybe<Own<ReadableDirectory>> tryOpenSubdir(PathPtr path) override {
+  Maybe<Own<const ReadableDirectory>> tryOpenSubdir(PathPtr path) const override {
     return DiskHandle::tryOpenSubdir(path);
   }
-  Maybe<String> tryReadlink(PathPtr path) override { return DiskHandle::tryReadlink(path); }
+  Maybe<String> tryReadlink(PathPtr path) const override { return DiskHandle::tryReadlink(path); }
 };
 
 class DiskDirectory final: public Directory, public DiskHandle {
@@ -1556,46 +1564,48 @@ public:
 
   FSNODE_METHODS(DiskDirectory);
 
-  Array<String> listNames() override { return DiskHandle::listNames(); }
-  Array<Entry> listEntries() override { return DiskHandle::listEntries(); }
-  bool exists(PathPtr path) override { return DiskHandle::exists(path); }
-  Maybe<FsNode::Metadata> tryLstat(PathPtr path) override { return DiskHandle::tryLstat(path); }
-  Maybe<Own<ReadableFile>> tryOpenFile(PathPtr path) override {
+  Array<String> listNames() const override { return DiskHandle::listNames(); }
+  Array<Entry> listEntries() const override { return DiskHandle::listEntries(); }
+  bool exists(PathPtr path) const override { return DiskHandle::exists(path); }
+  Maybe<FsNode::Metadata> tryLstat(PathPtr path) const override {
+    return DiskHandle::tryLstat(path);
+  }
+  Maybe<Own<const ReadableFile>> tryOpenFile(PathPtr path) const override {
     return DiskHandle::tryOpenFile(path);
   }
-  Maybe<Own<ReadableDirectory>> tryOpenSubdir(PathPtr path) override {
+  Maybe<Own<const ReadableDirectory>> tryOpenSubdir(PathPtr path) const override {
     return DiskHandle::tryOpenSubdir(path);
   }
-  Maybe<String> tryReadlink(PathPtr path) override { return DiskHandle::tryReadlink(path); }
+  Maybe<String> tryReadlink(PathPtr path) const override { return DiskHandle::tryReadlink(path); }
 
-  Maybe<Own<File>> tryOpenFile(PathPtr path, WriteMode mode) override {
+  Maybe<Own<const File>> tryOpenFile(PathPtr path, WriteMode mode) const override {
     return DiskHandle::tryOpenFile(path, mode);
   }
-  Own<Replacer<File>> replaceFile(PathPtr path, WriteMode mode) override {
+  Own<Replacer<File>> replaceFile(PathPtr path, WriteMode mode) const override {
     return DiskHandle::replaceFile(path, mode);
   }
-  Own<File> createTemporary() override {
+  Own<const File> createTemporary() const override {
     return DiskHandle::createTemporary();
   }
-  Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) override {
+  Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) const override {
     return DiskHandle::tryAppendFile(path, mode);
   }
-  Maybe<Own<Directory>> tryOpenSubdir(PathPtr path, WriteMode mode) override {
+  Maybe<Own<const Directory>> tryOpenSubdir(PathPtr path, WriteMode mode) const override {
     return DiskHandle::tryOpenSubdir(path, mode);
   }
-  Own<Replacer<Directory>> replaceSubdir(PathPtr path, WriteMode mode) override {
+  Own<Replacer<Directory>> replaceSubdir(PathPtr path, WriteMode mode) const override {
     return DiskHandle::replaceSubdir(path, mode);
   }
-  bool trySymlink(PathPtr linkpath, StringPtr content, WriteMode mode) override {
+  bool trySymlink(PathPtr linkpath, StringPtr content, WriteMode mode) const override {
     return DiskHandle::trySymlink(linkpath, content, mode);
   }
   bool tryTransfer(PathPtr toPath, WriteMode toMode,
-                   Directory& fromDirectory, PathPtr fromPath,
-                   TransferMode mode) override {
+                   const Directory& fromDirectory, PathPtr fromPath,
+                   TransferMode mode) const override {
     return DiskHandle::tryTransfer(toPath, toMode, fromDirectory, fromPath, mode, *this);
   }
   // tryTransferTo() not implemented because we have nothing special we can do.
-  bool tryRemove(PathPtr path) override {
+  bool tryRemove(PathPtr path) const override {
     return DiskHandle::tryRemove(path);
   }
 };
@@ -1607,15 +1617,15 @@ public:
         current(openDir(".")),
         currentPath(computeCurrentPath()) {}
 
-  Directory& getRoot() override {
+  const Directory& getRoot() const override {
     return root;
   }
 
-  Directory& getCurrent() override {
+  const Directory& getCurrent() const override {
     return current;
   }
 
-  PathPtr getCurrentPath() override {
+  PathPtr getCurrentPath() const override {
     return currentPath;
   }
 

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -298,7 +298,7 @@ protected:
   }
 };
 
-#if _MSC_VER < 1910
+#if _MSC_VER && _MSC_VER < 1910
 // TODO(msvc): MSVC 2015 can't initialize a constexpr's vtable correctly.
 const MmapDisposer mmapDisposer = MmapDisposer();
 #else

--- a/c++/src/kj/filesystem-test.c++
+++ b/c++/src/kj/filesystem-test.c++
@@ -86,6 +86,47 @@ KJ_TEST("Path") {
   KJ_EXPECT(kj::str(Path({"foo", "bar"})) == "foo/bar");
 }
 
+KJ_TEST("Path comparisons") {
+  KJ_EXPECT(Path({"foo", "bar"}) == Path({"foo", "bar"}));
+  KJ_EXPECT(!(Path({"foo", "bar"}) != Path({"foo", "bar"})));
+  KJ_EXPECT(Path({"foo", "bar"}) != Path({"foo", "baz"}));
+  KJ_EXPECT(!(Path({"foo", "bar"}) == Path({"foo", "baz"})));
+
+  KJ_EXPECT(Path({"foo", "bar"}) != Path({"fob", "bar"}));
+  KJ_EXPECT(Path({"foo", "bar"}) != Path({"foo", "bar", "baz"}));
+  KJ_EXPECT(Path({"foo", "bar", "baz"}) != Path({"foo", "bar"}));
+
+  KJ_EXPECT(Path({"foo", "bar"}) <= Path({"foo", "bar"}));
+  KJ_EXPECT(Path({"foo", "bar"}) >= Path({"foo", "bar"}));
+  KJ_EXPECT(!(Path({"foo", "bar"}) < Path({"foo", "bar"})));
+  KJ_EXPECT(!(Path({"foo", "bar"}) > Path({"foo", "bar"})));
+
+  KJ_EXPECT(Path({"foo", "bar"}) < Path({"foo", "bar", "baz"}));
+  KJ_EXPECT(!(Path({"foo", "bar"}) > Path({"foo", "bar", "baz"})));
+  KJ_EXPECT(Path({"foo", "bar", "baz"}) > Path({"foo", "bar"}));
+  KJ_EXPECT(!(Path({"foo", "bar", "baz"}) < Path({"foo", "bar"})));
+
+  KJ_EXPECT(Path({"foo", "bar"}) < Path({"foo", "baz"}));
+  KJ_EXPECT(Path({"foo", "bar"}) > Path({"foo", "baa"}));
+  KJ_EXPECT(Path({"foo", "bar"}) > Path({"foo"}));
+
+  KJ_EXPECT(Path({"foo", "bar"}).startsWith(Path({})));
+  KJ_EXPECT(Path({"foo", "bar"}).startsWith(Path({"foo"})));
+  KJ_EXPECT(Path({"foo", "bar"}).startsWith(Path({"foo", "bar"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).startsWith(Path({"foo", "bar", "baz"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).startsWith(Path({"foo", "baz"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).startsWith(Path({"baz", "foo", "bar"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).startsWith(Path({"baz"})));
+
+  KJ_EXPECT(Path({"foo", "bar"}).endsWith(Path({})));
+  KJ_EXPECT(Path({"foo", "bar"}).endsWith(Path({"bar"})));
+  KJ_EXPECT(Path({"foo", "bar"}).endsWith(Path({"foo", "bar"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).endsWith(Path({"baz", "foo", "bar"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).endsWith(Path({"fob", "bar"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).endsWith(Path({"foo", "bar", "baz"})));
+  KJ_EXPECT(!Path({"foo", "bar"}).endsWith(Path({"baz"})));
+}
+
 KJ_TEST("Path exceptions") {
   KJ_EXPECT_THROW_MESSAGE("invalid path component", Path(""));
   KJ_EXPECT_THROW_MESSAGE("invalid path component", Path("."));

--- a/c++/src/kj/filesystem-test.c++
+++ b/c++/src/kj/filesystem-test.c++
@@ -264,13 +264,13 @@ public:
     time += 1 * SECONDS;
   }
 
-  Date now() override { return time; }
+  Date now() const override { return time; }
 
-  void expectChanged(FsNode& file) {
+  void expectChanged(const FsNode& file) {
     KJ_EXPECT(file.stat().lastModified == time);
     time += 1 * SECONDS;
   }
-  void expectUnchanged(FsNode& file) {
+  void expectUnchanged(const FsNode& file) {
     KJ_EXPECT(file.stat().lastModified != time);
   }
 

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -779,7 +779,8 @@ public:
   }
 
   Metadata stat() override {
-    return Metadata { Type::FILE, size, size, lastModified, 1 };
+    uint64_t hash = reinterpret_cast<uintptr_t>(this);
+    return Metadata { Type::FILE, size, size, lastModified, 1, hash };
   }
 
   void sync() override {}
@@ -967,7 +968,8 @@ public:
   }
 
   Metadata stat() override {
-    return Metadata { Type::DIRECTORY, 0, 0, lastModified, 1 };
+    uint64_t hash = reinterpret_cast<uintptr_t>(this);
+    return Metadata { Type::DIRECTORY, 0, 0, lastModified, 1, hash };
   }
 
   void sync() override {}
@@ -1023,7 +1025,8 @@ public:
           return entry->node.get<DirectoryNode>().directory->stat();
         } else if (entry->node.is<SymlinkNode>()) {
           auto& link = entry->node.get<SymlinkNode>();
-          return FsNode::Metadata { FsNode::Type::SYMLINK, 0, 0, link.lastModified, 1 };
+          uint64_t hash = reinterpret_cast<uintptr_t>(link.content.begin());
+          return FsNode::Metadata { FsNode::Type::SYMLINK, 0, 0, link.lastModified, 1, hash };
         } else {
           KJ_FAIL_ASSERT("unknown node type") { return nullptr; }
         }

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -25,6 +25,7 @@
 #include "one-of.h"
 #include "encoding.h"
 #include "refcount.h"
+#include "mutex.h"
 #include <map>
 
 namespace kj {
@@ -482,7 +483,7 @@ bool Path::isWin32Special(StringPtr part) {
 
 // =======================================================================================
 
-String ReadableFile::readAllText() {
+String ReadableFile::readAllText() const {
   String result = heapString(stat().size);
   size_t n = read(0, result.asBytes());
   if (n < result.size()) {
@@ -492,7 +493,7 @@ String ReadableFile::readAllText() {
   return result;
 }
 
-Array<byte> ReadableFile::readAllBytes() {
+Array<byte> ReadableFile::readAllBytes() const {
   Array<byte> result = heapArray<byte>(stat().size);
   size_t n = read(0, result.asBytes());
   if (n < result.size()) {
@@ -502,16 +503,17 @@ Array<byte> ReadableFile::readAllBytes() {
   return result;
 }
 
-void File::writeAll(ArrayPtr<const byte> bytes) {
+void File::writeAll(ArrayPtr<const byte> bytes) const {
   truncate(0);
   write(0, bytes);
 }
 
-void File::writeAll(StringPtr text) {
+void File::writeAll(StringPtr text) const {
   writeAll(text.asBytes());
 }
 
-size_t File::copy(uint64_t offset, ReadableFile& from, uint64_t fromOffset, uint64_t size) {
+size_t File::copy(uint64_t offset, const ReadableFile& from,
+                  uint64_t fromOffset, uint64_t size) const {
   byte buffer[8192];
 
   size_t result = 0;
@@ -531,7 +533,7 @@ size_t File::copy(uint64_t offset, ReadableFile& from, uint64_t fromOffset, uint
   return result;
 }
 
-FsNode::Metadata ReadableDirectory::lstat(PathPtr path) {
+FsNode::Metadata ReadableDirectory::lstat(PathPtr path) const {
   KJ_IF_MAYBE(meta, tryLstat(path)) {
     return *meta;
   } else {
@@ -540,7 +542,7 @@ FsNode::Metadata ReadableDirectory::lstat(PathPtr path) {
   }
 }
 
-Own<ReadableFile> ReadableDirectory::openFile(PathPtr path) {
+Own<const ReadableFile> ReadableDirectory::openFile(PathPtr path) const {
   KJ_IF_MAYBE(file, tryOpenFile(path)) {
     return kj::mv(*file);
   } else {
@@ -549,7 +551,7 @@ Own<ReadableFile> ReadableDirectory::openFile(PathPtr path) {
   }
 }
 
-Own<ReadableDirectory> ReadableDirectory::openSubdir(PathPtr path) {
+Own<const ReadableDirectory> ReadableDirectory::openSubdir(PathPtr path) const {
   KJ_IF_MAYBE(dir, tryOpenSubdir(path)) {
     return kj::mv(*dir);
   } else {
@@ -558,7 +560,7 @@ Own<ReadableDirectory> ReadableDirectory::openSubdir(PathPtr path) {
   }
 }
 
-String ReadableDirectory::readlink(PathPtr path) {
+String ReadableDirectory::readlink(PathPtr path) const {
   KJ_IF_MAYBE(p, tryReadlink(path)) {
     return kj::mv(*p);
   } else {
@@ -567,7 +569,7 @@ String ReadableDirectory::readlink(PathPtr path) {
   }
 }
 
-Own<File> Directory::openFile(PathPtr path, WriteMode mode) {
+Own<const File> Directory::openFile(PathPtr path, WriteMode mode) const {
   KJ_IF_MAYBE(f, tryOpenFile(path, mode)) {
     return kj::mv(*f);
   } else if (has(mode, WriteMode::CREATE) && !has(mode, WriteMode::MODIFY)) {
@@ -583,7 +585,7 @@ Own<File> Directory::openFile(PathPtr path, WriteMode mode) {
   return newInMemoryFile(nullClock());
 }
 
-Own<AppendableFile> Directory::appendFile(PathPtr path, WriteMode mode) {
+Own<AppendableFile> Directory::appendFile(PathPtr path, WriteMode mode) const {
   KJ_IF_MAYBE(f, tryAppendFile(path, mode)) {
     return kj::mv(*f);
   } else if (has(mode, WriteMode::CREATE) && !has(mode, WriteMode::MODIFY)) {
@@ -599,7 +601,7 @@ Own<AppendableFile> Directory::appendFile(PathPtr path, WriteMode mode) {
   return newFileAppender(newInMemoryFile(nullClock()));
 }
 
-Own<Directory> Directory::openSubdir(PathPtr path, WriteMode mode) {
+Own<const Directory> Directory::openSubdir(PathPtr path, WriteMode mode) const {
   KJ_IF_MAYBE(f, tryOpenSubdir(path, mode)) {
     return kj::mv(*f);
   } else if (has(mode, WriteMode::CREATE) && !has(mode, WriteMode::MODIFY)) {
@@ -615,7 +617,7 @@ Own<Directory> Directory::openSubdir(PathPtr path, WriteMode mode) {
   return newInMemoryDirectory(nullClock());
 }
 
-void Directory::symlink(PathPtr linkpath, StringPtr content, WriteMode mode) {
+void Directory::symlink(PathPtr linkpath, StringPtr content, WriteMode mode) const {
   if (!trySymlink(linkpath, content, mode)) {
     if (has(mode, WriteMode::CREATE)) {
       KJ_FAIL_REQUIRE("path already exsits", linkpath) { break; }
@@ -627,8 +629,8 @@ void Directory::symlink(PathPtr linkpath, StringPtr content, WriteMode mode) {
 }
 
 void Directory::transfer(PathPtr toPath, WriteMode toMode,
-                         Directory& fromDirectory, PathPtr fromPath,
-                         TransferMode mode) {
+                         const Directory& fromDirectory, PathPtr fromPath,
+                         TransferMode mode) const {
   if (!tryTransfer(toPath, toMode, fromDirectory, fromPath, mode)) {
     if (has(toMode, WriteMode::CREATE)) {
       KJ_FAIL_REQUIRE("toPath already exists or fromPath doesn't exist", toPath, fromPath) {
@@ -640,10 +642,10 @@ void Directory::transfer(PathPtr toPath, WriteMode toMode,
   }
 }
 
-static void copyContents(Directory& to, ReadableDirectory& from);
+static void copyContents(const Directory& to, const ReadableDirectory& from);
 
-static bool tryCopyDirectoryEntry(Directory& to, PathPtr toPath, WriteMode toMode,
-                                  ReadableDirectory& from, PathPtr fromPath,
+static bool tryCopyDirectoryEntry(const Directory& to, PathPtr toPath, WriteMode toMode,
+                                  const ReadableDirectory& from, PathPtr fromPath,
                                   FsNode::Type type, bool atomic) {
   // TODO(cleanup): Make this reusable?
 
@@ -699,7 +701,7 @@ static bool tryCopyDirectoryEntry(Directory& to, PathPtr toPath, WriteMode toMod
   }
 }
 
-static void copyContents(Directory& to, ReadableDirectory& from) {
+static void copyContents(const Directory& to, const ReadableDirectory& from) {
   for (auto& entry: from.listEntries()) {
     Path subPath(kj::mv(entry.name));
     tryCopyDirectoryEntry(to, subPath, WriteMode::CREATE, from, subPath, entry.type, false);
@@ -707,8 +709,8 @@ static void copyContents(Directory& to, ReadableDirectory& from) {
 }
 
 bool Directory::tryTransfer(PathPtr toPath, WriteMode toMode,
-                            Directory& fromDirectory, PathPtr fromPath,
-                            TransferMode mode) {
+                            const Directory& fromDirectory, PathPtr fromPath,
+                            TransferMode mode) const {
   KJ_REQUIRE(toPath.size() > 0, "can't replace self") { return false; }
 
   // First try reversing.
@@ -739,12 +741,12 @@ bool Directory::tryTransfer(PathPtr toPath, WriteMode toMode,
   KJ_UNREACHABLE;
 }
 
-Maybe<bool> Directory::tryTransferTo(Directory& toDirectory, PathPtr toPath, WriteMode toMode,
-                                     PathPtr fromPath, TransferMode mode) {
+Maybe<bool> Directory::tryTransferTo(const Directory& toDirectory, PathPtr toPath, WriteMode toMode,
+                                     PathPtr fromPath, TransferMode mode) const {
   return nullptr;
 }
 
-void Directory::remove(PathPtr path) {
+void Directory::remove(PathPtr path) const {
   if (!tryRemove(path)) {
     KJ_FAIL_REQUIRE("path to remove doesn't exist", path) { break; }
   }
@@ -766,47 +768,50 @@ void Directory::commitFailed(WriteMode mode) {
 
 namespace {
 
-class InMemoryFile final: public File, public Refcounted {
+class InMemoryFile final: public File, public AtomicRefcounted {
 public:
-  InMemoryFile(Clock& clock): clock(clock), lastModified(clock.now()) {}
+  InMemoryFile(const Clock& clock): impl(clock) {}
 
-  Own<FsNode> cloneFsNode() override {
-    return addRef(*this);
+  Own<const FsNode> cloneFsNode() const override {
+    return atomicAddRef(*this);
   }
 
-  Maybe<int> getFd() override {
+  Maybe<int> getFd() const override {
     return nullptr;
   }
 
-  Metadata stat() override {
+  Metadata stat() const override {
+    auto lock = impl.lockShared();
     uint64_t hash = reinterpret_cast<uintptr_t>(this);
-    return Metadata { Type::FILE, size, size, lastModified, 1, hash };
+    return Metadata { Type::FILE, lock->size, lock->size, lock->lastModified, 1, hash };
   }
 
-  void sync() override {}
-  void datasync() override {}
+  void sync() const override {}
+  void datasync() const override {}
   // no-ops
 
-  size_t read(uint64_t offset, ArrayPtr<byte> buffer) override {
-    if (offset >= size) {
+  size_t read(uint64_t offset, ArrayPtr<byte> buffer) const override {
+    auto lock = impl.lockShared();
+    if (offset >= lock->size) {
       // Entirely out-of-range.
       return 0;
     }
 
-    size_t readSize = kj::min(buffer.size(), size - offset);
-    memcpy(buffer.begin(), bytes.begin() + offset, readSize);
+    size_t readSize = kj::min(buffer.size(), lock->size - offset);
+    memcpy(buffer.begin(), lock->bytes.begin() + offset, readSize);
     return readSize;
   }
 
-  Array<const byte> mmap(uint64_t offset, uint64_t size) override {
+  Array<const byte> mmap(uint64_t offset, uint64_t size) const override {
     KJ_REQUIRE(offset + size >= offset, "mmap() request overflows uint64");
-    ensureCapacity(offset + size);
+    auto lock = impl.lockExclusive();
+    lock->ensureCapacity(offset + size);
 
-    ArrayDisposer* disposer = new MmapDisposer(addRef(*this));
-    return Array<const byte>(bytes.begin() + offset, size, *disposer);
+    ArrayDisposer* disposer = new MmapDisposer(atomicAddRef(*this));
+    return Array<const byte>(lock->bytes.begin() + offset, size, *disposer);
   }
 
-  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) override {
+  Array<byte> mmapPrivate(uint64_t offset, uint64_t size) const override {
     // Return a copy.
 
     // Allocate exactly the size requested.
@@ -823,47 +828,51 @@ public:
     return result;
   }
 
-  void write(uint64_t offset, ArrayPtr<const byte> data) override {
+  void write(uint64_t offset, ArrayPtr<const byte> data) const override {
     if (data.size() == 0) return;
-    modified();
+    auto lock = impl.lockExclusive();
+    lock->modified();
     uint64_t end = offset + data.size();
     KJ_REQUIRE(end >= offset, "write() request overflows uint64");
-    ensureCapacity(end);
-    size = kj::max(size, end);
-    memcpy(bytes.begin() + offset, data.begin(), data.size());
+    lock->ensureCapacity(end);
+    lock->size = kj::max(lock->size, end);
+    memcpy(lock->bytes.begin() + offset, data.begin(), data.size());
   }
 
-  void zero(uint64_t offset, uint64_t zeroSize) override {
+  void zero(uint64_t offset, uint64_t zeroSize) const override {
     if (zeroSize == 0) return;
-    modified();
+    auto lock = impl.lockExclusive();
+    lock->modified();
     uint64_t end = offset + zeroSize;
     KJ_REQUIRE(end >= offset, "zero() request overflows uint64");
-    ensureCapacity(end);
-    size = kj::max(size, end);
-    memset(bytes.begin() + offset, 0, zeroSize);
+    lock->ensureCapacity(end);
+    lock->size = kj::max(lock->size, end);
+    memset(lock->bytes.begin() + offset, 0, zeroSize);
   }
 
-  void truncate(uint64_t newSize) override {
-    if (newSize < size) {
-      modified();
-      memset(bytes.begin() + newSize, 0, size - newSize);
-      size = newSize;
-    } else if (newSize > size) {
-      modified();
-      ensureCapacity(newSize);
-      size = newSize;
+  void truncate(uint64_t newSize) const override {
+    auto lock = impl.lockExclusive();
+    if (newSize < lock->size) {
+      lock->modified();
+      memset(lock->bytes.begin() + newSize, 0, lock->size - newSize);
+      lock->size = newSize;
+    } else if (newSize > lock->size) {
+      lock->modified();
+      lock->ensureCapacity(newSize);
+      lock->size = newSize;
     }
   }
 
-  Own<WritableFileMapping> mmapWritable(uint64_t offset, uint64_t size) override {
+  Own<const WritableFileMapping> mmapWritable(uint64_t offset, uint64_t size) const override {
     uint64_t end = offset + size;
     KJ_REQUIRE(end >= offset, "mmapWritable() request overflows uint64");
-    ensureCapacity(end);
-    return heap<WritableFileMappingImpl>(addRef(*this), bytes.slice(offset, end));
+    auto lock = impl.lockExclusive();
+    lock->ensureCapacity(end);
+    return heap<WritableFileMappingImpl>(atomicAddRef(*this), lock->bytes.slice(offset, end));
   }
 
-  size_t copy(uint64_t offset, ReadableFile& from,
-              uint64_t fromOffset, uint64_t copySize) override {
+  size_t copy(uint64_t offset, const ReadableFile& from,
+              uint64_t fromOffset, uint64_t copySize) const override {
     size_t fromFileSize = from.stat().size;
     if (fromFileSize <= fromOffset) return 0;
 
@@ -871,48 +880,55 @@ public:
     copySize = kj::min(copySize, fromFileSize - fromOffset);
     if (copySize == 0) return 0;
 
+    auto lock = impl.lockExclusive();
+
     // Allocate space for the copy.
     uint64_t end = offset + copySize;
-    ensureCapacity(end);
+    lock->ensureCapacity(end);
 
     // Read directly into our backing store.
-    size_t n = from.read(fromOffset, bytes.slice(offset, end));
-    size = kj::max(size, offset + n);
+    size_t n = from.read(fromOffset, lock->bytes.slice(offset, end));
+    lock->size = kj::max(lock->size, offset + n);
 
-    modified();
+    lock->modified();
     return n;
   }
 
 private:
-  Clock& clock;
-  Array<byte> bytes;
-  size_t size = 0;     // bytes may be larger than this to accommodate mmaps
-  Date lastModified;
-  uint mmapCount = 0;  // number of mappings outstanding
+  struct Impl {
+    const Clock& clock;
+    Array<byte> bytes;
+    size_t size = 0;     // bytes may be larger than this to accommodate mmaps
+    Date lastModified;
+    uint mmapCount = 0;  // number of mappings outstanding
 
-  void ensureCapacity(size_t capacity) {
-    if (bytes.size() < capacity) {
-      KJ_ASSERT(mmapCount == 0,
-          "InMemoryFile cannot resize the file backing store while memory mappings exist.");
+    Impl(const Clock& clock): clock(clock), lastModified(clock.now()) {}
 
-      auto newBytes = heapArray<byte>(kj::max(capacity, bytes.size() * 2));
-      memcpy(newBytes.begin(), bytes.begin(), size);
-      memset(newBytes.begin() + size, 0, newBytes.size() - size);
-      bytes = kj::mv(newBytes);
+    void ensureCapacity(size_t capacity) {
+      if (bytes.size() < capacity) {
+        KJ_ASSERT(mmapCount == 0,
+            "InMemoryFile cannot resize the file backing store while memory mappings exist.");
+
+        auto newBytes = heapArray<byte>(kj::max(capacity, bytes.size() * 2));
+        memcpy(newBytes.begin(), bytes.begin(), size);
+        memset(newBytes.begin() + size, 0, newBytes.size() - size);
+        bytes = kj::mv(newBytes);
+      }
     }
-  }
 
-  void modified() {
-    lastModified = clock.now();
-  }
+    void modified() {
+      lastModified = clock.now();
+    }
+  };
+  kj::MutexGuarded<Impl> impl;
 
   class MmapDisposer final: public ArrayDisposer {
   public:
-    MmapDisposer(Own<InMemoryFile>&& refParam): ref(kj::mv(refParam)) {
-      ++ref->mmapCount;
+    MmapDisposer(Own<const InMemoryFile>&& refParam): ref(kj::mv(refParam)) {
+      ++ref->impl.getAlreadyLockedExclusive().mmapCount;
     }
     ~MmapDisposer() noexcept(false) {
-      --ref->mmapCount;
+      --ref->impl.lockExclusive()->mmapCount;
     }
 
     void disposeImpl(void* firstElement, size_t elementSize, size_t elementCount,
@@ -921,67 +937,71 @@ private:
     }
 
   private:
-    Own<InMemoryFile> ref;
+    Own<const InMemoryFile> ref;
   };
 
   class WritableFileMappingImpl final: public WritableFileMapping {
   public:
-    WritableFileMappingImpl(Own<InMemoryFile>&& refParam, ArrayPtr<byte> range)
+    WritableFileMappingImpl(Own<const InMemoryFile>&& refParam, ArrayPtr<byte> range)
         : ref(kj::mv(refParam)), range(range) {
-      ++ref->mmapCount;
+      ++ref->impl.getAlreadyLockedExclusive().mmapCount;
     }
     ~WritableFileMappingImpl() noexcept(false) {
-      --ref->mmapCount;
+      --ref->impl.lockExclusive()->mmapCount;
     }
 
-    ArrayPtr<byte> get() override {
-      return range;
+    ArrayPtr<byte> get() const override {
+      // const_cast OK because WritableFileMapping does indeed provide a writable view despite
+      // being const itself.
+      return arrayPtr(const_cast<byte*>(range.begin()), range.size());
     }
 
-    void changed(ArrayPtr<byte> slice) override {
-      ref->modified();
+    void changed(ArrayPtr<byte> slice) const override {
+      ref->impl.lockExclusive()->modified();
     }
 
-    void sync(ArrayPtr<byte> slice) override {
-      ref->modified();
+    void sync(ArrayPtr<byte> slice) const override {
+      ref->impl.lockExclusive()->modified();
     }
 
   private:
-    Own<InMemoryFile> ref;
+    Own<const InMemoryFile> ref;
     ArrayPtr<byte> range;
   };
 };
 
 // -----------------------------------------------------------------------------
 
-class InMemoryDirectory final: public Directory, public Refcounted {
+class InMemoryDirectory final: public Directory, public AtomicRefcounted {
 public:
-  InMemoryDirectory(Clock& clock)
-      : clock(clock), lastModified(clock.now()) {}
+  InMemoryDirectory(const Clock& clock): impl(clock) {}
 
-  Own<FsNode> cloneFsNode() override {
-    return addRef(*this);
+  Own<const FsNode> cloneFsNode() const override {
+    return atomicAddRef(*this);
   }
 
-  Maybe<int> getFd() override {
+  Maybe<int> getFd() const override {
     return nullptr;
   }
 
-  Metadata stat() override {
+  Metadata stat() const override {
+    auto lock = impl.lockShared();
     uint64_t hash = reinterpret_cast<uintptr_t>(this);
-    return Metadata { Type::DIRECTORY, 0, 0, lastModified, 1, hash };
+    return Metadata { Type::DIRECTORY, 0, 0, lock->lastModified, 1, hash };
   }
 
-  void sync() override {}
-  void datasync() override {}
+  void sync() const override {}
+  void datasync() const override {}
   // no-ops
 
-  Array<String> listNames()  override {
-    return KJ_MAP(e, entries) { return heapString(e.first); };
+  Array<String> listNames() const override {
+    auto lock = impl.lockShared();
+    return KJ_MAP(e, lock->entries) { return heapString(e.first); };
   }
 
-  Array<Entry> listEntries() override {
-    return KJ_MAP(e, entries) {
+  Array<Entry> listEntries() const override {
+    auto lock = impl.lockShared();
+    return KJ_MAP(e, lock->entries) {
       FsNode::Type type;
       if (e.second.node.is<SymlinkNode>()) {
         type = FsNode::Type::SYMLINK;
@@ -996,12 +1016,13 @@ public:
     };
   }
 
-  bool exists(PathPtr path) override {
+  bool exists(PathPtr path) const override {
     if (path.size() == 0) {
       return true;
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, tryGetEntry(path[0])) {
-        return exists(*entry);
+      auto lock = impl.lockShared();
+      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
+        return exists(lock, *entry);
       } else {
         return false;
       }
@@ -1014,11 +1035,12 @@ public:
     }
   }
 
-  Maybe<FsNode::Metadata> tryLstat(PathPtr path) override {
+  Maybe<FsNode::Metadata> tryLstat(PathPtr path) const override {
     if (path.size() == 0) {
       return stat();
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, tryGetEntry(path[0])) {
+      auto lock = impl.lockShared();
+      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
         if (entry->node.is<FileNode>()) {
           return entry->node.get<FileNode>().file->stat();
         } else if (entry->node.is<DirectoryNode>()) {
@@ -1042,12 +1064,13 @@ public:
     }
   }
 
-  Maybe<Own<ReadableFile>> tryOpenFile(PathPtr path) override {
+  Maybe<Own<const ReadableFile>> tryOpenFile(PathPtr path) const override {
     if (path.size() == 0) {
       KJ_FAIL_REQUIRE("not a file") { return nullptr; }
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, tryGetEntry(path[0])) {
-        return asFile(*entry);
+      auto lock = impl.lockShared();
+      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
+        return asFile(lock, *entry);
       } else {
         return nullptr;
       }
@@ -1060,12 +1083,13 @@ public:
     }
   }
 
-  Maybe<Own<ReadableDirectory>> tryOpenSubdir(PathPtr path) override {
+  Maybe<Own<const ReadableDirectory>> tryOpenSubdir(PathPtr path) const override {
     if (path.size() == 0) {
       return clone();
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, tryGetEntry(path[0])) {
-        return asDirectory(*entry);
+      auto lock = impl.lockShared();
+      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
+        return asDirectory(lock, *entry);
       } else {
         return nullptr;
       }
@@ -1078,12 +1102,13 @@ public:
     }
   }
 
-  Maybe<String> tryReadlink(PathPtr path) override {
+  Maybe<String> tryReadlink(PathPtr path) const override {
     if (path.size() == 0) {
       KJ_FAIL_REQUIRE("not a symlink") { return nullptr; }
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, tryGetEntry(path[0])) {
-        return asSymlink(*entry);
+      auto lock = impl.lockShared();
+      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
+        return asSymlink(lock, *entry);
       } else {
         return nullptr;
       }
@@ -1096,7 +1121,7 @@ public:
     }
   }
 
-  Maybe<Own<File>> tryOpenFile(PathPtr path, WriteMode mode) override {
+  Maybe<Own<const File>> tryOpenFile(PathPtr path, WriteMode mode) const override {
     if (path.size() == 0) {
       if (has(mode, WriteMode::MODIFY)) {
         KJ_FAIL_REQUIRE("not a file") { return nullptr; }
@@ -1106,8 +1131,9 @@ public:
         KJ_FAIL_REQUIRE("can't replace self") { return nullptr; }
       }
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, openEntry(path[0], mode)) {
-        return asFile(*entry, mode);
+      auto lock = impl.lockExclusive();
+      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
+        return asFile(lock, *entry, mode);
       } else {
         return nullptr;
       }
@@ -1120,31 +1146,34 @@ public:
     }
   }
 
-  Own<Replacer<File>> replaceFile(PathPtr path, WriteMode mode) override {
+  Own<Replacer<File>> replaceFile(PathPtr path, WriteMode mode) const override {
     if (path.size() == 0) {
       KJ_FAIL_REQUIRE("can't replace self") { break; }
     } else if (path.size() == 1) {
-      return heap<ReplacerImpl<File>>(*this, path[0], newInMemoryFile(clock), mode);
+      // don't need lock just to read the clock ref
+      return heap<ReplacerImpl<File>>(*this, path[0],
+          newInMemoryFile(impl.getWithoutLock().clock), mode);
     } else {
       KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
         return child->get()->replaceFile(path.slice(1, path.size()), mode);
       }
     }
-    return heap<BrokenReplacer<File>>(newInMemoryFile(clock));
+    return heap<BrokenReplacer<File>>(newInMemoryFile(impl.getWithoutLock().clock));
   }
 
-  Maybe<Own<Directory>> tryOpenSubdir(PathPtr path, WriteMode mode) override {
+  Maybe<Own<const Directory>> tryOpenSubdir(PathPtr path, WriteMode mode) const override {
     if (path.size() == 0) {
       if (has(mode, WriteMode::MODIFY)) {
-        return addRef(*this);
+        return atomicAddRef(*this);
       } else if (has(mode, WriteMode::CREATE)) {
         return nullptr;  // already exists
       } else {
         KJ_FAIL_REQUIRE("can't replace self") { return nullptr; }
       }
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, openEntry(path[0], mode)) {
-        return asDirectory(*entry, mode);
+      auto lock = impl.lockExclusive();
+      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
+        return asDirectory(lock, *entry, mode);
       } else {
         return nullptr;
       }
@@ -1157,20 +1186,22 @@ public:
     }
   }
 
-  Own<Replacer<Directory>> replaceSubdir(PathPtr path, WriteMode mode) override {
+  Own<Replacer<Directory>> replaceSubdir(PathPtr path, WriteMode mode) const override {
     if (path.size() == 0) {
       KJ_FAIL_REQUIRE("can't replace self") { break; }
     } else if (path.size() == 1) {
-      return heap<ReplacerImpl<Directory>>(*this, path[0], newInMemoryDirectory(clock), mode);
+      // don't need lock just to read the clock ref
+      return heap<ReplacerImpl<Directory>>(*this, path[0],
+          newInMemoryDirectory(impl.getWithoutLock().clock), mode);
     } else {
       KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
         return child->get()->replaceSubdir(path.slice(1, path.size()), mode);
       }
     }
-    return heap<BrokenReplacer<Directory>>(newInMemoryDirectory(clock));
+    return heap<BrokenReplacer<Directory>>(newInMemoryDirectory(impl.getWithoutLock().clock));
   }
 
-  Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) override {
+  Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) const override {
     if (path.size() == 0) {
       if (has(mode, WriteMode::MODIFY)) {
         KJ_FAIL_REQUIRE("not a file") { return nullptr; }
@@ -1180,8 +1211,9 @@ public:
         KJ_FAIL_REQUIRE("can't replace self") { return nullptr; }
       }
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, openEntry(path[0], mode)) {
-        return asFile(*entry, mode).map(newFileAppender);
+      auto lock = impl.lockExclusive();
+      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
+        return asFile(lock, *entry, mode).map(newFileAppender);
       } else {
         return nullptr;
       }
@@ -1194,7 +1226,7 @@ public:
     }
   }
 
-  bool trySymlink(PathPtr path, StringPtr content, WriteMode mode) override {
+  bool trySymlink(PathPtr path, StringPtr content, WriteMode mode) const override {
     if (path.size() == 0) {
       if (has(mode, WriteMode::CREATE)) {
         return false;
@@ -1202,9 +1234,10 @@ public:
         KJ_FAIL_REQUIRE("can't replace self") { return false; }
       }
     } else if (path.size() == 1) {
-      KJ_IF_MAYBE(entry, openEntry(path[0], mode)) {
-        entry->init(SymlinkNode { clock.now(), heapString(content) });
-        modified();
+      auto lock = impl.lockExclusive();
+      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
+        entry->init(SymlinkNode { lock->clock.now(), heapString(content) });
+        lock->modified();
         return true;
       } else {
         return false;
@@ -1218,12 +1251,14 @@ public:
     }
   }
 
-  Own<File> createTemporary() override {
-    return newInMemoryFile(clock);
+  Own<const File> createTemporary() const override {
+    // Don't need lock just to read the clock ref.
+    return newInMemoryFile(impl.getWithoutLock().clock);
   }
 
   bool tryTransfer(PathPtr toPath, WriteMode toMode,
-                   Directory& fromDirectory, PathPtr fromPath, TransferMode mode) override {
+                   const Directory& fromDirectory, PathPtr fromPath,
+                   TransferMode mode) const override {
     if (toPath.size() == 0) {
       if (has(toMode, WriteMode::CREATE)) {
         return false;
@@ -1233,15 +1268,16 @@ public:
     } else if (toPath.size() == 1) {
       // tryTransferChild() needs to at least know the node type, so do an lstat.
       KJ_IF_MAYBE(meta, fromDirectory.tryLstat(fromPath)) {
-        KJ_IF_MAYBE(entry, openEntry(toPath[0], toMode)) {
+        auto lock = impl.lockExclusive();
+        KJ_IF_MAYBE(entry, lock->openEntry(toPath[0], toMode)) {
           // Make sure if we just cerated a new entry, and we don't successfully transfer to it, we
           // remove the entry before returning.
           bool needRollback = entry->node == nullptr;
-          KJ_DEFER(if (needRollback) { entries.erase(toPath[0]); });
+          KJ_DEFER(if (needRollback) { lock->entries.erase(toPath[0]); });
 
-          if (tryTransferChild(*entry, meta->type, meta->lastModified, meta->size,
-                               fromDirectory, fromPath, mode)) {
-            modified();
+          if (lock->tryTransferChild(*entry, meta->type, meta->lastModified, meta->size,
+                                     fromDirectory, fromPath, mode)) {
+            lock->modified();
             needRollback = false;
             return true;
           } else {
@@ -1267,8 +1303,8 @@ public:
     }
   }
 
-  Maybe<bool> tryTransferTo(Directory& toDirectory, PathPtr toPath, WriteMode toMode,
-                            PathPtr fromPath, TransferMode mode) override {
+  Maybe<bool> tryTransferTo(const Directory& toDirectory, PathPtr toPath, WriteMode toMode,
+                            PathPtr fromPath, TransferMode mode) const override {
     if (fromPath.size() <= 1) {
       // If `fromPath` is in this directory (or *is* this directory) then we don't have any
       // optimizations.
@@ -1289,16 +1325,17 @@ public:
     }
   }
 
-  bool tryRemove(PathPtr path) override {
+  bool tryRemove(PathPtr path) const override {
     if (path.size() == 0) {
       KJ_FAIL_REQUIRE("can't remove self from self") { return false; }
     } else if (path.size() == 1) {
-      auto iter = entries.find(path[0]);
-      if (iter == entries.end()) {
+      auto lock = impl.lockExclusive();
+      auto iter = lock->entries.find(path[0]);
+      if (iter == lock->entries.end()) {
         return false;
       } else {
-        entries.erase(iter);
-        modified();
+        lock->entries.erase(iter);
+        lock->modified();
         return true;
       }
     } else {
@@ -1312,16 +1349,16 @@ public:
 
 private:
   struct FileNode {
-    Own<File> file;
+    Own<const File> file;
   };
   struct DirectoryNode {
-    Own<Directory> directory;
+    Own<const Directory> directory;
   };
   struct SymlinkNode {
     Date lastModified;
     String content;
 
-    Path parse() {
+    Path parse() const {
       KJ_CONTEXT("parsing symlink", content);
       return Path::parse(content);
     }
@@ -1333,10 +1370,10 @@ private:
 
     EntryImpl(String&& name): name(kj::mv(name)) {}
 
-    Own<File> init(FileNode&& value) {
+    Own<const File> init(FileNode&& value) {
       return node.init<FileNode>(kj::mv(value)).file->clone();
     }
-    Own<Directory> init(DirectoryNode&& value) {
+    Own<const Directory> init(DirectoryNode&& value) {
       return node.init<DirectoryNode>(kj::mv(value)).directory->clone();
     }
     void init(SymlinkNode&& value) {
@@ -1347,37 +1384,31 @@ private:
       return node != nullptr;
     }
 
-    void set(Own<File>&& value) {
+    void set(Own<const File>&& value) {
       node.init<FileNode>(FileNode { kj::mv(value) });
     }
-    void set(Own<Directory>&& value) {
+    void set(Own<const Directory>&& value) {
       node.init<DirectoryNode>(DirectoryNode { kj::mv(value) });
     }
   };
 
-  Clock& clock;
-
-  std::map<StringPtr, EntryImpl> entries;
-  // Note: If this changes to a non-sorted map, listNames() and listEntries() must be updated to
-  //   sort their results.
-
-  Date lastModified;
-
   template <typename T>
   class ReplacerImpl final: public Replacer<T> {
   public:
-    ReplacerImpl(InMemoryDirectory& directory, kj::StringPtr name, Own<T> inner, WriteMode mode)
-        : Replacer<T>(mode), directory(addRef(directory)), name(heapString(name)),
+    ReplacerImpl(const InMemoryDirectory& directory, kj::StringPtr name,
+                 Own<const T> inner, WriteMode mode)
+        : Replacer<T>(mode), directory(atomicAddRef(directory)), name(heapString(name)),
           inner(kj::mv(inner)) {}
 
-    T& get() override { return *inner; }
+    const T& get() override { return *inner; }
 
     bool tryCommit() override {
       KJ_REQUIRE(!committed, "commit() already called") { return true; }
 
-      KJ_IF_MAYBE(entry, directory->openEntry(name, Replacer<T>::mode)) {
+      auto lock = directory->impl.lockExclusive();
+      KJ_IF_MAYBE(entry, lock->openEntry(name, Replacer<T>::mode)) {
         entry->set(inner->clone());
-        directory->modified();
+        lock->modified();
         return true;
       } else {
         return false;
@@ -1386,9 +1417,9 @@ private:
 
   private:
     bool committed = false;
-    Own<InMemoryDirectory> directory;
+    Own<const InMemoryDirectory> directory;
     kj::String name;
-    Own<T> inner;
+    Own<const T> inner;
   };
 
   template <typename T>
@@ -1396,75 +1427,258 @@ private:
     // For recovery path when exceptions are disabled.
 
   public:
-    BrokenReplacer(Own<T> inner)
+    BrokenReplacer(Own<const T> inner)
         : Replacer<T>(WriteMode::CREATE | WriteMode::MODIFY),
           inner(kj::mv(inner)) {}
 
-    T& get() override { return *inner; }
+    const T& get() override { return *inner; }
     bool tryCommit() override { return false; }
 
   private:
-    Own<T> inner;
+    Own<const T> inner;
   };
 
-  Maybe<EntryImpl&> openEntry(kj::StringPtr name, WriteMode mode) {
-    // TODO(perf): We could avoid a copy if the entry exists, at the expense of a double-lookup if
-    //   it doesn't. Maybe a better map implementation will solve everything?
-    return openEntry(heapString(name), mode);
-  }
+  struct Impl {
+    const Clock& clock;
 
-  Maybe<EntryImpl&> openEntry(String&& name, WriteMode mode) {
-    if (has(mode, WriteMode::CREATE)) {
-      EntryImpl entry(kj::mv(name));
-      StringPtr nameRef = entry.name;
-      auto insertResult = entries.insert(std::make_pair(nameRef, kj::mv(entry)));
+    std::map<StringPtr, EntryImpl> entries;
+    // Note: If this changes to a non-sorted map, listNames() and listEntries() must be updated to
+    //   sort their results.
 
-      if (!insertResult.second && !has(mode, WriteMode::MODIFY)) {
-        // Entry already existed and MODIFY not specified.
+    Date lastModified;
+
+    Impl(const Clock& clock): clock(clock), lastModified(clock.now()) {}
+
+    Maybe<EntryImpl&> openEntry(kj::StringPtr name, WriteMode mode) {
+      // TODO(perf): We could avoid a copy if the entry exists, at the expense of a double-lookup
+      //   if it doesn't. Maybe a better map implementation will solve everything?
+      return openEntry(heapString(name), mode);
+    }
+
+    Maybe<EntryImpl&> openEntry(String&& name, WriteMode mode) {
+      if (has(mode, WriteMode::CREATE)) {
+        EntryImpl entry(kj::mv(name));
+        StringPtr nameRef = entry.name;
+        auto insertResult = entries.insert(std::make_pair(nameRef, kj::mv(entry)));
+
+        if (!insertResult.second && !has(mode, WriteMode::MODIFY)) {
+          // Entry already existed and MODIFY not specified.
+          return nullptr;
+        }
+
+        return insertResult.first->second;
+      } else if (has(mode, WriteMode::MODIFY)) {
+        return tryGetEntry(name);
+      } else {
+        // Neither CREATE nor MODIFY specified: precondition always fails.
         return nullptr;
       }
+    }
 
-      return insertResult.first->second;
-    } else if (has(mode, WriteMode::MODIFY)) {
-      return tryGetEntry(name);
+    kj::Maybe<const EntryImpl&> tryGetEntry(kj::StringPtr name) const {
+      auto iter = entries.find(name);
+      if (iter == entries.end()) {
+        return nullptr;
+      } else {
+        return iter->second;
+      }
+    }
+
+    kj::Maybe<EntryImpl&> tryGetEntry(kj::StringPtr name) {
+      auto iter = entries.find(name);
+      if (iter == entries.end()) {
+        return nullptr;
+      } else {
+        return iter->second;
+      }
+    }
+
+    void modified() {
+      lastModified = clock.now();
+    }
+
+    bool tryTransferChild(EntryImpl& entry, const FsNode::Type type, kj::Maybe<Date> lastModified,
+                          kj::Maybe<uint64_t> size, const Directory& fromDirectory,
+                          PathPtr fromPath, TransferMode mode) {
+      switch (type) {
+        case FsNode::Type::FILE:
+          KJ_IF_MAYBE(file, fromDirectory.tryOpenFile(fromPath, WriteMode::MODIFY)) {
+            if (mode == TransferMode::COPY) {
+              auto copy = newInMemoryFile(clock);
+              copy->copy(0, **file, 0, size.orDefault(kj::maxValue));
+              entry.set(kj::mv(copy));
+            } else {
+              if (mode == TransferMode::MOVE) {
+                KJ_ASSERT(fromDirectory.tryRemove(fromPath), "could't move node", fromPath) {
+                  return false;
+                }
+              }
+              entry.set(kj::mv(*file));
+            }
+            return true;
+          } else {
+            KJ_FAIL_ASSERT("source node deleted concurrently during transfer", fromPath) {
+              return false;
+            }
+          }
+        case FsNode::Type::DIRECTORY:
+          KJ_IF_MAYBE(subdir, fromDirectory.tryOpenSubdir(fromPath, WriteMode::MODIFY)) {
+            if (mode == TransferMode::COPY) {
+              auto copy = atomicRefcounted<InMemoryDirectory>(clock);
+              auto& cpim = copy->impl.getWithoutLock();  // safe because just-created
+              for (auto& subEntry: subdir->get()->listEntries()) {
+                EntryImpl newEntry(kj::mv(subEntry.name));
+                Path filename(newEntry.name);
+                if (!cpim.tryTransferChild(newEntry, subEntry.type, nullptr, nullptr, **subdir,
+                                           filename, TransferMode::COPY)) {
+                  KJ_LOG(ERROR, "couldn't copy node of type not supported by InMemoryDirectory",
+                         filename);
+                } else {
+                  StringPtr nameRef = newEntry.name;
+                  cpim.entries.insert(std::make_pair(nameRef, kj::mv(newEntry)));
+                }
+              }
+              entry.set(kj::mv(copy));
+            } else {
+              if (mode == TransferMode::MOVE) {
+                KJ_ASSERT(fromDirectory.tryRemove(fromPath), "could't move node", fromPath) {
+                  return false;
+                }
+              }
+              entry.set(kj::mv(*subdir));
+            }
+            return true;
+          } else {
+            KJ_FAIL_ASSERT("source node deleted concurrently during transfer", fromPath) {
+              return false;
+            }
+          }
+        case FsNode::Type::SYMLINK:
+          KJ_IF_MAYBE(content, fromDirectory.tryReadlink(fromPath)) {
+            // Since symlinks are immutable, we can implement LINK the same as COPY.
+            entry.init(SymlinkNode { lastModified.orDefault(clock.now()), kj::mv(*content) });
+            if (mode == TransferMode::MOVE) {
+              KJ_ASSERT(fromDirectory.tryRemove(fromPath), "could't move node", fromPath) {
+                return false;
+              }
+            }
+            return true;
+          } else {
+            KJ_FAIL_ASSERT("source node deleted concurrently during transfer", fromPath) {
+              return false;
+            }
+          }
+        default:
+          return false;
+      }
+    }
+  };
+
+  kj::MutexGuarded<Impl> impl;
+
+  bool exists(kj::Locked<const Impl>& lock, const EntryImpl& entry) const {
+    if (entry.node.is<SymlinkNode>()) {
+      auto newPath = entry.node.get<SymlinkNode>().parse();
+      lock.release();
+      return exists(newPath);
     } else {
-      // Neither CREATE nor MODIFY specified: precondition always fails.
+      return true;
+    }
+  }
+  Maybe<Own<const ReadableFile>> asFile(
+      kj::Locked<const Impl>& lock, const EntryImpl& entry) const {
+    if (entry.node.is<FileNode>()) {
+      return entry.node.get<FileNode>().file->clone();
+    } else if (entry.node.is<SymlinkNode>()) {
+      auto newPath = entry.node.get<SymlinkNode>().parse();
+      lock.release();
+      return tryOpenFile(newPath);
+    } else {
+      KJ_FAIL_REQUIRE("not a file") { return nullptr; }
+    }
+  }
+  Maybe<Own<const ReadableDirectory>> asDirectory(
+      kj::Locked<const Impl>& lock, const EntryImpl& entry) const {
+    if (entry.node.is<DirectoryNode>()) {
+      return entry.node.get<DirectoryNode>().directory->clone();
+    } else if (entry.node.is<SymlinkNode>()) {
+      auto newPath = entry.node.get<SymlinkNode>().parse();
+      lock.release();
+      return tryOpenSubdir(newPath);
+    } else {
+      KJ_FAIL_REQUIRE("not a directory") { return nullptr; }
+    }
+  }
+  Maybe<String> asSymlink(kj::Locked<const Impl>& lock, const EntryImpl& entry) const {
+    if (entry.node.is<SymlinkNode>()) {
+      return heapString(entry.node.get<SymlinkNode>().content);
+    } else {
+      KJ_FAIL_REQUIRE("not a symlink") { return nullptr; }
+    }
+  }
+
+  Maybe<Own<const File>> asFile(kj::Locked<Impl>& lock, EntryImpl& entry, WriteMode mode) const {
+    if (entry.node.is<FileNode>()) {
+      return entry.node.get<FileNode>().file->clone();
+    } else if (entry.node.is<SymlinkNode>()) {
+      // CREATE_PARENT doesn't apply to creating the parents of a symlink target. However, the
+      // target itself can still be created.
+      auto newPath = entry.node.get<SymlinkNode>().parse();
+      lock.release();
+      return tryOpenFile(newPath, mode - WriteMode::CREATE_PARENT);
+    } else if (entry.node == nullptr) {
+      KJ_ASSERT(has(mode, WriteMode::CREATE));
+      lock->modified();
+      return entry.init(FileNode { newInMemoryFile(lock->clock) });
+    } else {
+      KJ_FAIL_REQUIRE("not a file") { return nullptr; }
+    }
+  }
+  Maybe<Own<const Directory>> asDirectory(
+      kj::Locked<Impl>& lock, EntryImpl& entry, WriteMode mode) const {
+    if (entry.node.is<DirectoryNode>()) {
+      return entry.node.get<DirectoryNode>().directory->clone();
+    } else if (entry.node.is<SymlinkNode>()) {
+      // CREATE_PARENT doesn't apply to creating the parents of a symlink target. However, the
+      // target itself can still be created.
+      auto newPath = entry.node.get<SymlinkNode>().parse();
+      lock.release();
+      return tryOpenSubdir(newPath, mode - WriteMode::CREATE_PARENT);
+    } else if (entry.node == nullptr) {
+      KJ_ASSERT(has(mode, WriteMode::CREATE));
+      lock->modified();
+      return entry.init(DirectoryNode { newInMemoryDirectory(lock->clock) });
+    } else {
+      KJ_FAIL_REQUIRE("not a directory") { return nullptr; }
+    }
+  }
+
+  kj::Maybe<Own<const ReadableDirectory>> tryGetParent(kj::StringPtr name) const {
+    auto lock = impl.lockShared();
+    KJ_IF_MAYBE(entry, impl.lockShared()->tryGetEntry(name)) {
+      return asDirectory(lock, *entry);
+    } else {
       return nullptr;
     }
   }
 
-  kj::Maybe<EntryImpl&> tryGetEntry(kj::StringPtr name) {
-    auto iter = entries.find(name);
-    if (iter == entries.end()) {
-      return nullptr;
-    } else {
-      return iter->second;
-    }
-  }
-
-  kj::Maybe<Own<ReadableDirectory>> tryGetParent(kj::StringPtr name) {
-    KJ_IF_MAYBE(entry, tryGetEntry(name)) {
-      return asDirectory(*entry);
-    } else {
-      return nullptr;
-    }
-  }
-
-  kj::Maybe<Own<Directory>> tryGetParent(kj::StringPtr name, WriteMode mode) {
+  kj::Maybe<Own<const Directory>> tryGetParent(kj::StringPtr name, WriteMode mode) const {
     // Get a directory which is a parent of the eventual target. If `mode` includes
     // WriteMode::CREATE_PARENTS, possibly create the parent directory.
+
+    auto lock = impl.lockExclusive();
 
     WriteMode parentMode = has(mode, WriteMode::CREATE) && has(mode, WriteMode::CREATE_PARENT)
         ? WriteMode::CREATE | WriteMode::MODIFY   // create parent
         : WriteMode::MODIFY;                      // don't create parent
 
     // Possibly create parent.
-    KJ_IF_MAYBE(entry, openEntry(name, parentMode)) {
+    KJ_IF_MAYBE(entry, lock->openEntry(name, parentMode)) {
       if (entry->node.is<DirectoryNode>()) {
         return entry->node.get<DirectoryNode>().directory->clone();
       } else if (entry->node == nullptr) {
-        modified();
-        return entry->init(DirectoryNode { newInMemoryDirectory(clock) });
+        lock->modified();
+        return entry->init(DirectoryNode { newInMemoryDirectory(lock->clock) });
       }
       // Continue on.
     }
@@ -1477,191 +1691,48 @@ private:
       return nullptr;
     }
   }
-
-  bool exists(EntryImpl& entry) {
-    if (entry.node.is<SymlinkNode>()) {
-      return exists(entry.node.get<SymlinkNode>().parse());
-    } else {
-      return true;
-    }
-  }
-  Maybe<Own<ReadableFile>> asFile(EntryImpl& entry) {
-    if (entry.node.is<FileNode>()) {
-      return entry.node.get<FileNode>().file->clone();
-    } else if (entry.node.is<SymlinkNode>()) {
-      return tryOpenFile(entry.node.get<SymlinkNode>().parse());
-    } else {
-      KJ_FAIL_REQUIRE("not a file") { return nullptr; }
-    }
-  }
-  Maybe<Own<ReadableDirectory>> asDirectory(EntryImpl& entry) {
-    if (entry.node.is<DirectoryNode>()) {
-      return entry.node.get<DirectoryNode>().directory->clone();
-    } else if (entry.node.is<SymlinkNode>()) {
-      return tryOpenSubdir(entry.node.get<SymlinkNode>().parse());
-    } else {
-      KJ_FAIL_REQUIRE("not a directory") { return nullptr; }
-    }
-  }
-  Maybe<String> asSymlink(EntryImpl& entry) {
-    if (entry.node.is<SymlinkNode>()) {
-      return heapString(entry.node.get<SymlinkNode>().content);
-    } else {
-      KJ_FAIL_REQUIRE("not a symlink") { return nullptr; }
-    }
-  }
-
-  Maybe<Own<File>> asFile(EntryImpl& entry, WriteMode mode) {
-    if (entry.node.is<FileNode>()) {
-      return entry.node.get<FileNode>().file->clone();
-    } else if (entry.node.is<SymlinkNode>()) {
-      // CREATE_PARENT doesn't apply to creating the parents of a symlink target. However, the
-      // target itself can still be created.
-      return tryOpenFile(entry.node.get<SymlinkNode>().parse(), mode - WriteMode::CREATE_PARENT);
-    } else if (entry.node == nullptr) {
-      KJ_ASSERT(has(mode, WriteMode::CREATE));
-      modified();
-      return entry.init(FileNode { newInMemoryFile(clock) });
-    } else {
-      KJ_FAIL_REQUIRE("not a file") { return nullptr; }
-    }
-  }
-  Maybe<Own<Directory>> asDirectory(EntryImpl& entry, WriteMode mode) {
-    if (entry.node.is<DirectoryNode>()) {
-      return entry.node.get<DirectoryNode>().directory->clone();
-    } else if (entry.node.is<SymlinkNode>()) {
-      // CREATE_PARENT doesn't apply to creating the parents of a symlink target. However, the
-      // target itself can still be created.
-      return tryOpenSubdir(entry.node.get<SymlinkNode>().parse(), mode - WriteMode::CREATE_PARENT);
-    } else if (entry.node == nullptr) {
-      KJ_ASSERT(has(mode, WriteMode::CREATE));
-      modified();
-      return entry.init(DirectoryNode { newInMemoryDirectory(clock) });
-    } else {
-      KJ_FAIL_REQUIRE("not a directory") { return nullptr; }
-    }
-  }
-
-  void modified() {
-    lastModified = clock.now();
-  }
-
-  bool tryTransferChild(EntryImpl& entry, const FsNode::Type type, kj::Maybe<Date> lastModified,
-                        kj::Maybe<uint64_t> size, Directory& fromDirectory, PathPtr fromPath,
-                        TransferMode mode) {
-    switch (type) {
-      case FsNode::Type::FILE:
-        KJ_IF_MAYBE(file, fromDirectory.tryOpenFile(fromPath, WriteMode::MODIFY)) {
-          if (mode == TransferMode::COPY) {
-            auto copy = newInMemoryFile(clock);
-            copy->copy(0, **file, 0, size.orDefault(kj::maxValue));
-            entry.set(kj::mv(copy));
-          } else {
-            if (mode == TransferMode::MOVE) {
-              KJ_ASSERT(fromDirectory.tryRemove(fromPath), "could't move node", fromPath) {
-                return false;
-              }
-            }
-            entry.set(kj::mv(*file));
-          }
-          return true;
-        } else {
-          KJ_FAIL_ASSERT("source node deleted concurrently during transfer", fromPath) {
-            return false;
-          }
-        }
-      case FsNode::Type::DIRECTORY:
-        KJ_IF_MAYBE(subdir, fromDirectory.tryOpenSubdir(fromPath, WriteMode::MODIFY)) {
-          if (mode == TransferMode::COPY) {
-            auto copy = refcounted<InMemoryDirectory>(clock);
-            for (auto& subEntry: subdir->get()->listEntries()) {
-              EntryImpl newEntry(kj::mv(subEntry.name));
-              Path filename(newEntry.name);
-              if (!copy->tryTransferChild(newEntry, subEntry.type, nullptr, nullptr, **subdir,
-                                          filename, TransferMode::COPY)) {
-                KJ_LOG(ERROR, "couldn't copy node of type not supported by InMemoryDirectory",
-                       filename);
-              } else {
-                StringPtr nameRef = newEntry.name;
-                copy->entries.insert(std::make_pair(nameRef, kj::mv(newEntry)));
-              }
-            }
-            entry.set(kj::mv(copy));
-          } else {
-            if (mode == TransferMode::MOVE) {
-              KJ_ASSERT(fromDirectory.tryRemove(fromPath), "could't move node", fromPath) {
-                return false;
-              }
-            }
-            entry.set(kj::mv(*subdir));
-          }
-          return true;
-        } else {
-          KJ_FAIL_ASSERT("source node deleted concurrently during transfer", fromPath) {
-            return false;
-          }
-        }
-      case FsNode::Type::SYMLINK:
-        KJ_IF_MAYBE(content, fromDirectory.tryReadlink(fromPath)) {
-          // Since symlinks are immutable, we can implement LINK the same as COPY.
-          entry.init(SymlinkNode { lastModified.orDefault(clock.now()), kj::mv(*content) });
-          if (mode == TransferMode::MOVE) {
-            KJ_ASSERT(fromDirectory.tryRemove(fromPath), "could't move node", fromPath) {
-              return false;
-            }
-          }
-          return true;
-        } else {
-          KJ_FAIL_ASSERT("source node deleted concurrently during transfer", fromPath) {
-            return false;
-          }
-        }
-      default:
-        return false;
-    }
-  }
 };
 
 // -----------------------------------------------------------------------------
 
 class AppendableFileImpl final: public AppendableFile {
 public:
-  AppendableFileImpl(Own<File>&& fileParam): file(kj::mv(fileParam)) {}
+  AppendableFileImpl(Own<const File>&& fileParam): file(kj::mv(fileParam)) {}
 
-  Own<FsNode> cloneFsNode() override {
+  Own<const FsNode> cloneFsNode() const override {
     return heap<AppendableFileImpl>(file->clone());
   }
 
-  Maybe<int> getFd() override {
+  Maybe<int> getFd() const override {
     return nullptr;
   }
 
-  Metadata stat() override {
+  Metadata stat() const override {
     return file->stat();
   }
 
-  void sync() override { file->sync(); }
-  void datasync() override { file->datasync(); }
+  void sync() const override { file->sync(); }
+  void datasync() const override { file->datasync(); }
 
   void write(const void* buffer, size_t size) override {
     file->write(file->stat().size, arrayPtr(reinterpret_cast<const byte*>(buffer), size));
   }
 
 private:
-  Own<File> file;
+  Own<const File> file;
 };
 
 }  // namespace
 
 // -----------------------------------------------------------------------------
 
-Own<File> newInMemoryFile(Clock& clock) {
-  return refcounted<InMemoryFile>(clock);
+Own<File> newInMemoryFile(const Clock& clock) {
+  return atomicRefcounted<InMemoryFile>(clock);
 }
-Own<Directory> newInMemoryDirectory(Clock& clock) {
-  return refcounted<InMemoryDirectory>(clock);
+Own<Directory> newInMemoryDirectory(const Clock& clock) {
+  return atomicRefcounted<InMemoryDirectory>(clock);
 }
-Own<AppendableFile> newFileAppender(Own<File> inner) {
+Own<AppendableFile> newFileAppender(Own<const File> inner) {
   return heap<AppendableFileImpl>(kj::mv(inner));
 }
 

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -155,6 +155,29 @@ Path Path::slice(size_t start, size_t end) && {
   return Path(KJ_MAP(p, parts.slice(start, end)) { return kj::mv(p); });
 }
 
+bool PathPtr::operator==(PathPtr other) const {
+  return parts == other.parts;
+}
+bool PathPtr::operator< (PathPtr other) const {
+  for (size_t i = 0; i < kj::min(parts.size(), other.parts.size()); i++) {
+    int comp = strcmp(parts[i].cStr(), other.parts[i].cStr());
+    if (comp < 0) return true;
+    if (comp > 0) return false;
+  }
+
+  return parts.size() < other.parts.size();
+}
+
+bool PathPtr::startsWith(PathPtr prefix) const {
+  return parts.size() >= prefix.parts.size() &&
+         parts.slice(0, prefix.parts.size()) == prefix.parts;
+}
+
+bool PathPtr::endsWith(PathPtr suffix) const {
+  return parts.size() >= suffix.parts.size() &&
+         parts.slice(parts.size() - suffix.parts.size(), parts.size()) == suffix.parts;
+}
+
 Path PathPtr::evalWin32(StringPtr pathText) const {
   Vector<String> newParts(parts.size() + Path::countPartsWin32(pathText));
   for (auto& p: parts) newParts.add(heapString(p));

--- a/c++/src/kj/filesystem.h
+++ b/c++/src/kj/filesystem.h
@@ -149,6 +149,18 @@ public:
   Path slice(size_t start, size_t end) &&;
   // A Path can be accessed as an array of strings.
 
+  bool operator==(PathPtr other) const;
+  bool operator!=(PathPtr other) const;
+  bool operator< (PathPtr other) const;
+  bool operator> (PathPtr other) const;
+  bool operator<=(PathPtr other) const;
+  bool operator>=(PathPtr other) const;
+  // Compare path components lexically.
+
+  bool startsWith(PathPtr prefix) const;
+  bool endsWith(PathPtr suffix) const;
+  // Compare prefix / suffix.
+
   Path evalWin32(StringPtr pathText) const&;
   Path evalWin32(StringPtr pathText) &&;
   // Evaluates a Win32-style path, as might be written by a user. Differences from `eval()`
@@ -236,6 +248,14 @@ public:
   const String* begin() const;
   const String* end() const;
   PathPtr slice(size_t start, size_t end) const;
+  bool operator==(PathPtr other) const;
+  bool operator!=(PathPtr other) const;
+  bool operator< (PathPtr other) const;
+  bool operator> (PathPtr other) const;
+  bool operator<=(PathPtr other) const;
+  bool operator>=(PathPtr other) const;
+  bool startsWith(PathPtr prefix) const;
+  bool endsWith(PathPtr suffix) const;
   Path evalWin32(StringPtr pathText) const;
   String toWin32String(bool absolute = false) const;
   Array<wchar_t> forWin32Api(bool absolute) const;
@@ -927,6 +947,14 @@ inline const String* Path::end() const { return parts.end(); }
 inline PathPtr Path::slice(size_t start, size_t end) const& {
   return PathPtr(*this).slice(start, end);
 }
+inline bool Path::operator==(PathPtr other) const { return PathPtr(*this) == other; }
+inline bool Path::operator!=(PathPtr other) const { return PathPtr(*this) != other; }
+inline bool Path::operator< (PathPtr other) const { return PathPtr(*this) <  other; }
+inline bool Path::operator> (PathPtr other) const { return PathPtr(*this) >  other; }
+inline bool Path::operator<=(PathPtr other) const { return PathPtr(*this) <= other; }
+inline bool Path::operator>=(PathPtr other) const { return PathPtr(*this) >= other; }
+inline bool Path::startsWith(PathPtr prefix) const { return PathPtr(*this).startsWith(prefix); }
+inline bool Path::endsWith  (PathPtr suffix) const { return PathPtr(*this).endsWith  (suffix); }
 inline String Path::toString(bool absolute) const { return PathPtr(*this).toString(absolute); }
 inline Path Path::evalWin32(StringPtr pathText) const& {
   return PathPtr(*this).evalWin32(pathText);
@@ -950,6 +978,10 @@ inline const String* PathPtr::end() const { return parts.end(); }
 inline PathPtr PathPtr::slice(size_t start, size_t end) const {
   return PathPtr(parts.slice(start, end));
 }
+inline bool PathPtr::operator!=(PathPtr other) const { return !(*this == other); }
+inline bool PathPtr::operator> (PathPtr other) const { return other < *this; }
+inline bool PathPtr::operator<=(PathPtr other) const { return !(other < *this); }
+inline bool PathPtr::operator>=(PathPtr other) const { return !(*this < other); }
 inline String PathPtr::toWin32String(bool absolute) const {
   return toWin32StringImpl(absolute, false);
 }

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -29,7 +29,11 @@
 #endif
 
 #if _MSC_VER
+#if _MSC_VER < 1910
+#include <intrin.h>
+#else
 #include <intrin0.h>
+#endif
 #endif
 
 namespace kj {

--- a/c++/src/kj/time.c++
+++ b/c++/src/kj/time.c++
@@ -26,12 +26,12 @@
 
 namespace kj {
 
-Clock& nullClock() {
+const Clock& nullClock() {
   class NullClock final: public Clock {
   public:
-    Date now() override { return UNIX_EPOCH; }
+    Date now() const override { return UNIX_EPOCH; }
   };
-  static NullClock NULL_CLOCK;
+  static KJ_CONSTEXPR(const) NullClock NULL_CLOCK;
   return NULL_CLOCK;
 }
 

--- a/c++/src/kj/time.h
+++ b/c++/src/kj/time.h
@@ -63,10 +63,10 @@ constexpr Date UNIX_EPOCH = origin<Date>();
 class Clock {
   // Interface to read the current date and time.
 public:
-  virtual Date now() = 0;
+  virtual Date now() const = 0;
 };
 
-Clock& nullClock();
+const Clock& nullClock();
 // A clock which always returns UNIX_EPOCH as the current time. Useful when you don't care about
 // time.
 


### PR DESCRIPTION
In addition to cleaner code, this has the effect of fixing a number of issues:
- Fixes #494: Windows paths are now parsed and handled a lot better. On Windows, backslashes are handled appropriately, as are absolute paths with drive letters.
- Fixes #288: Specifing a source path starting with ".." without an appropriate --src-prefix will no longer cause output files to be generated outside of the specified output directory. Instead, the output name will be based on the absolute path, and a warning will be written since this is probably not what anyone wants.
- It's no longer necessary for --src-prefix to exactly match character-for-character. Instead, the prefix and source paths are canonicalized before matching. It even works if one is relative and the other absolute.
- Relative paths are now consistently always evaluated in path space, so ".." always cancels the previous path component and the OS/filesystem never even sees that it was there. This used to be the case in some places but not others. This behavior is important for symlink-heavy source trees: the path "foo/some-symlink/.." is now always designates "foo", rather than designating the parent directory of the symlink's target.