### PR TITLE
KJ_SWITCH_ONEOF should parenthesize its argument

### DIFF
--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -151,4 +151,23 @@ TEST(OneOf, Switch) {
   }
 }
 
+TEST(OneOf, Maybe) {
+  Maybe<OneOf<int, float>> var;
+  var = OneOf<int, float>(123);
+
+  KJ_IF_MAYBE(v, var) {
+    // At one time this failed to compile. Note that a Maybe<OneOf<...>> isn't necessarily great
+    // style -- you might be better off with an explicit OneOf<Empty, ...>. Nevertheless, it should
+    // compile.
+    KJ_SWITCH_ONEOF(*v) {
+      KJ_CASE_ONEOF(i, int) {
+        KJ_EXPECT(i == 123);
+      }
+      KJ_CASE_ONEOF(n, float) {
+        KJ_FAIL_ASSERT("expected int, got float", n);
+      }
+    }
+  }
+}
+
 }  // namespace kj

--- a/c++/src/kj/one-of.h
+++ b/c++/src/kj/one-of.h
@@ -238,11 +238,11 @@ void OneOf<Variants...>::allHandled() {
 
 #if __cplusplus > 201402L
 #define KJ_SWITCH_ONEOF(value) \
-  switch (auto _kj_switch_subject = value._switchSubject(); _kj_switch_subject->which())
+  switch (auto _kj_switch_subject = (value)._switchSubject(); _kj_switch_subject->which())
 #else
 #define KJ_SWITCH_ONEOF(value) \
   /* Without C++17, we can only support one switch per containing block. Deal with it. */ \
-  auto _kj_switch_subject = value._switchSubject(); \
+  auto _kj_switch_subject = (value)._switchSubject(); \
   switch (_kj_switch_subject->which())
 #endif
 #define KJ_CASE_ONEOF(name, ...) \


### PR DESCRIPTION
This allows us to deal with Maybe<OneOf<...>> variables properly inside a KJ_IF_MAYBE block.