### PR TITLE
Extend membrane framework to make revocation easy.

### DIFF
--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -104,6 +104,16 @@ public:
   // object actually to be the *same* membrane. This is relevant when an object passes into the
   // membrane and then back out (or out and then back in): instead of double-wrapping the object,
   // the wrapping will be removed.
+
+  virtual kj::Maybe<kj::Promise<void>> onRevoked() { return nullptr; }
+  // If this returns non-null, then it is a promise that will reject (throw an exception) when the
+  // membrane should be revoked. On revocation, all capabilities pointing across the membrane will
+  // be dropped and all outstanding calls canceled. The exception thrown by the promise will be
+  // propagated to all these calls. It is an error for the promise to resolve without throwing.
+  //
+  // After the revocation promise has rejected, inboundCall() and outboundCall() will still be
+  // invoked for new calls, but the `target` passed to them will be a capability that always
+  // rethrows the revocation exception.
 };
 
 Capability::Client membrane(Capability::Client inner, kj::Own<MembranePolicy> policy);

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -866,6 +866,8 @@ interface TestMembrane {
   callIntercept @2 (thing :Thing, tailCall :Bool) -> Result;
   loopback @3 (thing :Thing) -> (thing :Thing);
 
+  waitForever @4 ();
+
   interface Thing {
     passThrough @0 () -> Result;
     intercept @1 () -> Result;


### PR DESCRIPTION
I realized upon trying to use this framework in Sandstorm that proper revocation was not easy to implement as-is. It's easy enough to revoke new calls, but canceling existing calls requires implementing a custom RequestHook and such. Since revocation is arguably the most important thing one might want to do with a membrane, this should be built-in.

@harrishancock Since this is purely for Sandstorm, not for Cloudflare, I'm not marking you as a reviewer. Just doing the PR to get CI results.