### PR TITLE
Treat 'Premature EOF' error on async stream as DISCONNECTED.

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -53,12 +53,14 @@ Promise<void> AsyncInputStream::read(void* buffer, size_t bytes) {
 
 Promise<size_t> AsyncInputStream::read(void* buffer, size_t minBytes, size_t maxBytes) {
   return tryRead(buffer, minBytes, maxBytes).then([=](size_t result) {
-    KJ_REQUIRE(result >= minBytes, "Premature EOF") {
+    if (result >= minBytes) {
+      return result;
+    } else {
+      kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED, "stream disconnected prematurely"));
       // Pretend we read zeros from the input.
       memset(reinterpret_cast<byte*>(buffer) + result, 0, minBytes - result);
       return minBytes;
     }
-    return result;
   });
 }
 

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -54,7 +54,9 @@ Promise<size_t> GzipAsyncInputStream::readImpl(
     return inner.tryRead(buffer, 1, sizeof(buffer))
         .then([this,out,minBytes,maxBytes,alreadyRead](size_t amount) -> Promise<size_t> {
       if (amount == 0) {
-        KJ_REQUIRE(atValidEndpoint, "gzip compressed stream ended prematurely");
+        if (!atValidEndpoint) {
+          return KJ_EXCEPTION(DISCONNECTED, "gzip compressed stream ended prematurely");
+        }
         return alreadyRead;
       } else {
         ctx.next_in = buffer;


### PR DESCRIPTION
Unfortunately TCP does not always distinguish between dirty connection failure and clean connection shutdown. In practice, though, "Premature EOF" errors on streams basically always appear to be due to disconnects (including when the peer crashes).