### PR TITLE
Allow working around the message size limit

### DIFF
--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -354,12 +354,12 @@ TEST(TwoPartyNetwork, HugeMessage) {
     auto req = client.methodWithDefaultsRequest();
     req.initA(100000000);  // 100 MB
 
-    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("larger than the single-message size limit",
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("larger than our single-message size limit",
         req.send().ignoreResult().wait(ioContext.waitScope));
   }
 
   // Oversized response fails.
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("larger than the single-message size limit",
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("larger than our single-message size limit",
       client.getEnormousStringRequest().send().ignoreResult().wait(ioContext.waitScope));
 
   // Connection is still up.

--- a/c++/src/capnp/rpc-twoparty.c++
+++ b/c++/src/capnp/rpc-twoparty.c++
@@ -86,10 +86,10 @@ public:
     for (auto& segment: message.getSegmentsForOutput()) {
       size += segment.size();
     }
-    KJ_REQUIRE(size < ReaderOptions().traversalLimitInWords, size,
-               "Trying to send Cap'n Proto message larger than the single-message size limit. The "
-               "other side probably won't accept it and would abort the connection, so I won't "
-               "send it.") {
+    KJ_REQUIRE(size < network.receiveOptions.traversalLimitInWords, size,
+               "Trying to send Cap'n Proto message larger than our single-message size limit. The "
+               "other side probably won't accept it (assuming its traversalLimitInWords matches "
+               "ours) and would abort the connection, so I won't send it.") {
       return;
     }
 


### PR DESCRIPTION
AFAICT, without this, there's no way to convince capnp to send a message larger than 64MB, even if you know the other side will accept it. This should cause it to work reasonably, assuming both sides set their message limits identically.