### PR TITLE
Add Array::attach() and ArrayPtr::attach().

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -870,7 +870,7 @@ template <typename... Attachments>
 Array<T> ArrayPtr<T>::attach(Attachments&&... attachments) const {
   T* ptrCopy = ptr;
 
-  KJ_IREQUIRE(ptr != nullptr, "cannot attach to null pointer");
+  KJ_IREQUIRE(ptrCopy != nullptr, "cannot attach to null pointer");
 
   // HACK: If someone accidentally calls .attach() on a null pointer in opt mode, try our best to
   //   accomplish reasonable behavior: We turn the pointer non-null but still invalid, so that the
@@ -879,7 +879,7 @@ Array<T> ArrayPtr<T>::attach(Attachments&&... attachments) const {
 
   auto bundle = new _::ArrayDisposableOwnedBundle<Attachments...>(
       kj::fwd<Attachments>(attachments)...);
-  return Array<T>(ptr, size_, *bundle);
+  return Array<T>(ptrCopy, size_, *bundle);
 }
 
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1248,6 +1248,9 @@ private:
 // So common that we put it in common.h rather than array.h.
 
 template <typename T>
+class Array;
+
+template <typename T>
 class ArrayPtr: public DisallowConstCopyIfNotConst<T> {
   // A pointer to an array.  Includes a size.  Like any pointer, it doesn't own the target data,
   // and passing by value only copies the pointer, not the target.
@@ -1355,6 +1358,13 @@ public:
   }
   template <typename U>
   inline bool operator!=(const ArrayPtr<U>& other) const { return !(*this == other); }
+
+  template <typename... Attachments>
+  Array<T> attach(Attachments&&... attachments) const KJ_WARN_UNUSED_RESULT;
+  // Like Array<T>::attach(), but also promotes an ArrayPtr to an Array. Generally the attachment
+  // should be an object that actually owns the array that the ArrayPtr is pointing at.
+  //
+  // You must include kj/array.h to call this.
 
 private:
   T* ptr;

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -197,7 +197,7 @@ public:
   }
 
   template <typename... Attachments>
-  Own<T> attach(Attachments&&... attachments);
+  Own<T> attach(Attachments&&... attachments) KJ_WARN_UNUSED_RESULT;
   // Returns an Own<T> which points to the same object but which also ensures that all values
   // passed to `attachments` remain alive until after this object is destroyed. Normally
   // `attachments` are other Own<?>s pointing to objects that this one depends on.


### PR DESCRIPTION
Array::attach() is like Own::attach().

ArrayPtr::attach() promotes an ArrayPtr to an Array by attaching other objects to it. (Hopefully one of those objects actually owns the underlying array data.)