### PR TITLE
Fix bugs in relative URL parser

### DIFF
--- a/c++/src/kj/compat/url-test.c++
+++ b/c++/src/kj/compat/url-test.c++
@@ -371,5 +371,10 @@ KJ_TEST("parse relative URL") {
                         "https://capnproto.org/http%3A/grault");
 }
 
+KJ_TEST("parse relative URL failure") {
+  auto base = Url::parse("https://example.com/");
+  KJ_EXPECT(base.tryParseRelative("https://[not a host]") == nullptr);
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/compat/url-test.c++
+++ b/c++/src/kj/compat/url-test.c++
@@ -369,6 +369,9 @@ KJ_TEST("parse relative URL") {
   parseAndCheckRelative("https://capnproto.org/foo/bar?baz=qux#corge",
                         "/http:/grault",
                         "https://capnproto.org/http%3A/grault");
+  parseAndCheckRelative("https://capnproto.org/",
+                        "/foo/../bar",
+                        "https://capnproto.org/bar");
 }
 
 KJ_TEST("parse relative URL failure") {

--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -312,7 +312,7 @@ Maybe<Url> Url::tryParseRelative(StringPtr text) const {
     for (;;) {
       auto part = split(text, END_PATH_PART);
       if (part.size() == 2 && part[0] == '.' && part[1] == '.') {
-        if (path.size() != 0) {
+        if (result.path.size() != 0) {
           result.path.removeLast();
         }
         result.hasTrailingSlash = true;

--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -279,6 +279,8 @@ Maybe<Url> Url::tryParseRelative(StringPtr text) const {
     }
 
     result.host = percentDecode(authority, err);
+    if (!HOST_CHARS.containsAll(result.host)) return nullptr;
+    toLower(result.host);
   } else {
     // copy authority
     result.host = kj::str(this->host);


### PR DESCRIPTION
The relative URL parser allowed certain hosts which the absolute parser correctly weeded out. This change copies two lines from the absolute parser over to the relative parser.