### PR TITLE
Make all tests pass on qemu-aarch64

### DIFF
--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -822,7 +822,7 @@ int base64_decode_block(const char* code_in, const int length_in,
                         char* plaintext_out, base64_decodestate* state_in) {
   const char* codechar = code_in;
   char* plainchar = plaintext_out;
-  char fragment;
+  signed char fragment;
 
   if (state_in->step != step_a) {
     *plainchar = state_in->plainchar;
@@ -841,7 +841,7 @@ int base64_decode_block(const char* code_in, const int length_in,
           state_in->plainchar = '\0';
           return plainchar - plaintext_out;
         }
-        fragment = (char)base64_decode_value(*codechar++);
+        fragment = (signed char)base64_decode_value(*codechar++);
         // It is an error to see invalid or padding bytes in step A.
         ERROR_IF(fragment < -1);
       } while (fragment < 0);
@@ -857,7 +857,7 @@ int base64_decode_block(const char* code_in, const int length_in,
           state_in->hadErrors = true;
           return plainchar - plaintext_out;
         }
-        fragment = (char)base64_decode_value(*codechar++);
+        fragment = (signed char)base64_decode_value(*codechar++);
         // It is an error to see invalid or padding bytes in step B.
         ERROR_IF(fragment < -1);
       } while (fragment < 0);
@@ -874,7 +874,7 @@ int base64_decode_block(const char* code_in, const int length_in,
           ERROR_IF(state_in->nPaddingBytesSeen == 1);
           return plainchar - plaintext_out;
         }
-        fragment = (char)base64_decode_value(*codechar++);
+        fragment = (signed char)base64_decode_value(*codechar++);
         // It is an error to see invalid bytes or more than two padding bytes in step C.
         ERROR_IF(fragment < -2 || (fragment == -2 && ++state_in->nPaddingBytesSeen > 2));
       } while (fragment < 0);
@@ -889,7 +889,7 @@ int base64_decode_block(const char* code_in, const int length_in,
           state_in->plainchar = *plainchar;
           return plainchar - plaintext_out;
         }
-        fragment = (char)base64_decode_value(*codechar++);
+        fragment = (signed char)base64_decode_value(*codechar++);
         // It is an error to see invalid bytes or more than one padding byte in step D.
         ERROR_IF(fragment < -2 || (fragment == -2 && ++state_in->nPaddingBytesSeen > 1));
       } while (fragment < 0);

--- a/c++/src/kj/filesystem-disk-old-kernel-test.c++
+++ b/c++/src/kj/filesystem-disk-old-kernel-test.c++
@@ -122,3 +122,12 @@ SetupSeccompForFilesystemTest setupSeccompForFilesystemTest;
 #endif
 #endif
 #endif
+
+#if __linux__ && !__x86_64__
+// HACK: We may be cross-compiling. Ekam's cross-compiling is currently hacky -- if a test is a
+//   test on the host platform then it needs to be a test on all other targets, too. So add a dummy
+//   test here.
+// TODO(cleanup): Make Ekam cross-compiling better.
+#include <kj/test.h>
+KJ_TEST("old kernel test -- not supported on this architecture") {}
+#endif


### PR DESCRIPTION
In particular, when using the new Ekam cross-compiling support that I'm working on.