### PR TITLE
Implement various WHATWG URL percent encoding functions

### DIFF
--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -375,10 +375,10 @@ String Url::toString(Context context) const {
 
     if (context == REMOTE_HREF) {
       KJ_IF_MAYBE(user, userInfo) {
-        chars.addAll(encodeUriComponent(user->username));
+        chars.addAll(encodeUriUserInfo(user->username));
         KJ_IF_MAYBE(pass, user->password) {
           chars.add(':');
-          chars.addAll(encodeUriComponent(*pass));
+          chars.addAll(encodeUriUserInfo(*pass));
         }
         chars.add('@');
       }
@@ -407,7 +407,7 @@ String Url::toString(Context context) const {
       continue;
     }
     chars.add('/');
-    chars.addAll(encodeUriComponent(pathPart));
+    chars.addAll(encodeUriPath(pathPart));
   }
   if (hasTrailingSlash || (path.size() == 0 && context == HTTP_REQUEST)) {
     chars.add('/');
@@ -427,7 +427,7 @@ String Url::toString(Context context) const {
   if (context == REMOTE_HREF) {
     KJ_IF_MAYBE(f, fragment) {
       chars.add('#');
-      chars.addAll(encodeUriComponent(*f));
+      chars.addAll(encodeUriFragment(*f));
     }
   }
 

--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -390,9 +390,67 @@ EncodingResult<Array<byte>> decodeHex(ArrayPtr<const char> text) {
 String encodeUriComponent(ArrayPtr<const byte> bytes) {
   Vector<char> result(bytes.size() + 1);
   for (byte b: bytes) {
-    if (('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z') || ('0' <= b && b <= '9') ||
+    if (('A' <= b && b <= 'Z') ||
+        ('a' <= b && b <= 'z') ||
+        ('0' <= b && b <= '9') ||
         b == '-' || b == '_' || b == '.' || b == '!' || b == '~' || b == '*' || b == '\'' ||
         b == '(' || b == ')') {
+      result.add(b);
+    } else {
+      result.add('%');
+      result.add(HEX_DIGITS_URI[b/16]);
+      result.add(HEX_DIGITS_URI[b%16]);
+    }
+  }
+  result.add('\0');
+  return String(result.releaseAsArray());
+}
+
+String encodeUriFragment(ArrayPtr<const byte> bytes) {
+  Vector<char> result(bytes.size() + 1);
+  for (byte b: bytes) {
+    if (('?' <= b && b <= '_') || // covers A-Z
+        ('a' <= b && b <= '~') || // covers a-z
+        ('#' <= b && b <= ';') || // covers 0-9
+        b == '!' || b == '=') {
+      result.add(b);
+    } else {
+      result.add('%');
+      result.add(HEX_DIGITS_URI[b/16]);
+      result.add(HEX_DIGITS_URI[b%16]);
+    }
+  }
+  result.add('\0');
+  return String(result.releaseAsArray());
+}
+
+String encodeUriPath(ArrayPtr<const byte> bytes) {
+  Vector<char> result(bytes.size() + 1);
+  for (byte b: bytes) {
+    if (('@' <= b && b <= '[') || // covers A-Z
+        ('a' <= b && b <= 'z') ||
+        ('0' <= b && b <= ';') || // covers 0-9
+        ('$' <= b && b <= '.') ||
+        b == '_' || b == '!' || b == '=' || b == ']' || b == '^' || b == '|' || b == '~') {
+      result.add(b);
+    } else {
+      result.add('%');
+      result.add(HEX_DIGITS_URI[b/16]);
+      result.add(HEX_DIGITS_URI[b%16]);
+    }
+  }
+  result.add('\0');
+  return String(result.releaseAsArray());
+}
+
+String encodeUriUserInfo(ArrayPtr<const byte> bytes) {
+  Vector<char> result(bytes.size() + 1);
+  for (byte b: bytes) {
+    if (('A' <= b && b <= 'Z') ||
+        ('a' <= b && b <= 'z') ||
+        ('0' <= b && b <= '9') ||
+        ('$' <= b && b <= '.') ||
+        b == '_' || b == '!' || b == '~') {
       result.add(b);
     } else {
       result.add('%');
@@ -407,7 +465,9 @@ String encodeUriComponent(ArrayPtr<const byte> bytes) {
 String encodeWwwForm(ArrayPtr<const byte> bytes) {
   Vector<char> result(bytes.size() + 1);
   for (byte b: bytes) {
-    if (('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z') || ('0' <= b && b <= '9') ||
+    if (('A' <= b && b <= 'Z') ||
+        ('a' <= b && b <= 'z') ||
+        ('0' <= b && b <= '9') ||
         b == '-' || b == '_' || b == '.' || b == '*') {
       result.add(b);
     } else if (b == ' ') {

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -130,6 +130,33 @@ EncodingResult<String> decodeUriComponent(ArrayPtr<const char> text);
 //
 // See https://tools.ietf.org/html/rfc2396#section-2.3
 
+String encodeUriFragment(ArrayPtr<const byte> bytes);
+String encodeUriFragment(ArrayPtr<const char> bytes);
+// Encode URL fragment components using the fragment percent encode set defined by the WHATWG URL
+// specification. Use decodeUriComponent() to decode.
+//
+// See https://url.spec.whatwg.org/#fragment-percent-encode-set
+
+String encodeUriPath(ArrayPtr<const byte> bytes);
+String encodeUriPath(ArrayPtr<const char> bytes);
+// Encode URL path components (not entire paths!) using the path percent encode set defined by the
+// WHATWG URL specification. Use decodeUriComponent() to decode.
+//
+// Quirk: This percent-encodes '/' and '\' characters as well, which are not actually in the set
+//   defined by the WHATWG URL spec. Since a conforming URL implementation will only ever call this
+//   function on individual path components, and never entire paths, augmenting the character set to
+//   include these separators allows this function to be used to implement a URL class that stores
+//   its path components in either percent-encoded OR percent-decoded form.
+//
+// See https://url.spec.whatwg.org/#path-percent-encode-set
+
+String encodeUriUserInfo(ArrayPtr<const byte> bytes);
+String encodeUriUserInfo(ArrayPtr<const char> bytes);
+// Encode URL userinfo components using the userinfo percent encode set defined by the WHATWG URL
+// specification. Use decodeUriComponent() to decode.
+//
+// See https://url.spec.whatwg.org/#userinfo-percent-encode-set
+
 String encodeWwwForm(ArrayPtr<const byte> bytes);
 String encodeWwwForm(ArrayPtr<const char> bytes);
 EncodingResult<String> decodeWwwForm(ArrayPtr<const char> text);
@@ -215,6 +242,16 @@ inline EncodingResult<String> decodeUriComponent(ArrayPtr<const char> text) {
   return { String(result.releaseAsChars()), result.hadErrors };
 }
 
+inline String encodeUriFragment(ArrayPtr<const char> text) {
+  return encodeUriFragment(text.asBytes());
+}
+inline String encodeUriPath(ArrayPtr<const char> text) {
+  return encodeUriPath(text.asBytes());
+}
+inline String encodeUriUserInfo(ArrayPtr<const char> text) {
+  return encodeUriUserInfo(text.asBytes());
+}
+
 inline String encodeWwwForm(ArrayPtr<const char> text) {
   return encodeWwwForm(text.asBytes());
 }
@@ -276,6 +313,18 @@ inline Array<byte> decodeBinaryUriComponent(const char (&text)[s]) {
 template <size_t s>
 inline EncodingResult<String> decodeUriComponent(const char (&text)[s]) {
   return decodeUriComponent(arrayPtr(text, s-1));
+}
+template <size_t s>
+inline String encodeUriFragment(const char (&text)[s]) {
+  return encodeUriFragment(arrayPtr(text, s - 1));
+}
+template <size_t s>
+inline String encodeUriPath(const char (&text)[s]) {
+  return encodeUriPath(arrayPtr(text, s - 1));
+}
+template <size_t s>
+inline String encodeUriUserInfo(const char (&text)[s]) {
+  return encodeUriUserInfo(arrayPtr(text, s - 1));
 }
 template <size_t s>
 inline String encodeWwwForm(const char (&text)[s]) {


### PR DESCRIPTION
~DRAFT - do not merge yet. See below about path serialization for my main concern.~

This adds `encodeUriFragment()`, `encodeUriPath()`, and `encodeUriUserInfo()` to kj-encoding, and uses them in `kj::Url::toString()` to become slightly more conformant in the eyes of the WHATWG URL spec.

It's worth noting that the reserved character set of `encodeUriFragment()` is a subset of `encodeUriPath()`, which in turn is a subset of `encodeUriUserInfo()`, owing to their positions in URL strings. All three functions' reserved character sets are subsets of `encodeUriComponent()` (RFC 2396).

~**Path serialization:** I implemented `encodeUrlPath()` the obvious way: by following what the spec says to do. However, the spec says not to encode `/` characters. This means that if we parse a URL with one path component, and we set that one path component to "foo/bar", then if we serialize and reparse it, we will now magically have two path components. I'm not sure if this is a problem or not. For our use case, it may not matter.~

**Implementation:** I think it would be more elegant implementation-wise if we refactored all of these new functions, and `encodeUriComponent()`, into one function parameterized on a `CharGroup_` expressing the unreserved (or reserved) character sets in question. However, I wanted to get your opinion on this draft, first, as I'm unsure if that would change performance characteristics significantly in one way or another. Note that I'm not sure that `encodeWwwForm()` could be rolled into such a refactor, owing to its weird plus-to-space rules.

~**Naming:** I'm open to suggestions. It makes sense to me that `encodeUriComponent()` is named the way it is, because it duplicates the similarly-named JS function. Likewise, it makes sense that these new functions are named `encodeUrl*()`, since they implement functionality standardized by the URL spec. Nevertheless, the resulting inconsistency between Url and Uri is a bit glaring. (Note that I don't think `encodeWwwForm()` should be named `encodeUrlQueryParameter()`, since it's a bit more special than these new functions.):~