### PR TITLE
Distinguish between empty- and null-valued query parameters

### DIFF
--- a/c++/src/kj/compat/url.h
+++ b/c++/src/kj/compat/url.h
@@ -63,7 +63,14 @@ struct Url {
   };
   Vector<QueryParam> query;
   // Query, e.g. from "?key=value&key2=value2". If a component of the query contains no '=' sign,
-  // it will be parsed as a key with an empty value.
+  // it will be parsed as a key with a null value, and later serialized with no '=' sign if you call
+  // Url::toString().
+  //
+  // To distinguish between null-valued and empty-valued query parameters, we test whether
+  // QueryParam::value is an allocated or unallocated string. For example:
+  //
+  //     QueryParam { kj::str("name"), nullptr }      // Null-valued; will not have an '=' sign.
+  //     QueryParam { kj::str("name"), kj::str("") }  // Empty-valued; WILL have an '=' sign.
 
   Maybe<String> fragment;
   // The stuff after the '#' character (not including the '#' character itself), if present.


### PR DESCRIPTION
~This makes `kj::Url::query`'s value type a `Maybe<String>` instead of just a `String`. **This is a breaking source change.** I think we could get the best of both worlds if we include `kj/encoding.h` and make it an `EncodingResult<String>` instead, with a "failed" empty string value for null valued query parameters, and a "successful" empty string value for empty valued query params. Any preference?~

~Also, note that this PR is based on the WHATWG URL percent-encoding PR (to avoid conflicts), which isn't merged yet. Hopefully when that gets merged, this one will magically become one single commit? Or maybe this one will break and I'll have to rebase manually anyway. :)~

Edit: now distinguishes based on allocated-ness of `QueryParam::value`, as discussed.