### PR TITLE
 Implement in-process byte stream pipes.

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -689,7 +689,7 @@ private:
           if (actual < amount) {
             // We din't complete pumping. Restart from the pipe.
             return input.pumpTo(pipe, amount - actual)
-                .then([actual](size_t actual2) { return actual + actual2; });
+                .then([actual](uint64_t actual2) { return actual + actual2; });
           }
         }
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -484,8 +484,8 @@ private:
         if (actual >= minBytes) {
           return actual;
         } else {
-          return pipe.read(reinterpret_cast<byte*>(readBuffer) + actual,
-                           minBytes - actual, maxBytes - actual)
+          return pipe.tryRead(reinterpret_cast<byte*>(readBuffer) + actual,
+                              minBytes - actual, maxBytes - actual)
               .then([actual](size_t actual2) { return actual + actual2; });
         }
       }));

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -689,7 +689,7 @@ private:
           if (actual < amount) {
             // We din't complete pumping. Restart from the pipe.
             return input.pumpTo(pipe, amount - actual)
-                .then([actual](uint64_t actual2) { return actual + actual2; });
+                .then([actual](uint64_t actual2) -> uint64_t { return actual + actual2; });
           }
         }
 
@@ -723,7 +723,7 @@ private:
     // AsyncPipe state when a pumpTo() is currently waiting for a corresponding write().
 
   public:
-    BlockedPumpTo(PromiseFulfiller<size_t>& fulfiller, AsyncPipe& pipe,
+    BlockedPumpTo(PromiseFulfiller<uint64_t>& fulfiller, AsyncPipe& pipe,
                   AsyncOutputStream& output, uint64_t amount)
         : fulfiller(fulfiller), pipe(pipe), output(output), amount(amount) {
       KJ_REQUIRE(pipe.state == nullptr);
@@ -879,7 +879,7 @@ private:
     }
 
   private:
-    PromiseFulfiller<size_t>& fulfiller;
+    PromiseFulfiller<uint64_t>& fulfiller;
     AsyncPipe& pipe;
     AsyncOutputStream& output;
     uint64_t amount;

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -175,12 +175,23 @@ struct OneWayPipe {
   Own<AsyncOutputStream> out;
 };
 
+OneWayPipe newOneWayPipe(kj::Maybe<uint64_t> expectedLength = nullptr);
+// Constructs a OneWayPipe that operates in-process. The pipe does not do any buffering -- it waits
+// until both a read() and a write() call are pending, then resolves both.
+//
+// If `expectedLength` is non-null, then the pipe will be expected to transmit exactly that many
+// bytes. The input end's `tryGetLength()` will return the number of bytes left.
+
 struct TwoWayPipe {
   // A data pipe that supports sending in both directions.  Each end's output sends data to the
   // other end's input.  (Typically backed by socketpair() system call.)
 
   Own<AsyncIoStream> ends[2];
 };
+
+TwoWayPipe newTwoWayPipe();
+// Constructs a TwoWayPipe that operates in-process. The pipe does not do any buffering -- it waits
+// until both a read() and a write() call are pending, then resolves both.
 
 struct CapabilityPipe {
   // Like TwoWayPipe but allowing capability-passing.

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -593,18 +593,10 @@ template <>
 class Canceler::AdapterImpl<void>: public AdapterBase {
 public:
   AdapterImpl(kj::PromiseFulfiller<void>& fulfiller,
-              Canceler& canceler, kj::Promise<void> inner)
-      : AdapterBase(canceler),
-        fulfiller(fulfiller),
-        inner(inner.then(
-            [&fulfiller]() { fulfiller.fulfill(); },
-            [&fulfiller](kj::Exception&& e) { fulfiller.reject(kj::mv(e)); })
-            .eagerlyEvaluate(nullptr)) {}
-
-  void cancel(kj::Exception&& e) override {
-    fulfiller.reject(kj::mv(e));
-    inner = nullptr;
-  }
+              Canceler& canceler, kj::Promise<void> inner);
+  void cancel(kj::Exception&& e) override;
+  // These must be defined in async.c++ to prevent translation units compiled by MSVC from trying to
+  // link with symbols defined in async.c++ merely because they included async.h.
 
 private:
   kj::PromiseFulfiller<void>& fulfiller;

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -501,6 +501,117 @@ PromiseFulfillerPair<T> newPromiseAndFulfiller();
 // `fulfill()` callback, and the promises are chained.
 
 // =======================================================================================
+// Canceler
+
+class Canceler {
+  // A Canceler can wrap some set of Promises and then forcefully cancel them on-demand, or
+  // implicitly when the Canceler is destroyed.
+  //
+  // The cancellation is done in such a way that once cancel() (or the Canceler's destructor)
+  // returns, it's guaranteed that the promise has already been canceled and destroyed. This
+  // guarantee is important for enforcing ownership constraints. For example, imagine that Alice
+  // calls a method on Bob that returns a Promise. That Promise encapsulates a task that uses Bob's
+  // internal state. But, imagine that Alice does not own Bob, and indeed Bob might be destroyed
+  // at random without Alice having canceled the promise. In this case, it is necessary for Bob to
+  // ensure that the promise will be forcefully canceled. Bob can do this by constructing a
+  // Canceler and using it to wrap promises before returning them to callers. When Bob is
+  // destroyed, the Canceler is destroyed too, and all promises Bob wrapped with it throw errors.
+  //
+  // Note that another common strategy for cancelation is to use exclusiveJoin() to join a promise
+  // with some "cancellation promise" which only resolves if the operation should be canceled. The
+  // cancellation promise could itself be created by newPromiseAndFulfiller<void>(), and thus
+  // calling the PromiseFulfiller cancels the operation. There is a major problem with this
+  // approach: upon invoking the fulfiller, an arbitrary amount of time may pass before the
+  // exclusive-joined promise actually resolves and cancels its other fork. During that time, the
+  // task might continue to execute. If it holds pointers to objects that have been destroyed, this
+  // might cause segfaults. Thus, it is safer to use a Canceler.
+
+public:
+  inline Canceler() {}
+  ~Canceler() noexcept(false);
+  KJ_DISALLOW_COPY(Canceler);
+
+  template <typename T>
+  Promise<T> wrap(Promise<T> promise) {
+    return newAdaptedPromise<T, AdapterImpl<T>>(*this, kj::mv(promise));
+  }
+
+  void cancel(StringPtr cancelReason);
+  void cancel(const Exception& exception);
+  // Cancel all previously-wrapped promises that have not already completed, causing them to throw
+  // the given exception. If you provide just a description message instead of an exception, then
+  // an exception object will be constructed from it -- but only if there are requests to cancel.
+
+  void release();
+  // Releases previously-wrapped promises, so that they will not be canceled regardless of what
+  // happens to this Canceler.
+
+  bool isEmpty() { return list == nullptr; }
+  // Indicates if any previously-wrapped promises are still executing. (If this returns false, then
+  // cancel() would be a no-op.)
+
+private:
+  class AdapterBase {
+  public:
+    AdapterBase(Canceler& canceler);
+    ~AdapterBase() noexcept(false);
+
+    virtual void cancel(Exception&& e) = 0;
+
+  private:
+    Maybe<Maybe<AdapterBase&>&> prev;
+    Maybe<AdapterBase&> next;
+    friend class Canceler;
+  };
+
+  template <typename T>
+  class AdapterImpl: public AdapterBase {
+  public:
+    AdapterImpl(PromiseFulfiller<T>& fulfiller,
+                Canceler& canceler, Promise<T> inner)
+        : AdapterBase(canceler),
+          fulfiller(fulfiller),
+          inner(inner.then(
+              [&fulfiller](T&& value) { fulfiller.fulfill(kj::mv(value)); },
+              [&fulfiller](Exception&& e) { fulfiller.reject(kj::mv(e)); })
+              .eagerlyEvaluate(nullptr)) {}
+
+    void cancel(Exception&& e) override {
+      fulfiller.reject(kj::mv(e));
+      inner = nullptr;
+    }
+
+  private:
+    PromiseFulfiller<T>& fulfiller;
+    Promise<void> inner;
+  };
+
+  Maybe<AdapterBase&> list;
+};
+
+template <>
+class Canceler::AdapterImpl<void>: public AdapterBase {
+public:
+  AdapterImpl(kj::PromiseFulfiller<void>& fulfiller,
+              Canceler& canceler, kj::Promise<void> inner)
+      : AdapterBase(canceler),
+        fulfiller(fulfiller),
+        inner(inner.then(
+            [&fulfiller]() { fulfiller.fulfill(); },
+            [&fulfiller](kj::Exception&& e) { fulfiller.reject(kj::mv(e)); })
+            .eagerlyEvaluate(nullptr)) {}
+
+  void cancel(kj::Exception&& e) override {
+    fulfiller.reject(kj::mv(e));
+    inner = nullptr;
+  }
+
+private:
+  kj::PromiseFulfiller<void>& fulfiller;
+  kj::Promise<void> inner;
+};
+
+// =======================================================================================
 // TaskSet
 
 class TaskSet {

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -131,7 +131,7 @@ public:
 
   inline bool isShared() const {
 #if _MSC_VER
-    KJ_MSVC_INTERLOCKED(Or, acq)(&refcount, 0) > 1;
+    return KJ_MSVC_INTERLOCKED(Or, acq)(&refcount, 0) > 1;
 #else
     return __atomic_load_n(&refcount, __ATOMIC_ACQUIRE) > 1;
 #endif


### PR DESCRIPTION
This lets you construct an AsyncInputStream / AsyncOutputStream pair that operates entirely within userspace, rather than pushing through a kernel-level pipe. This is far more efficient, avoiding system calls and reducing copies.

The pipe does not buffer at all. Instead, it waits for both a read() and a write() call to be active at the same time, and then it fulfills one with the other.

This implementation also optimizes pumps. Imagine the situation: you create a pipe; you call pumpTo() on the write end to pump it to some other; then you write to the write end of the pipe. In this case, the write will *directly* call the target stream to which the pipe is being pumped. Hence, adding daisy-chained pipes on top of a final output stream does not incur additional copies of the data. Similarly, tryPumpFrom() is optimized on the read end.