### PR TITLE
Fix filesystem-disk-test to support platforms with non-4K filesystem block size

### DIFF
--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -897,7 +897,14 @@ KJ_TEST("DiskFile holes") {
 #endif
 
   // Try punching a hole with zero().
-  file->zero(1 << 20, 4096);
+#if _WIN32
+  uint64_t blockSize = 4096; // TODO(someday): Actually ask the OS.
+#else
+  struct stat stats;
+  KJ_SYSCALL(fstat(KJ_ASSERT_NONNULL(file->getFd()), &stats));
+  uint64_t blockSize = stats.st_blksize;
+#endif
+  file->zero(1 << 20, blockSize);
   file->datasync();
 #if !_WIN32
   // TODO(someday): This doesn't work on Windows. I don't know why. We're definitely using the


### PR DESCRIPTION
Some memory-based filesystems, namely tmpfs, select their underlying block size
equal to the configured page size of the platform/OS.

On systems with page size not equal to 4K (for example, arm64 can be configured
to have 16K or 64K page sizes -
https://www.kernel.org/doc/Documentation/arm64/memory.txt) "DiskFile holes"
test fails, when creating a file on a memory-based filesystem, because it
"punches" a 4096 byte hole in the file (using fallocate) and expects the number
of filesystem blocks used by the file to decrease. When the system page size is
greater than 4K, 4096 byte hole is not enough to make the OS release the
underlying blocks.

Need to punch a whole, which is equal to the underlying filesystem block size at
least.