### PR TITLE
Fix problem on android api < 23

### DIFF
--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -244,7 +244,9 @@ static String makeDescriptionImpl(DescriptionStyle style, const char* code, int 
     StringPtr colon = ": ";
 
     StringPtr sysErrorArray;
-#if __USE_GNU
+// On android before marshmallow only the posix version of stderror_r was
+// available, even with __USE_GNU.
+#if __USE_GNU && !(defined(__ANDROID_API__) && __ANDROID_API__ < 23)
     char buffer[256];
     if (style == SYSCALL) {
       if (sysErrorString == nullptr) {


### PR DESCRIPTION
This fixes a problem when building for older android versions,

```
capnproto/c++/src/kj/debug.c++:250:23: error: no viable overloaded '='
        sysErrorArray = strerror_r(errorNumber, buffer, sizeof(buffer));
        ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
capnproto/c++/src/kj/string.h:53:7: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'int' to 'const kj::StringPtr' for 1st argument
class StringPtr {
      ^
capnproto/c++/src/kj/string.h:53:7: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'int' to 'kj::StringPtr' for 1st argument
1 error generated.
```

I've rewritten it slightly to make it more obvious when it applies.