### PR TITLE
Rewrite JSON decoding

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ Harris Hancock <vortrab@gmail.com>: MSVC support
 Branislav Katreniak <branislav.katreniak@digitalstrom.com>: JSON decode
 Matthew Maurer <matthew.r.maurer@gmail.com>: Canonicalization Support
 David Renshaw <david@sandstorm.io>: bugfixes and miscellaneous maintenance
+Ingvar Stepanyan <me@rreverser.com> <ingvar@cloudflare.com>: Custom handlers for JSON decode
 
 This file does not list people who maintain their own Cap'n Proto
 implementations as separate projects.  Those people are awesome too!  :)

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -258,6 +258,8 @@ KJ_TEST("decode all types") {
   CASE_NO_ROUNDTRIP(R"({"float32Field":"-infinity"})", root.getFloat32Field() == -kj::inf());
   CASE_NO_ROUNDTRIP(R"({"float32Field":"INF"})", root.getFloat32Field() == kj::inf());
   CASE_NO_ROUNDTRIP(R"({"float32Field":"-INF"})", root.getFloat32Field() == -kj::inf());
+  CASE_NO_ROUNDTRIP(R"({"float32Field":1e39})", root.getFloat32Field() == kj::inf());
+  CASE_NO_ROUNDTRIP(R"({"float32Field":-1e39})", root.getFloat32Field() == -kj::inf());
   CASE_NO_ROUNDTRIP(R"({"float64Field":0})", root.getFloat64Field() == 0);
   CASE(R"({"float64Field":4.5})", root.getFloat64Field() == 4.5);
   CASE_NO_ROUNDTRIP(R"({"float64Field":null})", kj::isNaN(root.getFloat64Field()));
@@ -268,6 +270,8 @@ KJ_TEST("decode all types") {
   CASE_NO_ROUNDTRIP(R"({"float64Field":"-infinity"})", root.getFloat64Field() == -kj::inf());
   CASE_NO_ROUNDTRIP(R"({"float64Field":"INF"})", root.getFloat64Field() == kj::inf());
   CASE_NO_ROUNDTRIP(R"({"float64Field":"-INF"})", root.getFloat64Field() == -kj::inf());
+  CASE_NO_ROUNDTRIP(R"({"float64Field":1e309})", root.getFloat64Field() == kj::inf());
+  CASE_NO_ROUNDTRIP(R"({"float64Field":-1e309})", root.getFloat64Field() == -kj::inf());
   CASE(R"({"textField":"hello"})", kj::str("hello") == root.getTextField());
   CASE(R"({"dataField":[7,0,122]})",
       kj::heapArray<byte>({7,0,122}).asPtr() == root.getDataField());
@@ -529,20 +533,6 @@ KJ_TEST("basic json decoding") {
 
     // Leading + not allowed in numbers.
     KJ_EXPECT_THROW_MESSAGE("Unexpected", json.decodeRaw("+123", root));
-  }
-
-  {
-    MallocMessageBuilder message;
-    auto root = message.initRoot<JsonValue>();
-
-    KJ_EXPECT_THROW_MESSAGE("Overflow", json.decodeRaw("1e1024", root));
-  }
-
-  {
-    MallocMessageBuilder message;
-    auto root = message.initRoot<JsonValue>();
-
-    KJ_EXPECT_THROW_MESSAGE("Underflow", json.decodeRaw("1e-1023", root));
   }
 
   {

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -530,6 +530,8 @@ Orphan<DynamicValue> JsonCodec::decode(
       KJ_FAIL_REQUIRE("don't know how to JSON-decode AnyPointer; "
                       "please register a JsonCodec::Handler for this");
   }
+
+  KJ_CLANG_KNOWS_THIS_IS_UNREACHABLE_BUT_GCC_DOESNT;
 }
 
 // -----------------------------------------------------------------------------

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -658,19 +658,7 @@ public:
   }
 
   void parseNumber(JsonValue::Builder& output) {
-    auto numberStr = consumeNumber();
-    char *endPtr;
-
-    errno = 0;
-    double value = strtod(numberStr.begin(), &endPtr);
-
-    KJ_ASSERT(endPtr != numberStr.begin(), "strtod should not fail! Is consumeNumber wrong?");
-    KJ_REQUIRE((value != HUGE_VAL && value != -HUGE_VAL) || errno != ERANGE,
-        "Overflow in JSON number.");
-    KJ_REQUIRE(value != 0.0 || errno != ERANGE,
-        "Underflow in JSON number.");
-
-    output.setNumber(value);
+    output.setNumber(consumeNumber().parseAs<double>());
   }
 
   void parseString(JsonValue::Builder& output) {

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -498,7 +498,7 @@ Orphan<DynamicValue> JsonCodec::decode(
             KJ_REQUIRE(byte(x) == x, "Number in byte array is not an integer in [0, 255]");
             data[i] = x;
           }
-          return orphan;
+          return kj::mv(orphan);
         }
         default:
           KJ_FAIL_REQUIRE("Expected data value");
@@ -521,7 +521,7 @@ Orphan<DynamicValue> JsonCodec::decode(
       auto structType = type.asStruct();
       auto orphan = orphanage.newOrphan(structType);
       decodeObject(input, structType, orphanage, orphan.get());
-      return orphan;
+      return kj::mv(orphan);
     }
     case schema::Type::INTERFACE:
       KJ_FAIL_REQUIRE("don't know how to JSON-decode capabilities; "

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -220,8 +220,8 @@ private:
 
   void encodeField(StructSchema::Field field, DynamicValue::Reader input,
                    JsonValue::Builder output) const;
-  void decodeArray(List<JsonValue>::Reader input, DynamicList::Builder output) const;
-  void decodeObject(List<JsonValue::Field>::Reader input, DynamicStruct::Builder output) const;
+  Orphan<DynamicList> decodeArray(List<JsonValue>::Reader input, ListSchema type, Orphanage orphanage) const;
+  void decodeObject(JsonValue::Reader input, StructSchema type, Orphanage orphanage, DynamicStruct::Builder output) const;
   void addTypeHandlerImpl(Type type, HandlerBase& handler);
   void addFieldHandlerImpl(StructSchema::Field field, Type type, HandlerBase& handler);
 };

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -49,7 +49,7 @@ class JsonCodec {
   // - 64-bit integers are encoded as strings, since JSON "numbers" are double-precision floating
   //   points which cannot store a 64-bit integer without losing data.
   // - NaNs and infinite floating point numbers are not allowed by the JSON spec, and so are encoded
-  //   as null. This matches the behavior of `JSON.stringify` in at least Firefox and Chrome.
+  //   as strings.
   // - Data is encoded as an array of numbers in the range [0,255]. You probably want to register
   //   a handler that does something better, like maybe base64 encoding, but there are a zillion
   //   different ways people do this.


### PR DESCRIPTION
 - Add support for decoding with Orphanage (as a consequence, allow decoding of non-struct root objects).
 - Add support for custom decoding type and field handlers.
 - Make basic tests verify that they roundtrip to the same string.
 - Simplify implementation of number decoding and, as a bonus, allow overflowing floating numbers to convert to +/-`Infinity` like they do in `JSON.parse`.