### PR TITLE
cmake: drop NO_DEFAULT_PATHS when searching libraries

### DIFF
--- a/c++/cmake/CapnProtoTargets.cmake
+++ b/c++/cmake/CapnProtoTargets.cmake
@@ -86,7 +86,6 @@ function(_capnp_import_pkg_config_target target)
   find_library(CapnProto_${target}_IMPORTED_LOCATION
     NAMES ${target_name_shared} ${target_name_static}  # prefer libfoo-version.so over libfoo.a
     PATHS ${${target}_LIBRARY_DIRS}
-    NO_DEFAULT_PATH
   )
   if(NOT CapnProto_${target}_IMPORTED_LOCATION)
     # Not an error if the library doesn't exist -- we may have found a lite mode installation.

--- a/c++/cmake/CapnProtoTargets.cmake
+++ b/c++/cmake/CapnProtoTargets.cmake
@@ -86,7 +86,14 @@ function(_capnp_import_pkg_config_target target)
   find_library(CapnProto_${target}_IMPORTED_LOCATION
     NAMES ${target_name_shared} ${target_name_static}  # prefer libfoo-version.so over libfoo.a
     PATHS ${${target}_LIBRARY_DIRS}
+    NO_DEFAULT_PATH
   )
+  # If the installed version of Cap'n Proto is in a system location, pkg-config will not have filled
+  # in ${target}_LIBRARY_DIRS. To account for this, fall back to a regular search.
+  find_library(CapnProto_${target}_IMPORTED_LOCATION
+    NAMES ${target_name_shared} ${target_name_static}  # prefer libfoo-version.so over libfoo.a
+  )
+
   if(NOT CapnProto_${target}_IMPORTED_LOCATION)
     # Not an error if the library doesn't exist -- we may have found a lite mode installation.
     if(CapnProto_DEBUG)


### PR DESCRIPTION
It looks like pkg-config silently drops -I and -L flags pointing to
default directories:

```
$ cat /usr/lib/pkgconfig/capnp.pc
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: Cap'n Proto
Description: Insanely fast serialization system
Version: 0.7-dev
Libs: -L${libdir} -lcapnp -pthread  -lpthread
Libs.private:  -lpthread
Requires: kj = 0.7-dev
Cflags: -I${includedir} -pthread

$ pkg-config --libs capnp
-lcapnp -pthread -lpthread -lkj -pthread -lpthread
```

Ideally, however, we should use FindPkgConfig.cmake's own facilities
to generate IMPORTED targets from pkg-config files.