### PR TITLE
Add GzipAsyncOutputStream::Decompress and ::flush

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -158,6 +158,31 @@ if(NOT CAPNP_LITE)
   install(FILES ${kj-http_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
 endif()
 
+# kj-gzip ======================================================================
+
+set(kj-gzip_sources
+  compat/gzip.c++
+)
+set(kj-gzip_headers
+  compat/gzip.h
+)
+if(NOT CAPNP_LITE)
+  add_library(kj-gzip ${kj-gzip_sources})
+  add_library(CapnProto::kj-gzip ALIAS kj-gzip)
+
+  find_package(ZLIB)
+  if(ZLIB_FOUND)
+    add_definitions(-D KJ_HAS_ZLIB=1)
+    include_directories(${ZLIB_INCLUDE_DIRS})
+    target_link_libraries(kj-gzip PUBLIC kj-async kj ${ZLIB_LIBRARIES})
+  endif()
+
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(kj-gzip PROPERTIES VERSION ${VERSION})
+  install(TARGETS kj-gzip ${INSTALL_TARGETS_DEFAULT_ARGS})
+  install(FILES ${kj-gzip_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
+endif()
+
 # Tests ========================================================================
 
 if(BUILD_TESTING)
@@ -200,8 +225,9 @@ if(BUILD_TESTING)
       parse/char-test.c++
       compat/url-test.c++
       compat/http-test.c++
+      compat/gzip-test.c++
     )
-    target_link_libraries(kj-heavy-tests kj-http kj-async kj-test kj)
+    target_link_libraries(kj-heavy-tests kj-http kj-gzip kj-async kj-test kj)
     add_dependencies(check kj-heavy-tests)
     add_test(NAME kj-heavy-tests-run COMMAND kj-heavy-tests)
   endif()  # NOT CAPNP_LITE

--- a/c++/src/kj/compat/gzip-test.c++
+++ b/c++/src/kj/compat/gzip-test.c++
@@ -214,7 +214,7 @@ KJ_TEST("async gzip decompression") {
   // Decompress using an output stream.
   {
     MockAsyncOutputStream rawOutput;
-    auto gzip = GzipAsyncOutputStream::Decompress(rawOutput);
+    GzipAsyncOutputStream gzip(rawOutput, GzipAsyncOutputStream::DECOMPRESS);
 
     auto mid = sizeof(FOOBAR_GZIP) / 2;
     gzip.write(FOOBAR_GZIP, mid).wait(io.waitScope);

--- a/c++/src/kj/compat/gzip-test.c++
+++ b/c++/src/kj/compat/gzip-test.c++
@@ -86,6 +86,48 @@ private:
   size_t blockSize;
 };
 
+class MockOutputStream: public OutputStream {
+public:
+  kj::Vector<byte> bytes;
+
+  kj::String decompress() {
+    MockInputStream rawInput(bytes, kj::maxValue);
+    GzipInputStream gzip(rawInput);
+    return gzip.readAllText();
+  }
+
+  void write(const void* buffer, size_t size) override {
+    bytes.addAll(arrayPtr(reinterpret_cast<const byte*>(buffer), size));
+  }
+  void write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    for (auto& piece: pieces) {
+      bytes.addAll(piece);
+    }
+  }
+};
+
+class MockAsyncOutputStream: public AsyncOutputStream {
+public:
+  kj::Vector<byte> bytes;
+
+  kj::String decompress(WaitScope& ws) {
+    MockAsyncInputStream rawInput(bytes, kj::maxValue);
+    GzipAsyncInputStream gzip(rawInput);
+    return gzip.readAllText().wait(ws);
+  }
+
+  Promise<void> write(const void* buffer, size_t size) override {
+    bytes.addAll(arrayPtr(reinterpret_cast<const byte*>(buffer), size));
+    return kj::READY_NOW;
+  }
+  Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    for (auto& piece: pieces) {
+      bytes.addAll(piece);
+    }
+    return kj::READY_NOW;
+  }
+};
+
 KJ_TEST("gzip decompression") {
   // Normal read.
   {
@@ -168,49 +210,24 @@ KJ_TEST("async gzip decompression") {
 
     KJ_EXPECT(gzip.readAllText().wait(io.waitScope) == "foobarfoobar");
   }
+
+  // Decompress using an output stream.
+  {
+    MockAsyncOutputStream rawOutput;
+    auto gzip = GzipAsyncOutputStream::Decompress(rawOutput);
+
+    auto mid = sizeof(FOOBAR_GZIP) / 2;
+    gzip.write(FOOBAR_GZIP, mid).wait(io.waitScope);
+    auto str1 = kj::heapString(rawOutput.bytes.asPtr().asChars());
+    KJ_EXPECT(str1 == "fo", str1);
+
+    gzip.write(FOOBAR_GZIP + mid, sizeof(FOOBAR_GZIP) - mid).wait(io.waitScope);
+    auto str2 = kj::heapString(rawOutput.bytes.asPtr().asChars());
+    KJ_EXPECT(str2 == "foobar", str2);
+
+    gzip.end().wait(io.waitScope);
+  }
 }
-
-class MockOutputStream: public OutputStream {
-public:
-  kj::Vector<byte> bytes;
-
-  kj::String decompress() {
-    MockInputStream rawInput(bytes, kj::maxValue);
-    GzipInputStream gzip(rawInput);
-    return gzip.readAllText();
-  }
-
-  void write(const void* buffer, size_t size) override {
-    bytes.addAll(arrayPtr(reinterpret_cast<const byte*>(buffer), size));
-  }
-  void write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
-    for (auto& piece: pieces) {
-      bytes.addAll(piece);
-    }
-  }
-};
-
-class MockAsyncOutputStream: public AsyncOutputStream {
-public:
-  kj::Vector<byte> bytes;
-
-  kj::String decompress(WaitScope& ws) {
-    MockAsyncInputStream rawInput(bytes, kj::maxValue);
-    GzipAsyncInputStream gzip(rawInput);
-    return gzip.readAllText().wait(ws);
-  }
-
-  Promise<void> write(const void* buffer, size_t size) override {
-    bytes.addAll(arrayPtr(reinterpret_cast<const byte*>(buffer), size));
-    return kj::READY_NOW;
-  }
-  Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
-    for (auto& piece: pieces) {
-      bytes.addAll(piece);
-    }
-    return kj::READY_NOW;
-  }
-};
 
 KJ_TEST("gzip compression") {
   // Normal write.
@@ -291,8 +308,18 @@ KJ_TEST("async gzip compression") {
   {
     MockAsyncOutputStream rawOutput;
     GzipAsyncOutputStream gzip(rawOutput);
+
     gzip.write("foo", 3).wait(io.waitScope);
+    auto prevSize = rawOutput.bytes.size();
+
     gzip.write("bar", 3).wait(io.waitScope);
+    auto curSize = rawOutput.bytes.size();
+    KJ_EXPECT(prevSize == curSize, prevSize, curSize);
+
+    gzip.flush().wait(io.waitScope);
+    curSize = rawOutput.bytes.size();
+    KJ_EXPECT(prevSize < curSize, prevSize, curSize);
+
     gzip.end().wait(io.waitScope);
 
     KJ_EXPECT(rawOutput.decompress(io.waitScope) == "foobar");

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -142,8 +142,11 @@ size_t GzipInputStream::readImpl(
 
 // =======================================================================================
 
-GzipOutputStream::GzipOutputStream(OutputStream& inner, kj::Maybe<int> compressionLevel)
+GzipOutputStream::GzipOutputStream(OutputStream& inner, int compressionLevel)
     : inner(inner), ctx(compressionLevel) {}
+
+GzipOutputStream::GzipOutputStream(OutputStream& inner, decltype(DECOMPRESS))
+    : inner(inner), ctx(nullptr) {}
 
 GzipOutputStream::~GzipOutputStream() noexcept(false) {
   pump(Z_FINISH);
@@ -228,8 +231,11 @@ Promise<size_t> GzipAsyncInputStream::readImpl(
 
 // =======================================================================================
 
-GzipAsyncOutputStream::GzipAsyncOutputStream(AsyncOutputStream& inner, kj::Maybe<int> compressionLevel)
+GzipAsyncOutputStream::GzipAsyncOutputStream(AsyncOutputStream& inner, int compressionLevel)
     : inner(inner), ctx(compressionLevel) {}
+
+GzipAsyncOutputStream::GzipAsyncOutputStream(AsyncOutputStream& inner, decltype(DECOMPRESS))
+    : inner(inner), ctx(nullptr) {}
 
 Promise<void> GzipAsyncOutputStream::write(const void* in, size_t size) {
   ctx.setInput(in, size);

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -29,12 +29,6 @@ namespace kj {
 namespace _ {  // private
 
 GzipOutputContext::GzipOutputContext(kj::Maybe<int> compressionLevel) {
-  memset(&ctx, 0, sizeof(ctx));
-  ctx.next_in = nullptr;
-  ctx.avail_in = 0;
-  ctx.next_out = nullptr;
-  ctx.avail_out = 0;
-
   int initResult;
 
   KJ_IF_MAYBE(level, compressionLevel) {
@@ -91,12 +85,6 @@ void GzipOutputContext::fail(int result) {
 
 GzipInputStream::GzipInputStream(InputStream& inner)
     : inner(inner) {
-  memset(&ctx, 0, sizeof(ctx));
-  ctx.next_in = nullptr;
-  ctx.avail_in = 0;
-  ctx.next_out = nullptr;
-  ctx.avail_out = 0;
-
   // windowBits = 15 (maximum) + magic value 16 to ask for gzip.
   KJ_ASSERT(inflateInit2(&ctx, 15 + 16) == Z_OK);
 }
@@ -180,12 +168,6 @@ void GzipOutputStream::pump(int flush) {
 
 GzipAsyncInputStream::GzipAsyncInputStream(AsyncInputStream& inner)
     : inner(inner) {
-  memset(&ctx, 0, sizeof(ctx));
-  ctx.next_in = nullptr;
-  ctx.avail_in = 0;
-  ctx.next_out = nullptr;
-  ctx.avail_out = 0;
-
   // windowBits = 15 (maximum) + magic value 16 to ask for gzip.
   KJ_ASSERT(inflateInit2(&ctx, 15 + 16) == Z_OK);
 }

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -27,6 +27,28 @@
 
 namespace kj {
 
+namespace _ {  // private
+
+class GzipOutputContext final {
+public:
+  GzipOutputContext(kj::Maybe<int> compressionLevel);
+  ~GzipOutputContext() noexcept(false);
+  KJ_DISALLOW_COPY(GzipOutputContext);
+  GzipOutputContext(GzipOutputContext&&) = default;
+
+  void setInput(const void* in, size_t size);
+  kj::Tuple<bool, kj::ArrayPtr<const byte>> pumpOnce(int flush);
+
+private:
+  bool compressing;
+  z_stream ctx;
+  byte buffer[4096];
+
+  void fail(int result);
+};
+
+}  // namespace _ (private)
+
 class GzipInputStream final: public InputStream {
 public:
   GzipInputStream(InputStream& inner);
@@ -47,20 +69,27 @@ private:
 
 class GzipOutputStream final: public OutputStream {
 public:
-  GzipOutputStream(OutputStream& inner, int compressionLevel = Z_DEFAULT_COMPRESSION);
+  GzipOutputStream(OutputStream& inner, kj::Maybe<int> compressionLevel = Z_DEFAULT_COMPRESSION);
   ~GzipOutputStream() noexcept(false);
   KJ_DISALLOW_COPY(GzipOutputStream);
+  GzipOutputStream(GzipOutputStream&&) = default;
+
+  static inline GzipOutputStream Decompress(OutputStream& inner) {
+    return GzipOutputStream(inner, nullptr);
+  }
 
   void write(const void* buffer, size_t size) override;
   using OutputStream::write;
 
+  inline void flush() {
+    pump(Z_SYNC_FLUSH);
+  }
+
 private:
   OutputStream& inner;
-  z_stream ctx;
+  _::GzipOutputContext ctx;
 
-  byte buffer[4096];
-
-  void pump();
+  void pump(int flush);
 };
 
 class GzipAsyncInputStream final: public AsyncInputStream {
@@ -84,7 +113,6 @@ private:
 class GzipAsyncOutputStream final: public AsyncOutputStream {
 public:
   GzipAsyncOutputStream(AsyncOutputStream& inner, kj::Maybe<int> compressionLevel = Z_DEFAULT_COMPRESSION);
-  ~GzipAsyncOutputStream() noexcept(false);
   KJ_DISALLOW_COPY(GzipAsyncOutputStream);
   GzipAsyncOutputStream(GzipAsyncOutputStream&&) = default;
 
@@ -95,23 +123,23 @@ public:
   Promise<void> write(const void* buffer, size_t size) override;
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
 
-  Promise<void> flush();
+  inline Promise<void> flush() {
+    return pump(Z_SYNC_FLUSH);
+  }
   // Call if you need to flush a stream at an arbitrary data point.
 
-  Promise<void> end();
+  Promise<void> end() {
+    return pump(Z_FINISH);
+  }
   // Must call to flush and finish the stream, since some data may be buffered.
   //
   // TODO(cleanup): This should be a virtual method on AsyncOutputStream.
 
 private:
   AsyncOutputStream& inner;
-  bool compressing;
-  z_stream ctx;
-
-  byte buffer[4096];
+  _::GzipOutputContext ctx;
 
   kj::Promise<void> pump(int flush);
-  void fail(int result);
 };
 
 }  // namespace kj

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -34,7 +34,6 @@ public:
   GzipOutputContext(kj::Maybe<int> compressionLevel);
   ~GzipOutputContext() noexcept(false);
   KJ_DISALLOW_COPY(GzipOutputContext);
-  GzipOutputContext(GzipOutputContext&&) = default;
 
   void setInput(const void* in, size_t size);
   kj::Tuple<bool, kj::ArrayPtr<const byte>> pumpOnce(int flush);
@@ -69,14 +68,12 @@ private:
 
 class GzipOutputStream final: public OutputStream {
 public:
-  GzipOutputStream(OutputStream& inner, kj::Maybe<int> compressionLevel = Z_DEFAULT_COMPRESSION);
+  enum { DECOMPRESS };
+
+  GzipOutputStream(OutputStream& inner, int compressionLevel = Z_DEFAULT_COMPRESSION);
+  GzipOutputStream(OutputStream& inner, decltype(DECOMPRESS));
   ~GzipOutputStream() noexcept(false);
   KJ_DISALLOW_COPY(GzipOutputStream);
-  GzipOutputStream(GzipOutputStream&&) = default;
-
-  static inline GzipOutputStream Decompress(OutputStream& inner) {
-    return GzipOutputStream(inner, nullptr);
-  }
 
   void write(const void* buffer, size_t size) override;
   using OutputStream::write;
@@ -112,13 +109,11 @@ private:
 
 class GzipAsyncOutputStream final: public AsyncOutputStream {
 public:
-  GzipAsyncOutputStream(AsyncOutputStream& inner, kj::Maybe<int> compressionLevel = Z_DEFAULT_COMPRESSION);
-  KJ_DISALLOW_COPY(GzipAsyncOutputStream);
-  GzipAsyncOutputStream(GzipAsyncOutputStream&&) = default;
+  enum { DECOMPRESS };
 
-  static inline GzipAsyncOutputStream Decompress(AsyncOutputStream& inner) {
-    return GzipAsyncOutputStream(inner, nullptr);
-  }
+  GzipAsyncOutputStream(AsyncOutputStream& inner, int compressionLevel = Z_DEFAULT_COMPRESSION);
+  GzipAsyncOutputStream(AsyncOutputStream& inner, decltype(DECOMPRESS));
+  KJ_DISALLOW_COPY(GzipAsyncOutputStream);
 
   Promise<void> write(const void* buffer, size_t size) override;
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override;

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -41,7 +41,7 @@ public:
 
 private:
   bool compressing;
-  z_stream ctx;
+  z_stream ctx = {};
   byte buffer[4096];
 
   void fail(int result);
@@ -59,7 +59,7 @@ public:
 
 private:
   InputStream& inner;
-  z_stream ctx;
+  z_stream ctx = {};
   bool atValidEndpoint = false;
 
   byte buffer[4096];
@@ -102,7 +102,7 @@ public:
 
 private:
   AsyncInputStream& inner;
-  z_stream ctx;
+  z_stream ctx = {};
   bool atValidEndpoint = false;
 
   byte buffer[4096];


### PR DESCRIPTION
- Split gzip tests
- Add kj-gzip to CMakeLists.txt
- Add decompress mode to `GzipAsyncOutputStream` for granular push-based decompression API.
- Add ability to flush `GzipAsyncOutputStream` at an arbitrary point.
