### PR TITLE
Chunked body fixes in kj-http

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -376,7 +376,7 @@ private:
       // Write the first piece.
       auto promise = output.write(writeBuffer.begin(), writeBuffer.size());
 
-      // Write full pieces as a singcle gather-write.
+      // Write full pieces as a single gather-write.
       if (i > 0) {
         auto more = morePieces.slice(0, i);
         promise = promise.then([&output,more]() { return output.write(more); });

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1879,8 +1879,8 @@ public:
 
     if (size == 0) return kj::READY_NOW;  // can't encode zero-size chunk since it indicates EOF.
 
-    auto header = kj::str(size, "\r\n");
-    auto partsBuilder = kj::heapArrayBuilder<ArrayPtr<const byte>>(pieces.size());
+    auto header = kj::str(kj::hex(size), "\r\n");
+    auto partsBuilder = kj::heapArrayBuilder<ArrayPtr<const byte>>(pieces.size() + 2);
     partsBuilder.add(header.asBytes());
     for (auto& piece: pieces) {
       partsBuilder.add(piece);
@@ -1897,7 +1897,7 @@ public:
       // Hey, we know exactly how large the input is, so we can write just one chunk.
 
       uint64_t length = kj::min(amount, *l);
-      inner.writeBodyData(kj::str(length, "\r\n"));
+      inner.writeBodyData(kj::str(kj::hex(length), "\r\n"));
       return inner.pumpBodyFrom(input, length)
           .then([this,length](uint64_t actual) {
         if (actual < length) {

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -667,7 +667,7 @@ struct HttpServerSettings {
   // completes, we'll let the connection stay open to handle more requests.
 };
 
-class HttpServer: private kj::TaskSet::ErrorHandler {
+class HttpServer final: private kj::TaskSet::ErrorHandler {
   // Class which listens for requests on ports or connections and sends them to an HttpService.
 
 public:


### PR DESCRIPTION
I ran into these because the userspace pipe's `BlockedWrite` state uses a gather-write in its `pumpTo()` implementation.