### PR TITLE
Add limit to readAllBytes()/readAllText()

### DIFF
--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -79,9 +79,13 @@ public:
   // The default implementation first tries calling output.tryPumpFrom(), but if that fails, it
   // performs a naive pump by allocating a buffer and reading to it / writing from it in a loop.
 
-  Promise<Array<byte>> readAllBytes();
-  Promise<String> readAllText();
-  // Read until EOF and return as one big byte array or string.
+  Promise<Array<byte>> readAllBytes(uint64_t limit = kj::maxValue);
+  Promise<String> readAllText(uint64_t limit = kj::maxValue);
+  // Read until EOF and return as one big byte array or string. Throw an exception if EOF is not
+  // seen before reading `limit` bytes.
+  //
+  // To prevent runaway memory allocation, consider using a more conservative value for `limit` than
+  // the default, particularly on untrusted data streams which may never see EOF.
 };
 
 class AsyncOutputStream {

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -29,6 +29,7 @@
 #include "common.h"
 #include "array.h"
 #include "exception.h"
+#include <stdint.h>
 
 namespace kj {
 
@@ -66,9 +67,13 @@ public:
   // Skips past the given number of bytes, discarding them.  The default implementation read()s
   // into a scratch buffer.
 
-  String readAllText();
-  Array<byte> readAllBytes();
-  // Read until EOF and return as one big byte array or string.
+  String readAllText(uint64_t limit = kj::maxValue);
+  Array<byte> readAllBytes(uint64_t limit = kj::maxValue);
+  // Read until EOF and return as one big byte array or string. Throw an exception if EOF is not
+  // seen before reading `limit` bytes.
+  //
+  // To prevent runaway memory allocation, consider using a more conservative value for `limit` than
+  // the default, particularly on untrusted data streams which may never see EOF.
 };
 
 class OutputStream {


### PR DESCRIPTION
Reading an unbounded amount of data from a stream is a potential DoS vector. To manage this risk, `readAllText()` and `readAllBytes()` now accept a `limit` parameter. For source backwards-compatibility, this limit defaults to `kj::maxValue`.

The presence of this limit might make it seem that `readAllText()`/`readAllBytes()` are now misnamed. If we care, we could add `read*Until()` overloads that accept a mandatory parameter, and deprecate the `readAll*()` versions.