### PR TITLE
Fix handling of disconnect during WebSocket::pumpTo().

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -424,7 +424,7 @@ private:
 
     void abortRead() override {
       canceler.cancel("abortRead() was called");
-      fulfiller.reject(KJ_EXCEPTION(FAILED, "read end of pipe was aborted"));
+      fulfiller.reject(KJ_EXCEPTION(DISCONNECTED, "read end of pipe was aborted"));
       pipe.endState(*this);
       pipe.abortRead();
     }
@@ -537,7 +537,7 @@ private:
           if (n == 0) {
             fulfiller.fulfill(kj::cp(pumpedSoFar));
           } else {
-            fulfiller.reject(KJ_EXCEPTION(FAILED, "read end of pipe was aborted"));
+            fulfiller.reject(KJ_EXCEPTION(DISCONNECTED, "read end of pipe was aborted"));
           }
         }).eagerlyEvaluate([this](kj::Exception&& e) {
           fulfiller.reject(kj::mv(e));
@@ -595,7 +595,7 @@ private:
 
     void abortRead() override {
       canceler.cancel("abortRead() was called");
-      fulfiller.reject(KJ_EXCEPTION(FAILED, "read end of pipe was aborted"));
+      fulfiller.reject(KJ_EXCEPTION(DISCONNECTED, "read end of pipe was aborted"));
       pipe.endState(*this);
       pipe.abortRead();
     }
@@ -765,7 +765,7 @@ private:
 
     void abortRead() override {
       canceler.cancel("abortRead() was called");
-      fulfiller.reject(KJ_EXCEPTION(FAILED, "read end of pipe was aborted"));
+      fulfiller.reject(KJ_EXCEPTION(DISCONNECTED, "read end of pipe was aborted"));
       pipe.endState(*this);
       pipe.abortRead();
     }

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2445,6 +2445,12 @@ static kj::Promise<void> pumpWebSocketLoop(WebSocket& from, WebSocket& to) {
       }
     }
     KJ_UNREACHABLE;
+  }, [&to](kj::Exception&& e) {
+    if (e.getType() == kj::Exception::Type::DISCONNECTED) {
+      return to.disconnect();
+    } else {
+      return to.close(1002, e.getDescription());
+    }
   });
 }
 
@@ -2456,12 +2462,6 @@ kj::Promise<void> WebSocket::pumpTo(WebSocket& other) {
     // Fall back to default implementation.
     return kj::evalNow([&]() {
       return pumpWebSocketLoop(*this, other);
-    }).catch_([&other](kj::Exception&& e) -> kj::Promise<void> {
-      if (e.getType() == kj::Exception::Type::DISCONNECTED) {
-        return other.disconnect();
-      } else {
-        return other.close(1002, e.getDescription());
-      }
     });
   }
 }


### PR DESCRIPTION
Before this change, if *either* the `from` or the `to` end of the pump threw a DISCONNECTED exception, we'd then try to call `to.disconnect()`. But if the exception had been thrown from `to` in the first place, then this would throw again, this time complaining about a previous write not having completed. But the whole point was always to propagate errors from the *receiving* end to the sending end. An error on the sending end should just propagate up the stack.