### PR TITLE
Fix an issue with force append -std=gnu++11 to cmake CXX_FLAGS

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -66,8 +66,10 @@ set(kj-std_headers
 )
 add_library(kj ${kj_sources})
 add_library(CapnProto::kj ALIAS kj)
-target_compile_features(kj PUBLIC cxx_constexpr)
-# Requiring the cxx_std_11 metafeature would be preferable, but that doesn't exist until CMake 3.8.
+if(NOT CYGWIN)
+  target_compile_features(kj PUBLIC cxx_constexpr)
+  # Requiring the cxx_std_11 metafeature would be preferable, but that doesn't exist until CMake 3.8.
+endif()
 
 if(UNIX AND NOT ANDROID)
   target_link_libraries(kj PUBLIC pthread)


### PR DESCRIPTION
target_compile_features(kj PUBLIC cxx_constexpr) force globally append -std=gnu++11 to CXX_FLAGS:

CXX_FLAGS =  -std=gnu++17 -Wall -Werror -O2 -g -DNDEBUG   -std=gnu++11

I replaced it with set(CMAKE_CXX_STANDARD 11)