### PR TITLE
Automatically reduce `Promise<RemotePromise<T>>` -> `RemotePromise<T>`.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@
 #     support for.
 #   - Use CMake to ...
 #       build Cap'n Proto with MinGW.
-#       build Cap'n Proto with VS2015 and VS2017.
-#       build Cap'n Proto samples with VS2015 and VS2017.
+#       build Cap'n Proto with VS2017.
+#       build Cap'n Proto samples with VS2017.
 
 version: "{build}"
 
@@ -41,10 +41,6 @@ environment:
       EXTRA_BUILD_FLAGS: # /maxcpucount
       # TODO(someday): Right now /maxcpucount occasionally expresses a filesystem-related race:
       #   capnp-capnpc++ complains that it can't create test.capnp.h.
-
-    - CMAKE_GENERATOR: Visual Studio 14 2015
-      BUILD_NAME: vs2015
-      EXTRA_BUILD_FLAGS: # /maxcpucount
 
     - CMAKE_GENERATOR: MinGW Makefiles
       BUILD_NAME: mingw

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -44,7 +44,7 @@ template <typename T>
 struct PromiseFulfillerPair;
 
 template <typename Func, typename T>
-using PromiseForResult = Promise<_::JoinPromises<_::ReturnType<Func, T>>>;
+using PromiseForResult = _::ReducePromises<_::ReturnType<Func, T>>;
 // Evaluates to the type of Promise for the result of calling functor type Func with parameter type
 // T.  If T is void, then the promise is for the result of calling Func with no arguments.  If
 // Func itself returns a promise, the promises are joined, so you never get Promise<Promise<T>>.
@@ -482,7 +482,7 @@ Promise<T> newAdaptedPromise(Params&&... adapterConstructorParams);
 
 template <typename T>
 struct PromiseFulfillerPair {
-  Promise<_::JoinPromises<T>> promise;
+  _::ReducePromises<T> promise;
   Own<PromiseFulfiller<T>> fulfiller;
 };
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -60,8 +60,8 @@
     #endif
   #endif
 #elif defined(_MSC_VER)
-  #if _MSC_VER < 1900
-    #error "You need Visual Studio 2015 or better to compile this code."
+  #if _MSC_VER < 1910
+    #error "You need Visual Studio 2017 or better to compile this code."
   #endif
 #else
   #warning "I don't recognize your compiler.  As of this writing, Clang and GCC are the only "\


### PR DESCRIPTION
Just like `Promise<Promise<T>>` reduces to `Promise<T>`, we should be able to reduce `Promise<RemotePromise<T>>`. Moreover, this reduction should support pipelining, hence the reduced type should itself be `RemotePromise<T>`.

Fixes #341