### PR TITLE
fix const-correctness on AnyPointer equality checks

### DIFF
--- a/c++/src/capnp/any.c++
+++ b/c++/src/capnp/any.c++
@@ -79,7 +79,7 @@ kj::Own<ClientHook> AnyPointer::Pipeline::asCap() {
 
 #endif  // !CAPNP_LITE
 
-Equality AnyStruct::Reader::equals(AnyStruct::Reader right) {
+Equality AnyStruct::Reader::equals(AnyStruct::Reader right) const {
   auto dataL = getDataSection();
   size_t dataSizeL = dataL.size();
   while(dataSizeL > 0 && dataL[dataSizeL - 1] == 0) {
@@ -150,7 +150,7 @@ kj::StringPtr KJ_STRINGIFY(Equality res) {
   KJ_UNREACHABLE;
 }
 
-Equality AnyList::Reader::equals(AnyList::Reader right) {
+Equality AnyList::Reader::equals(AnyList::Reader right) const {
   if(size() != right.size()) {
     return Equality::NOT_EQUAL;
   }
@@ -209,7 +209,7 @@ Equality AnyList::Reader::equals(AnyList::Reader right) {
   KJ_UNREACHABLE;
 }
 
-Equality AnyPointer::Reader::equals(AnyPointer::Reader right) {
+Equality AnyPointer::Reader::equals(AnyPointer::Reader right) const {
   if(getPointerType() != right.getPointerType()) {
     return Equality::NOT_EQUAL;
   }
@@ -227,7 +227,7 @@ Equality AnyPointer::Reader::equals(AnyPointer::Reader right) {
   KJ_UNREACHABLE;
 }
 
-bool AnyPointer::Reader::operator==(AnyPointer::Reader right) {
+bool AnyPointer::Reader::operator==(AnyPointer::Reader right) const {
   switch(equals(right)) {
     case Equality::EQUAL:
       return true;
@@ -240,7 +240,7 @@ bool AnyPointer::Reader::operator==(AnyPointer::Reader right) {
   KJ_UNREACHABLE;
 }
 
-bool AnyStruct::Reader::operator==(AnyStruct::Reader right) {
+bool AnyStruct::Reader::operator==(AnyStruct::Reader right) const {
   switch(equals(right)) {
     case Equality::EQUAL:
       return true;
@@ -253,7 +253,7 @@ bool AnyStruct::Reader::operator==(AnyStruct::Reader right) {
   KJ_UNREACHABLE;
 }
 
-bool AnyList::Reader::operator==(AnyList::Reader right) {
+bool AnyList::Reader::operator==(AnyList::Reader right) const {
   switch(equals(right)) {
     case Equality::EQUAL:
       return true;

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -104,9 +104,9 @@ struct AnyPointer {
     inline bool isList() const { return getPointerType() == PointerType::LIST; }
     inline bool isCapability() const { return getPointerType() == PointerType::CAPABILITY; }
 
-    Equality equals(AnyPointer::Reader right);
-    bool operator==(AnyPointer::Reader right);
-    inline bool operator!=(AnyPointer::Reader right) {
+    Equality equals(AnyPointer::Reader right) const;
+    bool operator==(AnyPointer::Reader right) const;
+    inline bool operator!=(AnyPointer::Reader right) const {
       return !(*this == right);
     }
 
@@ -158,13 +158,13 @@ struct AnyPointer {
     inline bool isList() { return getPointerType() == PointerType::LIST; }
     inline bool isCapability() { return getPointerType() == PointerType::CAPABILITY; }
 
-    inline Equality equals(AnyPointer::Reader right) {
+    inline Equality equals(AnyPointer::Reader right) const {
       return asReader().equals(right);
     }
-    inline bool operator==(AnyPointer::Reader right) {
+    inline bool operator==(AnyPointer::Reader right) const {
       return asReader() == right;
     }
-    inline bool operator!=(AnyPointer::Reader right) {
+    inline bool operator!=(AnyPointer::Reader right) const {
       return !(*this == right);
     }
 
@@ -477,9 +477,9 @@ public:
     return _reader.canonicalize();
   }
 
-  Equality equals(AnyStruct::Reader right);
-  bool operator==(AnyStruct::Reader right);
-  inline bool operator!=(AnyStruct::Reader right) {
+  Equality equals(AnyStruct::Reader right) const;
+  bool operator==(AnyStruct::Reader right) const;
+  inline bool operator!=(AnyStruct::Reader right) const {
     return !(*this == right);
   }
 
@@ -521,13 +521,13 @@ public:
     return List<AnyPointer>::Builder(_builder.getPointerSectionAsList());
   }
 
-  inline Equality equals(AnyStruct::Reader right) {
+  inline Equality equals(AnyStruct::Reader right) const {
     return asReader().equals(right);
   }
-  inline bool operator==(AnyStruct::Reader right) {
+  inline bool operator==(AnyStruct::Reader right) const {
     return asReader() == right;
   }
-  inline bool operator!=(AnyStruct::Reader right) {
+  inline bool operator!=(AnyStruct::Reader right) const {
     return !(*this == right);
   }
 
@@ -651,9 +651,9 @@ public:
 
   inline kj::ArrayPtr<const byte> getRawBytes() { return _reader.asRawBytes(); }
 
-  Equality equals(AnyList::Reader right);
-  bool operator==(AnyList::Reader right);
-  inline bool operator!=(AnyList::Reader right) {
+  Equality equals(AnyList::Reader right) const;
+  bool operator==(AnyList::Reader right) const;
+  inline bool operator!=(AnyList::Reader right) const {
     return !(*this == right);
   }
 
@@ -689,11 +689,11 @@ public:
   inline ElementSize getElementSize() { return _builder.getElementSize(); }
   inline uint size() { return unbound(_builder.size() / ELEMENTS); }
 
-  Equality equals(AnyList::Reader right);
-  inline bool operator==(AnyList::Reader right) {
+  Equality equals(AnyList::Reader right) const;
+  inline bool operator==(AnyList::Reader right) const{
     return asReader() == right;
   }
-  inline bool operator!=(AnyList::Reader right) {
+  inline bool operator!=(AnyList::Reader right) const{
     return !(*this == right);
   }
 

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -466,10 +466,10 @@ public:
 
   inline MessageSize totalSize() const { return _reader.totalSize().asPublic(); }
 
-  kj::ArrayPtr<const byte> getDataSection() {
+  kj::ArrayPtr<const byte> getDataSection() const {
     return _reader.getDataSectionAsBlob();
   }
-  List<AnyPointer>::Reader getPointerSection() {
+  List<AnyPointer>::Reader getPointerSection() const {
     return List<AnyPointer>::Reader(_reader.getPointerSectionAsList());
   }
 
@@ -646,10 +646,10 @@ public:
       : _reader(_::PointerHelpers<FromReader<T>>::getInternalReader(kj::fwd<T>(value))) {}
 #endif
 
-  inline ElementSize getElementSize() { return _reader.getElementSize(); }
-  inline uint size() { return unbound(_reader.size() / ELEMENTS); }
+  inline ElementSize getElementSize() const { return _reader.getElementSize(); }
+  inline uint size() const { return unbound(_reader.size() / ELEMENTS); }
 
-  inline kj::ArrayPtr<const byte> getRawBytes() { return _reader.asRawBytes(); }
+  inline kj::ArrayPtr<const byte> getRawBytes() const { return _reader.asRawBytes(); }
 
   Equality equals(AnyList::Reader right) const;
   bool operator==(AnyList::Reader right) const;
@@ -661,7 +661,7 @@ public:
     return _reader.totalSize().asPublic();
   }
 
-  template <typename T> ReaderFor<T> as() {
+  template <typename T> ReaderFor<T> as() const {
     // T must be List<U>.
     return ReaderFor<T>(_reader);
   }

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -3079,7 +3079,7 @@ Data::Reader ListReader::asData() {
   return Data::Reader(reinterpret_cast<const byte*>(ptr), unbound(elementCount / ELEMENTS));
 }
 
-kj::ArrayPtr<const byte> ListReader::asRawBytes() {
+kj::ArrayPtr<const byte> ListReader::asRawBytes() const {
   KJ_REQUIRE(structPointerCount == ZERO * POINTERS,
              "Expected data only, got pointers.") {
     return kj::ArrayPtr<const byte>();

--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -597,8 +597,8 @@ public:
 
   inline StructDataBitCount getDataSectionSize() const { return dataSize; }
   inline StructPointerCount getPointerSectionSize() const { return pointerCount; }
-  inline kj::ArrayPtr<const byte> getDataSectionAsBlob();
-  inline _::ListReader getPointerSectionAsList();
+  inline kj::ArrayPtr<const byte> getDataSectionAsBlob() const;
+  inline _::ListReader getPointerSectionAsList() const;
 
   kj::Array<word> canonicalize();
 
@@ -780,7 +780,7 @@ public:
   Data::Reader asData();
   // Reinterpret the list as a blob.  Throws an exception if the elements are not byte-sized.
 
-  kj::ArrayPtr<const byte> asRawBytes();
+  kj::ArrayPtr<const byte> asRawBytes() const;
 
   template <typename T>
   KJ_ALWAYS_INLINE(T getDataElement(ElementCount index) const);
@@ -1080,12 +1080,12 @@ inline PointerBuilder StructBuilder::getPointerField(StructPointerOffset ptrInde
 
 // -------------------------------------------------------------------
 
-inline kj::ArrayPtr<const byte> StructReader::getDataSectionAsBlob() {
+inline kj::ArrayPtr<const byte> StructReader::getDataSectionAsBlob() const {
   return kj::ArrayPtr<const byte>(reinterpret_cast<const byte*>(data),
       unbound(dataSize / BITS_PER_BYTE / BYTES));
 }
 
-inline _::ListReader StructReader::getPointerSectionAsList() {
+inline _::ListReader StructReader::getPointerSectionAsList() const {
   return _::ListReader(segment, capTable, pointers, pointerCount * (ONE * ELEMENTS / POINTERS),
                        ONE * POINTERS * BITS_PER_POINTER / ELEMENTS, ZERO * BITS, ONE * POINTERS,
                        ElementSize::POINTER, nestingLimit);


### PR DESCRIPTION
Stumbled upon this, by writing a gtest like this:

```c++
AnyStruct as1;
AnyStruct as2;
// do stuff with as1 & as2…
EXPECT_EQ(as1, as2); // does not compile because ==/!= operators are expected to be const

// we can workaround this currently by using the "equals" function
EXPECT_EQ(capnp::Equality::Equal, as1.equals(as2));
```

Compiles fine in local build setup (Clang 6.0,Debian 9); Waiting for Travis and Appveyor builds…