### PR TITLE
Ignore ECHILD in UnixEventPort::ChildSet::checkExits

### DIFF
--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -707,12 +707,7 @@ TEST(AsyncUnixTest, ChildProcess) {
   KJ_DEFER(KJ_SYSCALL(sigprocmask(SIG_SETMASK, &oldsigs, nullptr)) { break; });
 
   TestChild child1(port, 123);
-  TestChild child2(port, 234);
-  TestChild child3(port, 345);
-
   KJ_EXPECT(!child1.promise.poll(waitScope));
-  KJ_EXPECT(!child2.promise.poll(waitScope));
-  KJ_EXPECT(!child3.promise.poll(waitScope));
 
   child1.kill(SIGTERM);
 
@@ -721,6 +716,9 @@ TEST(AsyncUnixTest, ChildProcess) {
     KJ_EXPECT(WIFEXITED(status));
     KJ_EXPECT(WEXITSTATUS(status) == 123);
   }
+
+  TestChild child2(port, 234);
+  TestChild child3(port, 345);
 
   KJ_EXPECT(!child2.promise.poll(waitScope));
   KJ_EXPECT(!child3.promise.poll(waitScope));

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -145,7 +145,12 @@ void UnixEventPort::ChildSet::checkExits() {
   for (;;) {
     int status;
     pid_t pid;
-    KJ_SYSCALL(pid = waitpid(-1, &status, WNOHANG));
+    KJ_SYSCALL_HANDLE_ERRORS(pid = waitpid(-1, &status, WNOHANG)) {
+      case ECHILD:
+        return;
+      default:
+        KJ_FAIL_SYSCALL("waitpid()", error);
+    }
     if (pid == 0) break;
 
     auto iter = waiters.find(pid);


### PR DESCRIPTION
If no child process has changed state, `waitpid()` returns zero. But if there are no more child processes at all, it returns -1 and sets `errno` to `ECHILD`.

Since `checkExits` calls `waitpid()` in a loop, it should probably not throw an exception, and instead ignore `ECHILD`.

+Unit test modified to exhibit the behaviour