### PR TITLE
Makefile.am: Remove ldconfig to fix a sandbox violation.

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -347,13 +347,8 @@ capnpc_c___SOURCES = src/capnp/compiler/capnpc-c++.c++
 
 # Symlink capnpc -> capnp.  The capnp binary will behave like the old capnpc
 # binary (i.e. like "capnp compile") when invoked via this symlink.
-#
-# Also attempt to run ldconfig, because otherwise users get confused.  If
-# it fails (e.g. because the platform doesn't have it, or because the
-# user doesn't have root privileges), don't worry about it.
 install-exec-hook:
 	ln -sf capnp $(DESTDIR)$(bindir)/capnpc
-	ldconfig < /dev/null > /dev/null 2>&1 || true
 
 uninstall-hook:
 	rm -f $(DESTDIR)$(bindir)/capnpc
@@ -361,7 +356,6 @@ uninstall-hook:
 else LITE_MODE
 
 install-exec-hook:
-	ldconfig < /dev/null > /dev/null 2>&1 || true
 
 endif LITE_MODE
 


### PR DESCRIPTION
During `make install` sandbox will report violations for when ldconfig is run where it will attempt to edit `/etc/ld.so.cache~`.

Modifying the root file system during installation when using `DESTDIR` is highly undesirable and since these commands are not critical I suggest removing them.

More information on sandbox can be found here.

https://wiki.gentoo.org/wiki/Project:Sandbox
```
make[3]: Entering directory '/tmp/capnproto/c++'
ln -sf capnp /tmp/capnproto/usr/local/bin/capnpc
ldconfig < /dev/null > /dev/null 2>&1 || true
 * ACCESS DENIED:  open_wr:      /etc/ld.so.cache~
make[3]: Leaving directory '/tmp/capnproto/c++'
make[2]: Leaving directory '/tmp/capnproto/c++'
make[1]: Leaving directory '/tmp/capnproto/c++'
 * --------------------------- ACCESS VIOLATION SUMMARY ----
 * LOG FILE: "/tmp/sandbox-22967.log"
 *
VERSION 1.0
FORMAT: F - Function called
FORMAT: S - Access Status
FORMAT: P - Path as passed to function
FORMAT: A - Absolute Path (not canonical)
FORMAT: R - Canonical Path
FORMAT: C - Command Line

F: open_wr
S: deny
P: /etc/ld.so.cache~
A: /etc/ld.so.cache~
R: /etc/ld.so.cache~
C: ldconfig
 * ---------------------------------------------------------
```