### PR TITLE
Disallow copy construction/assignment of (Atomic)Refcounted classes

### DIFF
--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -67,7 +67,9 @@ class Refcounted: private Disposer {
   //   Own<T> could also be nice.
 
 public:
+  Refcounted() = default;
   virtual ~Refcounted() noexcept(false);
+  KJ_DISALLOW_COPY(Refcounted);
 
   inline bool isShared() const { return refcount > 1; }
   // Check if there are multiple references to this object. This is sometimes useful for deciding
@@ -127,7 +129,9 @@ Own<T> Refcounted::addRefInternal(T* object) {
 
 class AtomicRefcounted: private kj::Disposer {
 public:
+  AtomicRefcounted() = default;
   virtual ~AtomicRefcounted() noexcept(false);
+  KJ_DISALLOW_COPY(AtomicRefcounted);
 
   inline bool isShared() const {
 #if _MSC_VER


### PR DESCRIPTION
If a multiply-inherited subclass of `kj::Refcounted` is move-assigned from an object of its other parent class's type, the reference count would get zeroed out. This change makes such mistakes a compile error.