### PR TITLE
Fix linking during lite builds

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -16,12 +16,12 @@ set(kj_sources_lite
   main.c++
   arena.c++
   test-helpers.c++
+  units.c++
+  encoding.c++
 )
 set(kj_sources_heavy
-  units.c++
   refcount.c++
   string-tree.c++
-  encoding.c++
   time.c++
   filesystem.c++
   filesystem-disk-unix.c++


### PR DESCRIPTION
Add `units.c++` and `encoding.c++` to allow the linking of `kj::ThrowOverflow::operator()()` and `kj::decodeWideString` respectively. The lite build remains a fair amount smaller than heavy build and has been tested as working on Clang and GCC both.

This is needed in order to fix #576 and other undefined symbols with current CMake setups. I am unsure of the scope of lite builds and their exact exclusions but, without these two sources in the build process, the library seems to have major issues linking to a usable state.