### PR TITLE
Two fixes for build failure on Android

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -72,6 +72,11 @@ namespace {
 #undef SEEK_HOLE
 #endif
 
+#if __ANDROID__
+// no DTTOIF function
+#undef DT_UNKNOWN
+#endif
+
 static void setCloexec(int fd) KJ_UNUSED;
 static void setCloexec(int fd) {
   // Set the O_CLOEXEC flag on the given fd.

--- a/c++/src/kj/table.c++
+++ b/c++/src/kj/table.c++
@@ -288,8 +288,20 @@ void BTreeImpl::growTree(uint minCapacity) {
   // aligned_alloc() function. Unfortunately, many platforms don't implement it. Luckily, there
   // are usually alternatives.
 
-#if __APPLE__
-  // OSX lacks aligned_alloc(), but has posix_memalign(). Fine.
+#if _WIN32
+  // Windows lacks aligned_alloc() but has its own _aligned_malloc() (which requires freeing using
+  // _aligned_free()).
+  // WATCH OUT: The argument order for _aligned_malloc() is opposite of aligned_alloc()!
+  NodeUnion* newTree = reinterpret_cast<NodeUnion*>(
+      _aligned_malloc(newCapacity * sizeof(BTreeImpl::NodeUnion), sizeof(BTreeImpl::NodeUnion)));
+  KJ_ASSERT(newTree != nullptr, "memory allocation failed", newCapacity);
+#elif _ISOC11_SOURCE // macro available since glibc 2.16
+  // Let's use the C11 standard.
+  NodeUnion* newTree = reinterpret_cast<NodeUnion*>(
+      aligned_alloc(sizeof(BTreeImpl::NodeUnion), newCapacity * sizeof(BTreeImpl::NodeUnion)));
+  KJ_ASSERT(newTree != nullptr, "memory allocation failed", newCapacity);
+#else
+  // OSX and Android lack aligned_alloc(), but have posix_memalign(). Fine.
   void* allocPtr;
   int error = posix_memalign(&allocPtr,
       sizeof(BTreeImpl::NodeUnion), newCapacity * sizeof(BTreeImpl::NodeUnion));
@@ -297,18 +309,6 @@ void BTreeImpl::growTree(uint minCapacity) {
     KJ_FAIL_SYSCALL("posix_memalign", error);
   }
   NodeUnion* newTree = reinterpret_cast<NodeUnion*>(allocPtr);
-#elif _WIN32
-  // Windows lacks aligned_alloc() but has its own _aligned_malloc() (which requires freeing using
-  // _aligned_free()).
-  // WATCH OUT: The argument order for _aligned_malloc() is opposite of aligned_alloc()!
-  NodeUnion* newTree = reinterpret_cast<NodeUnion*>(
-      _aligned_malloc(newCapacity * sizeof(BTreeImpl::NodeUnion), sizeof(BTreeImpl::NodeUnion)));
-  KJ_ASSERT(newTree != nullptr, "memory allocation failed", newCapacity);
-#else
-  // Let's use the C11 standard.
-  NodeUnion* newTree = reinterpret_cast<NodeUnion*>(
-      aligned_alloc(sizeof(BTreeImpl::NodeUnion), newCapacity * sizeof(BTreeImpl::NodeUnion)));
-  KJ_ASSERT(newTree != nullptr, "memory allocation failed", newCapacity);
 #endif
 
   acopy(newTree, tree, treeCapacity);


### PR DESCRIPTION
Hi! I've noticed that master fails to compile for Android but I needed that to verify some things. Tested with the fixes and it still builds fine on Linux, Mac OS 10.13 and Android using NDK r16b. Linux build still uses aligned_alloc because _ISOC11_SOURCE is actually defined in C++ as well with g++ and clang++ both. Using feature test macros seemed more robust to me than sprinkling __ANDROID__ everywhere.