### PR TITLE
Fix Android build/test issues.

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -116,7 +116,7 @@ struct JsonCodec::Impl {
         case '\r': escaped.addAll(kj::StringPtr("\\r")); break;
         case '\t': escaped.addAll(kj::StringPtr("\\t")); break;
         default:
-          if (c >= 0 && c < 0x20) {
+          if (static_cast<uint8_t>(c) < 0x20) {
             escaped.addAll(kj::StringPtr("\\u00"));
             uint8_t c2 = c;
             escaped.add(HEXDIGITS[c2 / 16]);

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -1416,7 +1416,8 @@ private:
           break;
       }
 
-      if ((c >= 0 && c < ' ' && c != '\n' && c != '\r' && c != '\t' && c != '\v') || c == 0x7f) {
+      if ((static_cast<uint8_t>(c) < 0x20 && c != '\n' && c != '\r' && c != '\t' && c != '\v')
+          || c == 0x7f) {
         // Unprintable character.
         return IMPOSSIBLE;
       }

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -504,7 +504,7 @@ TEST(AsyncIo, AbstractUnixSocket) {
   int originalDirFd;
   KJ_SYSCALL(originalDirFd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC));
   KJ_DEFER(close(originalDirFd));
-  KJ_SYSCALL(chdir("/tmp"));
+  KJ_SYSCALL(chdir("/"));
   KJ_DEFER(KJ_SYSCALL(fchdir(originalDirFd)));
 
   addr->connect().attach(kj::mv(listener)).wait(ioContext.waitScope);

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -200,8 +200,14 @@ bool isWine() { return false; }
 #define HOLES_NOT_SUPPORTED 1
 #endif
 
+#if __ANDROID__
+#define VAR_TMP "/data/local/tmp"
+#else
+#define VAR_TMP "/var/tmp"
+#endif
+
 static Own<File> newTempFile() {
-  char filename[] = "/var/tmp/kj-filesystem-test.XXXXXX";
+  char filename[] = VAR_TMP "/kj-filesystem-test.XXXXXX";
   int fd;
   KJ_SYSCALL(fd = mkstemp(filename));
   KJ_DEFER(KJ_SYSCALL(unlink(filename)));
@@ -210,7 +216,7 @@ static Own<File> newTempFile() {
 
 class TempDir {
 public:
-  TempDir(): filename(heapString("/var/tmp/kj-filesystem-test.XXXXXX")) {
+  TempDir(): filename(heapString(VAR_TMP "/kj-filesystem-test.XXXXXX")) {
     if (mkdtemp(filename.begin()) == nullptr) {
       KJ_FAIL_SYSCALL("mkdtemp", errno, filename);
     }

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -82,14 +82,18 @@ double parseDouble(const StringPtr& s) {
   errno = 0;
   auto value = strtod(s.begin(), &endPtr);
   KJ_REQUIRE(endPtr == s.end(), "String does not contain valid floating number", s) { return 0; }
-#if _WIN32 || __CYGWIN__
+#if _WIN32 || __CYGWIN__ || __BIONIC__
   // When Windows' strtod() parses "nan", it returns a value with the sign bit set. But, our
   // preferred canonical value for NaN does not have the sign bit set, and all other platforms
   // return one without the sign bit set. So, on Windows, detect NaN and return our preferred
   // version.
   //
   // Cygwin seemingly does not try to emulate Linux behavior here, but rather allows Windows'
-  // behavior to leak through.
+  // behavior to leak through. (Conversely, WINE actually produces the Linux behavior despite
+  // trying to behave like Win32...)
+  //
+  // Bionic (Android) failed the unit test and so I added it to the list without investigating
+  // further.
   if (isNaN(value)) {
     // NaN
     return kj::nan();

--- a/super-test.sh
+++ b/super-test.sh
@@ -126,7 +126,9 @@ while [ $# -gt 0 ]; do
     android )
       # To install Android SDK:
       # - Download command-line tools: https://developer.android.com/studio/index.html#command-tools
+      # - export SDKMANAGER_OPTS="--add-modules java.se.ee"
       # - Run $SDK_HOME/tools/bin/sdkmanager platform-tools 'platforms;android-25' 'system-images;android-25;google_apis;armeabi-v7a' emulator 'build-tools;25.0.2' ndk-bundle
+      # - export AVDMANAGER_OPTS="--add-modules java.se.ee"
       # - Run $SDK_HOME/tools/bin/avdmanager create avd -n capnp -k 'system-images;android-25;google_apis;armeabi-v7a' -b google_apis/armeabi-v7a
       # - Run $SDK_HOME/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm --api 24 --install-dir $TOOLCHAIN_HOME
       if [ "$#" -ne 4 ]; then
@@ -148,7 +150,7 @@ while [ $# -gt 0 ]; do
 
       export PATH="$TOOLCHAIN_HOME/bin:$PATH"
       doit make distclean
-      doit ./configure --host="$CROSS_HOST" --with-external-capnp --disable-shared CXXFLAGS='-pie -fPIE' CAPNP=./capnp-host CAPNPC_CXX=./capnpc-c++-host
+      doit ./configure --host="$CROSS_HOST" CC=clang CXX=clang++ --with-external-capnp --disable-shared CXXFLAGS='-fPIE' LDFLAGS='-pie' LIBS='-static-libstdc++ -static-libgcc -ldl' CAPNP=./capnp-host CAPNPC_CXX=./capnpc-c++-host
 
       doit make -j$PARALLEL
       doit make -j$PARALLEL capnp-test


### PR DESCRIPTION
No real bug fixes here, just:

- Update bitrot in super-test.sh, e.g. GCC is deprecated in favor of Clang on Android.
- Fix warnings due to char being unsigned.
- Fix NaN canonicalization, which only matters for tests doing bitwise comparisons.
- Fix tests using /tmp, which is in a different location on Android.