### PR TITLE
Wrap KJ_LOG in braces

### DIFF
--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -131,9 +131,9 @@ namespace kj {
 #define KJ_EXPAND(X) X
 
 #define KJ_LOG(severity, ...) \
-  if (!::kj::_::Debug::shouldLog(::kj::LogSeverity::severity)) {} else \
+{ if (!::kj::_::Debug::shouldLog(::kj::LogSeverity::severity)) {} else \
     ::kj::_::Debug::log(__FILE__, __LINE__, ::kj::LogSeverity::severity, \
-                        "" #__VA_ARGS__, __VA_ARGS__)
+                        "" #__VA_ARGS__, __VA_ARGS__); }
 
 #define KJ_DBG(...) KJ_EXPAND(KJ_LOG(DBG, __VA_ARGS__))
 
@@ -210,9 +210,9 @@ namespace kj {
 #else
 
 #define KJ_LOG(severity, ...) \
-  if (!::kj::_::Debug::shouldLog(::kj::LogSeverity::severity)) {} else \
+{ if (!::kj::_::Debug::shouldLog(::kj::LogSeverity::severity)) {} else \
     ::kj::_::Debug::log(__FILE__, __LINE__, ::kj::LogSeverity::severity, \
-                        #__VA_ARGS__, ##__VA_ARGS__)
+                        #__VA_ARGS__, ##__VA_ARGS__); }
 
 #define KJ_DBG(...) KJ_LOG(DBG, ##__VA_ARGS__)
 

--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -131,9 +131,10 @@ namespace kj {
 #define KJ_EXPAND(X) X
 
 #define KJ_LOG(severity, ...) \
-{ if (!::kj::_::Debug::shouldLog(::kj::LogSeverity::severity)) {} else \
+  for (bool _kj_shouldLog = ::kj::_::Debug::shouldLog(::kj::LogSeverity::severity); \
+       _kj_shouldLog; _kj_shouldLog = false) \
     ::kj::_::Debug::log(__FILE__, __LINE__, ::kj::LogSeverity::severity, \
-                        "" #__VA_ARGS__, __VA_ARGS__); }
+                        "" #__VA_ARGS__, __VA_ARGS__)
 
 #define KJ_DBG(...) KJ_EXPAND(KJ_LOG(DBG, __VA_ARGS__))
 
@@ -210,9 +211,10 @@ namespace kj {
 #else
 
 #define KJ_LOG(severity, ...) \
-{ if (!::kj::_::Debug::shouldLog(::kj::LogSeverity::severity)) {} else \
+  for (bool _kj_shouldLog = ::kj::_::Debug::shouldLog(::kj::LogSeverity::severity); \
+       _kj_shouldLog; _kj_shouldLog = false) \
     ::kj::_::Debug::log(__FILE__, __LINE__, ::kj::LogSeverity::severity, \
-                        #__VA_ARGS__, ##__VA_ARGS__); }
+                        #__VA_ARGS__, ##__VA_ARGS__)
 
 #define KJ_DBG(...) KJ_LOG(DBG, ##__VA_ARGS__)
 


### PR DESCRIPTION
This fixes "dangling else" warnings when KJ_LOG is used after unbraced if statement.

The code such as:
```
if (some_function1())
    KJ_LOG(ERROR, "failed1");
if (some_function2())
    KJ_LOG(ERROR, "failed2");
```
produces warnings about ambiguous or dangling else. I know this form is sometimes frowned upon but I do not think that the library provided macro should impose any particular style on the surrounding code.