### PR TITLE
Allow immovable types in Maybe

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -45,6 +45,11 @@ struct ImplicitToInt {
   }
 };
 
+struct Immovable {
+  Immovable() = default;
+  KJ_DISALLOW_COPY(Immovable);
+};
+
 TEST(Common, Maybe) {
   {
     Maybe<int> m = 123;
@@ -215,6 +220,16 @@ TEST(Common, Maybe) {
     } else {
       ADD_FAILURE();
     }
+  }
+
+  {
+    // Test usage of immovable types.
+    Maybe<Immovable> m;
+    KJ_EXPECT(m == nullptr);
+    m.emplace();
+    KJ_EXPECT(m != nullptr);
+    m.clear();
+    KJ_EXPECT(m == nullptr);
   }
 }
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -897,9 +897,7 @@ public:
       noexcept(noexcept(instance<T&>().~T()))
 #endif
   {
-    if (isSet) {
-      dtor(value);
-    }
+    clear();
   }
 
   inline T& operator*() & { return value; }
@@ -911,12 +909,16 @@ public:
   inline operator T*() { return isSet ? &value : nullptr; }
   inline operator const T*() const { return isSet ? &value : nullptr; }
 
-  template <typename... Params>
-  inline T& emplace(Params&&... params) {
+  inline void clear() {
     if (isSet) {
       isSet = false;
       dtor(value);
     }
+  }
+
+  template <typename... Params>
+  inline T& emplace(Params&&... params) {
+    clear();
     ctor(value, kj::fwd<Params>(params)...);
     isSet = true;
     return value;
@@ -965,10 +967,7 @@ public:
   inline NullableValue& operator=(NullableValue&& other) {
     if (&other != this) {
       // Careful about throwing destructors/constructors here.
-      if (isSet) {
-        isSet = false;
-        dtor(value);
-      }
+      clear();
       if (other.isSet) {
         ctor(value, kj::mv(other.value));
         isSet = true;
@@ -980,10 +979,7 @@ public:
   inline NullableValue& operator=(NullableValue& other) {
     if (&other != this) {
       // Careful about throwing destructors/constructors here.
-      if (isSet) {
-        isSet = false;
-        dtor(value);
-      }
+      clear();
       if (other.isSet) {
         ctor(value, other.value);
         isSet = true;
@@ -995,10 +991,7 @@ public:
   inline NullableValue& operator=(const NullableValue& other) {
     if (&other != this) {
       // Careful about throwing destructors/constructors here.
-      if (isSet) {
-        isSet = false;
-        dtor(value);
-      }
+      clear();
       if (other.isSet) {
         ctor(value, other.value);
         isSet = true;
@@ -1082,6 +1075,8 @@ public:
   }
 
   Maybe(decltype(nullptr)) noexcept: ptr(nullptr) {}
+
+  inline Maybe& clear() { ptr.clear(); return *this; }
 
   template <typename... Params>
   inline T& emplace(Params&&... params) {


### PR DESCRIPTION
Immovable types can be already wrapped into `Maybe`, which can be constructed as default `nullptr`, set to a constructed value via `.emplace()`, but couldn't be set back to `nullptr` without this fix.