### PR TITLE
Implement kj::newTee()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
+            - g++-5
       env:
-        - MATRIX_CC=gcc-4.9
-        - MATRIX_CXX=g++-4.9
+        - MATRIX_CC=gcc-5
+        - MATRIX_CXX=g++-5
 
     # New GCC
     - os: linux

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -447,6 +447,7 @@ TEST(Array, AttachNested) {
   Array<Own<DestructionOrderRecorder>> combined = arr.attach(kj::mv(obj2)).attach(kj::mv(obj3));
 
   KJ_EXPECT(combined.begin() == ptr);
+  KJ_EXPECT(combined.size() == 1);
 
   KJ_EXPECT(obj1.get() == nullptr);
   KJ_EXPECT(obj2.get() == nullptr);

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -862,6 +862,7 @@ template <typename T>
 template <typename... Attachments>
 Array<T> Array<T>::attach(Attachments&&... attachments) {
   T* ptrCopy = ptr;
+  auto sizeCopy = size_;
 
   KJ_IREQUIRE(ptrCopy != nullptr, "cannot attach to null pointer");
 
@@ -872,7 +873,7 @@ Array<T> Array<T>::attach(Attachments&&... attachments) {
 
   auto bundle = new _::ArrayDisposableOwnedBundle<Array<T>, Attachments...>(
       kj::mv(*this), kj::fwd<Attachments>(attachments)...);
-  return Array<T>(ptrCopy, size_, *bundle);
+  return Array<T>(ptrCopy, sizeCopy, *bundle);
 }
 
 template <typename T>

--- a/c++/src/kj/compat/url.h
+++ b/c++/src/kj/compat/url.h
@@ -37,12 +37,6 @@ struct UrlOptions {
   bool percentDecode = true;
   // True if URL components should be automatically percent-decoded during parsing, and
   // percent-encoded during serialization.
-
-#if __cplusplus < 201402L
-  inline constexpr UrlOptions(bool percentDecode = true): percentDecode(percentDecode) {}
-  // TODO(cleanup): This constructor is only here to support brace initialization in C++11. It
-  //   should be removed once we upgrade to C++14.
-#endif
 };
 
 struct Url {
@@ -102,17 +96,6 @@ struct Url {
   Url(Url&&) = default;
   ~Url() noexcept(false);
   Url& operator=(Url&&) = default;
-
-#if __cplusplus < 201402L
-  inline Url(String&& scheme, Maybe<UserInfo>&& userInfo, String&& host, Vector<String>&& path,
-             bool hasTrailingSlash, Vector<QueryParam>&& query, Maybe<String>&& fragment,
-             UrlOptions options)
-      : scheme(kj::mv(scheme)), userInfo(kj::mv(userInfo)), host(kj::mv(host)), path(kj::mv(path)),
-        hasTrailingSlash(hasTrailingSlash), query(kj::mv(query)), fragment(kj::mv(fragment)),
-        options(options) {}
-  // TODO(cleanup): This constructor is only here to support brace initialization in C++11. It
-  //   should be removed once we upgrade to C++14.
-#endif
 
   Url clone() const;
 


### PR DESCRIPTION
`kj::newTee()` accepts an `Own<AsyncInputStream>` and returns two `Own<AsyncInputStream>`s which provide access to the same data as the original.

The two new `Own<AsyncInputStream>` objects are called branches of the tee. Each branch may have a sink. A caller may create a sink on a branch by calling `tryRead()` or `pumpTo()` on it. The returned promise *is* the sink.

Sinks created by `tryRead()` provide vacuum, whereas sinks created by `pumpTo()` do not. If a tee has at least one branch with a sink with vacuum, it will wait for any backpressure from any `pumpTo()` sinks to subside, then perform an inner read to try to fill the vacuum. This means that in a pristine state, the first `tryRead()` finishes as soon as data is available (because the pump has zero backpressure), but subsequent `tryRead()`s wait for the backpressure of other branches' `pumpTo()`s caused by the initial inner read.

While `pumpTo()` sinks do not provide vacuum, if there is ever a point at which all branches have active sinks (of any type), the tee considers there to be vacuum, and pumps freely, respecting the backpressure of the slowest sink.

If a branch has no active sink when the inner read finishes (either because one was never created, or a promise was canceled), the newly-read data is buffered for that branch, instead.

An exception encountered by the inner read prevents further inner reads. The encountered exception is propagated to all branches once their sinks have reached the end of their buffer. I decided to err on the side of filling `tryRead()` sinks as much as possible rather than eagerly rejecting them: if a read exception occurs, `tryRead()` sinks will see short reads *before* the exception. Similarly, `pumpTo()` sinks will pump all buffered data before seeing the exception. However, `pumpTo()` promises are rejected immediately upon flushing their buffer (and waiting for backpressure).

EOF propagation follows the same rules as exception propagation, except that instead of rejecting promises, it fulfills them with zero.

An exception encountered during a `write()` operation inside of `pumpTo()` rejects that branch's `pumpTo()` promise, but does not propagate to the other branch. Canceling a `pumpTo()` promise cancels any `write()` promises it has in flight.