### PR TITLE
Implement JSON-RPC adapter to Cap'n Proto interfaces.

### DIFF
--- a/c++/src/capnp/compat/json-rpc-test.c++
+++ b/c++/src/capnp/compat/json-rpc-test.c++
@@ -1,0 +1,100 @@
+// Copyright (c) 2018 Kenton Varda and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "json-rpc.h"
+#include <kj/test.h>
+#include <capnp/test-util.h>
+
+namespace capnp {
+namespace _ {  // private
+namespace {
+
+KJ_TEST("json-rpc basics") {
+  auto io = kj::setupAsyncIo();
+  auto pipe = kj::newTwoWayPipe();
+
+  JsonRpc::ContentLengthTransport clientTransport(*pipe.ends[0]);
+  JsonRpc::ContentLengthTransport serverTransport(*pipe.ends[1]);
+
+  int callCount = 0;
+
+  JsonRpc client(clientTransport);
+  JsonRpc server(serverTransport, toDynamic(kj::heap<TestInterfaceImpl>(callCount)));
+
+  auto cap = client.getPeer<test::TestInterface>();
+  auto req = cap.fooRequest();
+  req.setI(123);
+  req.setJ(true);
+  auto resp = req.send().wait(io.waitScope);
+  KJ_EXPECT(resp.getX() == "foo");
+
+  KJ_EXPECT(callCount == 1);
+}
+
+KJ_TEST("json-rpc error") {
+  auto io = kj::setupAsyncIo();
+  auto pipe = kj::newTwoWayPipe();
+
+  JsonRpc::ContentLengthTransport clientTransport(*pipe.ends[0]);
+  JsonRpc::ContentLengthTransport serverTransport(*pipe.ends[1]);
+
+  int callCount = 0;
+
+  JsonRpc client(clientTransport);
+  JsonRpc server(serverTransport, toDynamic(kj::heap<TestInterfaceImpl>(callCount)));
+
+  auto cap = client.getPeer<test::TestInterface>();
+  KJ_EXPECT_THROW_MESSAGE("Method not implemented", cap.barRequest().send().wait(io.waitScope));
+}
+
+KJ_TEST("json-rpc multiple calls") {
+  auto io = kj::setupAsyncIo();
+  auto pipe = kj::newTwoWayPipe();
+
+  JsonRpc::ContentLengthTransport clientTransport(*pipe.ends[0]);
+  JsonRpc::ContentLengthTransport serverTransport(*pipe.ends[1]);
+
+  int callCount = 0;
+
+  JsonRpc client(clientTransport);
+  JsonRpc server(serverTransport, toDynamic(kj::heap<TestInterfaceImpl>(callCount)));
+
+  auto cap = client.getPeer<test::TestInterface>();
+  auto req1 = cap.fooRequest();
+  req1.setI(123);
+  req1.setJ(true);
+  auto promise1 = req1.send();
+
+  auto req2 = cap.bazRequest();
+  initTestMessage(req2.initS());
+  auto promise2 = req2.send();
+
+  auto resp1 = promise1.wait(io.waitScope);
+  KJ_EXPECT(resp1.getX() == "foo");
+
+  auto resp2 = promise2.wait(io.waitScope);
+
+  KJ_EXPECT(callCount == 2);
+}
+
+}  // namespace
+}  // namespace _ (private)
+}  // namespace capnp

--- a/c++/src/capnp/compat/json-rpc.c++
+++ b/c++/src/capnp/compat/json-rpc.c++
@@ -1,0 +1,341 @@
+// Copyright (c) 2018 Kenton Varda and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "json-rpc.h"
+#include <kj/compat/http.h>
+#include <capnp/compat/json-rpc.capnp.h>
+
+namespace capnp {
+
+static constexpr uint64_t JSON_NAME_ANNOTATION_ID = 0xfa5b1fd61c2e7c3dull;
+static constexpr uint64_t JSON_NOTIFICATION_ANNOTATION_ID = 0xa0a054dea32fd98cull;
+
+class JsonRpc::CapabilityImpl final: public DynamicCapability::Server {
+public:
+  CapabilityImpl(JsonRpc& parent, InterfaceSchema schema)
+      : DynamicCapability::Server(schema), parent(parent) {}
+
+  kj::Promise<void> call(InterfaceSchema::Method method,
+                         CallContext<DynamicStruct, DynamicStruct> context) override {
+    auto proto = method.getProto();
+    bool isNotification = false;
+    kj::StringPtr name = proto.getName();
+    for (auto annotation: proto.getAnnotations()) {
+      switch (annotation.getId()) {
+        case JSON_NAME_ANNOTATION_ID:
+          name = annotation.getValue().getText();
+          break;
+        case JSON_NOTIFICATION_ANNOTATION_ID:
+          isNotification = true;
+          break;
+      }
+    }
+
+    capnp::MallocMessageBuilder message;
+    auto value = message.getRoot<json::Value>();
+    auto list = value.initObject(3 + !isNotification);
+
+    uint index = 0;
+
+    auto jsonrpc = list[index++];
+    jsonrpc.setName("jsonrpc");
+    jsonrpc.initValue().setString("2.0");
+
+    uint callId = parent.callCount++;
+
+    if (!isNotification) {
+      auto id = list[index++];
+      id.setName("id");
+      id.initValue().setNumber(callId);
+    }
+
+    auto methodName = list[index++];
+    methodName.setName("method");
+    methodName.initValue().setString(name);
+
+    auto params = list[index++];
+    params.setName("params");
+    parent.codec.encode(context.getParams(), params.initValue());
+
+    auto writePromise = parent.queueWrite(parent.codec.encode(value));
+
+    if (isNotification) {
+      auto sproto = context.getResultsType().getProto().getStruct();
+      MessageSize size { sproto.getDataWordCount(), sproto.getPointerCount() };
+      context.initResults(size);
+      return kj::mv(writePromise);
+    } else {
+      auto paf = kj::newPromiseAndFulfiller<void>();
+      parent.awaitedResponses.insert(callId, AwaitedResponse { context, kj::mv(paf.fulfiller) });
+      auto promise = writePromise.then([p = kj::mv(paf.promise)]() mutable { return kj::mv(p); });
+      auto& parentRef = parent;
+      return promise.attach(kj::defer([&parentRef,callId]() {
+        parentRef.awaitedResponses.erase(callId);
+      }));
+    }
+  }
+
+private:
+  JsonRpc& parent;
+};
+
+JsonRpc::JsonRpc(Transport& transport, DynamicCapability::Client interface)
+    : JsonRpc(transport, kj::mv(interface), kj::newPromiseAndFulfiller<void>()) {}
+JsonRpc::JsonRpc(Transport& transport, DynamicCapability::Client interfaceParam,
+                 kj::PromiseFulfillerPair<void> paf)
+    : transport(transport),
+      interface(kj::mv(interfaceParam)),
+      errorPromise(paf.promise.fork()),
+      errorFulfiller(kj::mv(paf.fulfiller)),
+      readTask(readLoop().eagerlyEvaluate([this](kj::Exception&& e) {
+        errorFulfiller->reject(kj::mv(e));
+      })),
+      tasks(*this) {
+  codec.handleByAnnotation(interface.getSchema());
+  codec.handleByAnnotation<json::RpcMessage>();
+
+  for (auto method: interface.getSchema().getMethods()) {
+    auto proto = method.getProto();
+    kj::StringPtr name = proto.getName();
+    for (auto annotation: proto.getAnnotations()) {
+      switch (annotation.getId()) {
+        case JSON_NAME_ANNOTATION_ID:
+          name = annotation.getValue().getText();
+          break;
+      }
+    }
+    methodMap.insert(name, method);
+  }
+}
+
+DynamicCapability::Client JsonRpc::getPeer(InterfaceSchema schema) {
+  codec.handleByAnnotation(interface.getSchema());
+  return kj::heap<CapabilityImpl>(*this, schema);
+}
+
+static kj::HttpHeaderTable& staticHeaderTable() {
+  static kj::HttpHeaderTable HEADER_TABLE;
+  return HEADER_TABLE;
+}
+
+kj::Promise<void> JsonRpc::queueWrite(kj::String text) {
+  auto fork = writeQueue.then([this, text = kj::mv(text)]() mutable {
+    auto promise = transport.send(text);
+    return promise.attach(kj::mv(text));
+  }).eagerlyEvaluate([this](kj::Exception&& e) {
+    errorFulfiller->reject(kj::mv(e));
+  }).fork();
+  writeQueue = fork.addBranch();
+  return fork.addBranch();
+}
+
+void JsonRpc::queueError(kj::Maybe<json::Value::Reader> id, int code, kj::StringPtr message) {
+  MallocMessageBuilder capnpMessage;
+  auto jsonResponse = capnpMessage.getRoot<json::RpcMessage>();
+  jsonResponse.setJsonrpc("2.0");
+  KJ_IF_MAYBE(i, id) {
+    jsonResponse.setId(*i);
+  } else {
+    jsonResponse.initId().setNull();
+  }
+  auto error = jsonResponse.initError();
+  error.setCode(code);
+  error.setMessage(message);
+
+  // OK to discard result of queueWrite() since it's just one branch of a fork.
+  queueWrite(codec.encode(jsonResponse));
+}
+
+kj::Promise<void> JsonRpc::readLoop() {
+  return transport.receive().then([this](kj::String message) -> kj::Promise<void> {
+    MallocMessageBuilder capnpMessage;
+    auto rpcMessageBuilder = capnpMessage.getRoot<json::RpcMessage>();
+
+    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+      codec.decode(message, rpcMessageBuilder);
+    })) {
+      queueError(nullptr, -32700, kj::str("Parse error: ", exception->getDescription()));
+      return readLoop();
+    }
+
+    KJ_CONTEXT("decoding JSON-RPC message", message);
+
+    auto rpcMessage = rpcMessageBuilder.asReader();
+
+    if (!rpcMessage.hasJsonrpc()) {
+      queueError(nullptr, -32700, kj::str("Missing 'jsonrpc' field."));
+      return readLoop();
+    } else if (rpcMessage.getJsonrpc() != "2.0") {
+      queueError(nullptr, -32700,
+          kj::str("Unknown JSON-RPC version. This peer implements version '2.0'."));
+      return readLoop();
+    }
+
+    switch (rpcMessage.which()) {
+      case json::RpcMessage::NONE:
+        queueError(nullptr, -32700, kj::str("message has none of params, result, or error"));
+        break;
+
+      case json::RpcMessage::PARAMS: {
+        // a call
+        auto schema = interface.getSchema();
+        KJ_IF_MAYBE(method, schema.findMethodByName(rpcMessage.getMethod())) {
+          auto req = interface.newRequest(*method);
+          KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+            codec.decode(rpcMessage.getParams(), req);
+          })) {
+            kj::Maybe<JsonValue::Reader> id;
+            if (rpcMessage.hasId()) id = rpcMessage.getId();
+            queueError(id, -32602,
+                kj::str("Type error in method params: ", exception->getDescription()));
+            break;
+          }
+
+          if (rpcMessage.hasId()) {
+            auto id = rpcMessage.getId();
+            auto idCopy = kj::heapArray<word>(id.totalSize().wordCount + 1);
+            memset(idCopy.begin(), 0, idCopy.asBytes().size());
+            copyToUnchecked(id, idCopy);
+            auto idPtr = readMessageUnchecked<json::Value>(idCopy.begin());
+
+            auto promise = req.send()
+                .then([this,idPtr](Response<DynamicStruct> response) mutable {
+              MallocMessageBuilder capnpMessage;
+              auto jsonResponse = capnpMessage.getRoot<json::RpcMessage>();
+              jsonResponse.setJsonrpc("2.0");
+              jsonResponse.setId(idPtr);
+              codec.encode(DynamicStruct::Reader(response), jsonResponse.initResult());
+              return queueWrite(codec.encode(jsonResponse));
+            }, [this,idPtr](kj::Exception&& e) {
+              MallocMessageBuilder capnpMessage;
+              auto jsonResponse = capnpMessage.getRoot<json::RpcMessage>();
+              jsonResponse.setJsonrpc("2.0");
+              jsonResponse.setId(idPtr);
+              auto error = jsonResponse.initError();
+              switch (e.getType()) {
+                case kj::Exception::Type::FAILED:
+                  error.setCode(-32000);
+                  break;
+                case kj::Exception::Type::DISCONNECTED:
+                  error.setCode(-32001);
+                  break;
+                case kj::Exception::Type::OVERLOADED:
+                  error.setCode(-32002);
+                  break;
+                case kj::Exception::Type::UNIMPLEMENTED:
+                  error.setCode(-32601);  // method not found
+                  break;
+              }
+              error.setMessage(e.getDescription());
+              return queueWrite(codec.encode(jsonResponse));
+            });
+            tasks.add(promise.attach(kj::mv(idCopy)));
+          } else {
+            // No 'id', so this is a notification.
+            tasks.add(req.send().ignoreResult().catch_([](kj::Exception&& exception) {
+              if (exception.getType() != kj::Exception::Type::UNIMPLEMENTED) {
+                KJ_LOG(ERROR, "JSON-RPC notification threw exception into the abyss", exception);
+              }
+            }));
+          }
+        } else {
+          if (rpcMessage.hasId()) {
+            queueError(rpcMessage.getId(), -32601, "Method not found");
+          } else {
+            // Ignore notification for unknown method.
+          }
+        }
+        break;
+      }
+
+      case json::RpcMessage::RESULT: {
+        auto id = rpcMessage.getId();
+        if (!id.isNumber()) {
+          // JSON-RPC doesn't define what to do if receiving a response with an invalid id.
+          KJ_LOG(ERROR, "JSON-RPC response has invalid ID");
+        } else KJ_IF_MAYBE(awaited, awaitedResponses.find((uint)id.getNumber())) {
+          KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+            codec.decode(rpcMessage.getResult(), awaited->context.getResults());
+            awaited->fulfiller->fulfill();
+          })) {
+            // Errors always propagate from callee to caller, so we don't want to throw this error
+            // back to the server.
+            awaited->fulfiller->reject(kj::mv(*exception));
+          }
+        } else {
+          // Probably, this is the response to a call that was canceled.
+        }
+        break;
+      }
+
+      case json::RpcMessage::ERROR: {
+        auto id = rpcMessage.getId();
+        if (id.isNull()) {
+          // Error message will be logged by KJ_CONTEXT, above.
+          KJ_LOG(ERROR, "peer reports JSON-RPC protocol error");
+        } else if (!id.isNumber()) {
+          // JSON-RPC doesn't define what to do if receiving a response with an invalid id.
+          KJ_LOG(ERROR, "JSON-RPC response has invalid ID");
+        } else KJ_IF_MAYBE(awaited, awaitedResponses.find((uint)id.getNumber())) {
+          auto error = rpcMessage.getError();
+          auto code = error.getCode();
+          kj::Exception::Type type =
+              code == -32601 ? kj::Exception::Type::UNIMPLEMENTED
+                             : kj::Exception::Type::FAILED;
+          awaited->fulfiller->reject(kj::Exception(
+              type, __FILE__, __LINE__, kj::str(error.getMessage())));
+        } else {
+          // Probably, this is the response to a call that was canceled.
+        }
+        break;
+      }
+    }
+
+    return readLoop();
+  });
+}
+
+void JsonRpc::taskFailed(kj::Exception&& exception) {
+  errorFulfiller->reject(kj::mv(exception));
+}
+
+// =======================================================================================
+
+JsonRpc::ContentLengthTransport::ContentLengthTransport(kj::AsyncIoStream& stream)
+    : stream(stream), input(kj::newHttpInputStream(stream, staticHeaderTable())) {}
+JsonRpc::ContentLengthTransport::~ContentLengthTransport() noexcept(false) {}
+
+kj::Promise<void> JsonRpc::ContentLengthTransport::send(kj::StringPtr text) {
+  auto headers = kj::str("Content-Length: ", text.size(), "\r\n\r\n");
+  parts[0] = headers.asBytes();
+  parts[1] = text.asBytes();
+  return stream.write(parts).attach(kj::mv(headers));
+}
+
+kj::Promise<kj::String> JsonRpc::ContentLengthTransport::receive() {
+  return input->readMessage()
+      .then([this](kj::HttpInputStream::Message&& message) {
+    auto promise = message.body->readAllText();
+    return promise.attach(kj::mv(message.body));
+  });
+}
+
+}  // namespace capnp

--- a/c++/src/capnp/compat/json-rpc.capnp
+++ b/c++/src/capnp/compat/json-rpc.capnp
@@ -1,0 +1,43 @@
+@0xd04299800d6725ba;
+
+$import "/capnp/c++.capnp".namespace("capnp::json");
+
+using Json = import "json.capnp";
+
+struct RpcMessage {
+  jsonrpc @0 :Text;
+  # Must always be "2.0".
+
+  id @1 :Json.Value;
+  # Correlates a request to a response. Technically must be a string or number. Our implementation
+  # will always use a number for calls it initiates, and will reflect IDs of any type for calls
+  # it receives.
+  #
+  # May be omitted when caller doesn't care about the response. The implementation will omit `id`
+  # and return immediately when calling methods with the annotation `@notification` (defined in
+  # `json.capnp`). The `@notification` annotation only matters for outgoing calls; for incoming
+  # calls, it's the client's decision whether it wants to receive the response.
+
+  method @2 :Text;
+  # Method name. Only expected when `params` is sent.
+
+  union {
+    none @3 :Void $Json.name("!missing params, result, or error");
+    # Dummy default value of union, to detect when none of the fields below were received.
+
+    params @4 :Json.Value;
+    # Initiates a call.
+
+    result @5 :Json.Value;
+    # Completes a call.
+
+    error @6 :Error;
+    # Completes a call throwing an exception.
+  }
+
+  struct Error {
+    code @0 :Int32;
+    message @1 :Text;
+    data @2 :Json.Value;
+  }
+}

--- a/c++/src/capnp/compat/json-rpc.h
+++ b/c++/src/capnp/compat/json-rpc.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 Kenton Varda and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "json.h"
+#include <kj/async-io.h>
+#include <capnp/capability.h>
+#include <kj/map.h>
+
+namespace kj { class HttpInputStream; }
+
+namespace capnp {
+
+class JsonRpc: private kj::TaskSet::ErrorHandler {
+  // An implementation of JSON-RPC 2.0: https://www.jsonrpc.org/specification
+  //
+  // This allows you to use Cap'n Proto interface declarations to implement JSON-RPC protocols.
+  // Of course, JSON-RPC does not support capabilities. So, the client and server each expose
+  // exactly one object to the other.
+
+public:
+  class Transport;
+  class ContentLengthTransport;
+
+  JsonRpc(Transport& transport, DynamicCapability::Client interface = {});
+  KJ_DISALLOW_COPY(JsonRpc);
+
+  DynamicCapability::Client getPeer(InterfaceSchema schema);
+
+  template <typename T>
+  typename T::Client getPeer() {
+    return getPeer(Schema::from<T>()).template castAs<T>();
+  }
+
+  kj::Promise<void> onError() { return errorPromise.addBranch(); }
+
+private:
+  JsonCodec codec;
+  Transport& transport;
+  DynamicCapability::Client interface;
+  kj::HashMap<kj::StringPtr, InterfaceSchema::Method> methodMap;
+  uint callCount = 0;
+  kj::Promise<void> writeQueue = kj::READY_NOW;
+  kj::ForkedPromise<void> errorPromise;
+  kj::Own<kj::PromiseFulfiller<void>> errorFulfiller;
+  kj::Promise<void> readTask;
+
+  struct AwaitedResponse {
+    CallContext<DynamicStruct, DynamicStruct> context;
+    kj::Own<kj::PromiseFulfiller<void>> fulfiller;
+  };
+  kj::HashMap<uint, AwaitedResponse> awaitedResponses;
+
+  kj::TaskSet tasks;
+
+  class CapabilityImpl;
+
+  kj::Promise<void> queueWrite(kj::String text);
+  void queueError(kj::Maybe<json::Value::Reader> id, int code, kj::StringPtr message);
+
+  kj::Promise<void> readLoop();
+
+  void taskFailed(kj::Exception&& exception) override;
+
+  JsonRpc(Transport& transport, DynamicCapability::Client interface,
+          kj::PromiseFulfillerPair<void> paf);
+};
+
+class JsonRpc::Transport {
+public:
+  virtual kj::Promise<void> send(kj::StringPtr text) = 0;
+  virtual kj::Promise<kj::String> receive() = 0;
+};
+
+class JsonRpc::ContentLengthTransport: public Transport {
+  // The transport used by Visual Studio Code: Each message is composed like an HTTP message
+  // without the first line. That is, a list of headers, followed by a blank line, followed by the
+  // content whose length is determined by the content-length header.
+public:
+  explicit ContentLengthTransport(kj::AsyncIoStream& stream);
+  ~ContentLengthTransport() noexcept(false);
+  KJ_DISALLOW_COPY(ContentLengthTransport);
+
+  kj::Promise<void> send(kj::StringPtr text) override;
+  kj::Promise<kj::String> receive() override;
+
+private:
+  kj::AsyncIoStream& stream;
+  kj::Own<kj::HttpInputStream> input;
+  kj::ArrayPtr<const byte> parts[2];
+};
+
+}  // namespace capnp

--- a/c++/src/capnp/compat/json.capnp
+++ b/c++/src/capnp/compat/json.capnp
@@ -66,14 +66,14 @@ struct Value {
 #
 #     myField @0 :Text $Json.name("my_field");
 
-annotation name @0xfa5b1fd61c2e7c3d (field, enumerant, method, group, union): Text;
+annotation name @0xfa5b1fd61c2e7c3d (field, enumerant, method, group, union) :Text;
 # Define an alternative name to use when encoding the given item in JSON. This can be used, for
 # example, to use snake_case names where needed, even though Cap'n Proto uses strictly camelCase.
 #
 # (However, because JSON is derived from JavaScript, you *should* use camelCase names when
 # defining JSON-based APIs. But, when supporting a pre-existing API you may not have a choice.)
 
-annotation flatten @0x82d3e852af0336bf (field, group, union): FlattenOptions;
+annotation flatten @0x82d3e852af0336bf (field, group, union) :FlattenOptions;
 # Specifies that an aggregate field should be flattened into its parent.
 #
 # In order to flatten a member of a union, the union (or, for an anonymous union, the parent
@@ -87,7 +87,7 @@ struct FlattenOptions {
   # Optional: Adds the given prefix to flattened field names.
 }
 
-annotation discriminator @0xcfa794e8d19a0162 (struct, union): DiscriminatorOptions;
+annotation discriminator @0xcfa794e8d19a0162 (struct, union) :DiscriminatorOptions;
 # Specifies that a union's variant will be decided not by which fields are present, but instead
 # by a special discriminator field. The value of the discriminator field is a string naming which
 # variant is active. This allows the members of the union to have the $jsonFlatten annotation, or
@@ -105,8 +105,11 @@ struct DiscriminatorOptions {
   # It is an error to use `valueName` while also declaring some variants as $flatten.
 }
 
-annotation base64 @0xd7d879450a253e4b (field): Void;
+annotation base64 @0xd7d879450a253e4b (field) :Void;
 # Place on a field of type `Data` to indicate that its JSON representation is a Base64 string.
 
-annotation hex @0xf061e22f0ae5c7b5 (field): Void;
+annotation hex @0xf061e22f0ae5c7b5 (field) :Void;
 # Place on a field of type `Data` to indicate that its JSON representation is a hex string.
+
+annotation notification @0xa0a054dea32fd98c (method) :Void;
+# Indicates that this method is a JSON-RPC "notification", meaning it expects no response.

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -303,6 +303,12 @@ void JsonCodec::encode(T&& value, JsonValue::Builder output) const {
   encode(DynamicValue::Reader(ReaderFor<Base>(kj::fwd<T>(value))), Type::from<Base>(), output);
 }
 
+template <>
+inline void JsonCodec::encode<DynamicStruct::Reader>(
+      DynamicStruct::Reader&& value, JsonValue::Builder output) const {
+  encode(DynamicValue::Reader(value), value.getSchema(), output);
+}
+
 template <typename T>
 inline Orphan<T> JsonCodec::decode(JsonValue::Reader input, Orphanage orphanage) const {
   return decode(input, Type::from<T>(), orphanage).template releaseAs<T>();

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -584,6 +584,9 @@ public:
   kj::Promise<void> tailCall(Request<SubParams, DynamicStruct>&& tailRequest);
   void allowCancellation();
 
+  StructSchema getParamsType() const { return paramType; }
+  StructSchema getResultsType() const { return resultType; }
+
 private:
   CallContextHook* hook;
   StructSchema paramType;


### PR DESCRIPTION
I wrote this in order to implement the vscode Language Server Protocol for Ekam, but @RReverser might find it interesting for work he has been doing.

Ekam vscode integration implemented in: https://github.com/capnproto/ekam/pull/20