### PR TITLE
Zero-length HTTP responses get no Content-Length header

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -809,6 +809,18 @@ kj::ArrayPtr<const HttpResponseTestCase> responseTestCases() {
       HttpMethod::HEAD,
     },
 
+    // Zero-length expected size response to HEAD request has no Content-Length header.
+    {
+      "HTTP/1.1 200 OK\r\n"
+      "\r\n",
+
+      200, "OK",
+      {},
+      uint64_t(0), {},
+
+      HttpMethod::HEAD,
+    },
+
     {
       "HTTP/1.1 200 OK\r\n"
       "Content-Length: 8\r\n"
@@ -1177,6 +1189,22 @@ kj::ArrayPtr<const HttpTestCase> pipelineTestCases() {
         "\r\n",
 
         200, "OK", {}, 7, { "foo bar" }
+      },
+    },
+
+    // Zero-length expected size response to HEAD request has no Content-Length header.
+    {
+      {
+        "HEAD / HTTP/1.1\r\n"
+        "\r\n",
+
+        HttpMethod::HEAD, "/", {}, uint64_t(0), {},
+      },
+      {
+        "HTTP/1.1 200 OK\r\n"
+        "\r\n",
+
+        200, "OK", {}, uint64_t(0), {}, HttpMethod::HEAD,
       },
     },
   };


### PR DESCRIPTION
There is currently no way to explicitly omit a Content-Length/Transfer-Encoding header on an HTTP response. This is awkward for a proxy, which would ideally pass along responses as-is, even if they have no such headers.

This change allows an author to pass zero as the expected body length to HttpService::Response::send() to mean "do not set any body header." This means that a proxy might strip Content-Length: 0 headers, but will never add a Content-Length header where there was none before.