### PR TITLE
Don't escape forward slashes in JSON output

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -109,7 +109,6 @@ struct JsonCodec::Impl {
       switch (c) {
         case '\"': escaped.addAll(kj::StringPtr("\\\"")); break;
         case '\\': escaped.addAll(kj::StringPtr("\\\\")); break;
-        case '/' : escaped.addAll(kj::StringPtr("\\/" )); break;
         case '\b': escaped.addAll(kj::StringPtr("\\b")); break;
         case '\f': escaped.addAll(kj::StringPtr("\\f")); break;
         case '\n': escaped.addAll(kj::StringPtr("\\n")); break;


### PR DESCRIPTION
Forward slashes don't need to be escaped in JSON.

Not tested but I assume you have some kind of CI system (and it's a trivial change anyway).