### PR TITLE
initialize anonymous enums in isPlausiblyText() and isPlausiblyJson()

### DIFF
--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -1377,7 +1377,7 @@ private:
   }
 
   Plausibility isPlausiblyText(kj::ArrayPtr<const byte> prefix) {
-    enum { PREAMBLE, COMMENT, BODY } state;
+    enum { PREAMBLE, COMMENT, BODY } state = PREAMBLE;
 
     for (char c: prefix.asChars()) {
       switch (state) {
@@ -1427,7 +1427,7 @@ private:
   }
 
   Plausibility isPlausiblyJson(kj::ArrayPtr<const byte> prefix) {
-    enum { PREAMBLE, COMMENT, BODY } state;
+    enum { PREAMBLE, COMMENT, BODY } state = PREAMBLE;
 
     for (char c: prefix.asChars()) {
       switch (state) {


### PR DESCRIPTION
Fixes #754.

Bug found with the help of `CXX=clang++ -fsanitize=undefined`.