### PR TITLE
Detect EOF in copyChunk

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -502,6 +502,7 @@ public:
           default:
             KJ_FAIL_SYSCALL("sendfile", error) { return fromPos - fromOffset; }
         }
+        if (n == 0) break;
       }
       return fromPos - fromOffset;
     }


### PR DESCRIPTION
If holes are not supported on the target system and size to `copy` was passed as `kj::maxValue()`, this could lead to near-infinite loops.