### PR TITLE
Log more info in VectorOutputStream::write() KJ_REQUIRE

### DIFF
--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -273,7 +273,7 @@ ArrayPtr<byte> ArrayOutputStream::getWriteBuffer() {
 void ArrayOutputStream::write(const void* src, size_t size) {
   if (src == fillPos) {
     // Oh goody, the caller wrote directly into our buffer.
-    KJ_REQUIRE(size <= array.end() - fillPos);
+    KJ_REQUIRE(size <= array.end() - fillPos, size, fillPos, array.end() - fillPos);
     fillPos += size;
   } else {
     KJ_REQUIRE(size <= (size_t)(array.end() - fillPos),
@@ -301,7 +301,7 @@ ArrayPtr<byte> VectorOutputStream::getWriteBuffer() {
 void VectorOutputStream::write(const void* src, size_t size) {
   if (src == fillPos) {
     // Oh goody, the caller wrote directly into our buffer.
-    KJ_REQUIRE(size <= vector.end() - fillPos);
+    KJ_REQUIRE(size <= vector.end() - fillPos, size, fillPos, vector.end() - fillPos);
     fillPos += size;
   } else {
     if (vector.end() - fillPos < size) {

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -271,7 +271,7 @@ ArrayPtr<byte> ArrayOutputStream::getWriteBuffer() {
 }
 
 void ArrayOutputStream::write(const void* src, size_t size) {
-  if (src == fillPos) {
+  if (src == fillPos && fillPos != array.end()) {
     // Oh goody, the caller wrote directly into our buffer.
     KJ_REQUIRE(size <= array.end() - fillPos, size, fillPos, array.end() - fillPos);
     fillPos += size;
@@ -299,7 +299,7 @@ ArrayPtr<byte> VectorOutputStream::getWriteBuffer() {
 }
 
 void VectorOutputStream::write(const void* src, size_t size) {
-  if (src == fillPos) {
+  if (src == fillPos && fillPos != vector.end()) {
     // Oh goody, the caller wrote directly into our buffer.
     KJ_REQUIRE(size <= vector.end() - fillPos, size, fillPos, vector.end() - fillPos);
     fillPos += size;


### PR DESCRIPTION
This is to help debug an issue in Cloudflare Workers. I also added the same debug info to the ArrayOutputStream case, mostly for pleasing symmetry.

/cc @RReverser 