### PR TITLE
Use fstatat instead of faccessat to check if file exists

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -711,12 +711,13 @@ public:
   }
 
   bool exists(PathPtr path) const {
-    KJ_SYSCALL_HANDLE_ERRORS(faccessat(fd, path.toString().cStr(), F_OK, 0)) {
+    struct stat stats;
+    KJ_SYSCALL_HANDLE_ERRORS(fstatat(fd, path.toString().cStr(), &stats, 0)) {
       case ENOENT:
       case ENOTDIR:
         return false;
       default:
-        KJ_FAIL_SYSCALL("faccessat(fd, path)", error, path) { return false; }
+        KJ_FAIL_SYSCALL("fstatat(fd, path)", error, path) { return false; }
     }
     return true;
   }
@@ -728,7 +729,7 @@ public:
       case ENOTDIR:
         return nullptr;
       default:
-        KJ_FAIL_SYSCALL("faccessat(fd, path)", error, path) { return nullptr; }
+        KJ_FAIL_SYSCALL("fstatat(fd, path)", error, path) { return nullptr; }
     }
     return statToMetadata(stats);
   }


### PR DESCRIPTION
This is not strictly equivalent, but should be interchangeable for most usecases, and fixes a test on WSL where calling `exists` on a symlink to non-existing directory was reported as existing by `faccessat`.

See (4) in https://github.com/capnproto/capnproto/issues/458#issuecomment-446344395