### PR TITLE
Fix HttpClient-from-HttpService wrapper prematurely cancelling service promise.

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1459,7 +1459,7 @@ KJ_TEST("HttpInputStream responses") {
     KJ_CONTEXT(testCase.raw);
 
     KJ_ASSERT(input->awaitNextMessage().wait(waitScope));
-    
+
     auto resp = input->readResponse(testCase.method).wait(waitScope);
     KJ_EXPECT(resp.statusCode == testCase.statusCode);
     KJ_EXPECT(resp.statusText == testCase.statusText);
@@ -2610,13 +2610,6 @@ KJ_TEST("newHttpService from HttpClient WebSockets") {
       .then([&]() { return backPipe.ends[1]->write({WEBSOCKET_REPLY_MESSAGE}); })
       .then([&]() { return expectRead(*backPipe.ends[1], WEBSOCKET_SEND_CLOSE); })
       .then([&]() { return backPipe.ends[1]->write({WEBSOCKET_REPLY_CLOSE}); })
-      // expect EOF
-      .then([&]() { return backPipe.ends[1]->readAllBytes(); })
-      .then([&](kj::ArrayPtr<byte> content) {
-        KJ_EXPECT(content.size() == 0);
-        // Send EOF.
-        backPipe.ends[1]->shutdownWrite();
-      })
       .eagerlyEvaluate([](kj::Exception&& e) { KJ_LOG(ERROR, e); });
 
   {

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2484,9 +2484,9 @@ static kj::Promise<void> pumpWebSocketLoop(WebSocket& from, WebSocket& to) {
             .then([&from,&to]() { return pumpWebSocketLoop(from, to); });
       }
       KJ_CASE_ONEOF(close, WebSocket::Close) {
+        // Once a close has passed through, the pump is complete.
         return to.close(close.code, close.reason)
-            .attach(kj::mv(close))
-            .then([&from,&to]() { return pumpWebSocketLoop(from, to); });
+            .attach(kj::mv(close));
       }
     }
     KJ_UNREACHABLE;


### PR DESCRIPTION
The client app will typically discard the returned response body upon reading EOF. However, the server app may not actually be "done" with the service callback yet at this point. Usually it completes very soon after, but it may need another turn or two of the event loop. If the client discards the response body stream, the server-side promise is discarded, cancelling whatever was left. This is awkward, so we should instead delay the client from seeing EOF until the server has actually finished up.