### PR TITLE
Make HttpServer detect client disconnect and cancel request processing

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -2133,7 +2133,9 @@ KJ_TEST("Userspace TwoWayPipe whenWriteDisconnected()") {
   abortedPromise.wait(ws);
 }
 
-#if !_WIN32  // IOCP doesn't support detecting disconnect AFAICT.
+#if !_WIN32  // We don't currently support detecting disconnect with IOCP.
+#if !__CYGWIN__  // TODO(soon): Figure out why whenWriteDisconnected() doesn't work on Cygwin.
+
 KJ_TEST("OS OneWayPipe whenWriteDisconnected()") {
   auto io = setupAsyncIo();
 
@@ -2190,7 +2192,9 @@ KJ_TEST("import socket FD that's already broken") {
   buffer[3] = '\0';
   KJ_EXPECT(buffer == "foo"_kj);
 }
-#endif
+
+#endif  // !__CYGWIN__
+#endif  // !_WIN32
 
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -106,6 +106,17 @@ public:
   // output stream. If it finds one, it performs the pump. Otherwise, it returns null.
   //
   // The default implementation always returns null.
+
+  virtual Promise<void> whenWriteDisconnected() = 0;
+  // Returns a promise that resolves when the stream has become disconnected such that new write()s
+  // will fail with a DISCONNECTED exception. This is particularly useful, for example, to cancel
+  // work early when it is detected that no one will receive the result.
+  //
+  // Note that not all streams are able to detect this condition without actually performing a
+  // write(); such stream implementations may return a promise that never resolves.
+  //
+  // Unlike most other asynchronous stream methods, it is safe to call whenWriteDisconnected()
+  // multiple times without canceling the previous promises.
 };
 
 class AsyncIoStream: public AsyncInputStream, public AsyncOutputStream {

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -113,7 +113,10 @@ public:
   // work early when it is detected that no one will receive the result.
   //
   // Note that not all streams are able to detect this condition without actually performing a
-  // write(); such stream implementations may return a promise that never resolves.
+  // write(); such stream implementations may return a promise that never resolves. (In particular,
+  // as of this writing, whenWriteDisconnected() is not implemented on Windows. Also, for TCP
+  // streams, not all disconnects are detectable -- a power or network failure may lead the
+  // connection to hang forever, or until configured socket options lead to a timeout.)
   //
   // Unlike most other asynchronous stream methods, it is safe to call whenWriteDisconnected()
   // multiple times without canceling the previous promises.

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -278,6 +278,9 @@ public:
   // WARNING: This has some known weird behavior on macOS. See
   //   https://github.com/sandstorm-io/capnproto/issues/374.
 
+  Promise<void> whenWriteDisconnected();
+  // Resolves when poll() on the file descriptor reports POLLHUP or POLLERR.
+
 private:
   UnixEventPort& eventPort;
   int fd;
@@ -286,6 +289,7 @@ private:
   kj::Maybe<Own<PromiseFulfiller<void>>> readFulfiller;
   kj::Maybe<Own<PromiseFulfiller<void>>> writeFulfiller;
   kj::Maybe<Own<PromiseFulfiller<void>>> urgentFulfiller;
+  kj::Maybe<Own<PromiseFulfiller<void>>> hupFulfiller;
   // Replaced each time `whenBecomesReadable()` or `whenBecomesWritable()` is called. Reverted to
   // null every time an event is fired.
 

--- a/c++/src/kj/compat/gzip-test.c++
+++ b/c++/src/kj/compat/gzip-test.c++
@@ -126,6 +126,8 @@ public:
     }
     return kj::READY_NOW;
   }
+
+  Promise<void> whenWriteDisconnected() override { KJ_UNIMPLEMENTED("not used"); }
 };
 
 KJ_TEST("gzip decompression") {

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -118,6 +118,8 @@ public:
   Promise<void> write(const void* buffer, size_t size) override;
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
 
+  Promise<void> whenWriteDisconnected() override { return inner.whenWriteDisconnected(); }
+
   inline Promise<void> flush() {
     return pump(Z_SYNC_FLUSH);
   }

--- a/c++/src/kj/compat/http-socketpair-test.c++
+++ b/c++/src/kj/compat/http-socketpair-test.c++
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Run http-test, but use real OS socketpairs to connect rather than using in-process pipes.
+// This is essentially an integration test between KJ HTTP and KJ OS socket handling.
+#define KJ_HTTP_TEST_USE_OS_PIPE 1
+#include "http-test.c++"

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -288,6 +288,10 @@ public:
     return inner.tryPumpFrom(input, amount);
   }
 
+  Promise<void> whenWriteDisconnected() override {
+    return inner.whenWriteDisconnected();
+  }
+
   void shutdownWrite() override {
     return inner.shutdownWrite();
   }
@@ -1791,6 +1795,10 @@ public:
     return out->tryPumpFrom(input, amount);
   }
 
+  Promise<void> whenWriteDisconnected() override {
+    return out->whenWriteDisconnected();
+  }
+
   void shutdownWrite() override {
     out = nullptr;
   }
@@ -2745,6 +2753,9 @@ public:
   kj::Maybe<kj::Promise<uint64_t>> tryPumpFrom(
       kj::AsyncInputStream& input, uint64_t amount = kj::maxValue) override {
     return inner->tryPumpFrom(input, amount);
+  }
+  Promise<void> whenWriteDisconnected() override {
+    return inner->whenWriteDisconnected();
   }
   void shutdownWrite() override {
     return inner->shutdownWrite();

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -27,7 +27,7 @@
 #include <map>
 
 #if KJ_HTTP_TEST_USE_OS_PIPE
-// Run the test using OS-leve socketpairs. (See http-socketpair-test.c++.)
+// Run the test using OS-level socketpairs. (See http-socketpair-test.c++.)
 #define KJ_HTTP_TEST_SETUP_IO \
   auto io = kj::setupAsyncIo(); \
   auto& waitScope = io.waitScope
@@ -2565,7 +2565,7 @@ private:
   kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> onCancelFulfiller;
 };
 
-KJ_TEST("HttpServer disconnects ") {
+KJ_TEST("HttpServer cancels request when client disconnects") {
   KJ_HTTP_TEST_SETUP_IO;
   kj::TimerImpl timer(kj::origin<kj::TimePoint>());
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -489,6 +489,17 @@ public:
   // shutdown, but is sometimes useful when you want the other end to trigger whatever behavior
   // it normally triggers when a connection is dropped.
 
+  virtual void abort() = 0;
+  // Forcefully close this WebSocket, such that the remote end should get a DISCONNECTED error if
+  // it continues to write. This differs from disconnect(), which only closes the sending
+  // direction, but still allows receives.
+
+  virtual kj::Promise<void> whenAborted() = 0;
+  // Resolves when the remote side aborts the connection such that send() would throw DISCONNECTED,
+  // if this can be detected without actually writing a message. (If not, this promise never
+  // resolves, but send() or receive() will throw DISCONNECTED when appropriate. See also
+  // kj::AsyncOutputStream::whenWriteDisconnected().)
+
   struct Close {
     uint16_t code;
     kj::String reason;

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -629,6 +629,9 @@ public:
   //
   // `url` and `headers` are invalidated on the first read from `requestBody` or when the returned
   // promise resolves, whichever comes first.
+  //
+  // Request processing can be canceled by dropping the returned promise. HttpServer may do so if
+  // the client disconnects prematurely.
 
   virtual kj::Promise<kj::Own<kj::AsyncIoStream>> connect(kj::StringPtr host);
   // Handles CONNECT requests. Only relevant for proxy services. Default implementation throws

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -180,6 +180,10 @@ public:
     return writeInternal(pieces[0], pieces.slice(1, pieces.size()));
   }
 
+  Promise<void> whenWriteDisconnected() override {
+    return inner.whenWriteDisconnected();
+  }
+
   void shutdownWrite() override {
     KJ_REQUIRE(shutdownTask == nullptr, "already called shutdownWrite()");
 


### PR DESCRIPTION
NOTE: The first two commits are from PR #787, on which the rest of this is based.

The strategy here is to add a method `AsyncOutputStream::whenWriteDisconnected()` which detects when the stream becomes writable-but-errored -- i.e. write() won't block, but will fail with some other error. This is indicated on Unix by POLLHUP or POLLERR.

Once we have that, we can easily join it with the promise returned by `HttpService::request()` to cancel processing on disconnect.

To help thoroughly test this, I arranged for http-test to run twice, once using userspace pipes (as it did before this change) and once using kernel socketpairs. The latter test is only run in the Ekam build at present, not automake/cmake. I expect it would fail on Windows (due to a missing implementation of `whenWriteDisconnected()` -- see comments) and OSX (due to the problem described in 6e4c5ce3c9f31a5e79b50cd9eaae6d03106edf98, since that commit is now reverted)... but I'm going to punt on fixing those issues.