### PR TITLE
Fix compile error with Array<const T>.

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -631,7 +631,8 @@ struct ArrayDisposer::Dispose_<T, false> {
 
   static void dispose(T* firstElement, size_t elementCount, size_t capacity,
                       const ArrayDisposer& disposer) {
-    disposer.disposeImpl(firstElement, sizeof(T), elementCount, capacity, &destruct);
+    disposer.disposeImpl(const_cast<RemoveConst<T>*>(firstElement),
+                         sizeof(T), elementCount, capacity, &destruct);
   }
 };
 


### PR DESCRIPTION
For trivial types, we already had this const_cast (line 622), but for non-trivial types it was missing.