### PR TITLE
 Define and implement HTTP-over-Cap'n-Proto

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -121,6 +121,10 @@ kj::Promise<void> ClientHook::whenResolved() {
   }
 }
 
+kj::Promise<void> Capability::Client::whenResolved() {
+  return hook->whenResolved().attach(hook->addRef());
+}
+
 // =======================================================================================
 
 static inline uint firstSegmentSize(kj::Maybe<MessageSize> sizeHint) {

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -882,7 +882,7 @@ inline typename T::Client Capability::Client::castAs() {
   return typename T::Client(hook->addRef());
 }
 inline kj::Promise<void> Capability::Client::whenResolved() {
-  return hook->whenResolved();
+  return hook->whenResolved().attach(hook->addRef());
 }
 inline Request<AnyPointer, AnyPointer> Capability::Client::typelessRequest(
     uint64_t interfaceId, uint16_t methodId,

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -407,6 +407,23 @@ public:
   // returns that FD. When FD passing has been enabled in the RPC layer, this FD may be sent to
   // other processes along with the capability.
 
+  virtual kj::Maybe<kj::Promise<Capability::Client>> shortenPath();
+  // If this returns non-null, then it is a promise which, when resolved, points to a new
+  // capability to which future calls can be sent. Use this in cases where an object implementation
+  // might discover a more-optimized path some time after it starts.
+  //
+  // Implementing this (and returning non-null) will cause the capability to be advertised as a
+  // promise at the RPC protocol level. Once the promise returned by shortenPath() resolves, the
+  // remote client will receive a `Resolve` message updating it to point at the new destination.
+  //
+  // `shortenPath()` can also be used as a hack to shut up the client. If shortenPath() returns
+  // a promise that resolves to an exception, then the client will be notified that the capability
+  // is now broken. Assuming the client is using a correct RPC implemnetation, this should cause
+  // all further calls initiated by the client to this capability to immediately fail client-side,
+  // sparing the server's bandwidth.
+  //
+  // The default implementation always returns nullptr.
+
   // TODO(someday):  Method which can optionally be overridden to implement Join when the object is
   //   a proxy.
 

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -898,9 +898,6 @@ template <typename T>
 inline typename T::Client Capability::Client::castAs() {
   return typename T::Client(hook->addRef());
 }
-inline kj::Promise<void> Capability::Client::whenResolved() {
-  return hook->whenResolved().attach(hook->addRef());
-}
 inline Request<AnyPointer, AnyPointer> Capability::Client::typelessRequest(
     uint64_t interfaceId, uint16_t methodId,
     kj::Maybe<MessageSize> sizeHint) {

--- a/c++/src/capnp/compat/byte-stream-test.c++
+++ b/c++/src/capnp/compat/byte-stream-test.c++
@@ -1,0 +1,374 @@
+// Copyright (c) 2019 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "byte-stream.h"
+#include <kj/test.h>
+
+namespace capnp {
+namespace {
+
+kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
+  if (expected.size() == 0) return kj::READY_NOW;
+
+  auto buffer = kj::heapArray<char>(expected.size());
+
+  auto promise = in.tryRead(buffer.begin(), 1, buffer.size());
+  return promise.then(kj::mvCapture(buffer, [&in,expected](kj::Array<char> buffer, size_t amount) {
+    if (amount == 0) {
+      KJ_FAIL_ASSERT("expected data never sent", expected);
+    }
+
+    auto actual = buffer.slice(0, amount);
+    if (memcmp(actual.begin(), expected.begin(), actual.size()) != 0) {
+      KJ_FAIL_ASSERT("data from stream doesn't match expected", expected, actual);
+    }
+
+    return expectRead(in, expected.slice(amount));
+  }));
+}
+
+KJ_TEST("KJ -> ByteStream -> KJ without shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory factory1;
+  ByteStreamFactory factory2;
+
+  auto pipe = kj::newOneWayPipe();
+
+  auto wrapped = factory1.capnpToKj(factory2.kjToCapnp(kj::mv(pipe.out)));
+
+  {
+    auto promise = wrapped->write("foo", 3);
+    KJ_EXPECT(!promise.poll(waitScope));
+    expectRead(*pipe.in, "foo").wait(waitScope);
+    promise.wait(waitScope);
+  }
+
+  wrapped = nullptr;
+  KJ_EXPECT(pipe.in->readAllText().wait(waitScope) == "");
+}
+
+class ExactPointerWriter: public kj::AsyncOutputStream {
+public:
+  kj::ArrayPtr<const char> receivedBuffer;
+  kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> fulfiller;
+
+  kj::Promise<void> write(const void* buffer, size_t size) override {
+    receivedBuffer = kj::arrayPtr(reinterpret_cast<const char*>(buffer), size);
+    auto paf = kj::newPromiseAndFulfiller<void>();
+    fulfiller = kj::mv(paf.fulfiller);
+    return kj::mv(paf.promise);
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
+    KJ_UNIMPLEMENTED("not implemented for test");
+  }
+  kj::Promise<void> whenWriteDisconnected() override {
+    return kj::NEVER_DONE;
+  }
+};
+
+KJ_TEST("KJ -> ByteStream -> KJ with shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory factory;
+
+  auto pipe = kj::newOneWayPipe();
+
+  ExactPointerWriter exactPointerWriter;
+  auto pumpPromise = pipe.in->pumpTo(exactPointerWriter);
+
+  auto wrapped = factory.capnpToKj(factory.kjToCapnp(kj::mv(pipe.out)));
+
+  {
+    char buffer[4] = "foo";
+    auto promise = wrapped->write(buffer, 3);
+    KJ_EXPECT(!promise.poll(waitScope));
+
+    // This first write won't have been path-shortened because we didn't know about the shorter
+    // path yet when it started.
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() != buffer);
+    KJ_EXPECT(kj::str(exactPointerWriter.receivedBuffer) == "foo");
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+    promise.wait(waitScope);
+  }
+
+  {
+    char buffer[4] = "foo";
+    auto promise = wrapped->write(buffer, 3);
+    KJ_EXPECT(!promise.poll(waitScope));
+
+    // The second write was path-shortened so passes through the exact buffer!
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer);
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 3);
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+    promise.wait(waitScope);
+  }
+
+  wrapped = nullptr;
+  KJ_EXPECT(pipe.in->readAllText().wait(waitScope) == "");
+}
+
+KJ_TEST("KJ -> ByteStream -> KJ -> ByteStream -> KJ with shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory factory;
+
+  auto pipe = kj::newOneWayPipe();
+
+  ExactPointerWriter exactPointerWriter;
+  auto pumpPromise = pipe.in->pumpTo(exactPointerWriter);
+
+  auto wrapped = factory.capnpToKj(factory.kjToCapnp(
+                 factory.capnpToKj(factory.kjToCapnp(kj::mv(pipe.out)))));
+
+  {
+    char buffer[4] = "foo";
+    auto promise = wrapped->write(buffer, 3);
+    KJ_EXPECT(!promise.poll(waitScope));
+
+    // This first write won't have been path-shortened because we didn't know about the shorter
+    // path yet when it started.
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() != buffer);
+    KJ_EXPECT(kj::str(exactPointerWriter.receivedBuffer) == "foo");
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+    promise.wait(waitScope);
+  }
+
+  {
+    char buffer[4] = "bar";
+    auto promise = wrapped->write(buffer, 3);
+    KJ_EXPECT(!promise.poll(waitScope));
+
+    // The second write was path-shortened so passes through the exact buffer!
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer);
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 3);
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+    promise.wait(waitScope);
+  }
+
+  wrapped = nullptr;
+  KJ_EXPECT(pumpPromise.wait(waitScope) == 6);
+}
+
+KJ_TEST("KJ -> ByteStream -> KJ pipe -> ByteStream -> KJ with shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory factory;
+
+  auto backPipe = kj::newOneWayPipe();
+  auto middlePipe = kj::newOneWayPipe();
+
+  ExactPointerWriter exactPointerWriter;
+  auto backPumpPromise = backPipe.in->pumpTo(exactPointerWriter);
+
+  auto backWrapped = factory.capnpToKj(factory.kjToCapnp(kj::mv(backPipe.out)));
+  auto midPumpPormise = middlePipe.in->pumpTo(*backWrapped, 3);
+
+  auto wrapped = factory.capnpToKj(factory.kjToCapnp(kj::mv(middlePipe.out)));
+
+  // Poll whenWriteDisconnected(), mainly as a way to let all the path-shortening settle.
+  auto disconnectPromise = wrapped->whenWriteDisconnected();
+  KJ_EXPECT(!disconnectPromise.poll(waitScope));
+
+  char buffer[7] = "foobar";
+  auto writePromise = wrapped->write(buffer, 6);
+  KJ_EXPECT(!writePromise.poll(waitScope));
+
+  // The first three bytes will tunnel all the way down to the destination.
+  KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer);
+  KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 3);
+  KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+
+  KJ_EXPECT(midPumpPormise.wait(waitScope) == 3);
+
+  ExactPointerWriter exactPointerWriter2;
+  midPumpPormise = middlePipe.in->pumpTo(exactPointerWriter2, 6);
+  KJ_EXPECT(!writePromise.poll(waitScope));
+
+  // The second half of the "foobar" write will have taken a slow path, because the write was
+  // restarted in the middle of the stream re-resolving itself.
+  KJ_EXPECT(kj::str(exactPointerWriter2.receivedBuffer) == "bar");
+  KJ_ASSERT_NONNULL(exactPointerWriter2.fulfiller)->fulfill();
+
+  // Now that write is done.
+  writePromise.wait(waitScope);
+  KJ_EXPECT(!midPumpPormise.poll(waitScope));
+
+  // If we write again, it'll hit the fast path.
+  char buffer2[4] = "baz";
+  writePromise = wrapped->write(buffer2, 3);
+  KJ_EXPECT(!writePromise.poll(waitScope));
+  KJ_EXPECT(exactPointerWriter2.receivedBuffer.begin() == buffer2);
+  KJ_EXPECT(exactPointerWriter2.receivedBuffer.size() == 3);
+  KJ_ASSERT_NONNULL(exactPointerWriter2.fulfiller)->fulfill();
+
+  KJ_EXPECT(midPumpPormise.wait(waitScope) == 6);
+  writePromise.wait(waitScope);
+}
+
+KJ_TEST("Two Substreams on one destination") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory factory;
+
+  auto backPipe = kj::newOneWayPipe();
+  auto middlePipe1 = kj::newOneWayPipe();
+  auto middlePipe2 = kj::newOneWayPipe();
+
+  ExactPointerWriter exactPointerWriter;
+  auto backPumpPromise = backPipe.in->pumpTo(exactPointerWriter);
+
+  auto backWrapped = factory.capnpToKj(factory.kjToCapnp(kj::mv(backPipe.out)));
+
+  auto wrapped1 = factory.capnpToKj(factory.kjToCapnp(kj::mv(middlePipe1.out)));
+  auto wrapped2 = factory.capnpToKj(factory.kjToCapnp(kj::mv(middlePipe2.out)));
+
+  // Declare these buffers out here so that they can't possibly end up with the same address.
+  char buffer1[4] = "foo";
+  char buffer2[4] = "bar";
+
+  {
+    auto wrapped = kj::mv(wrapped1);
+
+    // First pump 3 bytes from the first stream.
+    auto midPumpPormise = middlePipe1.in->pumpTo(*backWrapped, 3);
+
+    // Poll whenWriteDisconnected(), mainly as a way to let all the path-shortening settle.
+    auto disconnectPromise = wrapped->whenWriteDisconnected();
+    KJ_EXPECT(!disconnectPromise.poll(waitScope));
+
+    auto writePromise = wrapped->write(buffer1, 3);
+    KJ_EXPECT(!writePromise.poll(waitScope));
+
+    // The first write will tunnel all the way down to the destination.
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer1);
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 3);
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+
+    writePromise.wait(waitScope);
+    KJ_EXPECT(midPumpPormise.wait(waitScope) == 3);
+  }
+
+  {
+    auto wrapped = kj::mv(wrapped2);
+
+    // Now pump another 3 bytes from the second stream.
+    auto midPumpPormise = middlePipe2.in->pumpTo(*backWrapped, 3);
+
+    // Poll whenWriteDisconnected(), mainly as a way to let all the path-shortening settle.
+    auto disconnectPromise = wrapped->whenWriteDisconnected();
+    KJ_EXPECT(!disconnectPromise.poll(waitScope));
+
+    auto writePromise = wrapped->write(buffer2, 3);
+    KJ_EXPECT(!writePromise.poll(waitScope));
+
+    // The second write will also tunnel all the way down to the destination.
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer2);
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 3);
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+
+    writePromise.wait(waitScope);
+    KJ_EXPECT(midPumpPormise.wait(waitScope) == 3);
+  }
+}
+
+KJ_TEST("Two Substreams on one destination no limits (pump to EOF)") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory factory;
+
+  auto backPipe = kj::newOneWayPipe();
+  auto middlePipe1 = kj::newOneWayPipe();
+  auto middlePipe2 = kj::newOneWayPipe();
+
+  ExactPointerWriter exactPointerWriter;
+  auto backPumpPromise = backPipe.in->pumpTo(exactPointerWriter);
+
+  auto backWrapped = factory.capnpToKj(factory.kjToCapnp(kj::mv(backPipe.out)));
+
+  auto wrapped1 = factory.capnpToKj(factory.kjToCapnp(kj::mv(middlePipe1.out)));
+  auto wrapped2 = factory.capnpToKj(factory.kjToCapnp(kj::mv(middlePipe2.out)));
+
+  // Declare these buffers out here so that they can't possibly end up with the same address.
+  char buffer1[4] = "foo";
+  char buffer2[4] = "bar";
+
+  {
+    auto wrapped = kj::mv(wrapped1);
+
+    // First pump from the first stream until EOF.
+    auto midPumpPormise = middlePipe1.in->pumpTo(*backWrapped);
+
+    // Poll whenWriteDisconnected(), mainly as a way to let all the path-shortening settle.
+    auto disconnectPromise = wrapped->whenWriteDisconnected();
+    KJ_EXPECT(!disconnectPromise.poll(waitScope));
+
+    auto writePromise = wrapped->write(buffer1, 3);
+    KJ_EXPECT(!writePromise.poll(waitScope));
+
+    // The first write will tunnel all the way down to the destination.
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer1);
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 3);
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+
+    writePromise.wait(waitScope);
+    { auto drop = kj::mv(wrapped); }
+    KJ_EXPECT(midPumpPormise.wait(waitScope) == 3);
+  }
+
+  {
+    auto wrapped = kj::mv(wrapped2);
+
+    // Now pump from the second stream until EOF.
+    auto midPumpPormise = middlePipe2.in->pumpTo(*backWrapped);
+
+    // Poll whenWriteDisconnected(), mainly as a way to let all the path-shortening settle.
+    auto disconnectPromise = wrapped->whenWriteDisconnected();
+    KJ_EXPECT(!disconnectPromise.poll(waitScope));
+
+    auto writePromise = wrapped->write(buffer2, 3);
+    KJ_EXPECT(!writePromise.poll(waitScope));
+
+    // The second write will also tunnel all the way down to the destination.
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer2);
+    KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 3);
+    KJ_ASSERT_NONNULL(exactPointerWriter.fulfiller)->fulfill();
+
+    writePromise.wait(waitScope);
+    { auto drop = kj::mv(wrapped); }
+    KJ_EXPECT(midPumpPormise.wait(waitScope) == 3);
+  }
+}
+
+// TODO:
+// - Parallel writes (requires streaming)
+// - Write to KJ -> capnp -> RPC -> capnp -> KJ loopback without shortening, verify we can write
+//   several things to buffer (requires streaming).
+// - Again, but with shortening which only occurs after some promise resolve.
+
+}  // namespace
+}  // namespace capnp

--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -1,0 +1,997 @@
+// Copyright (c) 2019 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "byte-stream.h"
+#include <kj/one-of.h>
+#include <kj/debug.h>
+
+namespace capnp {
+
+class ByteStreamFactory::StreamServerBase: public capnp::ByteStream::Server {
+public:
+  virtual void returnStream(uint64_t written) = 0;
+  // Called after the StreamServerBase's internal kj::AsyncOutputStream has been borrowed, to
+  // indicate that the borrower is done.
+  //
+  // A stream becomes borrowed either when getShortestPath() returns a BorrowedStream, or when
+  // a SubstreamImpl is constructed wrapping an existing stream.
+
+  struct BorrowedStream {
+    // Represents permission to use the StreamServerBase's inner AsyncOutputStream directly, up
+    // to some limit of bytes written.
+
+    StreamServerBase& lender;
+    kj::AsyncOutputStream& stream;
+    uint64_t limit;
+  };
+
+  typedef kj::OneOf<kj::Promise<void>, capnp::ByteStream::Client*, BorrowedStream> ShortestPath;
+
+  virtual ShortestPath getShortestPath() = 0;
+  // Called by KjToCapnpStreamAdapter when it has determined that its inner ByteStream::Client
+  // actually points back to a StreamServerBase in the same process created by the same
+  // ByteStreamFactory. Returns the best shortened path to use, or a promise that resolves when the
+  // shortest path is known.
+
+  virtual void directEnd() = 0;
+  // Called by KjToCapnpStreamAdapter's destructor when it has determined that its inner
+  // ByteStream::Client actually points back to a StreamServerBase in the same process created by
+  // the same ByteStreamFactory. Since destruction of a KJ stream signals EOF, we need to propagate
+  // that by destroying our underlying stream.
+  // TODO(cleanup): When KJ streams evolve an end() method, this can go away.
+};
+
+class ByteStreamFactory::SubstreamImpl final: public StreamServerBase {
+public:
+  SubstreamImpl(ByteStreamFactory& factory,
+                StreamServerBase& parent,
+                capnp::ByteStream::Client ownParent,
+                kj::AsyncOutputStream& stream,
+                capnp::ByteStream::SubstreamCallback::Client callback,
+                uint64_t limit,
+                kj::PromiseFulfillerPair<void> paf = kj::newPromiseAndFulfiller<void>())
+      : factory(factory),
+        state(Streaming {parent, kj::mv(ownParent), stream, kj::mv(callback)}),
+        limit(limit),
+        resolveFulfiller(kj::mv(paf.fulfiller)),
+        resolvePromise(paf.promise.fork()) {}
+
+  // ---------------------------------------------------------------------------
+  // implements StreamServerBase
+
+  void returnStream(uint64_t written) override {
+    completed += written;
+    KJ_ASSERT(completed <= limit);
+    auto borrowed = kj::mv(state.get<Borrowed>());
+    state = kj::mv(borrowed.originalState);
+
+    if (completed == limit) {
+      limitReached();
+    }
+  }
+
+  ShortestPath getShortestPath() override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(redirected, Redirected) {
+        return &redirected.replacement;
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already called end()");
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("can't call other methods while substream is active");
+      }
+      KJ_CASE_ONEOF(streaming, Streaming) {
+        auto& stream = streaming.stream;
+        auto oldState = kj::mv(streaming);
+        state = Borrowed { kj::mv(oldState) };
+        return BorrowedStream { *this, stream, limit - completed };
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  void directEnd() override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(redirected, Redirected) {
+        // Ugh I guess we need to send a real end() request here.
+        redirected.replacement.endRequest(MessageSize {2, 0}).send().detach([](kj::Exception&&){});
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        // whatever
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        // ... whatever.
+      }
+      KJ_CASE_ONEOF(streaming, Streaming) {
+        auto req = streaming.callback.endedRequest(MessageSize {4, 0});
+        req.setByteCount(completed);
+        req.send().detach([](kj::Exception&&){});
+        streaming.parent.returnStream(completed);
+        state = Ended();
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // implements ByteStream::Server RPC interface
+
+  kj::Maybe<kj::Promise<Capability::Client>> shortenPath() override {
+    return resolvePromise.addBranch()
+        .then([this]() -> Capability::Client {
+      return state.get<Redirected>().replacement;
+    });
+  }
+
+  kj::Promise<void> write(WriteContext context) override {
+    auto params = context.getParams();
+    auto data = params.getBytes();
+
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(redirected, Redirected) {
+        auto req = redirected.replacement.writeRequest(params.totalSize());
+        req.setBytes(data);
+        return req.send();
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already called end()");
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("can't call other methods while stream is borrowed");
+      }
+      KJ_CASE_ONEOF(streaming, Streaming) {
+        if (completed + data.size() < limit) {
+          completed += data.size();
+          return streaming.stream.write(data.begin(), data.size());
+        } else {
+          // This write passes the limit.
+          uint64_t remainder = limit - completed;
+          auto leftover = data.slice(remainder, data.size());
+          return streaming.stream.write(data.begin(), remainder)
+              .then([this, leftover]() -> kj::Promise<void> {
+            completed = limit;
+            limitReached();
+
+            if (leftover.size() > 0) {
+              // Need to forward the leftover bytes to the next stream.
+              auto req = state.get<Redirected>().replacement.writeRequest(
+                  MessageSize { 4 + leftover.size() / sizeof(capnp::word), 0 });
+              req.setBytes(leftover);
+              return req.send();
+            } else {
+              return kj::READY_NOW;
+            }
+          });
+        }
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Promise<void> end(EndContext context) override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(redirected, Redirected) {
+        return context.tailCall(redirected.replacement.endRequest(MessageSize {2,0}));
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already called end()");
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("can't call other methods while stream is borrowed");
+      }
+      KJ_CASE_ONEOF(streaming, Streaming) {
+        auto req = streaming.callback.endedRequest(MessageSize {4, 0});
+        req.setByteCount(completed);
+        auto result = req.send().ignoreResult();
+        streaming.parent.returnStream(completed);
+        state = Ended();
+        return result;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Promise<void> getSubstream(GetSubstreamContext context) override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(redirected, Redirected) {
+        auto params = context.getParams();
+        auto req = redirected.replacement.getSubstreamRequest(params.totalSize());
+        req.setCallback(params.getCallback());
+        req.setLimit(params.getLimit());
+        return context.tailCall(kj::mv(req));
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already called end()");
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("can't call other methods while stream is borrowed");
+      }
+      KJ_CASE_ONEOF(streaming, Streaming) {
+        auto params = context.getParams();
+        auto callback = params.getCallback();
+        auto limit = params.getLimit();
+        context.releaseParams();
+        auto results = context.getResults(MessageSize { 2, 1 });
+        results.setSubstream(factory.streamSet.add(kj::heap<SubstreamImpl>(
+            factory, *this, thisCap(), streaming.stream, kj::mv(callback), kj::mv(limit))));
+        state = Borrowed { kj::mv(streaming) };
+        return kj::READY_NOW;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+private:
+  ByteStreamFactory& factory;
+
+  struct Streaming {
+    StreamServerBase& parent;
+    capnp::ByteStream::Client ownParent;
+    kj::AsyncOutputStream& stream;
+    capnp::ByteStream::SubstreamCallback::Client callback;
+  };
+  struct Borrowed {
+    Streaming originalState;
+  };
+  struct Redirected {
+    capnp::ByteStream::Client replacement;
+  };
+  struct Ended {};
+
+  kj::OneOf<Streaming, Borrowed, Redirected, Ended> state;
+
+  uint64_t limit;
+  uint64_t completed = 0;
+
+  kj::Own<kj::PromiseFulfiller<void>> resolveFulfiller;
+  kj::ForkedPromise<void> resolvePromise;
+
+  void limitReached() {
+    auto& streaming = state.get<Streaming>();
+    auto next = streaming.callback.reachedLimitRequest(capnp::MessageSize {2,0})
+        .send().getNext();
+
+    // Set the next stream as our replacement.
+    streaming.parent.returnStream(limit);
+    state = Redirected { kj::mv(next) };
+    resolveFulfiller->fulfill();
+  }
+};
+
+// =======================================================================================
+
+class ByteStreamFactory::CapnpToKjStreamAdapter final: public StreamServerBase {
+  // Implements Cap'n Proto ByteStream as a wrapper around a KJ stream.
+
+  class SubstreamCallbackImpl;
+
+public:
+  class PathProber;
+
+  CapnpToKjStreamAdapter(ByteStreamFactory& factory,
+                         kj::Own<kj::AsyncOutputStream> inner)
+      : factory(factory),
+        state(kj::heap<PathProber>(*this, kj::mv(inner))) {
+    state.get<kj::Own<PathProber>>()->startProbing();
+  }
+
+  CapnpToKjStreamAdapter(ByteStreamFactory& factory,
+                         kj::Own<PathProber> pathProber)
+      : factory(factory),
+        state(kj::mv(pathProber)) {
+    state.get<kj::Own<PathProber>>()->setNewParent(*this);
+  }
+
+  // ---------------------------------------------------------------------------
+  // implements StreamServerBase
+
+  void returnStream(uint64_t written) override {
+    auto stream = kj::mv(state.get<Borrowed>().stream);
+    state = kj::mv(stream);
+  }
+
+  ShortestPath getShortestPath() override {
+    // Called by KjToCapnpStreamAdapter when it has determined that its inner ByteStream::Client
+    // actually points back to a CapnpToKjStreamAdapter in the same process. Returns the best
+    // shortened path to use, or a promise that resolves when the shortest path is known.
+
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(prober, kj::Own<PathProber>) {
+        return prober->whenReady();
+      }
+      KJ_CASE_ONEOF(kjStream, kj::Own<kj::AsyncOutputStream>) {
+        auto& streamRef = *kjStream;
+        state = Borrowed { kj::mv(kjStream) };
+        return StreamServerBase::BorrowedStream { *this, streamRef, kj::maxValue };
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client) {
+        return &capnpStream;
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("concurrent streaming calls disallowed") { break; }
+        return kj::Promise<void>(kj::READY_NOW);
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already ended") { break; }
+        return kj::Promise<void>(kj::READY_NOW);
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  void directEnd() override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(prober, kj::Own<PathProber>) {
+        state = Ended();
+      }
+      KJ_CASE_ONEOF(kjStream, kj::Own<kj::AsyncOutputStream>) {
+        state = Ended();
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client) {
+        // Ugh I guess we need to send a real end() request here.
+        capnpStream.endRequest(MessageSize {2, 0}).send().detach([](kj::Exception&&){});
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        // Fine, ignore.
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        // Fine, ignore.
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // PathProber
+
+  class PathProber final: public kj::AsyncInputStream {
+  public:
+    PathProber(CapnpToKjStreamAdapter& parent, kj::Own<kj::AsyncOutputStream> inner,
+               kj::PromiseFulfillerPair<void> paf = kj::newPromiseAndFulfiller<void>())
+        : parent(parent), inner(kj::mv(inner)),
+          readyPromise(paf.promise.fork()),
+          readyFulfiller(kj::mv(paf.fulfiller)),
+          task(nullptr) {}
+
+    void startProbing() {
+      task = probeForShorterPath();
+    }
+
+    void setNewParent(CapnpToKjStreamAdapter& newParent) {
+      KJ_ASSERT(parent == nullptr);
+      parent = newParent;
+      auto paf = kj::newPromiseAndFulfiller<void>();
+      readyPromise = paf.promise.fork();
+      readyFulfiller = kj::mv(paf.fulfiller);
+    }
+
+    kj::Promise<void> whenReady() {
+      return readyPromise.addBranch();
+    }
+
+    kj::Promise<uint64_t> pumpToShorterPath(capnp::ByteStream::Client target, uint64_t limit) {
+      // If our probe succeeds in finding a KjToCapnpStreamAdapter somewhere down the stack, that
+      // will call this method to provide the shortened path.
+
+      KJ_IF_MAYBE(currentParent, parent) {
+        parent = nullptr;
+
+        auto self = kj::mv(currentParent->state.get<kj::Own<PathProber>>());
+        currentParent->state = Ended();  // temporary, we'll set this properly below
+        KJ_ASSERT(self.get() == this);
+
+        // Open a substream on the target stream.
+        auto req = target.getSubstreamRequest();
+        req.setLimit(limit);
+        auto paf = kj::newPromiseAndFulfiller<uint64_t>();
+        req.setCallback(kj::heap<SubstreamCallbackImpl>(currentParent->factory,
+            kj::mv(self), kj::mv(paf.fulfiller), limit));
+
+        // Now we hook up the incoming stream adapter to point directly to this substream, yay.
+        currentParent->state = req.send().getSubstream();
+
+        // Let the original CapnpToKjStreamAdapter know that it's safe to handle incoming requests.
+        readyFulfiller->fulfill();
+
+        // It's now up to the SubstreamCallbackImpl to signal when the pump is done.
+        return kj::mv(paf.promise);
+      } else {
+        // We already completed a path-shortening. Probably SubstreamCallbackImpl::ended() was
+        // eventually called, meaning the substream was ended without redirecting back to us. So,
+        // we're at EOF.
+        return uint64_t(0);
+      }
+    }
+
+    kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+      // If this is called, it means the tryPumpFrom() in probeForShorterPath() eventually invoked
+      // code that tries to read manually from the source. We don't know what this code is doing
+      // exactly, but we do know for sure that the endpoint is not a KjToCapnpStreamAdapter, so
+      // we can't optimize. Instead, we pretend that we immediately hit EOF, ending the pump. This
+      // works because pumps do not propagate EOF -- the destination can still receive further
+      // writes and pumps. Basically our probing pump becomes a no-op, and then we revert to having
+      // each write() RPC directly call write() on the inner stream.
+      return size_t(0);
+    }
+
+    kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
+      // Call the stream's `tryPumpFrom()` as a way to discover where the data will eventually go,
+      // in hopes that we find we can shorten the path.
+      KJ_IF_MAYBE(promise, output.tryPumpFrom(*this, amount)) {
+        // tryPumpFrom() returned non-null. Either it called `tryRead()` or `pumpTo()` (see
+        // below), or it plans to do so in the future.
+        return kj::mv(*promise);
+      } else {
+        // There is no shorter path. As with tryRead(), we pretend we get immediate EOF.
+        return uint64_t(0);
+      }
+    }
+
+  private:
+    kj::Maybe<CapnpToKjStreamAdapter&> parent;
+    kj::Own<kj::AsyncOutputStream> inner;
+    kj::ForkedPromise<void> readyPromise;
+    kj::Own<kj::PromiseFulfiller<void>> readyFulfiller;
+    kj::Promise<void> task;
+
+    friend class SubstreamCallbackImpl;
+
+    kj::Promise<void> probeForShorterPath() {
+      return kj::evalNow([&]() -> kj::Promise<uint64_t> {
+        return pumpTo(*inner, kj::maxValue);
+      }).then([this](uint64_t actual) {
+        KJ_IF_MAYBE(currentParent, parent) {
+          KJ_IF_MAYBE(prober, currentParent->state.tryGet<kj::Own<PathProber>>()) {
+            // Either we didn't find any shorter path at all during probing and faked an EOF
+            // to get out of the probe (see comments in tryRead(), or we DID find a shorter path,
+            // completed a pumpTo() using a substream, and that substream redirected back to us,
+            // and THEN we couldn't find any further shorter paths for subsequent pumps.
+
+            // HACK: If we overwrite the Probing state now, we'll delete ourselves and delete
+            //   this task promise, which is an error... let the event loop do it later by
+            //   detaching.
+            task.attach(kj::mv(*prober)).detach([](kj::Exception&&){});
+            parent = nullptr;
+
+            // OK, now we can change the parent state and signal it to proceed.
+            currentParent->state = kj::mv(inner);
+            readyFulfiller->fulfill();
+          }
+        }
+      }).eagerlyEvaluate([this](kj::Exception&& exception) mutable {
+        // Something threw, so propagate the exception to break the parent.
+        readyFulfiller->reject(kj::mv(exception));
+      });
+    }
+  };
+
+protected:
+  // ---------------------------------------------------------------------------
+  // implements ByteStream::Server RPC interface
+
+  kj::Maybe<kj::Promise<Capability::Client>> shortenPath() override {
+    return shortenPathImpl();
+  }
+  kj::Promise<Capability::Client> shortenPathImpl() {
+    // Called by RPC implementation to find out if a shorter path presents itself.
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(prober, kj::Own<PathProber>) {
+        return prober->whenReady().then([this]() {
+          KJ_ASSERT(!state.is<kj::Own<PathProber>>());
+          return shortenPathImpl();
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, kj::Own<kj::AsyncOutputStream>) {
+        // No shortening possible. Pretend we never resolve so that calls continue to be routed
+        // to us forever.
+        return kj::NEVER_DONE;
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client) {
+        return Capability::Client(capnpStream);
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("concurrent streaming calls disallowed") { break; }
+        return kj::NEVER_DONE;
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        // No shortening possible. Pretend we never resolve so that calls continue to be routed
+        // to us forever.
+        return kj::NEVER_DONE;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Promise<void> write(WriteContext context) override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(prober, kj::Own<PathProber>) {
+        return prober->whenReady().then([this, context]() mutable {
+          KJ_ASSERT(!state.is<kj::Own<PathProber>>());
+          return write(context);
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, kj::Own<kj::AsyncOutputStream>) {
+        auto data = context.getParams().getBytes();
+        return kjStream->write(data.begin(), data.size());
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client) {
+        auto params = context.getParams();
+        auto req = capnpStream.writeRequest(params.totalSize());
+        req.setBytes(params.getBytes());
+        return req.send();
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("concurrent streaming calls disallowed") { break; }
+        return kj::READY_NOW;
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already called end()") { break; }
+        return kj::READY_NOW;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Promise<void> end(EndContext context) override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(prober, kj::Own<PathProber>) {
+        return prober->whenReady().then([this, context]() mutable {
+          KJ_ASSERT(!state.is<kj::Own<PathProber>>());
+          return end(context);
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, kj::Own<kj::AsyncOutputStream>) {
+        // TODO(someday): When KJ adds a proper .end() call, use it here. For now, we must
+        //   drop the stream to close it.
+        state = Ended();
+        return kj::READY_NOW;
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client) {
+        auto params = context.getParams();
+        auto req = capnpStream.endRequest(params.totalSize());
+        return context.tailCall(kj::mv(req));
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("concurrent streaming calls disallowed") { break; }
+        return kj::READY_NOW;
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already called end()") { break; }
+        return kj::READY_NOW;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Promise<void> getSubstream(GetSubstreamContext context) override {
+    KJ_SWITCH_ONEOF(state) {
+      KJ_CASE_ONEOF(prober, kj::Own<PathProber>) {
+        return prober->whenReady().then([this, context]() mutable {
+          KJ_ASSERT(!state.is<kj::Own<PathProber>>());
+          return getSubstream(context);
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, kj::Own<kj::AsyncOutputStream>) {
+        auto params = context.getParams();
+        auto callback = params.getCallback();
+        uint64_t limit = params.getLimit();
+        context.releaseParams();
+
+        auto results = context.initResults(MessageSize {2, 1});
+        results.setSubstream(factory.streamSet.add(kj::heap<SubstreamImpl>(
+            factory, *this, thisCap(), *kjStream, kj::mv(callback), kj::mv(limit))));
+        state = Borrowed { kj::mv(kjStream) };
+        return kj::READY_NOW;
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client) {
+        auto params = context.getParams();
+        auto req = capnpStream.getSubstreamRequest(params.totalSize());
+        return context.tailCall(kj::mv(req));
+      }
+      KJ_CASE_ONEOF(b, Borrowed) {
+        KJ_FAIL_REQUIRE("concurrent streaming calls disallowed") { break; }
+        return kj::READY_NOW;
+      }
+      KJ_CASE_ONEOF(e, Ended) {
+        KJ_FAIL_REQUIRE("already called end()") { break; }
+        return kj::READY_NOW;
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+private:
+  ByteStreamFactory& factory;
+
+  struct Borrowed { kj::Own<kj::AsyncOutputStream> stream; };
+  struct Ended {};
+
+  kj::OneOf<kj::Own<PathProber>, kj::Own<kj::AsyncOutputStream>,
+            capnp::ByteStream::Client, Borrowed, Ended> state;
+
+  class SubstreamCallbackImpl final: public capnp::ByteStream::SubstreamCallback::Server {
+  public:
+    SubstreamCallbackImpl(ByteStreamFactory& factory,
+                          kj::Own<PathProber> pathProber,
+                          kj::Own<kj::PromiseFulfiller<uint64_t>> originalPumpfulfiller,
+                          uint64_t originalPumpLimit)
+        : factory(factory),
+          pathProber(kj::mv(pathProber)),
+          originalPumpfulfiller(kj::mv(originalPumpfulfiller)),
+          originalPumpLimit(originalPumpLimit) {}
+
+    ~SubstreamCallbackImpl() noexcept(false) {
+      if (!done) {
+        originalPumpfulfiller->reject(KJ_EXCEPTION(DISCONNECTED,
+            "stream disconnected because SubstreamCallbackImpl was never called back"));
+      }
+    }
+
+    kj::Promise<void> ended(EndedContext context) override {
+      KJ_REQUIRE(!done);
+      uint64_t actual = context.getParams().getByteCount();
+      KJ_REQUIRE(actual <= originalPumpLimit);
+
+      done = true;
+
+      // EOF before pump completed. Signal a short pump.
+      originalPumpfulfiller->fulfill(context.getParams().getByteCount());
+
+      // Give the original pump task a chance to finish up.
+      return pathProber->task.attach(kj::mv(pathProber));
+    }
+
+    kj::Promise<void> reachedLimit(ReachedLimitContext context) override {
+      KJ_REQUIRE(!done);
+      done = true;
+
+      // Allow the shortened stream to redirect back to our original underlying stream.
+      auto results = context.getResults(capnp::MessageSize { 4, 1 });
+      results.setNext(factory.streamSet.add(
+          kj::heap<CapnpToKjStreamAdapter>(factory, kj::mv(pathProber))));
+
+      // The full pump completed. Note that it's important that we fulfill this after the
+      // PathProber has been attached to the new CapnpToKjStreamAdapter, which will have happened
+      // in CapnpToKjStreamAdapter's constructor, which calls pathProber->setNewParent().
+      originalPumpfulfiller->fulfill(kj::cp(originalPumpLimit));
+
+      return kj::READY_NOW;
+    }
+
+  private:
+    ByteStreamFactory& factory;
+    kj::Own<PathProber> pathProber;
+    kj::Own<kj::PromiseFulfiller<uint64_t>> originalPumpfulfiller;
+    uint64_t originalPumpLimit;
+    bool done = false;
+  };
+};
+
+// =======================================================================================
+
+class ByteStreamFactory::KjToCapnpStreamAdapter final: public kj::AsyncOutputStream {
+public:
+  KjToCapnpStreamAdapter(ByteStreamFactory& factory, capnp::ByteStream::Client innerParam)
+      : factory(factory),
+        inner(kj::mv(innerParam)),
+        findShorterPathTask(findShorterPath(inner).fork()) {}
+
+  ~KjToCapnpStreamAdapter() noexcept(false) {
+    // HACK: KJ streams are implicitly ended on destruction, but the RPC stream needs a call. We
+    //   use a detached promise for now, which is probably OK since capabilities are refcounted and
+    //   asynchronously destroyed anyway.
+    // TODO(cleanup): Fix this when KJ streads add an explicit end() method.
+    KJ_IF_MAYBE(o, optimized) {
+      o->directEnd();
+    } else {
+      inner.endRequest(MessageSize {2, 0}).send().detach([](kj::Exception&&){});
+    }
+  }
+
+  kj::Promise<void> write(const void* buffer, size_t size) override {
+    KJ_SWITCH_ONEOF(getShortestPath()) {
+      KJ_CASE_ONEOF(promise, kj::Promise<void>) {
+        return promise.then([this,buffer,size]() {
+          return write(buffer, size);
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, StreamServerBase::BorrowedStream) {
+        if (size <= kjStream.limit) {
+          auto promise = kjStream.stream.write(buffer, size);
+          return promise.then([kjStream,size]() mutable {
+            kjStream.lender.returnStream(size);
+          });
+        } else {
+          auto promise = kjStream.stream.write(buffer, kjStream.limit);
+          return promise.then([this,kjStream,buffer,size]() mutable {
+            kjStream.lender.returnStream(kjStream.limit);
+            return write(reinterpret_cast<const byte*>(buffer) + kjStream.limit,
+                         size - kjStream.limit);
+          });
+        }
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client*) {
+        auto req = capnpStream->writeRequest(MessageSize { 8 + size / sizeof(word), 0 });
+        req.setBytes(kj::arrayPtr(reinterpret_cast<const byte*>(buffer), size));
+        return req.send();
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
+    KJ_SWITCH_ONEOF(getShortestPath()) {
+      KJ_CASE_ONEOF(promise, kj::Promise<void>) {
+        return promise.then([this,pieces]() {
+          return write(pieces);
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, StreamServerBase::BorrowedStream) {
+        size_t size = 0;
+        for (auto& piece: pieces) { size += piece.size(); }
+        if (size <= kjStream.limit) {
+          auto promise = kjStream.stream.write(pieces);
+          return promise.then([kjStream,size]() mutable {
+            kjStream.lender.returnStream(size);
+          });
+        } else {
+          // ughhhhhhhhhh, we need to split the pieces.
+          size_t splitByte = kjStream.limit;
+          size_t splitPiece = 0;
+          while (pieces[splitPiece].size() <= splitByte) {
+            splitByte -= pieces[splitPiece].size();
+            ++splitPiece;
+          }
+
+          if (splitByte == 0) {
+            // Oh thank god, the split is between two pieces.
+            auto rest = pieces.slice(splitPiece, pieces.size());
+            return kjStream.stream.write(pieces.slice(0, splitPiece))
+                .then([this,kjStream,rest]() {
+              kjStream.lender.returnStream(kjStream.limit);
+              return write(rest);
+            });
+          } else {
+            // FUUUUUUUU---- we need to split one of the pieces in two.
+            auto left = kj::heapArrayBuilder<kj::ArrayPtr<const byte>>(splitPiece + 1);
+            auto right = kj::heapArrayBuilder<kj::ArrayPtr<const byte>>(pieces.size() - splitPiece);
+
+            for (auto i: kj::zeroTo(splitPiece)) {
+              left[i] = pieces[i];
+            }
+            for (auto i: kj::zeroTo(right.size())) {
+              right[i] = pieces[splitPiece + i];
+            }
+
+            left.back() = pieces[splitPiece].slice(0, splitByte);
+            right.front() = pieces[splitPiece].slice(splitByte, pieces[splitPiece].size());
+
+            return kjStream.stream.write(left).attach(kj::mv(left))
+                .then([this,kjStream,right = kj::mv(right)]() mutable {
+              kjStream.lender.returnStream(kjStream.limit);
+              return write(right).attach(kj::mv(right));
+            });
+          }
+        }
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client*) {
+        size_t size = 0;
+        for (auto& piece: pieces) size += piece.size();
+        auto req = capnpStream->writeRequest(MessageSize { 8 + size / sizeof(word), 0 });
+
+        auto out = req.initBytes(size);
+        byte* ptr = out.begin();
+        for (auto& piece: pieces) {
+          memcpy(ptr, piece.begin(), piece.size());
+          ptr += piece.size();
+        }
+        KJ_ASSERT(ptr == out.end());
+
+        return req.send();
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  kj::Maybe<kj::Promise<uint64_t>> tryPumpFrom(
+      kj::AsyncInputStream& input, uint64_t amount = kj::maxValue) override {
+    KJ_IF_MAYBE(rpc, kj::dynamicDowncastIfAvailable<CapnpToKjStreamAdapter::PathProber>(input)) {
+      // Oh interesting, it turns we're hosting an incoming ByteStream which is pumping to this
+      // outgoing ByteStream. We can let the Cap'n Proto RPC layer know that it can shorten the
+      // path from one to the other.
+      return rpc->pumpToShorterPath(inner, amount);
+    } else {
+      return pumpLoop(input, 0, amount);
+    }
+  }
+
+  kj::Promise<void> whenWriteDisconnected() override {
+    return findShorterPathTask.addBranch();
+  }
+
+private:
+  ByteStreamFactory& factory;
+  capnp::ByteStream::Client inner;
+  kj::Maybe<StreamServerBase&> optimized;
+
+  kj::ForkedPromise<void> findShorterPathTask;
+  // This serves two purposes:
+  // 1. Waits for the capability to resolve (if it is a promise), and then shortens the path if
+  //    possible.
+  // 2. Implements whenWriteDisconnected().
+
+  kj::Promise<void> findShorterPath(capnp::ByteStream::Client& capnpClient) {
+    // If the capnp stream turns out to resolve back to this process, shorten the path.
+    // Also, implement whenWriteDisconnected() based on this.
+    return factory.streamSet.getLocalServer(capnpClient)
+        .then([this](kj::Maybe<capnp::ByteStream::Server&> server) -> kj::Promise<void> {
+      KJ_IF_MAYBE(s, server) {
+        // Yay, we discovered that the ByteStream actually points back to a local KJ stream.
+        // We can use this to shorten the path by skipping the RPC machinery.
+        return findShorterPath(kj::downcast<StreamServerBase>(*s));
+      } else {
+        // The capability is fully-resolved. This suggests that the remote implementation is
+        // NOT a CapnpToKjStreamAdapter at all, because CapnpToKjStreamAdapter is designed to
+        // always look like a promise. It's some other implementation that doesn't present
+        // itself as a promise. We have no way to detect when it is disconnected.
+        return kj::NEVER_DONE;
+      }
+    }, [](kj::Exception&& e) -> kj::Promise<void> {
+      // getLocalServer() thrown when the capability is a promise cap that rejects. We can
+      // use this to implement whenWriteDisconnected().
+      //
+      // (Note that because this exception handler is passed to the .then(), it does NOT catch
+      // eoxceptions thrown by the success handler immediately above it. This handler will ONLY
+      // catch exceptions from getLocalServer() itself.)
+      return kj::READY_NOW;
+    });
+  }
+
+  kj::Promise<void> findShorterPath(StreamServerBase& capnpServer) {
+    // We found a shorter path back to this process. Record it.
+    optimized = capnpServer;
+
+    KJ_SWITCH_ONEOF(capnpServer.getShortestPath()) {
+      KJ_CASE_ONEOF(promise, kj::Promise<void>) {
+        return promise.then([this,&capnpServer]() {
+          return findShorterPath(capnpServer);
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, StreamServerBase::BorrowedStream) {
+        // The ByteStream::Server wraps a regular KJ stream that does not wrap another capnp
+        // stream.
+        if (kjStream.limit < (uint64_t)kj::maxValue / 2) {
+          // But it isn't wrapping that stream forever. Eventually it plans to redirect back to
+          // some other stream. So, let's wait for that, and possibly shorten again.
+          kjStream.lender.returnStream(0);
+          return KJ_ASSERT_NONNULL(capnpServer.shortenPath())
+              .then([this, &capnpServer](auto&&) {
+            return findShorterPath(capnpServer);
+          });
+        } else {
+          // This KJ stream is (effectively) the permanent endpoint. We can't get any shorter
+          // from here. All we want to do now is watch for disconnect.
+          auto promise = kjStream.stream.whenWriteDisconnected();
+          kjStream.lender.returnStream(0);
+          return promise;
+        }
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client*) {
+        return findShorterPath(*capnpStream);
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  StreamServerBase::ShortestPath getShortestPath() {
+    KJ_IF_MAYBE(o, optimized) {
+      return o->getShortestPath();
+    } else {
+      return &inner;
+    }
+  }
+
+  kj::Promise<uint64_t> pumpLoop(kj::AsyncInputStream& input,
+                                 uint64_t completed, uint64_t remaining) {
+    if (remaining == 0) return completed;
+
+    KJ_SWITCH_ONEOF(getShortestPath()) {
+      KJ_CASE_ONEOF(promise, kj::Promise<void>) {
+        return promise.then([this,&input,completed,remaining]() {
+          return pumpLoop(input,completed,remaining);
+        });
+      }
+      KJ_CASE_ONEOF(kjStream, StreamServerBase::BorrowedStream) {
+        // Oh hell yes, this capability actually points back to a stream in our own thread. We can
+        // stop sending RPCs and just pump directly.
+
+        if (remaining <= kjStream.limit) {
+          return input.pumpTo(kjStream.stream, remaining)
+              .then([kjStream,completed](uint64_t actual) {
+            kjStream.lender.returnStream(actual);
+            return actual + completed;
+          });
+        } else {
+          auto promise = input.pumpTo(kjStream.stream, kjStream.limit);
+          return promise.then([this,&input,completed,remaining,kjStream]
+                              (uint64_t actual) mutable -> kj::Promise<uint64_t> {
+            kjStream.lender.returnStream(actual);
+            if (actual < kjStream.limit) {
+              // EOF reached.
+              return completed + actual;
+            } else {
+              return pumpLoop(input, completed + actual, remaining - actual);
+            }
+          });
+        }
+      }
+      KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client*) {
+        // Pumping from some other kind of steram. Optimize the pump by reading from the input
+        // directly into outgoing RPC messages.
+        size_t size = kj::min(remaining, 8192);
+        auto req = capnpStream->writeRequest(MessageSize { 8 + size / sizeof(word) });
+
+        auto orphanage = Orphanage::getForMessageContaining(
+            capnp::ByteStream::WriteParams::Builder(req));
+
+        auto buffer = orphanage.newOrphan<Data>(size);
+
+        struct WriteRequestAndBuffer {
+          // The order of construction/destruction of lambda captures is unspecified, but we care
+          // about ordering between these two things that we want to capture, so... we need a
+          // struct.
+          StreamingRequest<capnp::ByteStream::WriteParams> request;
+          Orphan<Data> buffer;  // points into `request`...
+        };
+
+        WriteRequestAndBuffer wrab = { kj::mv(req), kj::mv(buffer) };
+
+        return input.tryRead(wrab.buffer.get().begin(), 1, size)
+            .then([this, &input, completed, remaining, size, wrab = kj::mv(wrab)]
+                  (size_t actual) mutable -> kj::Promise<uint64_t> {
+          if (actual == 0) {
+            return completed;
+          } if (actual < size) {
+            wrab.buffer.truncate(actual);
+          }
+
+          wrab.request.adoptBytes(kj::mv(wrab.buffer));
+          return wrab.request.send()
+              .then([this, &input, completed, remaining, actual]() {
+            return pumpLoop(input, completed + actual, remaining - actual);
+          });
+        });
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+};
+
+// =======================================================================================
+
+capnp::ByteStream::Client ByteStreamFactory::kjToCapnp(kj::Own<kj::AsyncOutputStream> kjStream) {
+  return streamSet.add(kj::heap<CapnpToKjStreamAdapter>(*this, kj::mv(kjStream)));
+}
+
+kj::Own<kj::AsyncOutputStream> ByteStreamFactory::capnpToKj(capnp::ByteStream::Client capnpStream) {
+  return kj::heap<KjToCapnpStreamAdapter>(*this, kj::mv(capnpStream));
+}
+
+}  // namespace capnp

--- a/c++/src/capnp/compat/byte-stream.capnp
+++ b/c++/src/capnp/compat/byte-stream.capnp
@@ -1,0 +1,39 @@
+@0x8f5d14e1c273738d;
+
+$import "/capnp/c++.capnp".namespace("capnp");
+
+interface ByteStream {
+  write @0 (bytes :Data) -> stream;
+  # Write a chunk.
+
+  end @1 ();
+  # Signals clean EOF. (If the ByteStream is dropped without calling this, then the stream was
+  # prematurely canceled and so thet body should not be considered complete.)
+
+  getSubstream @2 (callback :SubstreamCallback,
+                   limit :UInt64 = 0xffffffffffffffff) -> (substream :ByteStream);
+  # This method is used to implement path shortening optimization. It is designed in particular
+  # with KJ streams' pumpTo() in mind.
+  #
+  # getSubstream() returns a new stream object that can be used to write to the same destination
+  # as this stream. The substream will operate until it has received `limit` bytes, or its `end()`
+  # method has been called, whichever occurs first. At that time, it invokes one of the methods of
+  # `callback` based on the termination condition.
+  #
+  # While a substream is active, it is an error to call write() on the original stream. Doing so
+  # may throw an exception or may arbitrarily interleave bytes with the substream's writes.
+
+  interface SubstreamCallback {
+    ended @0 (byteCount :UInt64);
+    # `end()` was called on the substream after writing `byteCount` bytes. The `end()` call was
+    # NOT forwarded to the underlying stream, which remains open.
+
+    reachedLimit @1 () -> (next :ByteStream);
+    # The number of bytes specified by the `limit` parameter of `getSubstream()` was reached.
+    # The substream will "resolve itself" to `next`, so that all future calls to the substream
+    # are forwarded to `next`.
+    #
+    # If the `write()` call which reached the limit included bytes past the limit, then the first
+    # `write()` call to `next` will be for those leftover bytes.
+  }
+}

--- a/c++/src/capnp/compat/byte-stream.h
+++ b/c++/src/capnp/compat/byte-stream.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+// Bridges from KJ streams to Cap'n Proto ByteStream RPC protocol.
+
+#include <capnp/compat/byte-stream.capnp.h>
+#include <kj/async-io.h>
+
+namespace capnp {
+
+class ByteStreamFactory {
+  // In order to allow path-shortening through KJ, a common factory must be used for converting
+  // between RPC ByteStreams and KJ streams.
+
+public:
+  capnp::ByteStream::Client kjToCapnp(kj::Own<kj::AsyncOutputStream> kjStream);
+  kj::Own<kj::AsyncOutputStream> capnpToKj(capnp::ByteStream::Client capnpStream);
+
+private:
+  CapabilityServerSet<capnp::ByteStream> streamSet;
+
+  class StreamServerBase;
+  class SubstreamImpl;
+  class CapnpToKjStreamAdapter;
+  class KjToCapnpStreamAdapter;
+};
+
+}  // namespace capnp

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -1,0 +1,530 @@
+// Copyright (c) 2019 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "http-over-capnp.h"
+#include <kj/test.h>
+
+namespace capnp {
+namespace {
+
+KJ_TEST("KJ and RPC HTTP method enums match") {
+#define EXPECT_MATCH(METHOD) \
+  KJ_EXPECT(static_cast<uint>(kj::HttpMethod::METHOD) == \
+            static_cast<uint>(capnp::HttpMethod::METHOD));
+
+  KJ_HTTP_FOR_EACH_METHOD(EXPECT_MATCH);
+#undef EXPECT_MATCH
+}
+
+// =======================================================================================
+
+kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
+  if (expected.size() == 0) return kj::READY_NOW;
+
+  auto buffer = kj::heapArray<char>(expected.size());
+
+  auto promise = in.tryRead(buffer.begin(), 1, buffer.size());
+  return promise.then(kj::mvCapture(buffer, [&in,expected](kj::Array<char> buffer, size_t amount) {
+    if (amount == 0) {
+      KJ_FAIL_ASSERT("expected data never sent", expected);
+    }
+
+    auto actual = buffer.slice(0, amount);
+    if (memcmp(actual.begin(), expected.begin(), actual.size()) != 0) {
+      KJ_FAIL_ASSERT("data from stream doesn't match expected", expected, actual);
+    }
+
+    return expectRead(in, expected.slice(amount));
+  }));
+}
+
+enum Direction {
+  CLIENT_TO_SERVER,
+  SERVER_TO_CLIENT
+};
+
+struct TestStep {
+  Direction direction;
+  kj::StringPtr send;
+  kj::StringPtr receive;
+
+  constexpr TestStep(Direction direction, kj::StringPtr send, kj::StringPtr receive)
+      : direction(direction), send(send), receive(receive) {}
+  constexpr TestStep(Direction direction, kj::StringPtr data)
+      : direction(direction), send(data), receive(data) {}
+};
+
+constexpr TestStep TEST_STEPS[] = {
+  // Test basic request.
+  {
+    CLIENT_TO_SERVER,
+
+    "GET / HTTP/1.1\r\n"
+    "Host: example.com\r\n"
+    "\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Length: 3\r\n"
+    "\r\n"
+    "foo"_kj
+  },
+
+  // Try PUT, vary path, vary status
+  {
+    CLIENT_TO_SERVER,
+
+    "PUT /foo/bar HTTP/1.1\r\n"
+    "Content-Length: 5\r\n"
+    "Host: example.com\r\n"
+    "\r\n"
+    "corge"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 403 Unauthorized\r\n"
+    "Content-Length: 4\r\n"
+    "\r\n"
+    "nope"_kj
+  },
+
+  // HEAD request
+  {
+    CLIENT_TO_SERVER,
+
+    "HEAD /foo/bar HTTP/1.1\r\n"
+    "Host: example.com\r\n"
+    "\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Length: 4\r\n"
+    "\r\n"_kj
+  },
+
+  // Empty-body response
+  {
+    CLIENT_TO_SERVER,
+
+    "GET /foo/bar HTTP/1.1\r\n"
+    "Host: example.com\r\n"
+    "\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 304 Not Modified\r\n"
+    "Server: foo\r\n"
+    "\r\n"_kj
+  },
+
+  // Chonky body
+  {
+    CLIENT_TO_SERVER,
+
+    "POST / HTTP/1.1\r\n"
+    "Transfer-Encoding: chunked\r\n"
+    "Host: example.com\r\n"
+    "\r\n"
+    "3\r\n"
+    "foo\r\n"
+    "5\r\n"
+    "corge\r\n"
+    "0\r\n"
+    "\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 200 OK\r\n"
+    "Transfer-Encoding: chunked\r\n"
+    "\r\n"
+    "6\r\n"
+    "barbaz\r\n"
+    "6\r\n"
+    "garply\r\n"
+    "0\r\n"
+    "\r\n"_kj
+  },
+
+  // Streaming
+  {
+    CLIENT_TO_SERVER,
+
+    "POST / HTTP/1.1\r\n"
+    "Content-Length: 9\r\n"
+    "Host: example.com\r\n"
+    "\r\n"_kj,
+  },
+  {
+    CLIENT_TO_SERVER,
+
+    "foo"_kj,
+  },
+  {
+    CLIENT_TO_SERVER,
+
+    "bar"_kj,
+  },
+  {
+    CLIENT_TO_SERVER,
+
+    "baz"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 200 OK\r\n"
+    "Transfer-Encoding: chunked\r\n"
+    "\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "6\r\n"
+    "barbaz\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "6\r\n"
+    "garply\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "0\r\n"
+    "\r\n"_kj
+  },
+
+  // Bidirectional.
+  {
+    CLIENT_TO_SERVER,
+
+    "POST / HTTP/1.1\r\n"
+    "Content-Length: 9\r\n"
+    "Host: example.com\r\n"
+    "\r\n"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 200 OK\r\n"
+    "Transfer-Encoding: chunked\r\n"
+    "\r\n"_kj,
+  },
+  {
+    CLIENT_TO_SERVER,
+
+    "foo"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "6\r\n"
+    "barbaz\r\n"_kj,
+  },
+  {
+    CLIENT_TO_SERVER,
+
+    "bar"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "6\r\n"
+    "garply\r\n"_kj,
+  },
+  {
+    CLIENT_TO_SERVER,
+
+    "baz"_kj,
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "0\r\n"
+    "\r\n"_kj
+  },
+
+  // Test headers being re-ordered by KJ. This isn't necessary behavior, but it does prove that
+  // we're not testing a pure streaming pass-through...
+  {
+    CLIENT_TO_SERVER,
+
+    "GET / HTTP/1.1\r\n"
+    "Host: example.com\r\n"
+    "Accept: text/html\r\n"
+    "Foo-Header: 123\r\n"
+    "User-Agent: kj\r\n"
+    "Accept-Language: en\r\n"
+    "\r\n"_kj,
+
+    "GET / HTTP/1.1\r\n"
+    "Host: example.com\r\n"
+    "Accept-Language: en\r\n"
+    "Accept: text/html\r\n"
+    "User-Agent: kj\r\n"
+    "Foo-Header: 123\r\n"
+    "\r\n"_kj
+  },
+  {
+    SERVER_TO_CLIENT,
+
+    "HTTP/1.1 200 OK\r\n"
+    "Server: kj\r\n"
+    "Bar: 321\r\n"
+    "Content-Length: 3\r\n"
+    "\r\n"
+    "foo"_kj,
+
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Length: 3\r\n"
+    "Server: kj\r\n"
+    "Bar: 321\r\n"
+    "\r\n"
+    "foo"_kj
+  },
+
+  // We finish up a request with no response, to test cancellation.
+  {
+    CLIENT_TO_SERVER,
+
+    "GET / HTTP/1.1\r\n"
+    "Host: example.com\r\n"
+    "\r\n"_kj,
+  },
+};
+
+class OneConnectNetworkAddress final: public kj::NetworkAddress {
+public:
+  OneConnectNetworkAddress(kj::Own<kj::AsyncIoStream> stream)
+      : stream(kj::mv(stream)) {}
+
+  kj::Promise<kj::Own<kj::AsyncIoStream>> connect() override {
+    auto result = KJ_ASSERT_NONNULL(kj::mv(stream));
+    stream = nullptr;
+    return kj::mv(result);
+  }
+
+  kj::Own<kj::ConnectionReceiver> listen() override { KJ_UNIMPLEMENTED("test"); }
+  kj::Own<kj::NetworkAddress> clone() override { KJ_UNIMPLEMENTED("test"); }
+  kj::String toString() override { KJ_UNIMPLEMENTED("test"); }
+
+private:
+  kj::Maybe<kj::Own<kj::AsyncIoStream>> stream;
+};
+
+void runEndToEndTests(kj::Timer& timer, kj::HttpHeaderTable& headerTable,
+                      HttpOverCapnpFactory& clientFactory, HttpOverCapnpFactory& serverFactory,
+                      kj::WaitScope& waitScope) {
+  auto clientPipe = kj::newTwoWayPipe();
+  auto serverPipe = kj::newTwoWayPipe();
+
+  OneConnectNetworkAddress oneConnectAddr(kj::mv(serverPipe.ends[0]));
+
+  auto backHttp = kj::newHttpClient(timer, headerTable, oneConnectAddr);
+  auto backCapnp = serverFactory.kjToCapnp(kj::newHttpService(*backHttp));
+  auto frontCapnp = clientFactory.capnpToKj(backCapnp);
+  kj::HttpServer frontKj(timer, headerTable, *frontCapnp);
+  auto listenTask = frontKj.listenHttp(kj::mv(clientPipe.ends[1]))
+      .eagerlyEvaluate([](kj::Exception&& e) { KJ_LOG(ERROR, e); });
+
+  for (auto& step: TEST_STEPS) {
+    KJ_CONTEXT(step.send);
+
+    kj::AsyncOutputStream* out;
+    kj::AsyncInputStream* in;
+
+    switch (step.direction) {
+      case CLIENT_TO_SERVER:
+        out = clientPipe.ends[0];
+        in = serverPipe.ends[1];
+        break;
+      case SERVER_TO_CLIENT:
+        out = serverPipe.ends[1];
+        in = clientPipe.ends[0];
+        break;
+    }
+
+    auto writePromise = out->write(step.send.begin(), step.send.size());
+    auto readPromise = expectRead(*in, step.receive);
+    if (!writePromise.poll(waitScope)) {
+      if (readPromise.poll(waitScope)) {
+        readPromise.wait(waitScope);
+        KJ_FAIL_ASSERT("write hung, read worked fine");
+      } else {
+        KJ_FAIL_ASSERT("write and read both hung");
+      }
+    }
+
+    writePromise.wait(waitScope);
+    KJ_ASSERT(readPromise.poll(waitScope), "read hung");
+    readPromise.wait(waitScope);
+  }
+
+  // The last test message was a request with no response. If we now close the client end, this
+  // should propagate all the way through to close the server end!
+  clientPipe.ends[0] = nullptr;
+  auto lastRead = serverPipe.ends[1]->readAllText();
+  KJ_ASSERT(lastRead.poll(waitScope), "last read hung");
+  KJ_EXPECT(lastRead.wait(waitScope) == 0);
+}
+
+KJ_TEST("HTTP-over-Cap'n-Proto E2E, no path shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  ByteStreamFactory streamFactory1;
+  ByteStreamFactory streamFactory2;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory1(streamFactory1, tableBuilder);
+  HttpOverCapnpFactory factory2(streamFactory2, tableBuilder);
+  auto headerTable = tableBuilder.build();
+
+  runEndToEndTests(timer, *headerTable, factory1, factory2, waitScope);
+}
+
+KJ_TEST("HTTP-over-Cap'n-Proto E2E, with path shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  ByteStreamFactory streamFactory;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder);
+  auto headerTable = tableBuilder.build();
+
+  runEndToEndTests(timer, *headerTable, factory, factory, waitScope);
+}
+
+// =======================================================================================
+
+class WebSocketAccepter final: public kj::HttpService {
+public:
+  WebSocketAccepter(kj::HttpHeaderTable& headerTable,
+                    kj::Own<kj::PromiseFulfiller<kj::Own<kj::WebSocket>>> fulfiller,
+                    kj::Promise<void> done)
+      : headerTable(headerTable), fulfiller(kj::mv(fulfiller)), done(kj::mv(done)) {}
+
+  kj::Promise<void> request(
+      kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody, Response& response) {
+    kj::HttpHeaders respHeaders(headerTable);
+    respHeaders.add("X-Foo", "bar");
+    fulfiller->fulfill(response.acceptWebSocket(respHeaders));
+    return kj::mv(done);
+  }
+
+private:
+  kj::HttpHeaderTable& headerTable;
+  kj::Own<kj::PromiseFulfiller<kj::Own<kj::WebSocket>>> fulfiller;
+  kj::Promise<void> done;
+};
+
+void runWebSocketTests(kj::HttpHeaderTable& headerTable,
+                       HttpOverCapnpFactory& clientFactory, HttpOverCapnpFactory& serverFactory,
+                       kj::WaitScope& waitScope) {
+  // We take a different approach here, because writing out raw WebSocket frames is a pain.
+  // It's easier to test WebSockets at the KJ API level.
+
+  auto wsPaf = kj::newPromiseAndFulfiller<kj::Own<kj::WebSocket>>();
+  auto donePaf = kj::newPromiseAndFulfiller<void>();
+
+  auto back = serverFactory.kjToCapnp(kj::heap<WebSocketAccepter>(
+    headerTable, kj::mv(wsPaf.fulfiller), kj::mv(donePaf.promise)));
+  auto front = clientFactory.capnpToKj(back);
+  auto client = kj::newHttpClient(*front);
+
+  auto resp = client->openWebSocket("/ws", kj::HttpHeaders(headerTable)).wait(waitScope);
+  KJ_ASSERT(resp.webSocketOrBody.is<kj::Own<kj::WebSocket>>());
+
+  auto clientWs = kj::mv(resp.webSocketOrBody.get<kj::Own<kj::WebSocket>>());
+  auto serverWs = wsPaf.promise.wait(waitScope);
+
+  {
+    auto promise = clientWs->send("foo"_kj);
+    auto message = serverWs->receive().wait(waitScope);
+    promise.wait(waitScope);
+    KJ_ASSERT(message.is<kj::String>());
+    KJ_EXPECT(message.get<kj::String>() == "foo");
+  }
+
+  {
+    auto promise = serverWs->send("bar"_kj.asBytes());
+    auto message = clientWs->receive().wait(waitScope);
+    promise.wait(waitScope);
+    KJ_ASSERT(message.is<kj::Array<kj::byte>>());
+    KJ_EXPECT(kj::str(message.get<kj::Array<kj::byte>>().asChars()) == "bar");
+  }
+
+  {
+    auto promise = clientWs->close(1234, "baz"_kj);
+    auto message = serverWs->receive().wait(waitScope);
+    promise.wait(waitScope);
+    KJ_ASSERT(message.is<kj::WebSocket::Close>());
+    KJ_EXPECT(message.get<kj::WebSocket::Close>().code == 1234);
+    KJ_EXPECT(message.get<kj::WebSocket::Close>().reason == "baz");
+  }
+
+  {
+    auto promise = serverWs->disconnect();
+    auto receivePromise = clientWs->receive();
+    KJ_EXPECT(receivePromise.poll(waitScope));
+    KJ_EXPECT_THROW(DISCONNECTED, receivePromise.wait(waitScope));
+    promise.wait(waitScope);
+  }
+}
+
+KJ_TEST("HTTP-over-Cap'n Proto WebSocket, no path shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory streamFactory1;
+  ByteStreamFactory streamFactory2;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory1(streamFactory1, tableBuilder);
+  HttpOverCapnpFactory factory2(streamFactory2, tableBuilder);
+  auto headerTable = tableBuilder.build();
+
+  runWebSocketTests(*headerTable, factory1, factory2, waitScope);
+}
+
+KJ_TEST("HTTP-over-Cap'n Proto WebSocket, with path shortening") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory streamFactory;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder);
+  auto headerTable = tableBuilder.build();
+
+  runWebSocketTests(*headerTable, factory, factory, waitScope);
+}
+
+}  // namespace
+}  // namespace capnp

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -694,9 +694,18 @@ kj::HttpHeaders HttpOverCapnpFactory::headersToKj(
             result.set(nameCapnpToKj[nameInt], valueCapnpToKj[cvInt]);
             break;
           }
-          case capnp::HttpHeader::Common::VALUE:
-            result.set(nameCapnpToKj[nameInt], nv.getValue());
+          case capnp::HttpHeader::Common::VALUE: {
+            auto headerId = nameCapnpToKj[nameInt];
+            if (result.get(headerId) == nullptr) {
+              result.set(headerId, nv.getValue());
+            } else {
+              // Unusual: This is a duplicate header, so fall back to add(), which may trigger
+              //   comma-concatenation, except in certain cases where comma-concatentaion would
+              //   be problematic.
+              result.add(headerId.toString(), nv.getValue());
+            }
             break;
+          }
         }
         break;
       }

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -1,0 +1,713 @@
+// Copyright (c) 2019 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "http-over-capnp.h"
+#include <kj/debug.h>
+#include <capnp/schema.h>
+
+namespace capnp {
+
+using kj::uint;
+using kj::byte;
+
+class HttpOverCapnpFactory::RequestState final
+    : public kj::Refcounted, public kj::TaskSet::ErrorHandler {
+public:
+  RequestState() {
+    tasks.emplace(*this);
+  }
+
+  template <typename T>
+  kj::Promise<T> wrap(kj::Promise<T>&& promise) {
+    if (tasks == nullptr) {
+      return KJ_EXCEPTION(DISCONNECTED, "client canceled HTTP request");
+    } else {
+      return canceler.wrap(kj::mv(promise));
+    }
+  }
+
+  void cancel() {
+    if (tasks != nullptr) {
+      if (canceler.isEmpty()) {
+        canceler.cancel(KJ_EXCEPTION(DISCONNECTED, "request canceled"));
+      }
+      tasks = nullptr;
+      webSocket = nullptr;
+    }
+  }
+
+  void assertNotCanceled() {
+    if (tasks == nullptr) {
+      kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "client canceled HTTP request"));
+    }
+  }
+
+  void addTask(kj::Promise<void> task) {
+    KJ_IF_MAYBE(t, tasks) {
+      t->add(kj::mv(task));
+    } else {
+      // Just drop the task.
+    }
+  }
+
+  kj::Promise<void> finishTasks() {
+    // This is merged into the final promise, so we don't need to worry about wrapping it for
+    // cancellation.
+    return KJ_REQUIRE_NONNULL(tasks).onEmpty()
+        .then([this]() {
+      KJ_IF_MAYBE(e, error) {
+        kj::throwRecoverableException(kj::mv(*e));
+      }
+    });
+  }
+
+  void taskFailed(kj::Exception&& exception) override {
+    if (error == nullptr) {
+      error = kj::mv(exception);
+    }
+  }
+
+  void holdWebSocket(kj::Own<kj::WebSocket> webSocket) {
+    // Hold on to this WebSocket until cancellation.
+    KJ_REQUIRE(this->webSocket == nullptr);
+    KJ_REQUIRE(tasks != nullptr);
+    this->webSocket = kj::mv(webSocket);
+  }
+
+  void disconnectWebSocket() {
+    KJ_IF_MAYBE(t, tasks) {
+      t->add(kj::evalNow([&]() { return KJ_ASSERT_NONNULL(webSocket)->disconnect(); }));
+    }
+  }
+
+private:
+  kj::Maybe<kj::Exception> error;
+  kj::Maybe<kj::Own<kj::WebSocket>> webSocket;
+  kj::Canceler canceler;
+  kj::Maybe<kj::TaskSet> tasks;
+};
+
+// =======================================================================================
+
+class HttpOverCapnpFactory::CapnpToKjWebSocketAdapter final: public capnp::WebSocket::Server {
+public:
+  CapnpToKjWebSocketAdapter(kj::Own<RequestState> state, kj::WebSocket& webSocket,
+                            kj::Promise<Capability::Client> shorteningPromise)
+      : state(kj::mv(state)), webSocket(webSocket),
+        shorteningPromise(kj::mv(shorteningPromise)) {}
+
+  ~CapnpToKjWebSocketAdapter() noexcept(false) {
+    state->disconnectWebSocket();
+  }
+
+  kj::Maybe<kj::Promise<Capability::Client>> shortenPath() override {
+    return kj::mv(shorteningPromise);
+  }
+
+  kj::Promise<void> sendText(SendTextContext context) override {
+    return state->wrap(webSocket.send(context.getParams().getText()));
+  }
+  kj::Promise<void> sendData(SendDataContext context) override {
+    return state->wrap(webSocket.send(context.getParams().getData()));
+  }
+  kj::Promise<void> close(CloseContext context) override {
+    auto params = context.getParams();
+    return state->wrap(webSocket.close(params.getCode(), params.getReason()));
+  }
+
+private:
+  kj::Own<RequestState> state;
+  kj::WebSocket& webSocket;
+  kj::Promise<Capability::Client> shorteningPromise;
+};
+
+class HttpOverCapnpFactory::KjToCapnpWebSocketAdapter final: public kj::WebSocket {
+public:
+  KjToCapnpWebSocketAdapter(
+      kj::Maybe<kj::Own<kj::WebSocket>> in, capnp::WebSocket::Client out,
+      kj::Own<kj::PromiseFulfiller<kj::Promise<Capability::Client>>> shorteningFulfiller)
+      : in(kj::mv(in)), out(kj::mv(out)), shorteningFulfiller(kj::mv(shorteningFulfiller)) {}
+  ~KjToCapnpWebSocketAdapter() noexcept(false) {
+    if (shorteningFulfiller->isWaiting()) {
+      // We want to make sure the fulfiller is not rejected with a bogus "PromiseFulfiller
+      // destroyed" error, so fulfill it with never-done.
+      shorteningFulfiller->fulfill(kj::NEVER_DONE);
+    }
+  }
+
+  kj::Promise<void> send(kj::ArrayPtr<const byte> message) override {
+    auto req = KJ_REQUIRE_NONNULL(out, "already called disconnect()").sendDataRequest(
+        MessageSize { 8 + message.size() / sizeof(word), 0 });
+    req.setData(message);
+    return req.send();
+  }
+
+  kj::Promise<void> send(kj::ArrayPtr<const char> message) override {
+    auto req = KJ_REQUIRE_NONNULL(out, "already called disconnect()").sendTextRequest(
+        MessageSize { 8 + message.size() / sizeof(word), 0 });
+    memcpy(req.initText(message.size()).begin(), message.begin(), message.size());
+    return req.send();
+  }
+
+  kj::Promise<void> close(uint16_t code, kj::StringPtr reason) override {
+    auto req = KJ_REQUIRE_NONNULL(out, "already called disconnect()").closeRequest();
+    req.setCode(code);
+    req.setReason(reason);
+    return req.send().ignoreResult();
+  }
+
+  kj::Promise<void> disconnect() override {
+    out = nullptr;
+    return kj::READY_NOW;
+  }
+
+  void abort() override {
+    KJ_ASSERT_NONNULL(in)->abort();
+  }
+
+  kj::Promise<void> whenAborted() override {
+    return KJ_ASSERT_NONNULL(out).whenResolved()
+        .then([]() -> kj::Promise<void> {
+      // It would seem this capability resolved to an implementation of the WebSocket RPC interface
+      // that does not support further path-shortening (so, it's not the implementation found in
+      // this file). Since the path-shortening facility is also how we discover disconnects, we
+      // apparently have no way to be alerted on disconnect. We have to assume the other end
+      // never aborts.
+      return kj::NEVER_DONE;
+    }, [](kj::Exception&& e) -> kj::Promise<void> {
+      if (e.getType() == kj::Exception::Type::DISCONNECTED) {
+        // Looks like we were aborted!
+        return kj::READY_NOW;
+      } else {
+        // Some other error... propagate it.
+        return kj::mv(e);
+      }
+    });
+  }
+
+  kj::Promise<Message> receive() override {
+    return KJ_ASSERT_NONNULL(in)->receive();
+  }
+
+  kj::Promise<void> pumpTo(WebSocket& other) override {
+    KJ_IF_MAYBE(optimized, kj::dynamicDowncastIfAvailable<KjToCapnpWebSocketAdapter>(other)) {
+      shorteningFulfiller->fulfill(
+          kj::cp(KJ_REQUIRE_NONNULL(optimized->out, "already called disconnect()")));
+
+      // We expect the `in` pipe will stop receiving messages after the redirect, but we need to
+      // pump anything already in-flight.
+      return KJ_ASSERT_NONNULL(in)->pumpTo(other);
+    } else KJ_IF_MAYBE(promise, other.tryPumpFrom(*this)) {
+      // We may have unwrapped some layers around `other` leading to a shorter path.
+      return kj::mv(*promise);
+    } else {
+      return KJ_ASSERT_NONNULL(in)->pumpTo(other);
+    }
+  }
+
+private:
+  kj::Maybe<kj::Own<kj::WebSocket>> in;   // One end of a WebSocketPipe, used only for receiving.
+  kj::Maybe<capnp::WebSocket::Client> out;  // Used only for sending.
+  kj::Own<kj::PromiseFulfiller<kj::Promise<Capability::Client>>> shorteningFulfiller;
+};
+
+// =======================================================================================
+
+class HttpOverCapnpFactory::ClientRequestContextImpl final
+    : public capnp::HttpService::ClientRequestContext::Server {
+public:
+  ClientRequestContextImpl(HttpOverCapnpFactory& factory,
+                           kj::Own<RequestState> state,
+                           kj::HttpService::Response& kjResponse)
+      : factory(factory), state(kj::mv(state)), kjResponse(kjResponse) {}
+
+  ~ClientRequestContextImpl() noexcept(false) {
+    // Note this implicitly cancels the upstream pump task.
+  }
+
+  kj::Promise<void> startResponse(StartResponseContext context) override {
+    KJ_REQUIRE(!sent, "already called startResponse() or startWebSocket()");
+    sent = true;
+    state->assertNotCanceled();
+
+    auto params = context.getParams();
+    auto rpcResponse = params.getResponse();
+
+    auto bodySize = rpcResponse.getBodySize();
+    kj::Maybe<uint64_t> expectedSize;
+    bool hasBody = true;
+    if (bodySize.isFixed()) {
+      auto size = bodySize.getFixed();
+      expectedSize = bodySize.getFixed();
+      hasBody = size > 0;
+    }
+
+    auto bodyStream = kjResponse.send(rpcResponse.getStatusCode(), rpcResponse.getStatusText(),
+        factory.headersToKj(rpcResponse.getHeaders()), expectedSize);
+
+    auto results = context.getResults(MessageSize { 16, 1 });
+    if (hasBody) {
+      auto pipe = kj::newOneWayPipe();
+      results.setBody(factory.streamFactory.kjToCapnp(kj::mv(pipe.out)));
+      state->addTask(pipe.in->pumpTo(*bodyStream)
+          .ignoreResult()
+          .attach(kj::mv(bodyStream), kj::mv(pipe.in)));
+    }
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> startWebSocket(StartWebSocketContext context) override {
+    KJ_REQUIRE(!sent, "already called startResponse() or startWebSocket()");
+    sent = true;
+    state->assertNotCanceled();
+
+    auto params = context.getParams();
+
+    auto shorteningPaf = kj::newPromiseAndFulfiller<kj::Promise<Capability::Client>>();
+
+    auto ownWebSocket = kjResponse.acceptWebSocket(factory.headersToKj(params.getHeaders()));
+    auto& webSocket = *ownWebSocket;
+    state->holdWebSocket(kj::mv(ownWebSocket));
+
+    auto upWrapper = kj::heap<KjToCapnpWebSocketAdapter>(
+        nullptr, params.getUpSocket(), kj::mv(shorteningPaf.fulfiller));
+    state->addTask(webSocket.pumpTo(*upWrapper).attach(kj::mv(upWrapper))
+        .catch_([&webSocket=webSocket](kj::Exception&& e) -> kj::Promise<void> {
+      // The pump in the client -> server direction failed. The error may have originated from
+      // either the client or the server. In case it came from the server, we want to call .abort()
+      // to propagate the problem back to the client. If the error came from the client, then
+      // .abort() probably is a noop.
+      webSocket.abort();
+      return kj::mv(e);
+    }));
+
+    auto results = context.getResults(MessageSize { 16, 1 });
+    results.setDownSocket(kj::heap<CapnpToKjWebSocketAdapter>(
+        kj::addRef(*state), webSocket, kj::mv(shorteningPaf.promise)));
+
+    return kj::READY_NOW;
+  }
+
+private:
+  HttpOverCapnpFactory& factory;
+  kj::Own<RequestState> state;
+  bool sent = false;
+
+  kj::HttpService::Response& kjResponse;
+  // Must check state->assertNotCanceled() before using this.
+};
+
+class HttpOverCapnpFactory::KjToCapnpHttpServiceAdapter final: public kj::HttpService {
+public:
+  KjToCapnpHttpServiceAdapter(HttpOverCapnpFactory& factory, capnp::HttpService::Client inner)
+      : factory(factory), inner(kj::mv(inner)) {}
+
+  kj::Promise<void> request(
+      kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody, kj::HttpService::Response& kjResponse) override {
+    auto rpcRequest = inner.startRequestRequest();
+
+    auto metadata = rpcRequest.initRequest();
+    metadata.setMethod(static_cast<capnp::HttpMethod>(method));
+    metadata.setUrl(url);
+    metadata.adoptHeaders(factory.headersToCapnp(
+        headers, Orphanage::getForMessageContaining(metadata)));
+
+    kj::Maybe<kj::AsyncInputStream&> maybeRequestBody;
+
+    KJ_IF_MAYBE(s, requestBody.tryGetLength()) {
+      metadata.getBodySize().setFixed(*s);
+      if (*s == 0) {
+        maybeRequestBody = nullptr;
+      } else {
+        maybeRequestBody = requestBody;
+      }
+    } else if ((method == kj::HttpMethod::GET || method == kj::HttpMethod::HEAD) &&
+               headers.get(kj::HttpHeaderId::TRANSFER_ENCODING) == nullptr) {
+      maybeRequestBody = nullptr;
+      metadata.getBodySize().setFixed(0);
+    } else {
+      metadata.getBodySize().setUnknown();
+      maybeRequestBody = requestBody;
+    }
+
+    auto state = kj::refcounted<RequestState>();
+    auto deferredCancel = kj::defer([state = kj::addRef(*state)]() mutable {
+      state->cancel();
+    });
+
+    rpcRequest.setContext(
+        kj::heap<ClientRequestContextImpl>(factory, kj::addRef(*state), kjResponse));
+
+    auto pipeline = rpcRequest.send();
+
+    // Pump upstream -- unless we don't expect a request body.
+    kj::Maybe<kj::Promise<void>> pumpRequestTask;
+    KJ_IF_MAYBE(rb, maybeRequestBody) {
+      auto bodyOut = factory.streamFactory.capnpToKj(pipeline.getRequestBody());
+      pumpRequestTask = rb->pumpTo(*bodyOut).attach(kj::mv(bodyOut)).ignoreResult()
+          .eagerlyEvaluate([state = kj::addRef(*state)](kj::Exception&& e) mutable {
+        state->taskFailed(kj::mv(e));
+      });
+    }
+
+    // Wait for the ServerRequestContext to resolve, which indicates completion. Meanwhile, if the
+    // promise is canceled from the client side, we drop the ServerRequestContext naturally, and we
+    // also call state->cancel().
+    return pipeline.getContext().whenResolved()
+        // Once the server indicates it is done, then we can cancel pumping the request, because
+        // obviously the server won't use it. We should not cancel pumping the response since there
+        // could be data in-flight still.
+        .attach(kj::mv(pumpRequestTask))
+        // finishTasks() will wait for the respones to complete.
+        .then([state = kj::mv(state)]() mutable { return state->finishTasks(); })
+        .attach(kj::mv(deferredCancel));
+  }
+
+private:
+  HttpOverCapnpFactory& factory;
+  capnp::HttpService::Client inner;
+};
+
+kj::Own<kj::HttpService> HttpOverCapnpFactory::capnpToKj(capnp::HttpService::Client rpcService) {
+  return kj::heap<KjToCapnpHttpServiceAdapter>(*this, kj::mv(rpcService));
+}
+
+// =======================================================================================
+
+namespace {
+
+class NullInputStream final: public kj::AsyncInputStream {
+  // TODO(cleanup): This class has been replicated in a bunch of places now, make it public
+  //   somewhere.
+
+public:
+  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+    return size_t(0);
+  }
+
+  kj::Maybe<uint64_t> tryGetLength() override {
+    return uint64_t(0);
+  }
+
+  kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
+    return uint64_t(0);
+  }
+};
+
+class NullOutputStream final: public kj::AsyncOutputStream {
+  // TODO(cleanup): This class has been replicated in a bunch of places now, make it public
+  //   somewhere.
+
+public:
+  kj::Promise<void> write(const void* buffer, size_t size) override {
+    return kj::READY_NOW;
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
+    return kj::READY_NOW;
+  }
+  kj::Promise<void> whenWriteDisconnected() override {
+    return kj::NEVER_DONE;
+  }
+
+  // We can't really optimize tryPumpFrom() unless AsyncInputStream grows a skip() method.
+};
+
+class ResolvedServerRequestContext final: public capnp::HttpService::ServerRequestContext::Server {
+public:
+  // Nothing! It's done.
+};
+
+}  // namespace
+
+class HttpOverCapnpFactory::ServerRequestContextImpl final
+    : public capnp::HttpService::ServerRequestContext::Server,
+      public kj::HttpService::Response {
+public:
+  ServerRequestContextImpl(HttpOverCapnpFactory& factory,
+                           capnp::HttpRequest::Reader request,
+                           capnp::HttpService::ClientRequestContext::Client clientContext,
+                           kj::Own<kj::AsyncInputStream> requestBodyIn,
+                           kj::HttpService& kjService)
+      : factory(factory),
+        method(validateMethod(request.getMethod())),
+        headers(factory.headersToKj(request.getHeaders()).clone()),
+        clientContext(kj::mv(clientContext)),
+        // Note we attach `requestBodyIn` to `task` so that we will implicitly cancel reading
+        // the request body as soon as the service returns. This is important in particular when
+        // the request body is not fully consumed, in order to propagate cancellation.
+        task(kjService.request(method, request.getUrl(), headers, *requestBodyIn, *this)
+                      .attach(kj::mv(requestBodyIn))) {}
+
+  KJ_DISALLOW_COPY(ServerRequestContextImpl);
+
+  kj::Maybe<kj::Promise<Capability::Client>> shortenPath() override {
+    return task.then([this]() -> kj::Promise<void> {
+      // Merge in any errors from our reply call, so that they propagate somewhere.
+      return kj::mv(KJ_REQUIRE_NONNULL(replyTask,
+          "server never called send() or acceptWebSocket()"));
+    }).then([]() -> Capability::Client {
+      // If all went well, resolve to a settled capability.
+      // TODO(perf): Could save a message by resolving to a capability hosted by the client, or
+      //     some special "null" capability that isn't an error but is still transmitted by value.
+      //     Otherwise we need a Release message from client -> server just to drop this...
+      return kj::heap<ResolvedServerRequestContext>();
+    });
+  }
+
+  kj::Own<kj::AsyncOutputStream> send(
+      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers,
+      kj::Maybe<uint64_t> expectedBodySize = nullptr) override {
+    KJ_REQUIRE(replyTask == nullptr, "already called send() or acceptWebSocket()");
+
+    auto req = clientContext.startResponseRequest();
+
+    if (method == kj::HttpMethod::HEAD ||
+        statusCode == 204 || statusCode == 205 || statusCode == 304) {
+      expectedBodySize = uint64_t(0);
+    }
+
+    auto rpcResponse = req.initResponse();
+    rpcResponse.setStatusCode(statusCode);
+    rpcResponse.setStatusText(statusText);
+    rpcResponse.adoptHeaders(factory.headersToCapnp(
+        headers, Orphanage::getForMessageContaining(rpcResponse)));
+    bool hasBody = true;
+    KJ_IF_MAYBE(s, expectedBodySize) {
+      rpcResponse.getBodySize().setFixed(*s);
+      hasBody = *s > 0;
+    }
+
+    if (hasBody) {
+      auto pipeline = req.send();
+      auto result = factory.streamFactory.capnpToKj(pipeline.getBody());
+      replyTask = pipeline.ignoreResult();
+      return result;
+    } else {
+      replyTask = req.send().ignoreResult();
+      return kj::heap<NullOutputStream>();
+    }
+  }
+
+  kj::Own<kj::WebSocket> acceptWebSocket(const kj::HttpHeaders& headers) override {
+    KJ_REQUIRE(replyTask == nullptr, "already called send() or acceptWebSocket()");
+
+    auto req = clientContext.startWebSocketRequest();
+
+    req.adoptHeaders(factory.headersToCapnp(
+        headers, Orphanage::getForMessageContaining(
+            capnp::HttpService::ClientRequestContext::StartWebSocketParams::Builder(req))));
+
+    auto pipe = kj::newWebSocketPipe();
+    auto shorteningPaf = kj::newPromiseAndFulfiller<kj::Promise<Capability::Client>>();
+
+    // We don't need the RequestState mechanism on the server side because
+    // CapnpToKjWebSocketAdapter wraps a pipe end, and that pipe end can continue to exist beyond
+    // the lifetime of the request, because the other end will have been dropped. We only create
+    // a RequestState here so that we can reuse the implementation of CapnpToKjWebSocketAdapter
+    // that needs this for the client side.
+    auto dummyState = kj::refcounted<RequestState>();
+    auto& pipeEnd0Ref = *pipe.ends[0];
+    dummyState->holdWebSocket(kj::mv(pipe.ends[0]));
+    req.setUpSocket(kj::heap<CapnpToKjWebSocketAdapter>(
+        kj::mv(dummyState), pipeEnd0Ref, kj::mv(shorteningPaf.promise)));
+
+    auto pipeline = req.send();
+    auto result = kj::heap<KjToCapnpWebSocketAdapter>(
+        kj::mv(pipe.ends[1]), pipeline.getDownSocket(), kj::mv(shorteningPaf.fulfiller));
+
+    // Note we need eagerlyEvaluate() here to force proactively discarding the response object,
+    // since it holds a reference to `downSocket`.
+    replyTask = pipeline.ignoreResult().eagerlyEvaluate(nullptr);
+
+    return result;
+  }
+
+private:
+  HttpOverCapnpFactory& factory;
+  kj::HttpMethod method;
+  kj::HttpHeaders headers;
+  capnp::HttpService::ClientRequestContext::Client clientContext;
+  kj::Promise<void> task;
+  kj::Maybe<kj::Promise<void>> replyTask;
+
+  static kj::HttpMethod validateMethod(capnp::HttpMethod method) {
+    KJ_REQUIRE(method <= capnp::HttpMethod::UNSUBSCRIBE, "unknown method", method);
+    return static_cast<kj::HttpMethod>(method);
+  }
+};
+
+class HttpOverCapnpFactory::CapnpToKjHttpServiceAdapter final: public capnp::HttpService::Server {
+public:
+  CapnpToKjHttpServiceAdapter(HttpOverCapnpFactory& factory, kj::Own<kj::HttpService> inner)
+      : factory(factory), inner(kj::mv(inner)) {}
+
+  kj::Promise<void> startRequest(StartRequestContext context) override {
+    auto params = context.getParams();
+    auto metadata = params.getRequest();
+
+    auto bodySize = metadata.getBodySize();
+    kj::Maybe<uint64_t> expectedSize;
+    bool hasBody = true;
+    if (bodySize.isFixed()) {
+      auto size = bodySize.getFixed();
+      expectedSize = bodySize.getFixed();
+      hasBody = size > 0;
+    }
+
+    auto results = context.getResults(MessageSize {8, 2});
+    kj::Own<kj::AsyncInputStream> requestBody;
+    if (hasBody) {
+      auto pipe = kj::newOneWayPipe(expectedSize);
+      results.setRequestBody(factory.streamFactory.kjToCapnp(kj::mv(pipe.out)));
+      requestBody = kj::mv(pipe.in);
+    } else {
+      requestBody = kj::heap<NullInputStream>();
+    }
+    results.setContext(kj::heap<ServerRequestContextImpl>(
+        factory, metadata, params.getContext(), kj::mv(requestBody), *inner));
+
+    return kj::READY_NOW;
+  }
+
+private:
+  HttpOverCapnpFactory& factory;
+  kj::Own<kj::HttpService> inner;
+};
+
+capnp::HttpService::Client HttpOverCapnpFactory::kjToCapnp(kj::Own<kj::HttpService> service) {
+  return kj::heap<CapnpToKjHttpServiceAdapter>(*this, kj::mv(service));
+}
+
+// =======================================================================================
+
+static constexpr uint64_t COMMON_TEXT_ANNOTATION = 0x857745131db6fc83ull;
+// Type ID of `commonText` from `http.capnp`.
+// TODO(cleanup): Cap'n Proto should auto-generate constants for these.
+
+HttpOverCapnpFactory::HttpOverCapnpFactory(ByteStreamFactory& streamFactory,
+                                           kj::HttpHeaderTable::Builder& headerTableBuilder)
+    : streamFactory(streamFactory), headerTable(headerTableBuilder.getFutureTable()) {
+  auto commonHeaderNames = Schema::from<capnp::CommonHeaderName>().getEnumerants();
+  size_t maxHeaderId = 0;
+  nameCapnpToKj = kj::heapArray<kj::HttpHeaderId>(commonHeaderNames.size());
+  for (size_t i = 1; i < commonHeaderNames.size(); i++) {
+    kj::StringPtr nameText;
+    for (auto ann: commonHeaderNames[i].getProto().getAnnotations()) {
+      if (ann.getId() == COMMON_TEXT_ANNOTATION) {
+        nameText = ann.getValue().getText();
+        break;
+      }
+    }
+    KJ_ASSERT(nameText != nullptr);
+    kj::HttpHeaderId headerId = headerTableBuilder.add(nameText);
+    nameCapnpToKj[i] = headerId;
+    maxHeaderId = kj::max(maxHeaderId, headerId.hashCode());
+  }
+
+  nameKjToCapnp = kj::heapArray<capnp::CommonHeaderName>(maxHeaderId + 1);
+  for (auto& slot: nameKjToCapnp) slot = capnp::CommonHeaderName::INVALID;
+
+  for (size_t i = 1; i < commonHeaderNames.size(); i++) {
+    auto& slot = nameKjToCapnp[nameCapnpToKj[i].hashCode()];
+    KJ_ASSERT(slot == capnp::CommonHeaderName::INVALID);
+    slot = static_cast<capnp::CommonHeaderName>(i);
+  }
+
+  auto commonHeaderValues = Schema::from<capnp::CommonHeaderValue>().getEnumerants();
+  valueCapnpToKj = kj::heapArray<kj::StringPtr>(commonHeaderValues.size());
+  for (size_t i = 1; i < commonHeaderValues.size(); i++) {
+    kj::StringPtr valueText;
+    for (auto ann: commonHeaderValues[i].getProto().getAnnotations()) {
+      if (ann.getId() == COMMON_TEXT_ANNOTATION) {
+        valueText = ann.getValue().getText();
+        break;
+      }
+    }
+    KJ_ASSERT(valueText != nullptr);
+    valueCapnpToKj[i] = valueText;
+    valueKjToCapnp.insert(valueText, static_cast<capnp::CommonHeaderValue>(i));
+  }
+}
+
+Orphan<List<capnp::HttpHeader>> HttpOverCapnpFactory::headersToCapnp(
+    const kj::HttpHeaders& headers, Orphanage orphanage) {
+  auto result = orphanage.newOrphan<List<capnp::HttpHeader>>(headers.size());
+  auto rpcHeaders = result.get();
+  uint i = 0;
+  headers.forEach([&](kj::HttpHeaderId id, kj::StringPtr value) {
+    auto capnpName = id.hashCode() < nameKjToCapnp.size()
+        ? nameKjToCapnp[id.hashCode()]
+        : capnp::CommonHeaderName::INVALID;
+    if (capnpName == capnp::CommonHeaderName::INVALID) {
+      auto header = rpcHeaders[i++].initUncommon();
+      header.setName(id.toString());
+      header.setValue(value);
+    } else {
+      auto header = rpcHeaders[i++].initCommon();
+      header.setName(capnpName);
+      header.setValue(value);
+    }
+  }, [&](kj::StringPtr name, kj::StringPtr value) {
+    auto header = rpcHeaders[i++].initUncommon();
+    header.setName(name);
+    header.setValue(value);
+  });
+  KJ_ASSERT(i == rpcHeaders.size());
+  return result;
+}
+
+kj::HttpHeaders HttpOverCapnpFactory::headersToKj(
+    List<capnp::HttpHeader>::Reader capnpHeaders) const {
+  kj::HttpHeaders result(headerTable);
+
+  for (auto header: capnpHeaders) {
+    switch (header.which()) {
+      case capnp::HttpHeader::COMMON: {
+        auto nv = header.getCommon();
+        auto nameInt = static_cast<uint>(nv.getName());
+        KJ_REQUIRE(nameInt < nameCapnpToKj.size(), "unknown common header name", nv.getName());
+
+        switch (nv.which()) {
+          case capnp::HttpHeader::Common::COMMON_VALUE: {
+            auto cvInt = static_cast<uint>(nv.getCommonValue());
+            KJ_REQUIRE(nameInt < valueCapnpToKj.size(),
+                "unknown common header value", nv.getCommonValue());
+            result.set(nameCapnpToKj[nameInt], valueCapnpToKj[cvInt]);
+            break;
+          }
+          case capnp::HttpHeader::Common::VALUE:
+            result.set(nameCapnpToKj[nameInt], nv.getValue());
+            break;
+        }
+        break;
+      }
+      case capnp::HttpHeader::UNCOMMON: {
+        auto nv = header.getUncommon();
+        result.add(nv.getName(), nv.getValue());
+      }
+    }
+  }
+
+  return result;
+}
+
+}  // namespace capnp

--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -1,0 +1,217 @@
+# Copyright (c) 2019 Cloudflare, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@0xb665280aaff2e632;
+# Cap'n Proto interface for HTTP.
+
+using import "byte-stream.capnp".ByteStream;
+
+$import "/capnp/c++.capnp".namespace("capnp");
+
+interface HttpService {
+  startRequest @0 (request :HttpRequest, context :ClientRequestContext)
+               -> (requestBody :ByteStream, context :ServerRequestContext);
+  # Begin an HTTP request.
+  #
+  # The client sends the request method/url/headers. The server responds with a `ByteStream` where
+  # the client can make calls to stream up the request body. `requestBody` will be null in the case
+  # that request.bodySize.fixed == 0.
+
+  interface ClientRequestContext {
+    # Provides callbacks for the server to send the response.
+
+    startResponse @0 (response :HttpResponse) -> (body :ByteStream);
+    # Server calls this method to send the response status and headers and to begin streaming the
+    # response body. `body` will be null in the case that response.bodySize.fixed == 0, which is
+    # required for HEAD responses and status codes 204, 205, and 304.
+
+    startWebSocket @1 (headers :List(HttpHeader), upSocket :WebSocket)
+                   -> (downSocket :WebSocket);
+    # Server calls this method to indicate that the request is a valid WebSocket handshake and it
+    # wishes to accept it as a WebSocket.
+    #
+    # Client -> Server WebSocket frames will be sent via method calls on `upSocket`, while
+    # Server -> Client will be sent as calls to `downSocket`.
+  }
+
+  interface ServerRequestContext {
+    # Represents execution of a particular request on the server side.
+    #
+    # Dropping this object before the request completes will cancel the request.
+    #
+    # ServerRequestContext is always a promise capability. The client must wait for it to
+    # resolve using whenMoreResolved() in order to find out when the server is really done
+    # processing the request. This will throw an exception if the server failed in some way that
+    # could not be captured in the HTTP response. Note that it's possible for such an exception to
+    # be thrown even after the response body has been completely transmitted.
+  }
+}
+
+interface WebSocket {
+  sendText @0 (text :Text) -> stream;
+  sendData @1 (data :Data) -> stream;
+  # Send a text or data frame.
+
+  close @2 (code :UInt16, reason :Text);
+  # Send a close frame.
+}
+
+struct HttpRequest {
+  # Standard HTTP request metadata.
+
+  method @0 :HttpMethod;
+  url @1 :Text;
+  headers @2 :List(HttpHeader);
+  bodySize :union {
+    unknown @3 :Void;   # e.g. due to transfer-encoding: chunked
+    fixed @4 :UInt64;   # e.g. due to content-length
+  }
+}
+
+struct HttpResponse {
+  # Standard HTTP response metadata.
+
+  statusCode @0 :UInt16;
+  statusText @1 :Text;  # leave null if it matches the default for statusCode
+  headers @2 :List(HttpHeader);
+  bodySize :union {
+    unknown @3 :Void;   # e.g. due to transfer-encoding: chunked
+    fixed @4 :UInt64;   # e.g. due to content-length
+  }
+}
+
+enum HttpMethod {
+  # This enum aligns precisely with the kj::HttpMethod enum. However, the backwards-compat
+  # constraints of a public-facing C++ enum vs. an internal Cap'n Proto interface differ in
+  # several ways, which could possibly lead to divergence someday. For now, a unit test verifies
+  # that they match exactly; if that test ever fails, we'll have to figure out what to do about it.
+
+  get @0;
+  head @1;
+  post @2;
+  put @3;
+  delete @4;
+  patch @5;
+  purge @6;
+  options @7;
+  trace @8;
+
+  copy @9;
+  lock @10;
+  mkcol @11;
+  move @12;
+  propfind @13;
+  proppatch @14;
+  search @15;
+  unlock @16;
+  acl @17;
+
+  report @18;
+  mkactivity @19;
+  checkout @20;
+  merge @21;
+
+  msearch @22;
+  notify @23;
+  subscribe @24;
+  unsubscribe @25;
+}
+
+annotation commonText @0x857745131db6fc83(enumerant) :Text;
+
+enum CommonHeaderName {
+  invalid @0;
+  # Dummy to serve as default value. Should never actually appear on wire.
+
+  acceptCharset @1 $commonText("Accept-Charset");
+  acceptEncoding @2 $commonText("Accept-Encoding");
+  acceptLanguage @3 $commonText("Accept-Language");
+  acceptRanges @4 $commonText("Accept-Ranges");
+  accept @5 $commonText("Accept");
+  accessControlAllowOrigin @6 $commonText("Access-Control-Allow-Origin");
+  age @7 $commonText("Age");
+  allow @8 $commonText("Allow");
+  authorization @9 $commonText("Authorization");
+  cacheControl @10 $commonText("Cache-Control");
+  contentDisposition @11 $commonText("Content-Disposition");
+  contentEncoding @12 $commonText("Content-Encoding");
+  contentLanguage @13 $commonText("Content-Language");
+  contentLength @14 $commonText("Content-Length");
+  contentLocation @15 $commonText("Content-Location");
+  contentRange @16 $commonText("Content-Range");
+  contentType @17 $commonText("Content-Type");
+  cookie @18 $commonText("Cookie");
+  date @19 $commonText("Date");
+  etag @20 $commonText("ETag");
+  expect @21 $commonText("Expect");
+  expires @22 $commonText("Expires");
+  from @23 $commonText("From");
+  host @24 $commonText("Host");
+  ifMatch @25 $commonText("If-Match");
+  ifModifiedSince @26 $commonText("If-Modified-Since");
+  ifNoneMatch @27 $commonText("If-None-Match");
+  ifRange @28 $commonText("If-Range");
+  ifUnmodifiedSince @29 $commonText("If-Unmodified-Since");
+  lastModified @30 $commonText("Last-Modified");
+  link @31 $commonText("Link");
+  location @32 $commonText("Location");
+  maxForwards @33 $commonText("Max-Forwards");
+  proxyAuthenticate @34 $commonText("Proxy-Authenticate");
+  proxyAuthorization @35 $commonText("Proxy-Authorization");
+  range @36 $commonText("Range");
+  referer @37 $commonText("Referer");
+  refresh @38 $commonText("Refresh");
+  retryAfter @39 $commonText("Retry-After");
+  server @40 $commonText("Server");
+  setCookie @41 $commonText("Set-Cookie");
+  strictTransportSecurity @42 $commonText("Strict-Transport-Security");
+  transferEncoding @43 $commonText("Transfer-Encoding");
+  userAgent @44 $commonText("User-Agent");
+  vary @45 $commonText("Vary");
+  via @46 $commonText("Via");
+  wwwAuthenticate @47 $commonText("WWW-Authenticate");
+}
+
+enum CommonHeaderValue {
+  invalid @0;
+
+  gzipDeflate @1 $commonText("gzip, deflate");
+
+  # TODO(someday): "gzip, deflate" is the only common header value recognized by HPACK.
+}
+
+struct HttpHeader {
+  union {
+    common :group {
+      name @0 :CommonHeaderName;
+      union {
+        commonValue @1 :CommonHeaderValue;
+        value @2 :Text;
+      }
+    }
+    uncommon @3 :NameValue;
+  }
+
+  struct NameValue {
+    name @0 :Text;
+    value @1 :Text;
+  }
+}

--- a/c++/src/capnp/compat/http-over-capnp.h
+++ b/c++/src/capnp/compat/http-over-capnp.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+// Bridges from KJ HTTP to Cap'n Proto HTTP-over-RPC.
+
+#include <capnp/compat/http-over-capnp.capnp.h>
+#include <kj/compat/http.h>
+#include <kj/map.h>
+#include "byte-stream.h"
+
+namespace capnp {
+
+class HttpOverCapnpFactory {
+public:
+  HttpOverCapnpFactory(ByteStreamFactory& streamFactory,
+                       kj::HttpHeaderTable::Builder& headerTableBuilder);
+
+  kj::Own<kj::HttpService> capnpToKj(capnp::HttpService::Client rpcService);
+  capnp::HttpService::Client kjToCapnp(kj::Own<kj::HttpService> service);
+
+private:
+  ByteStreamFactory& streamFactory;
+  kj::HttpHeaderTable& headerTable;
+  kj::Array<capnp::CommonHeaderName> nameKjToCapnp;
+  kj::Array<kj::HttpHeaderId> nameCapnpToKj;
+  kj::Array<kj::StringPtr> valueCapnpToKj;
+  kj::HashMap<kj::StringPtr, capnp::CommonHeaderValue> valueKjToCapnp;
+
+  class RequestState;
+
+  class CapnpToKjWebSocketAdapter;
+  class KjToCapnpWebSocketAdapter;
+
+  class ClientRequestContextImpl;
+  class KjToCapnpHttpServiceAdapter;
+
+  class ServerRequestContextImpl;
+  class CapnpToKjHttpServiceAdapter;
+
+  kj::HttpHeaders headersToKj(capnp::List<capnp::HttpHeader>::Reader capnpHeaders) const;
+  // Returned headers may alias into `capnpHeaders`.
+
+  capnp::Orphan<capnp::List<capnp::HttpHeader>> headersToCapnp(
+      const kj::HttpHeaders& headers, capnp::Orphanage orphanage);
+};
+
+}  // namespace capnp

--- a/c++/src/capnp/rpc-twoparty.c++
+++ b/c++/src/capnp/rpc-twoparty.c++
@@ -222,7 +222,12 @@ size_t TwoPartyVatNetwork::getWindow() {
       KJ_ASSERT(len == sizeof(bufSize));
     })) {
       if (exception->getType() != kj::Exception::Type::UNIMPLEMENTED) {
-        kj::throwRecoverableException(kj::mv(*exception));
+        // TODO(someday): Figure out why getting SO_SNDBUF sometimes throws EINVAL. I suspect it
+        //   happens when the remote side has closed their read end, meaning we no longer have
+        //   a send buffer, but I don't know what is the best way to verify that that was actually
+        //   the reason. I'd prefer not to ignore EINVAL errors in general.
+
+        // kj::throwRecoverableException(kj::mv(*exception));
       }
       solSndbufUnimplemented = true;
       bufSize = RpcFlowController::DEFAULT_WINDOW_SIZE;

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1702,6 +1702,36 @@ KJ_TEST("Userland pipe multi-part write doesn't quit early") {
   writePromise.wait(ws);
 }
 
+KJ_TEST("Userland pipe BlockedRead gets empty tryPumpFrom") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  auto pipe2 = newOneWayPipe();
+
+  // First start a read from the back end.
+  char buffer[4];
+  auto readPromise = pipe2.in->tryRead(buffer, 1, 4);
+
+  // Now arrange a pump between the pipes, using tryPumpFrom().
+  auto pumpPromise = KJ_ASSERT_NONNULL(pipe2.out->tryPumpFrom(*pipe.in));
+
+  // Disconnect the front pipe, causing EOF on the pump.
+  pipe.out = nullptr;
+
+  // The pump should have produced zero bytes.
+  KJ_EXPECT(pumpPromise.wait(ws) == 0);
+
+  // The read is incomplete.
+  KJ_EXPECT(!readPromise.poll(ws));
+
+  // A subsequent write() completes the read.
+  pipe2.out->write("foo", 3).wait(ws);
+  KJ_EXPECT(readPromise.wait(ws) == 3);
+  buffer[3] = '\0';
+  KJ_EXPECT(kj::StringPtr(buffer, 3) == "foo");
+}
+
 constexpr static auto TEE_MAX_CHUNK_SIZE = 1 << 14;
 // AsyncTee::MAX_CHUNK_SIZE, 16k as of this writing
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -951,20 +951,20 @@ private:
 
   public:
     Promise<size_t> tryRead(void* readBufferPtr, size_t minBytes, size_t maxBytes) override {
-      KJ_FAIL_REQUIRE("abortRead() has been called");
+      return KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called");
     }
     Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
-      KJ_FAIL_REQUIRE("abortRead() has been called");
+      return KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called");
     }
     void abortRead() override {
       // ignore repeated abort
     }
 
     Promise<void> write(const void* buffer, size_t size) override {
-      KJ_FAIL_REQUIRE("abortRead() has been called");
+      return KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called");
     }
     Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
-      KJ_FAIL_REQUIRE("abortRead() has been called");
+      return KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called");
     }
     Maybe<Promise<uint64_t>> tryPumpFrom(AsyncInputStream& input, uint64_t amount) override {
       // There might not actually be any data in `input`, in which case a pump wouldn't actually
@@ -984,7 +984,9 @@ private:
             return uint64_t(0);
           } else {
             // There was data in the input. The pump would have thrown.
-            KJ_FAIL_REQUIRE("abortRead() has been called");
+            kj::throwRecoverableException(
+                KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called"));
+            return uint64_t(0);
           }
         });
       }

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -724,32 +724,33 @@ private:
       auto maxToRead = kj::min(amount, readBuffer.size());
 
       return canceler.wrap(input.tryRead(readBuffer.begin(), minToRead, maxToRead)
-          .then([this,&input,amount,minToRead](size_t actual) -> Promise<uint64_t> {
+          .then([this,&input,amount](size_t actual) -> Promise<uint64_t> {
         readBuffer = readBuffer.slice(actual, readBuffer.size());
         readSoFar += actual;
 
-        if (readSoFar >= minBytes || actual < minToRead) {
-          // We've read enough to close out this read (readSoFar >= minBytes)
-          // OR we reached EOF and couldn't complete the read (actual < minToRead)
-          // Either way, we want to close out this read.
+        if (readSoFar >= minBytes) {
+          // We've read enough to close out this read (readSoFar >= minBytes).
           canceler.release();
           fulfiller.fulfill(kj::cp(readSoFar));
           pipe.endState(*this);
 
           if (actual < amount) {
-            // We din't complete pumping. Restart from the pipe.
+            // We didn't read as much data as the pump requested, but we did fulfill the read, so
+            // we don't know whether we reached EOF on the input. We need to continue the pump,
+            // replacing the BlockedRead state.
             return input.pumpTo(pipe, amount - actual)
                 .then([actual](uint64_t actual2) -> uint64_t { return actual + actual2; });
+          } else {
+            // We pumped as much data as was requested, so we can return that now.
+            return actual;
           }
+        } else {
+          // The pump completed without fulfilling the read. This either means that the pump
+          // reached EOF or the `amount` requested was not enough to satisfy the read in the first
+          // place. Pumps do not propagate EOF, so either way we want to leave the BlockedRead in
+          // place waiting for more data.
+          return actual;
         }
-
-        // If we read less than `actual`, but more than `minToRead`, it can only have been
-        // because we reached `minBytes`, so the conditional above would have executed. So, here
-        // we know that actual == amount.
-        KJ_ASSERT(actual == amount);
-
-        // We pumped the full amount, so we're done pumping.
-        return amount;
       }));
     }
 

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -307,6 +307,29 @@ KJ_TEST("HttpHeaders validation") {
   KJ_EXPECT_THROW_MESSAGE("invalid header value", headers.add("Valid-Name", "in\nvalid"));
 }
 
+KJ_TEST("HttpHeaders Set-Cookie handling") {
+  HttpHeaderTable::Builder builder;
+  auto hCookie = builder.add("Cookie");
+  auto hSetCookie = builder.add("Set-Cookie");
+  auto table = builder.build();
+
+  HttpHeaders headers(*table);
+  headers.set(hCookie, "Foo");
+  headers.add("Cookie", "Bar");
+  headers.add("Cookie", "Baz");
+  headers.set(hSetCookie, "Foo");
+  headers.add("Set-Cookie", "Bar");
+  headers.add("Set-Cookie", "Baz");
+
+  auto text = headers.toString();
+  KJ_EXPECT(text ==
+      "Cookie: Foo, Bar, Baz\r\n"
+      "Set-Cookie: Foo\r\n"
+      "Set-Cookie: Bar\r\n"
+      "Set-Cookie: Baz\r\n"
+      "\r\n", text);
+}
+
 // =======================================================================================
 
 class ReadFragmenter final: public kj::AsyncIoStream {

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -578,6 +578,16 @@ void HttpHeaders::clear() {
   unindexedHeaders.clear();
 }
 
+size_t HttpHeaders::size() const {
+  size_t result = unindexedHeaders.size();
+  for (auto i: kj::indices(indexedHeaders)) {
+    if (indexedHeaders[i] != nullptr) {
+      ++result;
+    }
+  }
+  return result;
+}
+
 HttpHeaders HttpHeaders::clone() const {
   HttpHeaders result(*table);
 

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -679,7 +679,12 @@ void HttpHeaders::addNoCheck(kj::StringPtr name, kj::StringPtr value) {
       indexedHeaders[id->id] = value;
     } else {
       // Duplicate HTTP headers are equivalent to the values being separated by a comma.
+
+#if _MSC_VER
+      if (_stricmp(name.cStr(), "set-cookie") == 0) {
+#else
       if (strcasecmp(name.cStr(), "set-cookie") == 0) {
+#endif
         // Uh-oh, Set-Cookie will be corrupted if we try to concatenate it. We'll make it an
         // unindexed header, which is weird, but the alternative is guaranteed corruption, so...
         // TODO(cleanup): Maybe HttpHeaders should just special-case set-cookie in general?


### PR DESCRIPTION
~*[NOTE: This PR is targeting the `streaming` branch because it builds on top of that, but should be redirected to `master` once `streaming` has been merged.]*~

This allows an HTTP request/response to be forwarded over Cap'n Proto RPC, multiplexed with arbitrary other RPC transactions.

This could be compared with HTTP/2, which is a binary protocol representation of HTTP that allows multiplexing. HTTP-over-Cap'n-Proto provides the same, but with some advantages inherent in leveraging Cap'n Proto:
- HTTP transactions can be multiplexed with regular Cap'n Proto RPC transactions. (While in theory you could also layer RPC on top of HTTP, as gRPC does, HTTP transactions are much heavier than basic RPC. In my opinion, layering HTTP over RPC makes much more sense because of this.)
- HTTP endpoints are object capabilities. Multiple private endpoints can be multiplexed over the same connection.
- Either end of the connection can act as the client or server, exposing endpoints to each other.
- Cap'n Proto path shortening can kick in. For instance, imagine a request that passes through several proxies, then eventually returns a large streaming response. If the proxies is each a Cap'n Proto server with a level 3 RPC implementation, and the response is simply passed through verbatim, the response stream will automatically be shortened to skip over the middleman servers. At present no Cap'n Proto implementation supports level 3, but path shortening can also apply with only level 1 RPC, if all calls proxy through a central hub process, as is often the case in multi-tenant sandboxing scenarios.

There are also disadvantages vs. HTTP/2:
- HTTP/2 is a standard. This is not.
- This protocol is not as finely optimized for the HTTP use case. It will take somewhat more bandwidth on the wire.
- No mechanism for server push has been defined, although this could be a relatively simple addition to the http-over-capnp interface definitions.
- No mechanism for stream prioritization is defined -- this would likely require new features in the Cap'n Proto RPC implementation itself.
- At present, the backpressure mechanism is naive and its performance will suffer as the network distance increases. I intend to solve this by adding better backpressure mechanisms into Cap'n Proto itself.

Shims are provided for compatibility with the KJ HTTP interfaces.

Note that Sandstorm has its own http-over-capnp protocol: https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/web-session.capnp

Sandstorm's protocol and this new one are intended for very different use cases. Sandstorm implements sandboxing of web applications on both the client and server sides. As a result, it cares deeply about the semantics of HTTP headers and how they affect the browser. This new http-over-capnp protocol is meant to be a dumb bridge that simply passes through all headers verbatim.