### PR TITLE
DO NOT MERGE: Use BSD-make-compatible shell expansion syntax.

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -237,7 +237,10 @@ endif
 
 # Don't include security release in soname -- we want to replace old binaries
 # in this case.
-SO_VERSION = $(shell echo $(VERSION) | sed -e 's/^\([0-9]*[.][0-9]*[.][0-9]*\)\([.][0-9]*\)*\(-.*\)*$$/\1\3/g')
+# NOTE: != is the "shell assignment operator", so the right side will be
+#   evaluated by the shell. We use this instead of $(shell) for compatibility
+#   with BSD make. Note that GNU Make added support for != as of 4.0, in 2013.
+SO_VERSION != echo $(VERSION) | sed -e 's/^\([0-9]*[.][0-9]*[.][0-9]*\)\([.][0-9]*\)*\(-.*\)*$$/\1\3/g'
 
 libkj_la_LIBADD = $(PTHREAD_LIBS)
 libkj_la_LDFLAGS = -release $(SO_VERSION) -no-undefined


### PR DESCRIPTION
GNU Make supports this as of 4.0, released in 2013.

Unfortunately, it appears my recently-updated MacOS/XCode ships with GNU Make 3.81, from 2006. WTF Apple.

We may need to either:
1. Extend configure.ac to detect gmake vs. BSD make and adjust the Makefile accordingly. (I think it's able to do this such that the branch it doesn't use is actually commended out entirely.)
2. Detect when people use BSD make and error out early, asking them to please use gmake instead, which I think most BSD users have installed (but they might be offended).