### PR TITLE
Calculate SO_VERSION in configure for compatibility with BSD make.

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -422,14 +422,14 @@ if USE_EXTERNAL_CAPNP
 
 test_capnpc_middleman: $(test_capnpc_inputs)
 	@$(MKDIR_P) src
-	$(CAPNP) compile --src-prefix=$(srcdir)/src -o$(CAPNPC_CXX):src -I$(srcdir)/src $^
+	$(CAPNP) compile --src-prefix=$(srcdir)/src -o$(CAPNPC_CXX):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
 	touch test_capnpc_middleman
 
 else
 
 test_capnpc_middleman: capnp$(EXEEXT) capnpc-c++$(EXEEXT) $(test_capnpc_inputs)
 	@$(MKDIR_P) src
-	echo $^ | (read CAPNP CAPNPC_CXX SOURCES && ./$$CAPNP compile --src-prefix=$(srcdir)/src -o./$$CAPNPC_CXX:src -I$(srcdir)/src $$SOURCES)
+	./capnp$(EXEEXT) compile --src-prefix=$(srcdir)/src -o./capnpc-c++$(EXEEXT):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
 	touch test_capnpc_middleman
 
 endif

--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -235,10 +235,6 @@ else
 lib_LTLIBRARIES = libkj.la libkj-test.la libkj-async.la libkj-http.la $(MAYBE_KJ_TLS_LA) libcapnp.la libcapnp-rpc.la libcapnp-json.la libcapnpc.la
 endif
 
-# Don't include security release in soname -- we want to replace old binaries
-# in this case.
-SO_VERSION = $(shell echo $(VERSION) | sed -e 's/^\([0-9]*[.][0-9]*[.][0-9]*\)\([.][0-9]*\)*\(-.*\)*$$/\1\3/g')
-
 libkj_la_LIBADD = $(PTHREAD_LIBS)
 libkj_la_LDFLAGS = -release $(SO_VERSION) -no-undefined
 libkj_la_SOURCES=                                              \

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -129,6 +129,11 @@ AC_DEFUN([CAPNP_CMAKE_CONFIG_FILES], [ \
 AC_SUBST([CAPNP_PKG_CONFIG_FILES])
 AC_SUBST([CAPNP_CMAKE_CONFIG_FILES])
 
+# Don't include security release in soname -- we want to replace old binaries
+# in this case.
+SO_VERSION=$(echo $VERSION | sed -e 's/^\([0-9]*[.][0-9]*[.][0-9]*\)\([.][0-9]*\)*\(-.*\)*$/\1\3/g')
+AC_SUBST([SO_VERSION])
+
 # CapnProtoConfig.cmake.in needs these PACKAGE_* output variables.
 PACKAGE_INIT="set([CAPNP_PKG_CONFIG_FILES] CAPNP_PKG_CONFIG_FILES)"
 PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR="\${CMAKE_CURRENT_LIST_DIR}/../../../include"


### PR DESCRIPTION
BSD Make does not support `$(shell ...)`. It does support an alternative, `!=` assignments (which, confusingly, don't mean "not equal" but rather "evaluate the right in the shell before assignment"). GNU Make also supports `!=` as of version 4.0, released in 2013. Unfortunately, f***ing Apple ships GNU Make version 3.81, from 2006, with MacOS/XCode.

@pwrdwnsys can you please test whether this fixes your build issue? I don't have a BSD box available to test with.