### PR TITLE
Implement MutexGuarded::when() (i.e. condvars) on all platforms.

### DIFF
--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -119,7 +119,6 @@ TEST(Mutex, MutexGuarded) {
   EXPECT_EQ(321u, value.getWithoutLock());
 }
 
-#if KJ_USE_FUTEX    // TODO(someday): Implement on pthread & win32
 TEST(Mutex, When) {
   MutexGuarded<uint> value(123);
 
@@ -170,7 +169,6 @@ TEST(Mutex, When) {
     KJ_EXPECT(*value.lockShared() == 101);
   }
 }
-#endif
 
 TEST(Mutex, Lazy) {
   Lazy<uint> lazy;

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -511,6 +511,11 @@ void Mutex::lockWhen(Predicate& predicate, Maybe<Duration> timeout) {
   LARGE_INTEGER endTime;
 
   KJ_IF_MAYBE(t, timeout) {
+    // Windows sleeps are inaccurate -- they can be longer *or shorter* than the requested amount.
+    // For many use cases of our API, a too-short sleep would be unacceptable. Experimentally, it
+    // seems like sleeps can be up to half a millisecond short, so we'll add a millisecond.
+    *t += 500 * kj::MICROSECONDS;
+
     // Compute initial sleep time.
     sleepMs = *t / kj::MILLISECONDS;
     if (*t % kj::MILLISECONDS > 0 * kj::SECONDS) {

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -374,9 +374,7 @@ void Once::reset() {
     } \
   }
 
-Mutex::Mutex() {
-  KJ_PTHREAD_CALL(pthread_rwlock_init(&mutex, nullptr));
-}
+Mutex::Mutex(): mutex(PTHREAD_RWLOCK_INITIALIZER) {}
 Mutex::~Mutex() {
   KJ_PTHREAD_CLEANUP(pthread_rwlock_destroy(&mutex));
 }
@@ -488,9 +486,9 @@ void Mutex::lockWhen(Predicate& predicate) {
   }
 }
 
-Once::Once(bool startInitialized): state(startInitialized ? INITIALIZED : UNINITIALIZED) {
-  KJ_PTHREAD_CALL(pthread_mutex_init(&mutex, nullptr));
-}
+Once::Once(bool startInitialized)
+    : state(startInitialized ? INITIALIZED : UNINITIALIZED),
+      mutex(PTHREAD_MUTEX_INITIALIZER) {}
 Once::~Once() {
   KJ_PTHREAD_CLEANUP(pthread_mutex_destroy(&mutex));
 }

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -524,7 +524,8 @@ void Mutex::lockWhen(Predicate& predicate, Maybe<Duration> timeout) {
   KJ_IF_MAYBE(t, timeout) {
     // Windows sleeps are inaccurate -- they can be longer *or shorter* than the requested amount.
     // For many use cases of our API, a too-short sleep would be unacceptable. Experimentally, it
-    // seems like sleeps can be up to half a millisecond short, so we'll add a millisecond.
+    // seems like sleeps can be up to half a millisecond short, so we'll add half a millisecond
+    // (and then we round up, below).
     *t += 500 * kj::MICROSECONDS;
 
     // Compute initial sleep time.

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -41,6 +41,8 @@
 
 namespace kj {
 
+class Exception;
+
 // =======================================================================================
 // Private details -- public interfaces follow below.
 
@@ -101,6 +103,7 @@ private:
     kj::Maybe<Waiter&> next;
     kj::Maybe<Waiter&>* prev;
     Predicate& predicate;
+    Maybe<Own<Exception>> exception;
 #if KJ_USE_FUTEX
     uint futex;
     bool hasTimeout;
@@ -122,6 +125,7 @@ private:
 
   inline void addWaiter(Waiter& waiter);
   inline void removeWaiter(Waiter& waiter);
+  bool checkPredicate(Waiter& waiter);
 };
 
 class Once {

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -27,6 +27,7 @@
 
 #include "memory.h"
 #include <inttypes.h>
+#include "time.h"
 
 #if __linux__ && !defined(KJ_USE_FUTEX)
 #define KJ_USE_FUTEX 1
@@ -71,8 +72,10 @@ public:
     virtual bool check() = 0;
   };
 
-  void lockWhen(Predicate& predicate);
-  // Lock (exclusively) when predicate.check() returns true.
+  void lockWhen(Predicate& predicate, Maybe<Duration> timeout = nullptr);
+  // Lock (exclusively) when predicate.check() returns true, or when the timeout (if any) expires.
+  // The mutex is always locked when this returns regardless of whether the timeout expired (and
+  // always unlocked if it throws).
 
 private:
 #if KJ_USE_FUTEX
@@ -100,6 +103,7 @@ private:
     Predicate& predicate;
 #if KJ_USE_FUTEX
     uint futex;
+    bool hasTimeout;
 #elif _WIN32
     uintptr_t condvar;
     // Actually CONDITION_VARIABLE, but don't want to #include <windows.h> in header.
@@ -284,7 +288,8 @@ public:
   // Like `getWithoutLock()`, but asserts that the lock is already held by the calling thread.
 
   template <typename Cond, typename Func>
-  auto when(Cond&& condition, Func&& callback) const -> decltype(callback(instance<T&>())) {
+  auto when(Cond&& condition, Func&& callback, Maybe<Duration> timeout = nullptr) const
+      -> decltype(callback(instance<T&>())) {
     // Waits until condition(state) returns true, then calls callback(state) under lock.
     //
     // `condition`, when called, receives as its parameter a const reference to the state, which is
@@ -295,6 +300,10 @@ public:
     // condition to become true. It may even return true once, but then be called more times.
     // It is guaranteed, though, that at the time `callback()` is finally called, `condition()`
     // would currently return true (assuming it is a pure function of the guarded data).
+    //
+    // If `timeout` is specified, then after the given amount of time, the callback will be called
+    // regardless of whether the condition is true. In this case, when `callback()` is called,
+    // `condition()` may in fact evaluate false, but *only* if the timeout was reached.
 
     struct PredicateImpl final: public _::Mutex::Predicate {
       bool check() override {
@@ -309,7 +318,7 @@ public:
     };
 
     PredicateImpl impl(kj::fwd<Cond>(condition), value);
-    mutex.lockWhen(impl);
+    mutex.lockWhen(impl, timeout);
     KJ_DEFER(mutex.unlock(_::Mutex::EXCLUSIVE));
     return callback(value);
   }

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -101,7 +101,8 @@ private:
 #if KJ_USE_FUTEX
     uint futex;
 #elif _WIN32
-    #error "TODO(now): implement Win32 support before merging"
+    uintptr_t condvar;
+    // Actually CONDITION_VARIABLE, but don't want to #include <windows.h> in header.
 #else
     pthread_cond_t condvar;
 

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -79,6 +79,11 @@ public:
   // The mutex is always locked when this returns regardless of whether the timeout expired (and
   // always unlocked if it throws).
 
+  void induceSpuriousWakeupForTest();
+  // Utility method for mutex-test.c++ which causes a spurious thread wakeup on all threads that
+  // are waiting for a lockWhen() condition. Assuming correct implementation, all those threads
+  // should immediately go back to sleep.
+
 private:
 #if KJ_USE_FUTEX
   uint futex;
@@ -246,6 +251,14 @@ private:
   friend class MutexGuarded;
   template <typename U>
   friend class ExternalMutexGuarded;
+
+#if KJ_MUTEX_TEST
+public:
+#endif
+  void induceSpuriousWakeupForTest() { mutex->induceSpuriousWakeupForTest(); }
+  // Utility method for mutex-test.c++ which causes a spurious thread wakeup on all threads that
+  // are waiting for a when() condition. Assuming correct implementation, all those threads should
+  // immediately go back to sleep.
 };
 
 template <typename T>


### PR DESCRIPTION
Also, add support for passing a timeout to when().