### PR TITLE
Add HttpServerErrorHandler interface to provide visibility and customization of protocol errors

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1283,15 +1283,15 @@ private:
 template <typename T>
 class Maybe<T&>: public DisallowConstCopyIfNotConst<T> {
 public:
-  Maybe(): ptr(nullptr) {}
-  Maybe(T& t): ptr(&t) {}
-  Maybe(T* t): ptr(t) {}
+  constexpr Maybe(): ptr(nullptr) {}
+  constexpr Maybe(T& t): ptr(&t) {}
+  constexpr Maybe(T* t): ptr(t) {}
 
   template <typename U>
-  inline Maybe(Maybe<U&>& other): ptr(other.ptr) {}
+  inline constexpr Maybe(Maybe<U&>& other): ptr(other.ptr) {}
   template <typename U>
-  inline Maybe(const Maybe<U&>& other): ptr(const_cast<const U*>(other.ptr)) {}
-  inline Maybe(decltype(nullptr)): ptr(nullptr) {}
+  inline constexpr Maybe(const Maybe<U&>& other): ptr(const_cast<const U*>(other.ptr)) {}
+  inline constexpr Maybe(decltype(nullptr)): ptr(nullptr) {}
 
   inline Maybe& operator=(T& other) { ptr = &other; return *this; }
   inline Maybe& operator=(T* other) { ptr = other; return *this; }


### PR DESCRIPTION
~~This avoids needing to add another option flag to control whether or not to log protocol errors. It's a bit more flexible, too -- we could use these hooks to log 400 responses, but ignore other errors or record them only as metrics.~~

Updated: separated the hook out into an interface and provided a `Response&` for response customization.