### PR TITLE
Give an example of returning an owning string for KJ_STRINGIFY

### DIFF
--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -487,6 +487,8 @@ inline _::Delimited<ArrayPtr<const T>> Stringifier::operator*(const Array<T>& ar
 //
 //    class Foo {...};
 //    inline StringPtr KJ_STRINGIFY(const Foo& foo) { return foo.name(); }
+//      // or perhaps
+//    inline String KJ_STRINGIFY(const Foo& foo) { return kj::str(foo.field1(), ",", foo.field2()); }
 //
 // This allows Foo to be passed to str().
 //

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -488,7 +488,7 @@ inline _::Delimited<ArrayPtr<const T>> Stringifier::operator*(const Array<T>& ar
 //    class Foo {...};
 //    inline StringPtr KJ_STRINGIFY(const Foo& foo) { return foo.name(); }
 //      // or perhaps
-//    inline String KJ_STRINGIFY(const Foo& foo) { return kj::str(foo.field1(), ",", foo.field2()); }
+//    inline String KJ_STRINGIFY(const Foo& foo) { return kj::str(foo.fld1(), ",", foo.fld2()); }
 //
 // This allows Foo to be passed to str().
 //


### PR DESCRIPTION
I initially didn't read the docs carefully enough and returned a StringPtr to a locally allocated string. Whoops. Make the doc a little clearer about this.