### PR TITLE
Increase arenaSpace for emscripten builds

### DIFF
--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -133,11 +133,17 @@ public:
 private:
   ReaderOptions options;
 
+#if defined(__EMSCRIPTEN__)
+  static constexpr size_t arenaSpacePadding = 19;
+#else
+  static constexpr size_t arenaSpacePadding = 18;
+#endif
+
   // Space in which we can construct a ReaderArena.  We don't use ReaderArena directly here
   // because we don't want clients to have to #include arena.h, which itself includes a bunch of
   // other headers.  We don't use a pointer to a ReaderArena because that would require an
   // extra malloc on every message which could be expensive when processing small messages.
-  void* arenaSpace[18 + sizeof(kj::MutexGuarded<void*>) / sizeof(void*)];
+  void* arenaSpace[arenaSpacePadding + sizeof(kj::MutexGuarded<void*>) / sizeof(void*)];
   bool allocatedArena;
 
   _::ReaderArena* arena() { return reinterpret_cast<_::ReaderArena*>(arenaSpace); }


### PR DESCRIPTION
Building with Emscripten fails with
capnproto\capnproto\c++\src\capnp\message.c++:55:5: error: static_assert failed "arenaSpace is too small to hold a ReaderArena.  Please increase it.  This will break ABI compatibility."

Is constexpr usable? I don't know what C++ standards this project aims to be compatible with.