### PR TITLE
Fix handling of queued RT signals, plus some other crap

### DIFF
--- a/c++/src/capnp/rpc-twoparty.c++
+++ b/c++/src/capnp/rpc-twoparty.c++
@@ -382,7 +382,9 @@ TwoPartyClient::TwoPartyClient(kj::AsyncCapabilityStream& connection, uint maxFd
       rpcSystem(network, bootstrapInterface) {}
 
 Capability::Client TwoPartyClient::bootstrap() {
-  MallocMessageBuilder message(4);
+  capnp::word scratch[4];
+  memset(&scratch, 0, sizeof(scratch));
+  capnp::MallocMessageBuilder message(scratch);
   auto vatId = message.getRoot<rpc::twoparty::VatId>();
   vatId.setSide(network.getSide() == rpc::twoparty::Side::CLIENT
                 ? rpc::twoparty::Side::SERVER

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -405,6 +405,12 @@ private:
               }
             }
           }
+
+          if (spaceLeft >= CMSG_LEN(0) && spaceLeft >= cmsg->cmsg_len) {
+            spaceLeft -= cmsg->cmsg_len;
+          } else {
+            spaceLeft = 0;
+          }
         }
 
 #ifndef MSG_CMSG_CLOEXEC

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -882,7 +882,12 @@ KJ_TEST("UnixEventPort poll for signals") {
   promise2.wait(waitScope);
 }
 
-#ifdef SIGRTMIN
+#if defined(SIGRTMIN) && !__CYGWIN__
+// TODO(someday): Figure out why RT signals don't seem to work correctly on Cygwin. It looks like
+//   only the first signal is delivered, like how non-RT signals work. Is it possible Cygwin
+//   advertites RT signal support but doesn't actually implement them correctly? I can't find any
+//   information on the internet about this and TBH I don't care about Cygwin enough to dig in.
+
 void testRtSignals(UnixEventPort& port, WaitScope& waitScope, bool doPoll) {
   union sigval value;
   memset(&value, 0, sizeof(value));

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -126,6 +126,7 @@ KJ_TEST("HttpHeaders::parseRequest") {
       "Content-Length: 123\r\n"
       "DATE:     early\r\n"
       "other-Header: yep\r\n"
+      "with.dots: sure\r\n"
       "\r\n");
   auto result = headers.tryParseRequest(text.asArray()).get<HttpHeaders::Request>();
 
@@ -143,12 +144,13 @@ KJ_TEST("HttpHeaders::parseRequest") {
   headers.forEach([&](kj::StringPtr name, kj::StringPtr value) {
     KJ_EXPECT(unpackedHeaders.insert(std::make_pair(name, value)).second);
   });
-  KJ_EXPECT(unpackedHeaders.size() == 5);
+  KJ_EXPECT(unpackedHeaders.size() == 6);
   KJ_EXPECT(unpackedHeaders["Content-Length"] == "123");
   KJ_EXPECT(unpackedHeaders["Host"] == "example.com");
   KJ_EXPECT(unpackedHeaders["Date"] == "early");
   KJ_EXPECT(unpackedHeaders["Foo-Bar"] == "Baz");
   KJ_EXPECT(unpackedHeaders["other-Header"] == "yep");
+  KJ_EXPECT(unpackedHeaders["with.dots"] == "sure");
 
   KJ_EXPECT(headers.serializeRequest(result.method, result.url) ==
       "POST /some/path HTTP/1.1\r\n"
@@ -157,6 +159,7 @@ KJ_TEST("HttpHeaders::parseRequest") {
       "Date: early\r\n"
       "Foo-Bar: Baz\r\n"
       "other-Header: yep\r\n"
+      "with.dots: sure\r\n"
       "\r\n");
 }
 


### PR DESCRIPTION
For regular (non-RT) POSIX signals, the process can only have at most one instance of each signal queued for delivery at a time. If another copy of the signal arrives before the first is delivered, the new signal is ignored. The idea was that signals are only meant to wake the process up to check some input; the signal itself is not the input.

POSIX RT signals are different. Multiple copies of the same signal can be queued, and each is delivered separately. Each signal may contain some additional information that needs to be processed. The signals themselves are input.

UnixEventPort's `onSignal()` method returns a Promise that resolves the next time the signal is delivered. When the Promise is resolved, the signal is also supposed to be blocked until `onSignal()` can be called again, so that the app cannot miss signals delivered in between.

However, the epoll/signalfd implementation had a bug where it would pull _all_ queued signals off the `signalfd` at once, only delivering the first instance of each signal number and dropping subsequent instances on the floor. That's fine for regular signals, but not RT signals.

This change fixes the bug and adds a test. Incidentally, the poll()-based implementation has been correct all along.

_Also, three other unrelated, tiny commits that were in my repo._