### PR TITLE
Suppress MSVC warnings in headers files

### DIFF
--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -21,15 +21,13 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "layout.h"
 #include "pointer-helpers.h"
 #include "orphan.h"
 #include "list.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -1093,3 +1091,5 @@ inline kj::Own<PipelineHook> PipelineHook::from(Pipeline&& pipeline) {
 #endif  // !CAPNP_LITE
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -21,10 +21,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #ifndef CAPNP_PRIVATE
 #error "This header is only meant to be included by Cap'n Proto's own source code."
 #endif
@@ -42,6 +38,8 @@
 #if !CAPNP_LITE
 #include "capability.h"
 #endif  // !CAPNP_LITE
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -499,3 +497,5 @@ inline bool SegmentBuilder::tryExtend(word* from, word* to) {
 
 }  // namespace _ (private)
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/blob.h
+++ b/c++/src/capnp/blob.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <kj/common.h>
 #include <kj/string.h>
 #include "common.h"
 #include <string.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -217,3 +215,5 @@ inline kj::ArrayPtr<char> Text::Builder::slice(size_t start, size_t end) {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -21,10 +21,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #if CAPNP_LITE
 #error "RPC APIs, including this header, are not available in lite mode."
 #endif
@@ -34,6 +30,8 @@
 #include "raw-schema.h"
 #include "any.h"
 #include "pointer-helpers.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -1033,3 +1031,5 @@ struct Orphanage::GetInnerReader<T, Kind::INTERFACE> {
 #define CAPNP_CAPABILITY_H_INCLUDED  // for testing includes in unit test
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -25,10 +25,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <inttypes.h>
 #include <kj/string.h>
 #include <kj/memory.h>
@@ -37,6 +33,16 @@
 #if CAPNP_DEBUG_TYPES
 #include <kj/units.h>
 #endif
+
+#if !defined(CAPNP_HEADER_WARNINGS) || !CAPNP_HEADER_WARNINGS
+#define CAPNP_BEGIN_HEADER KJ_BEGIN_SYSTEM_HEADER
+#define CAPNP_END_HEADER KJ_END_SYSTEM_HEADER
+#else
+#define CAPNP_BEGIN_HEADER
+#define CAPNP_END_HEADER
+#endif
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -741,3 +747,5 @@ inline constexpr kj::ArrayPtr<U> arrayPtr(U* ptr, T size) {
 #endif
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compiler/compiler.h
+++ b/c++/src/capnp/compiler/compiler.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <capnp/compiler/grammar.capnp.h>
 #include <capnp/schema.capnp.h>
 #include <capnp/schema-loader.h>
 #include "error-reporter.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace compiler {
@@ -199,3 +197,5 @@ private:
 
 }  // namespace compiler
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compiler/error-reporter.h
+++ b/c++/src/capnp/compiler/error-reporter.h
@@ -21,15 +21,13 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "../common.h"
 #include <kj/string.h>
 #include <kj/exception.h>
 #include <kj/vector.h>
 #include <kj/filesystem.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace compiler {
@@ -94,3 +92,5 @@ private:
 
 }  // namespace compiler
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compiler/lexer.h
+++ b/c++/src/capnp/compiler/lexer.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <capnp/compiler/lexer.capnp.h>
 #include <kj/parse/common.h>
 #include <kj/arena.h>
 #include "error-reporter.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace compiler {
@@ -97,3 +95,5 @@ private:
 
 }  // namespace compiler
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compiler/module-loader.h
+++ b/c++/src/capnp/compiler/module-loader.h
@@ -21,16 +21,14 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "compiler.h"
 #include "error-reporter.h"
 #include <kj/memory.h>
 #include <kj/array.h>
 #include <kj/string.h>
 #include <kj/filesystem.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace compiler {
@@ -60,3 +58,5 @@ private:
 
 }  // namespace compiler
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compiler/node-translator.h
+++ b/c++/src/capnp/compiler/node-translator.h
@@ -21,10 +21,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <capnp/orphan.h>
 #include <capnp/compiler/grammar.capnp.h>
 #include <capnp/schema.capnp.h>
@@ -33,6 +29,8 @@
 #include <kj/one-of.h>
 #include "error-reporter.h"
 #include <map>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace compiler {
@@ -318,3 +316,5 @@ private:
 
 }  // namespace compiler
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compiler/parser.h
+++ b/c++/src/capnp/compiler/parser.h
@@ -21,15 +21,13 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <capnp/compiler/grammar.capnp.h>
 #include <capnp/compiler/lexer.capnp.h>
 #include <kj/parse/common.h>
 #include <kj/arena.h>
 #include "error-reporter.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace compiler {
@@ -146,3 +144,5 @@ private:
 
 }  // namespace compiler
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -32,16 +32,14 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "schema.h"
 #include "layout.h"
 #include "message.h"
 #include "any.h"
 #include "capability.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -1678,3 +1676,5 @@ ReaderFor<T> ConstSchema::as() const {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/endian.h
+++ b/c++/src/capnp/endian.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "common.h"
 #include <inttypes.h>
 #include <string.h>  // memcpy
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace _ {  // private
@@ -304,3 +302,5 @@ using WireValue = ShiftingWireValue<T>;
 
 }  // namespace _ (private)
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/ez-rpc.h
+++ b/c++/src/capnp/ez-rpc.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "rpc.h"
 #include "message.h"
+
+CAPNP_BEGIN_HEADER
 
 struct sockaddr;
 
@@ -249,3 +247,5 @@ inline typename Type::Client EzRpcClient::importCap(kj::StringPtr name) {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -23,10 +23,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "raw-schema.h"
 #include "layout.h"
 #include "list.h"
@@ -36,6 +32,8 @@
 #include <kj/string.h>
 #include <kj/string-tree.h>
 #include <kj/hash.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -411,3 +409,5 @@ CAPNP_DECLARE_SCHEMA(995f9a3377c0b16e);
 //   files which declare streaming methods to avoid including stream.capnp.h.
 }
 }
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -28,16 +28,14 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <kj/common.h>
 #include <kj/memory.h>
 #include "common.h"
 #include "blob.h"
 #include "endian.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+
+CAPNP_BEGIN_HEADER
 
 #if (defined(__mips__) || defined(__hppa__)) && !defined(CAPNP_CANONICALIZE_NAN)
 #define CAPNP_CANONICALIZE_NAN 1
@@ -1271,3 +1269,5 @@ inline OrphanBuilder& OrphanBuilder::operator=(OrphanBuilder&& other) {
 
 }  // namespace _ (private)
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -21,16 +21,14 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "layout.h"
 #include "orphan.h"
 #include <initializer_list>
 #ifdef KJ_STD_COMPAT
 #include <iterator>
 #endif  // KJ_STD_COMPAT
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace _ {  // private
@@ -557,3 +555,5 @@ struct iterator_traits<capnp::_::IndexingIterator<Container, Element>>
 
 }  // namespace std
 #endif  // KJ_STD_COMPAT
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -19,6 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#pragma once
+
 #include <kj/common.h>
 #include <kj/memory.h>
 #include <kj/mutex.h>
@@ -28,11 +30,7 @@
 #include "layout.h"
 #include "any.h"
 
-#pragma once
-
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -564,3 +562,5 @@ kj::Array<word> canonicalize(T&& reader) {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/orphan.h
+++ b/c++/src/capnp/orphan.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "layout.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -435,3 +433,5 @@ inline Orphan<Data> Orphanage::referenceExternalData(Data::Reader data) const {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/pointer-helpers.h
+++ b/c++/src/capnp/pointer-helpers.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "layout.h"
 #include "list.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace _ {  // private
@@ -155,3 +153,5 @@ struct PointerHelpers<UncheckedMessage> {
 
 }  // namespace _ (private)
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/pretty-print.h
+++ b/c++/src/capnp/pretty-print.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "dynamic.h"
 #include <kj/string-tree.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -42,3 +40,5 @@ kj::StringTree prettyPrint(DynamicList::Builder value);
 // any of the KJ debug macros, etc.).
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/raw-schema.h
+++ b/c++/src/capnp/raw-schema.h
@@ -21,15 +21,13 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "common.h"  // for uint and friends
 
 #if _MSC_VER
 #include <atomic>
 #endif
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace _ {  // private
@@ -237,3 +235,5 @@ inline bool RawBrandedSchema::isUnbound() const {
 
 }  // namespace _ (private)
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -24,12 +24,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "capability.h"
 #include "persistent.capnp.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -127,3 +125,5 @@ using ExternalRefFromRealmGatewayClient = ExternalRefFromRealmGateway<typename T
 
 }  // namespace _ (private)
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/rpc-twoparty.h
+++ b/c++/src/capnp/rpc-twoparty.h
@@ -21,15 +21,13 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "rpc.h"
 #include "message.h"
 #include <kj/async-io.h>
 #include <capnp/rpc-twoparty.capnp.h>
 #include <kj/one-of.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -192,3 +190,5 @@ private:
 };
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "capability.h"
 #include "rpc-prelude.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace kj { class AutoCloseFd; }
 
@@ -653,3 +651,5 @@ RpcSystem<VatId> makeRpcClient(
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/schema-lite.h
+++ b/c++/src/capnp/schema-lite.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <capnp/schema.capnp.h>
 #include "message.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -43,3 +41,5 @@ inline schema::Node::Reader schemaProto() {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/schema-loader.h
+++ b/c++/src/capnp/schema-loader.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "schema.h"
 #include <kj/memory.h>
 #include <kj/mutex.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -168,3 +166,5 @@ inline void SchemaLoader::loadCompiledTypeAndDependencies() {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/schema-parser.h
+++ b/c++/src/capnp/schema-parser.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "schema-loader.h"
 #include <kj/string.h>
 #include <kj/filesystem.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -243,3 +241,5 @@ private:
 };
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/schema.h
+++ b/c++/src/capnp/schema.h
@@ -21,10 +21,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #if CAPNP_LITE
 #error "Reflection APIs, including this header, are not available in lite mode."
 #endif
@@ -32,6 +28,8 @@
 #include <capnp/schema.capnp.h>
 #include <kj/hash.h>
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -980,3 +978,5 @@ inline Type Type::wrapInList(uint depth) const {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/serialize-async.h
+++ b/c++/src/capnp/serialize-async.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <kj/async-io.h>
 #include "message.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -90,3 +88,5 @@ inline kj::Promise<void> writeMessage(
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/serialize-packed.h
+++ b/c++/src/capnp/serialize-packed.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "serialize.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -126,3 +124,5 @@ inline void writePackedMessageToFd(int fd, MessageBuilder& builder) {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/serialize-text.h
+++ b/c++/src/capnp/serialize-text.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <kj/string.h>
 #include "dynamic.h"
 #include "orphan.h"
 #include "schema.h"
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -91,3 +89,5 @@ inline Orphan<T> TextCodec::decode(kj::StringPtr input, Orphanage orphanage) con
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -40,12 +40,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include "message.h"
 #include <kj/io.h>
+
+CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
@@ -258,3 +256,5 @@ inline void writeMessageToFd(int fd, MessageBuilder& builder) {
 }
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -21,10 +21,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)
-#pragma GCC system_header
-#endif
-
 #include <capnp/test.capnp.h>
 #include <iostream>
 #include "blob.h"
@@ -34,6 +30,8 @@
 #include "dynamic.h"
 #include <kj/io.h>
 #endif  // !CAPNP_LITE
+
+CAPNP_BEGIN_HEADER
 
 // TODO(cleanup): Auto-generate stringification functions for union discriminants.
 namespace capnproto_test {
@@ -358,3 +356,5 @@ public:
 
 }  // namespace _ (private)
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/kj/arena.h
+++ b/c++/src/kj/arena.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "memory.h"
 #include "array.h"
 #include "string.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -208,3 +206,5 @@ ArrayBuilder<T> Arena::allocateOwnArrayBuilder(size_t capacity) {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "memory.h"
 #include <string.h>
 #include <initializer_list>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -903,3 +901,5 @@ Array<T> ArrayPtr<T>::attach(Attachments&&... attachments) const {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -26,14 +26,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #ifndef KJ_ASYNC_H_INCLUDED
 #error "Do not include this directly; include kj/async.h."
 #include "async.h"  // help IDE parse this file
 #endif
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace _ {  // private
@@ -1306,3 +1304,5 @@ PromiseForResult<Func, void> Executor::executeAsync(Func&& func) const {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "async.h"
 #include "function.h"
 #include "thread.h"
 #include "timer.h"
+
+KJ_BEGIN_HEADER
 
 struct sockaddr;
 
@@ -846,3 +844,5 @@ inline ArrayPtr<const T> AncillaryMessage::asArray() {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -24,12 +24,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "exception.h"
 #include "tuple.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -235,3 +233,5 @@ public:
 
 }  // namespace _ (private)
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -25,15 +25,13 @@
 #error "This file is Unix-specific. On Windows, include async-win32.h instead."
 #endif
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "async.h"
 #include "timer.h"
 #include "vector.h"
 #include "io.h"
 #include <signal.h>
+
+KJ_BEGIN_HEADER
 
 #if __linux__ && !__BIONIC__ && !defined(KJ_USE_EPOLL)
 // Default to epoll on Linux, except on Bionic (Android) which doesn't have signalfd.h.
@@ -323,3 +321,5 @@ private:
 };
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "async-prelude.h"
 #include "exception.h"
 #include "refcount.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -945,3 +943,5 @@ private:
 
 #define KJ_ASYNC_H_INCLUDED
 #include "async-inl.h"
+
+KJ_END_HEADER

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -25,9 +25,30 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
+#ifdef __GNUC__
+#define KJ_BEGIN_SYSTEM_HEADER _Pragma("GCC system_header")
+#elif defined(_MSC_VER)
+#define KJ_BEGIN_SYSTEM_HEADER __pragma(warning(push, 0))
+#define KJ_END_SYSTEM_HEADER __pragma(warning(pop))
 #endif
+
+#ifndef KJ_BEGIN_SYSTEM_HEADER
+#define KJ_BEGIN_SYSTEM_HEADER
+#endif
+
+#ifndef KJ_END_SYSTEM_HEADER
+#define KJ_END_SYSTEM_HEADER
+#endif
+
+#if !defined(KJ_HEADER_WARNINGS) || !KJ_HEADER_WARNINGS
+#define KJ_BEGIN_HEADER KJ_BEGIN_SYSTEM_HEADER
+#define KJ_END_HEADER KJ_END_SYSTEM_HEADER
+#else
+#define KJ_BEGIN_HEADER
+#define KJ_END_HEADER
+#endif
+
+KJ_BEGIN_HEADER
 
 #ifndef KJ_NO_COMPILER_CHECK
 // Technically, __cplusplus should be 201402L for C++14, but GCC 4.9 -- which is supported -- still
@@ -1577,3 +1598,5 @@ _::Deferred<Func> defer(Func&& func) {
 // Run the given code when the function exits, whether by return or exception.
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -106,13 +106,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "string.h"
 #include "exception.h"
 #include "windows-sanity.h"  // work-around macro conflict with `ERROR`
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -581,3 +579,5 @@ inline String Debug::makeDescription<>(const char* macroArgs) {
 
 }  // namespace _ (private)
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -26,11 +26,9 @@
 // - URI encoding
 // - Base64
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "string.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -368,3 +366,5 @@ EncodingResult<Array<byte>> decodeBase64(const char (&text)[s]) {
 }
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "memory.h"
 #include "array.h"
 #include "string.h"
 #include "windows-sanity.h"  // work-around macro conflict with `ERROR`
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -382,3 +380,5 @@ kj::String getCaughtExceptionType();
 // return "(unknown)".
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/function.h
+++ b/c++/src/kj/function.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "memory.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -291,3 +289,5 @@ BoundMethod<T, Func, ConstFunc> boundMethod(T&& t, Func&& func, ConstFunc&& cons
 // contain a copy (by move) of it. The method is allowed to be overloaded.
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "string.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace _ {  // private
@@ -176,3 +174,5 @@ inline uint HashCoder::operator*(const Array<T>& arr) const {
 
 }  // namespace _ (private)
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -21,15 +21,13 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include <stddef.h>
 #include "common.h"
 #include "array.h"
 #include "exception.h"
 #include <stdint.h>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -436,3 +434,5 @@ private:
 #endif  // _WIN32
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/main.h
+++ b/c++/src/kj/main.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "array.h"
 #include "string.h"
 #include "vector.h"
 #include "function.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -402,3 +400,5 @@ private:
 };
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/map.h
+++ b/c++/src/kj/map.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "table.h"
 #include "hash.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -534,3 +532,5 @@ size_t TreeMap<Key, Value>::eraseRange(K1&& k1, K2&& k2) {
 }
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "common.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -555,3 +553,5 @@ Own<Decay<T>> attachVal(T&& value, Attachments&&... attachments) {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/miniposix.h
+++ b/c++/src/kj/miniposix.h
@@ -24,10 +24,6 @@
 // This header provides a small subset of the POSIX API which also happens to be available on
 // Windows under slightly-different names.
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #if _WIN32
 #include <io.h>
 #include <direct.h>
@@ -46,6 +42,8 @@
 #if !_WIN32
 #include <sys/uio.h>
 #endif
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace miniposix {
@@ -147,3 +145,5 @@ inline size_t iovMax(size_t count) {
 
 }  // namespace miniposix
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "memory.h"
 #include <inttypes.h>
 #include "time.h"
+
+KJ_BEGIN_HEADER
 
 #if __linux__ && !defined(KJ_USE_FUTEX)
 #define KJ_USE_FUTEX 1
@@ -558,3 +556,5 @@ inline const T& Lazy<T>::get(Func&& init) const {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/one-of.h
+++ b/c++/src/kj/one-of.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "common.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -291,3 +289,5 @@ void OneOf<Variants...>::allHandled() {
 //   looping, but it's defined as a pointer since that's all we can define in this context.
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/parse/char.h
+++ b/c++/src/kj/parse/char.h
@@ -24,13 +24,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "common.h"
 #include "../string.h"
 #include <inttypes.h>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace parse {
@@ -364,3 +362,5 @@ constexpr auto doubleQuotedHexBinary = sequence(
 
 }  // namespace parse
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/parse/common.h
+++ b/c++/src/kj/parse/common.h
@@ -35,10 +35,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "../common.h"
 #include "../memory.h"
 #include "../array.h"
@@ -47,6 +43,8 @@
 #if _MSC_VER && !__clang__
 #include <type_traits>  // result_of_t
 #endif
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace parse {
@@ -819,3 +817,5 @@ constexpr EndOfInput_ endOfInput = EndOfInput_();
 
 }  // namespace parse
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -23,10 +23,6 @@
 
 #include "memory.h"
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #if _MSC_VER
 #if _MSC_VER < 1910
 #include <intrin.h>
@@ -34,6 +30,8 @@
 #include <intrin0.h>
 #endif
 #endif
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -225,3 +223,5 @@ kj::Own<const T> AtomicRefcounted::addRefInternal(const T* object) {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/std/iostream.h
+++ b/c++/src/kj/std/iostream.h
@@ -25,12 +25,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "../io.h"
 #include <iostream>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace std {
@@ -83,3 +81,5 @@ private:
 
 }  // namespace std
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/string-tree.h
+++ b/c++/src/kj/string-tree.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "string.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -217,3 +215,5 @@ StringTree strTree(Params&&... params) {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include <initializer_list>
 #include "array.h"
 #include <string.h>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
   class StringPtr;
@@ -702,3 +700,5 @@ _::Delimited<T> delimited(T&& arr, kj::StringPtr delim) {
 constexpr kj::StringPtr operator "" _kj(const char* str, size_t n) {
   return kj::StringPtr(kj::ArrayPtr<const char>(str, n + 1));
 };
+
+KJ_END_HEADER

--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -21,10 +21,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "common.h"
 #include "tuple.h"
 #include "vector.h"
@@ -38,6 +34,8 @@
 #include <intrin0.h>
 #endif
 #endif
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -1627,3 +1625,5 @@ private:
 };
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "debug.h"
 #include "vector.h"
 #include "function.h"
 #include "windows-sanity.h"  // work-around macro conflict with `ERROR`
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -163,3 +161,5 @@ private:
 
 }  // namespace _ (private)
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/thread.h
+++ b/c++/src/kj/thread.h
@@ -21,13 +21,11 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "common.h"
 #include "function.h"
 #include "exception.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -80,3 +78,5 @@ private:
 };
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/threadlocal.h
+++ b/c++/src/kj/threadlocal.h
@@ -22,9 +22,6 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
 // This file declares a macro `KJ_THREADLOCAL_PTR` for declaring thread-local pointer-typed
 // variables.  Use like:
 //     KJ_THREADLOCAL_PTR(MyType) foo = nullptr;
@@ -57,6 +54,8 @@
 #if KJ_USE_PTHREAD_TLS
 #include <pthread.h>
 #endif
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -131,3 +130,5 @@ private:
 #endif // KJ_USE_PTHREAD_TLS
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/time.h
+++ b/c++/src/kj/time.h
@@ -22,12 +22,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "units.h"
 #include <inttypes.h>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace _ {  // private
@@ -109,3 +107,5 @@ const MonotonicClock& systemPreciseMonotonicClock();
 // a reasonable operating system the difference is usually negligible.
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/timer.h
+++ b/c++/src/kj/timer.h
@@ -22,12 +22,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "time.h"
 #include "async.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -130,3 +128,5 @@ Promise<T> Timer::timeoutAfter(Duration delay, Promise<T>&& promise) {
 inline TimePoint TimerImpl::now() const { return time; }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/tuple.h
+++ b/c++/src/kj/tuple.h
@@ -37,11 +37,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "common.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace _ {  // private
@@ -441,3 +439,5 @@ template <size_t i, typename Tuple>
 using TypeOfIndex = typename TypeOfIndex_<i, Tuple>::Type;
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -25,12 +25,10 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "common.h"
 #include <inttypes.h>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -1174,3 +1172,5 @@ inline constexpr Range<Quantity<Bounded<value, uint>, Unit>>
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/vector.h
+++ b/c++/src/kj/vector.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#if defined(__GNUC__) && !KJ_HEADER_WARNINGS
-#pragma GCC system_header
-#endif
-
 #include "array.h"
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 
@@ -151,3 +149,5 @@ inline auto KJ_STRINGIFY(const Vector<T>& v) -> decltype(toCharSequence(v.asPtr(
 }
 
 }  // namespace kj
+
+KJ_END_HEADER


### PR DESCRIPTION
For Visual Studio we have to wrap the headers with push/pop pragmas
at the top and bottom of the file.

This diff was programmatically generated as:

```
cd c++
sed -i -f capnp_header_cleanup.sed $(grep
'defined(CAPNP_HEADER_WARNINGS)' --include=*.h -rl src/capnp/)
sed -i -f kj_header_cleanup.sed $(grep 'KJ_HEADER_WARNINGS' --include=*.h -rl
src/kj/)
```

capnp_header_cleanup.sed:
```
/#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)/{
i #ifndef CAPNP_HEADER_WARNINGS
a#ifdef __GNUC__
a#pragma GCC system_header
a#elif defined(_MSC_VER)
a#pragma warning(push, 0)
a#endif  // Compilers
a#endif  // !CAPNP_HEADER_WARNINGS
}

/#if defined(__GNUC__) && !defined(CAPNP_HEADER_WARNINGS)/,/#endif/d

$s/$/\n\n#if defined(_MSC_VER) && !defined(CAPNP_HEADER_WARNINGS)\n#pragma warning(pop)\n#endif/
```

kj_header_cleanup.sed:
```
/#if defined(__GNUC__) && !KJ_HEADER_WARNINGS/{
i #if !defined(KJ_HEADER_WARNINGS) || !KJ_HEADER_WARNINGS
a#ifdef __GNUC__
a#pragma GCC system_header
a#elif defined(_MSC_VER)
a#pragma warning(push, 0))
a#endif  // Compilers
a#endif  // !KJ_HEADER_WARNINGS
}

/#if defined(__GNUC__) && !KJ_HEADER_WARNINGS/,/#endif/d

$s/$/\n\n#if defined(_MSC_VER) && (!defined(KJ_HEADER_WARNINGS) || !KJ_HEADER_WARNINGS)\n#pragma warning(pop)\n#endif/
```

Fixes #893.