### PR TITLE
Add compat/std-iterator.h

### DIFF
--- a/c++/src/capnp/compat/std-iterator.h
+++ b/c++/src/capnp/compat/std-iterator.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+// This exposes IndexingIterator as something compatible with std::iterator so that things like
+// std::copy work with List::begin/List::end.
+
+// Make sure that if this header is before list.h by the user it includes it to make
+// IndexingIterator visible to avoid brittle header problems.
+#include "../list.h"
+#include <iterator>
+
+namespace std {
+
+template <typename Container, typename Element>
+struct iterator_traits<capnp::_::IndexingIterator<Container, Element>>
+      : public std::iterator<std::random_access_iterator_tag, Element, int> {};
+
+}  // namespace std
+

--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -28,9 +28,6 @@
 #include "layout.h"
 #include "orphan.h"
 #include <initializer_list>
-#ifdef KJ_STD_COMPAT
-#include <iterator>
-#endif  // KJ_STD_COMPAT
 
 namespace capnp {
 namespace _ {  // private
@@ -51,6 +48,8 @@ private:
   T value;
 };
 
+// By default this isn't compatible with STL algorithms. To add STL support either define
+// KJ_STD_COMPAT at the top of your compilation unit or include capnp/compat/std-iterator.h.
 template <typename Container, typename Element>
 class IndexingIterator {
 public:
@@ -549,11 +548,5 @@ private:
 }  // namespace capnp
 
 #ifdef KJ_STD_COMPAT
-namespace std {
-
-template <typename Container, typename Element>
-struct iterator_traits<capnp::_::IndexingIterator<Container, Element>>
-      : public std::iterator<std::random_access_iterator_tag, Element, int> {};
-
-}  // namespace std
+#include "compat/std-iterator.h"
 #endif  // KJ_STD_COMPAT


### PR DESCRIPTION
Allow including a header to obtain the iterator traits instead of
needing to carefully define a slightly more obscure macro that someone
might be tempted to define globally.

Fixes #892