### PR TITLE
Add getsockname() to ConnectionReceiver.

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1135,6 +1135,11 @@ public:
   void setsockopt(int level, int option, const void* value, uint length) override {
     KJ_SYSCALL(::setsockopt(fd, level, option, value, length));
   }
+  void getsockname(struct sockaddr* addr, uint* length) override {
+    socklen_t socklen = *length;
+    KJ_SYSCALL(::getsockname(fd, addr, &socklen));
+    *length = socklen;
+  }
 
 public:
   UnixEventPort& eventPort;

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -955,6 +955,11 @@ public:
     KJ_WINSOCK(::setsockopt(fd, level, option,
                             reinterpret_cast<const char*>(value), length));
   }
+  void getsockname(struct sockaddr* addr, uint* length) override {
+    socklen_t socklen = *length;
+    KJ_WINSOCK(::getsockname(fd, addr, &socklen));
+    *length = socklen;
+  }
 
 public:
   Win32EventPort& eventPort;

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -1939,6 +1939,9 @@ void ConnectionReceiver::getsockopt(int level, int option, void* value, uint* le
 void ConnectionReceiver::setsockopt(int level, int option, const void* value, uint length) {
   KJ_UNIMPLEMENTED("Not a socket.");
 }
+void ConnectionReceiver::getsockname(struct sockaddr* addr, uint* length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
 void DatagramPort::getsockopt(int level, int option, void* value, uint* length) {
   KJ_UNIMPLEMENTED("Not a socket.");
 }

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -295,6 +295,7 @@ public:
 
   virtual void getsockopt(int level, int option, void* value, uint* length);
   virtual void setsockopt(int level, int option, const void* value, uint length);
+  virtual void getsockname(struct sockaddr* addr, uint* length);
   // Same as the methods of AsyncIoStream.
 };
 


### PR DESCRIPTION
This is a no-brainer given AsyncIoStream has getsockopt() and getsockname(), whereas ConnectionReceiver has only getsockopt().