### PR TITLE
remove kj-test from CAPNP_LIBRARIES

### DIFF
--- a/c++/cmake/CapnProtoConfig.cmake.in
+++ b/c++/cmake/CapnProtoConfig.cmake.in
@@ -65,7 +65,7 @@ set(CAPNP_INCLUDE_DIRS ${CAPNP_INCLUDE_DIRECTORY})
 # No need to list all libraries, just the leaves of the dependency tree.
 set(CAPNP_LIBRARIES_LITE CapnProto::capnp)
 set(CAPNP_LIBRARIES CapnProto::capnp-rpc CapnProto::capnp-json
-                    CapnProto::kj-http CapnProto::kj-test)
+                    CapnProto::kj-http)
 
 set(CAPNP_DEFINITIONS)
 if(TARGET CapnProto::capnp AND NOT TARGET CapnProto::capnp-rpc)


### PR DESCRIPTION
as kj/test.c++ contains "KJ_MAIN(kj::TestRunner);", this will generate the main entry for a process, so as to hidden the one defined in the main program(which is maybe the most common use case of CAPNP_LIBRARIES)