### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -33,3 +33,15 @@ If you have permission, after you've pushed your changes back to github, you can
     ./push-site.sh
 
 Otherwise, send a pull request and let someone else actually push the new site.
+
+# Package Managers
+
+You can download and install capnproto using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install capnproto
+
+The capnproto port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/doc/README.md
+++ b/doc/README.md
@@ -33,15 +33,3 @@ If you have permission, after you've pushed your changes back to github, you can
     ./push-site.sh
 
 Otherwise, send a pull request and let someone else actually push the new site.
-
-# Package Managers
-
-You can download and install capnproto using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install capnproto
-
-The capnproto port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/doc/install.md
+++ b/doc/install.md
@@ -139,7 +139,7 @@ Cap'n Proto can also be built with MinGW or Cygwin, using the Unix/autotools bui
 The C++ sources are located under `c++` directory in the git repository. The build instructions are
 otherwise the same as for the release zip.
 
-# Installation: vcpkg
+## Installation: vcpkg
 
 You can download and install capnproto using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -139,3 +139,14 @@ Cap'n Proto can also be built with MinGW or Cygwin, using the Unix/autotools bui
 The C++ sources are located under `c++` directory in the git repository. The build instructions are
 otherwise the same as for the release zip.
 
+# Installation: vcpkg
+
+You can download and install capnproto using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install capnproto
+
+The capnproto port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
capnproto is available as a port in vcpkg, a C++ library manager that simplifies installation for capnproto and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build capnproto, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/capnproto/portfile.cmake). We try to keep the library maintained as close as possible to the original library.