### PR TITLE
Fix Table::findOrCreate() to be exception-safe.

### DIFF
--- a/c++/src/kj/map-test.c++
+++ b/c++/src/kj/map-test.c++
@@ -148,6 +148,25 @@ KJ_TEST("TreeMap range") {
   }
 }
 
+KJ_TEST("HashMap findOrCreate throws") {
+  HashMap<int, String> m;
+  try {
+    m.findOrCreate(1, []() -> HashMap<int, String>::Entry {
+      throw "foo";
+    });
+    KJ_FAIL_ASSERT("shouldn't get here");
+  } catch (const char*) {
+    // expected
+  }
+
+  KJ_EXPECT(m.find(1) == nullptr);
+  m.findOrCreate(1, []() {
+    return HashMap<int, String>::Entry { 1, kj::str("ok") };
+  });
+
+  KJ_EXPECT(KJ_ASSERT_NONNULL(m.find(1)) == "ok");
+}
+
 }  // namespace
 }  // namespace _
 }  // namespace kj

--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -638,11 +638,15 @@ public:
       return table.rows[*existing];
     } else {
       bool success = false;
+      KJ_DEFER({
+        if (!success) {
+          get<index>(table.indexes).erase(table.rows.asPtr(), pos, params...);
+        }
+      });
       auto& newRow = table.rows.add(createFunc());
       KJ_DEFER({
         if (!success) {
           table.rows.removeLast();
-          get<index>(table.indexes).erase(table.rows.asPtr(), pos, params...);
         }
       });
       if (Table<Row, Indexes...>::template Impl<>::insert(table, pos, newRow, index) == nullptr) {


### PR DESCRIPTION
If the creator callback throws, we shouldn't leave the table broken.