### PR TITLE
Fix bug in byte stream path-shortening.

### DIFF
--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -774,6 +774,9 @@ public:
   template <typename Pipeline, typename = FromPipeline<Pipeline>>
   static inline kj::Own<PipelineHook> from(Pipeline&& pipeline);
 
+  template <typename Pipeline, typename = FromPipeline<Pipeline>>
+  static inline PipelineHook& from(Pipeline& pipeline);
+
 private:
   template <typename T> struct FromImpl;
 };
@@ -1096,6 +1099,9 @@ struct PipelineHook::FromImpl {
   static inline kj::Own<PipelineHook> apply(typename T::Pipeline&& pipeline) {
     return from(kj::mv(pipeline._typeless));
   }
+  static inline PipelineHook& apply(typename T::Pipeline& pipeline) {
+    return from(pipeline._typeless);
+  }
 };
 
 template <>
@@ -1103,11 +1109,19 @@ struct PipelineHook::FromImpl<AnyPointer> {
   static inline kj::Own<PipelineHook> apply(AnyPointer::Pipeline&& pipeline) {
     return kj::mv(pipeline.hook);
   }
+  static inline PipelineHook& apply(AnyPointer::Pipeline& pipeline) {
+    return *pipeline.hook;
+  }
 };
 
 template <typename Pipeline, typename T>
 inline kj::Own<PipelineHook> PipelineHook::from(Pipeline&& pipeline) {
   return FromImpl<T>::apply(kj::fwd<Pipeline>(pipeline));
+}
+
+template <typename Pipeline, typename T>
+inline PipelineHook& PipelineHook::from(Pipeline& pipeline) {
+  return FromImpl<T>::apply(pipeline);
 }
 
 #endif  // !CAPNP_LITE

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -26,6 +26,7 @@
 #include "orphan.h"
 #include "list.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+#include <kj/hash.h>
 
 CAPNP_BEGIN_HEADER
 
@@ -734,6 +735,25 @@ struct PipelineOp {
     uint16_t pointerIndex;  // for GET_POINTER_FIELD
   };
 };
+
+inline uint KJ_HASHCODE(const PipelineOp& op) {
+  switch (op.type) {
+    case PipelineOp::NOOP: return kj::hashCode(op.type);
+    case PipelineOp::GET_POINTER_FIELD: return kj::hashCode(op.type, op.pointerIndex);
+  }
+}
+
+inline bool operator==(const PipelineOp& a, const PipelineOp& b) {
+  if (a.type != b.type) return false;
+  switch (a.type) {
+    case PipelineOp::NOOP: return true;
+    case PipelineOp::GET_POINTER_FIELD: return a.pointerIndex == b.pointerIndex;
+  }
+}
+
+inline bool operator!=(const PipelineOp& a, const PipelineOp& b) {
+  return !(a == b);
+}
 
 class PipelineHook {
   // Represents a currently-running call, and implements pipelined requests on its result.

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -741,6 +741,7 @@ inline uint KJ_HASHCODE(const PipelineOp& op) {
     case PipelineOp::NOOP: return kj::hashCode(op.type);
     case PipelineOp::GET_POINTER_FIELD: return kj::hashCode(op.type, op.pointerIndex);
   }
+  KJ_CLANG_KNOWS_THIS_IS_UNREACHABLE_BUT_GCC_DOESNT
 }
 
 inline bool operator==(const PipelineOp& a, const PipelineOp& b) {
@@ -749,6 +750,7 @@ inline bool operator==(const PipelineOp& a, const PipelineOp& b) {
     case PipelineOp::NOOP: return true;
     case PipelineOp::GET_POINTER_FIELD: return a.pointerIndex == b.pointerIndex;
   }
+  KJ_CLANG_KNOWS_THIS_IS_UNREACHABLE_BUT_GCC_DOESNT
 }
 
 inline bool operator!=(const PipelineOp& a, const PipelineOp& b) {

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -794,9 +794,9 @@ public:
 
 class BrokenClient final: public ClientHook, public kj::Refcounted {
 public:
-  BrokenClient(const kj::Exception& exception, bool resolved, const void* brand = nullptr)
+  BrokenClient(const kj::Exception& exception, bool resolved, const void* brand)
       : exception(exception), resolved(resolved), brand(brand) {}
-  BrokenClient(const kj::StringPtr description, bool resolved, const void* brand = nullptr)
+  BrokenClient(const kj::StringPtr description, bool resolved, const void* brand)
       : exception(kj::Exception::Type::FAILED, "", 0, kj::str(description)),
         resolved(resolved), brand(brand) {}
 
@@ -841,7 +841,7 @@ private:
 };
 
 kj::Own<ClientHook> BrokenPipeline::getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) {
-  return kj::refcounted<BrokenClient>(exception, false);
+  return kj::refcounted<BrokenClient>(exception, false, &ClientHook::BROKEN_CAPABILITY_BRAND);
 }
 
 kj::Own<ClientHook> newNullCap() {
@@ -853,11 +853,11 @@ kj::Own<ClientHook> newNullCap() {
 }  // namespace
 
 kj::Own<ClientHook> newBrokenCap(kj::StringPtr reason) {
-  return kj::refcounted<BrokenClient>(reason, false);
+  return kj::refcounted<BrokenClient>(reason, false, &ClientHook::BROKEN_CAPABILITY_BRAND);
 }
 
 kj::Own<ClientHook> newBrokenCap(kj::Exception&& reason) {
-  return kj::refcounted<BrokenClient>(kj::mv(reason), false);
+  return kj::refcounted<BrokenClient>(kj::mv(reason), false, &ClientHook::BROKEN_CAPABILITY_BRAND);
 }
 
 kj::Own<PipelineHook> newBrokenPipeline(kj::Exception&& reason) {

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -304,6 +304,49 @@ private:
 
   kj::Promise<void> selfResolutionOp;
   // Represents the operation which will set `redirect` when possible.
+
+  kj::HashMap<kj::Array<PipelineOp>, kj::Own<ClientHook>> clientMap;
+  // If the same pipelined cap is requested twice, we have to return the same object. This is
+  // necessary because each ClientHook we create is a QueuedClient which queues up calls. If we
+  // return a new one each time, there will be several queues, and ordering of calls will be lost
+  // between the queues.
+  //
+  // One case where this is particularly problematic is with promises resolved over RPC. Consider
+  // this case:
+  //
+  // * Alice holds a promise capability P pointing towards Bob.
+  // * Bob makes a call Q on an object hosted by Alice.
+  // * Without waiting for Q to complete, Bob obtains a pipelined-promise capability for Q's
+  //   eventual result, P2.
+  // * Alice invokes a method M on P. The call is sent to Bob.
+  // * Bob resolves Alice's original promise P to P2.
+  // * Alice receives a Resolve message from Bob resolving P to Q's eventual result.
+  //   * As a result, Alice calls getPipelinedCap() on the QueuedPipeline for Q's result, which
+  //     returns a QueuedClient for that result, which we'll call QR1.
+  //   * Alice also sends a Disembargo to Bob.
+  // * Alice calls a method M2 on P. This call is blocked locally waiting for the disembargo to
+  //   complete.
+  // * Bob receives Alice's first method call, M. Since it's addressed to P, which later resolved
+  //   to Q's result, Bob reflects the call back to Alice.
+  // * Alice receives the reflected call, which is addressed to Q's result.
+  //   * Alice calls getPipelinedCap() on the QueuedPipeline for Q's result, which returns a
+  //     QueuedClient for that result, which we'll call QR2.
+  //   * Alice enqueues the call M on QR2.
+  // * Bob receives Alice's Disembargo message, and reflects it back.
+  // * Alices receives the Disembrago.
+  //   * Alice unblocks the method cgall M2, which had been blocked on the embargo.
+  //   * The call M2 is then equeued onto QR1.
+  // * Finally, the call Q completes.
+  //   * This causes QR1 and QR2 to resolve to their final destinations. But if QR1 and QR2 are
+  //     separate objects, then one of them must resolve first. QR1 was created first, so naturally
+  //     it resolves first, followed by QR2.
+  //   * Because QR1 resolves first, method call M2 is delivered first.
+  //   * QR2 resolves second, so method call M1 is delivered next.
+  //   * THIS IS THE WRONG ORDER!
+  //
+  // In order to avoid this problem, it's necessary for QR1 and QR2 to be the same object, so that
+  // they share the same call queue. In this case, M2 is correctly enqueued onto QR2 *after* M1 was
+  // enqueued on QR1, and so the method calls are delivered in the correct order.
 };
 
 class QueuedClient final: public ClientHook, public kj::Refcounted {
@@ -444,12 +487,15 @@ kj::Own<ClientHook> QueuedPipeline::getPipelinedCap(kj::Array<PipelineOp>&& ops)
   KJ_IF_MAYBE(r, redirect) {
     return r->get()->getPipelinedCap(kj::mv(ops));
   } else {
-    auto clientPromise = promise.addBranch().then(kj::mvCapture(ops,
-        [](kj::Array<PipelineOp>&& ops, kj::Own<PipelineHook> pipeline) {
-          return pipeline->getPipelinedCap(kj::mv(ops));
-        }));
-
-    return kj::refcounted<QueuedClient>(kj::mv(clientPromise));
+    return clientMap.findOrCreate(ops.asPtr(), [&]() {
+      auto clientPromise = promise.addBranch()
+          .then([ops = KJ_MAP(op, ops) { return op; }](kj::Own<PipelineHook> pipeline) {
+        return pipeline->getPipelinedCap(kj::mv(ops));
+      });
+      return kj::HashMap<kj::Array<PipelineOp>, kj::Own<ClientHook>>::Entry {
+        kj::mv(ops), kj::refcounted<QueuedClient>(kj::mv(clientPromise))
+      };
+    })->addRef();
   }
 }
 

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -649,11 +649,15 @@ public:
   // therefore it can transfer the capability without proxying.
 
   static const uint NULL_CAPABILITY_BRAND;
-  // Value is irrelevant; used for pointer.
+  static const uint BROKEN_CAPABILITY_BRAND;
+  // Values are irrelevant; used for pointers.
 
   inline bool isNull() { return getBrand() == &NULL_CAPABILITY_BRAND; }
   // Returns true if the capability was created as a result of assigning a Client to null or by
   // reading a null pointer out of a Cap'n Proto message.
+
+  inline bool isError() { return getBrand() == &BROKEN_CAPABILITY_BRAND; }
+  // Returns true if the capability was created by newBrokenCap().
 
   virtual kj::Maybe<int> getFd() = 0;
   // Implements Capability::Client::getFd(). If this returns null but whenMoreResolved() returns

--- a/c++/src/capnp/compat/byte-stream-test.c++
+++ b/c++/src/capnp/compat/byte-stream-test.c++
@@ -379,6 +379,78 @@ KJ_TEST("KJ -> ByteStream RPC -> KJ pipe -> ByteStream RPC -> KJ with concurrent
   writePromise3.wait(waitScope);
 }
 
+KJ_TEST("KJ -> KJ pipe -> ByteStream RPC -> KJ pipe -> ByteStream RPC -> KJ with concurrent shortening") {
+  // Same as previous test, except we add a KJ pipe at the beginning and pump it into the top of
+  // the pipe, which invokes tryPumpFrom() on the KjToCapnpStreamAdapter.
+
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory clientFactory;
+  ByteStreamFactory serverFactory;
+
+  auto backPipe = kj::newOneWayPipe();
+  auto middlePipe = kj::newOneWayPipe();
+  auto frontPipe = kj::newOneWayPipe();
+
+  ExactPointerWriter exactPointerWriter;
+  auto backPumpPromise = backPipe.in->pumpTo(exactPointerWriter);
+
+  auto rpcConnection = kj::newTwoWayPipe();
+  capnp::TwoPartyClient client(*rpcConnection.ends[0],
+      clientFactory.kjToCapnp(kj::mv(backPipe.out)),
+      rpc::twoparty::Side::CLIENT);
+  capnp::TwoPartyClient server(*rpcConnection.ends[1],
+      serverFactory.kjToCapnp(kj::mv(middlePipe.out)),
+      rpc::twoparty::Side::CLIENT);
+
+  auto backWrapped = serverFactory.capnpToKj(server.bootstrap().castAs<ByteStream>());
+  auto midPumpPormise = middlePipe.in->pumpTo(*backWrapped);
+
+  auto wrapped = clientFactory.capnpToKj(client.bootstrap().castAs<ByteStream>());
+  auto frontPumpPromise = frontPipe.in->pumpTo(*wrapped);
+
+  char buffer[7] = "foobar";
+  auto writePromise = frontPipe.out->write(buffer, 6);
+
+  // The write went to RPC so it's not immediately received.
+  KJ_EXPECT(exactPointerWriter.receivedBuffer == nullptr);
+
+  // Write should be received after we turn the event loop.
+  waitScope.poll();
+  KJ_EXPECT(exactPointerWriter.receivedBuffer != nullptr);
+
+  // Note that the promise that write() returned above has already resolved, because it hit RPC
+  // and went into the streaming window.
+  KJ_ASSERT(writePromise.poll(waitScope));
+  writePromise.wait(waitScope);
+
+  // Let's start a second write. Even though the first write technically isn't done yet, it's
+  // legal for us to start a second one because the first write's returned promise optimistically
+  // resolved for streaming window reasons. This ends up being a very tricky case for our code!
+  char buffer2[7] = "bazqux";
+  auto writePromise2 = frontPipe.out->write(buffer2, 6);
+
+  // Now check the first write was correct, and close it out.
+  KJ_EXPECT(kj::str(exactPointerWriter.receivedBuffer) == "foobar");
+  exactPointerWriter.fulfill();
+
+  // Turn event loop again. Now the second write arrives.
+  waitScope.poll();
+  KJ_EXPECT(kj::str(exactPointerWriter.receivedBuffer) == "bazqux");
+  exactPointerWriter.fulfill();
+  writePromise2.wait(waitScope);
+
+  // If we do another write now, it should be zero-copy, because everything has settled.
+  char buffer3[6] = "corge";
+  auto writePromise3 = frontPipe.out->write(buffer3, 5);
+  KJ_EXPECT(exactPointerWriter.receivedBuffer.begin() == buffer3);
+  KJ_EXPECT(exactPointerWriter.receivedBuffer.size() == 5);
+  KJ_EXPECT(!writePromise3.poll(waitScope));
+  exactPointerWriter.fulfill();
+  writePromise3.wait(waitScope);
+}
+
 KJ_TEST("Two Substreams on one destination") {
   kj::EventLoop eventLoop;
   kj::WaitScope waitScope(eventLoop);

--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -730,6 +730,7 @@ public:
         }
       }
       KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client*) {
+        // TODO(perf): Split very large writes into many smaller writes.
         auto req = capnpStream->writeRequest(MessageSize { 8 + size / sizeof(word), 0 });
         req.setBytes(kj::arrayPtr(reinterpret_cast<const byte*>(buffer), size));
         return req.send();
@@ -794,6 +795,7 @@ public:
         }
       }
       KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client*) {
+        // TODO(perf): Split very large writes into many smaller writes.
         size_t size = 0;
         for (auto& piece: pieces) size += piece.size();
         auto req = capnpStream->writeRequest(MessageSize { 8 + size / sizeof(word), 0 });

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -53,6 +53,7 @@ void setGlobalBrokenCapFactoryForLayoutCpp(BrokenCapFactory& factory) {
 }  // namespace _ (private)
 
 const uint ClientHook::NULL_CAPABILITY_BRAND = 0;
+const uint ClientHook::BROKEN_CAPABILITY_BRAND = 0;
 // Defined here rather than capability.c++ so that we can safely call isNull() in this file.
 
 namespace _ {  // private

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -2973,7 +2973,7 @@ private:
 
         // We need to insert an evalLast() here to make sure that any pending calls towards this
         // cap have had time to find their way through the event loop.
-        tasks.add(kj::evalLast(kj::mvCapture(
+        tasks.add(canceler.wrap(kj::evalLast(kj::mvCapture(
             target, [this,embargoId](kj::Own<ClientHook>&& target) {
           if (!connection.is<Connected>()) {
             return;
@@ -3003,7 +3003,7 @@ private:
           builder.getContext().setReceiverLoopback(embargoId);
 
           message->send();
-        })));
+        }))));
 
         break;
       }

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -884,9 +884,9 @@ private:
           importId(importId),
           fork(eventual.then(
               [this](kj::Own<ClientHook>&& resolution) {
-                return resolve(kj::mv(resolution), false);
+                return resolve(kj::mv(resolution));
               }, [this](kj::Exception&& exception) {
-                return resolve(newBrokenCap(kj::mv(exception)), true);
+                return resolve(newBrokenCap(kj::mv(exception)));
               }).catch_([&](kj::Exception&& e) {
                 // Make any exceptions thrown from resolve() go to the connection's TaskSet which
                 // will cause the connection to be terminated.
@@ -1019,7 +1019,7 @@ private:
 
     bool receivedCall = false;
 
-    kj::Promise<kj::Own<ClientHook>> resolve(kj::Own<ClientHook> replacement, bool isError) {
+    kj::Promise<kj::Own<ClientHook>> resolve(kj::Own<ClientHook> replacement) {
       const void* replacementBrand = replacement->getBrand();
 
       // If the original capability was used for streaming calls, it will have a
@@ -1042,7 +1042,8 @@ private:
 
       if (replacementBrand != connectionState.get() &&
           replacementBrand != &ClientHook::NULL_CAPABILITY_BRAND &&
-          receivedCall && !isError && connectionState->connection.is<Connected>()) {
+          replacementBrand != &ClientHook::BROKEN_CAPABILITY_BRAND &&
+          receivedCall && connectionState->connection.is<Connected>()) {
         // The new capability is hosted locally, not on the remote machine.  And, we had made calls
         // to the promise.  We need to make sure those calls echo back to us before we allow new
         // calls to go directly to the local capability, so we need to set a local embargo and send

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -400,8 +400,8 @@ public:
           return kj::READY_NOW;
         });
     disconnectFulfiller->fulfill(DisconnectInfo { kj::mv(shutdownPromise) });
-    canceler.cancel(networkException);
     connection.init<Disconnected>(kj::mv(networkException));
+    canceler.cancel(networkException);
   }
 
   void setFlowLimit(size_t words) {

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -1562,7 +1562,7 @@ private:
           if (result->getBrand() == this) {
             result = kj::refcounted<TribbleRaceBlocker>(kj::mv(result));
           }
-          return result;
+          return kj::mv(result);
         } else {
           return newBrokenCap("invalid 'receiverHosted' export ID");
         }
@@ -1578,7 +1578,7 @@ private:
                 if (result->getBrand() == this) {
                   result = kj::refcounted<TribbleRaceBlocker>(kj::mv(result));
                 }
-                return result;
+                return kj::mv(result);
               } else {
                 return newBrokenCap("unrecognized pipeline ops");
               }

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -1147,10 +1147,9 @@ private:
         embargo.fulfiller = kj::mv(paf.fulfiller);
 
         // Make a promise which resolves to `replacement` as soon as the `Disembargo` comes back.
-        auto embargoPromise = paf.promise.then(
-            kj::mvCapture(replacement, [](kj::Own<ClientHook>&& replacement) {
-              return kj::mv(replacement);
-            }));
+        auto embargoPromise = paf.promise.then([replacement = kj::mv(replacement)]() mutable {
+          return kj::mv(replacement);
+        });
 
         // We need to queue up calls in the meantime, so we'll resolve ourselves to a local promise
         // client instead.

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -221,6 +221,8 @@ class TestCallOrderImpl final: public test::TestCallOrder::Server {
 public:
   kj::Promise<void> getCallSequence(GetCallSequenceContext context) override;
 
+  uint getCount() { return count; }
+
 private:
   uint count = 0;
 };


### PR DESCRIPTION
Apparently, I only initiated capability promise resolution in one of LocalClient's two constructors. Ironically, the other constructor is always the one used by ByteStreams created by ByteStreamFactory, because they are always placed in a CapabilityServerSet. The effect is that ByteStreams couldn't be path-shortened in cases that require promise capabilities to resolve before unwrapping can occur, such as over RPC.

This PR fixes the bug and adds a test covering the RPC use case.