### PR TITLE
Fix aliasing violation.

### DIFF
--- a/c++/src/kj/function.h
+++ b/c++/src/kj/function.h
@@ -229,7 +229,7 @@ public:
   }
 
 private:
-  void* space[2];
+  alignas(void*) char space[2 * sizeof(void*)];
 
   class WrapperBase {
   public:


### PR DESCRIPTION
Since we store a different type in this space, we need to allocate the space as `char` to comply with aliasing rules. This actually caused a problem under GCC 10 on armv7hl with optimizations enabled, and this patch is reported to fix it.

Fixes #937.