### PR TITLE
Fix cygwin hang.

### DIFF
--- a/super-test.sh
+++ b/super-test.sh
@@ -15,8 +15,8 @@ function test_samples() {
   ./calculator-server unix:/tmp/capnp-calculator-example-$$ &
   sleep 0.1
   ./calculator-client unix:/tmp/capnp-calculator-example-$$
-  kill %+
-  wait %+ || true
+  kill %./calculator-server
+  wait %./calculator-server || true
   rm -f /tmp/capnp-calculator-example-$$
 }
 


### PR DESCRIPTION
It turns out that this doesn't really work:

    kill %+
    wait %+

The problem is, as soon as bash notices that the job has exited, it reaps the job and forgets about it. If this happens before executing `wait %+`, then it will wait for the wrong thing. If there are no other background jobs, then it just fails (probably why I added `|| true`), but if there is some other background job, it'll wait for that, perhaps forever. This seems to be happening with our Cygwin build.

We can fix this by being more specific about which job we're trying to kill and wait for, namely `./calculator-server`. If bash reaps the job too quickly, the `wait` will now just fail since no jobs will match (... one hopes).