### PR TITLE
Double check endTime in Mutex::wait() on Windows

### DIFF
--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -547,8 +547,8 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout) {
     } else {
       DWORD error = GetLastError();
       if (error == ERROR_TIMEOUT) {
-        // Timed out. Skip predicate check.
-        return;
+        // Windows may have woken us up too early, so don't return yet. Instead, proceed through the
+        // loop and rely on our sleep time recalculation to detect if we timed out.
       } else {
         KJ_FAIL_WIN32("SleepConditionVariableSRW()", error);
       }


### PR DESCRIPTION
This fixes a failure I observed on my Windows VM at mutex-test.c++:281, in which value.when() was timing out up to 6ms too early.

I preserved the existing behavior in the event endTime is null and the error is ERROR_TIMEOUT. I'm not sure it's correct, though.