### PR TITLE
Remove `UnalignedFlatArrayMessageReader`.

### DIFF
--- a/c++/src/capnp/arena.c++
+++ b/c++/src/capnp/arena.c++
@@ -71,6 +71,22 @@ static SegmentWordCount verifySegmentSize(size_t size) {
   });
 }
 
+static SegmentWordCount verifySegment(kj::ArrayPtr<const word> segment) {
+#if !CAPNP_ALLOW_UNALIGNED
+  KJ_REQUIRE(reinterpret_cast<uintptr_t>(segment.begin()) % sizeof(void*) == 0,
+      "Detected unaligned data in Cap'n Proto message. Messages must be aligned to the "
+      "architecture's word size. Yes, even on x86: Unaligned access is undefined behavior "
+      "under the C/C++ language standard, and compilers can and do assume alignment for the "
+      "purpose of optimizations. Unaligned access may lead to crashes or subtle corruption. "
+      "For example, GCC will use SIMD instructions in optimizations, and those instrsuctions "
+      "require alignment. If you really insist on taking your changes with unaligned data, "
+      "compile the Cap'n Proto library with -DCAPNP_ALLOW_UNALIGNED to remove this check.") {
+    break;
+  }
+#endif
+  return verifySegmentSize(segment.size());
+}
+
 inline ReaderArena::ReaderArena(MessageReader* message, const word* firstSegment,
                                 SegmentWordCount firstSegmentSize)
     : message(message),
@@ -78,7 +94,7 @@ inline ReaderArena::ReaderArena(MessageReader* message, const word* firstSegment
       segment0(this, SegmentId(0), firstSegment, firstSegmentSize, &readLimiter) {}
 
 inline ReaderArena::ReaderArena(MessageReader* message, kj::ArrayPtr<const word> firstSegment)
-    : ReaderArena(message, firstSegment.begin(), verifySegmentSize(firstSegment.size())) {}
+    : ReaderArena(message, firstSegment.begin(), verifySegment(firstSegment)) {}
 
 ReaderArena::ReaderArena(MessageReader* message)
     : ReaderArena(message, message->getSegment(0)) {}
@@ -119,7 +135,7 @@ SegmentReader* ReaderArena::tryGetSegment(SegmentId id) {
     return nullptr;
   }
 
-  SegmentWordCount newSegmentSize = verifySegmentSize(newSegment.size());
+  SegmentWordCount newSegmentSize = verifySegment(newSegment);
 
   if (*lock == nullptr) {
     // OK, the segment exists, so allocate the map.
@@ -148,7 +164,7 @@ BuilderArena::BuilderArena(MessageBuilder* message,
                            kj::ArrayPtr<MessageBuilder::SegmentInit> segments)
     : message(message),
       segment0(this, SegmentId(0), segments[0].space.begin(),
-               verifySegmentSize(segments[0].space.size()),
+               verifySegment(segments[0].space),
                &this->dummyLimiter, verifySegmentSize(segments[0].wordsUsed)) {
   if (segments.size() > 1) {
     kj::Vector<kj::Own<SegmentBuilder>> builders(segments.size() - 1);
@@ -156,7 +172,7 @@ BuilderArena::BuilderArena(MessageBuilder* message,
     uint i = 1;
     for (auto& segment: segments.slice(1, segments.size())) {
       builders.add(kj::heap<SegmentBuilder>(
-          this, SegmentId(i++), segment.space.begin(), verifySegmentSize(segment.space.size()),
+          this, SegmentId(i++), segment.space.begin(), verifySegment(segment.space),
           &this->dummyLimiter, verifySegmentSize(segment.wordsUsed)));
     }
 
@@ -211,7 +227,7 @@ BuilderArena::AllocateResult BuilderArena::allocate(SegmentWordCount amount) {
   if (segment0.getArena() == nullptr) {
     // We're allocating the first segment.
     kj::ArrayPtr<word> ptr = message->allocateSegment(unbound(amount / WORDS));
-    auto actualSize = verifySegmentSize(ptr.size());
+    auto actualSize = verifySegment(ptr);
 
     // Re-allocate segment0 in-place.  This is a bit of a hack, but we have not returned any
     // pointers to this segment yet, so it should be fine.

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -3128,11 +3128,6 @@ StructReader ListReader::getStructElement(ElementCount index) const {
   const WirePointer* structPointers =
       reinterpret_cast<const WirePointer*>(structData + structDataSize / BITS_PER_BYTE);
 
-  // This check should pass if there are no bugs in the list pointer validation code.
-  KJ_DASSERT(structPointerCount == ZERO * POINTERS ||
-         (uintptr_t)structPointers % sizeof(void*) == 0,
-         "Pointer section of struct list element not aligned.");
-
   KJ_DASSERT(indexBit % BITS_PER_BYTE == ZERO * BITS);
   return StructReader(
       segment, capTable, structData, structPointers,

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -3128,6 +3128,11 @@ StructReader ListReader::getStructElement(ElementCount index) const {
   const WirePointer* structPointers =
       reinterpret_cast<const WirePointer*>(structData + structDataSize / BITS_PER_BYTE);
 
+  // This check should pass if there are no bugs in the list pointer validation code.
+  KJ_DASSERT(structPointerCount == ZERO * POINTERS ||
+         (uintptr_t)structPointers % sizeof(void*) == 0,
+         "Pointer section of struct list element not aligned.");
+
   KJ_DASSERT(indexBit % BITS_PER_BYTE == ZERO * BITS);
   return StructReader(
       segment, capTable, structData, structPointers,
@@ -3508,8 +3513,6 @@ OrphanBuilder OrphanBuilder::concat(
 }
 
 OrphanBuilder OrphanBuilder::referenceExternalData(BuilderArena* arena, Data::Reader data) {
-  // TODO(someday): We now allow unaligned segments on architectures thata support it. We could
-  //   consider relaxing this check as well?
   KJ_REQUIRE(reinterpret_cast<uintptr_t>(data.begin()) % sizeof(void*) == 0,
              "Cannot referenceExternalData() that is not aligned.");
 

--- a/c++/src/capnp/message-test.c++
+++ b/c++/src/capnp/message-test.c++
@@ -176,6 +176,22 @@ KJ_TEST("clone()") {
   checkTestMessage(*copy);
 }
 
+#if !CAPNP_ALLOW_UNALIGNED
+KJ_TEST("disallow unaligned") {
+  union {
+    char buffer[16];
+    word align;
+  };
+  memset(buffer, 0, sizeof(buffer));
+
+  auto unaligned = kj::arrayPtr(reinterpret_cast<word*>(buffer + 1), 1);
+
+  kj::ArrayPtr<const word> segments[1] = {unaligned};
+  SegmentArrayMessageReader message(segments);
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("unaligned", message.getRoot<TestAllTypes>());
+}
+#endif
+
 // TODO(test):  More tests.
 
 }  // namespace

--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -104,10 +104,6 @@ public:
   virtual kj::ArrayPtr<const word> getSegment(uint id) = 0;
   // Gets the segment with the given ID, or returns null if no such segment exists. This method
   // will be called at most once for each segment ID.
-  //
-  // The returned array must be aligned properly for the host architecture. This means that on
-  // x86/x64, alignment is optional, though recommended for performance, whereas on many other
-  // architectures, alignment is required.
 
   inline const ReaderOptions& getOptions();
   // Get the options passed to the constructor.
@@ -204,10 +200,6 @@ public:
   // allocateSegment() is responsible for zeroing the memory before returning. This is required
   // because otherwise the Cap'n Proto implementation would have to zero the memory anyway, and
   // many allocators are able to provide already-zero'd memory more efficiently.
-  //
-  // The returned array must be aligned properly for the host architecture. This means that on
-  // x86/x64, alignment is optional, though recommended for performance, whereas on many other
-  // architectures, alignment is required.
 
   template <typename RootType>
   typename RootType::Builder initRoot();

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -102,20 +102,6 @@ TEST(Serialize, FlatArray) {
     EXPECT_EQ(serializedWithSuffix.end() - 5, reader.getEnd());
   }
 
-#if __i386__ || __x86_64__ || __aarch64__ || _MSC_VER
-  // Try unaligned.
-  {
-    auto bytes = kj::heapArray<byte>(serializedWithSuffix.size() * sizeof(word) + 1);
-    auto unalignedWords = kj::arrayPtr(
-        reinterpret_cast<word*>(bytes.begin() + 1), serializedWithSuffix.size());
-    memcpy(unalignedWords.asBytes().begin(), serializedWithSuffix.asBytes().begin(),
-        serializedWithSuffix.asBytes().size());
-    UnalignedFlatArrayMessageReader reader(unalignedWords);
-    checkTestMessage(reader.getRoot<TestAllTypes>());
-    EXPECT_EQ(unalignedWords.end() - 5, reader.getEnd());
-  }
-#endif
-
   {
     MallocMessageBuilder builder2;
     auto remaining = initMessageBuilderFromFlatArrayCopy(serializedWithSuffix, builder2);

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -26,7 +26,7 @@
 
 namespace capnp {
 
-UnalignedFlatArrayMessageReader::UnalignedFlatArrayMessageReader(
+FlatArrayMessageReader::FlatArrayMessageReader(
     kj::ArrayPtr<const word> array, ReaderOptions options)
     : MessageReader(options), end(array.end()) {
   if (array.size() < 1) {
@@ -98,7 +98,7 @@ size_t expectedSizeInWordsFromPrefix(kj::ArrayPtr<const word> array) {
   return totalSize;
 }
 
-kj::ArrayPtr<const word> UnalignedFlatArrayMessageReader::getSegment(uint id) {
+kj::ArrayPtr<const word> FlatArrayMessageReader::getSegment(uint id) {
   if (id == 0) {
     return segment0;
   } else if (id <= moreSegments.size()) {
@@ -106,15 +106,6 @@ kj::ArrayPtr<const word> UnalignedFlatArrayMessageReader::getSegment(uint id) {
   } else {
     return nullptr;
   }
-}
-
-kj::ArrayPtr<const word> FlatArrayMessageReader::checkAlignment(kj::ArrayPtr<const word> array) {
-  KJ_REQUIRE((uintptr_t)array.begin() % sizeof(void*) == 0,
-      "Input to FlatArrayMessageReader is not aligned. If your architecture supports unaligned "
-      "access (e.g. x86/x64/modern ARM), you may use UnalignedFlatArrayMessageReader instead, "
-      "though this may harm performance.");
-
-  return array;
 }
 
 kj::ArrayPtr<const word> initMessageBuilderFromFlatArrayCopy(


### PR DESCRIPTION
This reverts commit 3aa2b2aa02edb1c160b154ad74c08c929a02512a.

This is not safe, even on x86. Unaligned access is undefined behavior in C/C++. Compilers can and do optimize under the assumption that access is aligned. For example, GCC may use SIMD instructions in optimizations, and these do in fact require alignment. In principle, a compiler could also choose to mask away the lowest bits of a pointer that should always be zero when aligned.

I considered deprecating this class instead of deleting it, but a Google search came up with no mentions of this class anywhere except our own code and issues, suggesting it is not used in any open source code. If it's used in any closed source codebases, then the code's own developers will be the first to see the build breakage and will be well-positioned to fix it. I decided it's better to force them to fix it now than to let them run into inscrutable bugs from unexpected compiler optimizations later.

I considered adding more explicit checks for alignment within the implementation but figured that would have a higher risk of breaking some open source code out there whose users may not easily be able to fix it...