### PR TITLE
Fixing CI badges to use new GitHub Actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Unix: [![Unix Build Status](https://travis-ci.org/capnproto/capnproto.svg?branch=master)](https://travis-ci.org/capnproto/capnproto) Windows: [![Windows Build Status](https://ci.appveyor.com/api/projects/status/9rxff2tujkae4hte?svg=true)](https://ci.appveyor.com/project/kentonv/capnproto)
+[![Quick Tests](https://github.com/capnproto/capnproto/workflows/Quick%20Tests/badge.svg)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Quick+Tests%22)
+[![Release Tests](https://github.com/capnproto/capnproto/workflows/Release%20Tests/badge.svg)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Release+Tests%22)
 
 <img src='http://kentonv.github.com/capnproto/images/infinity-times-faster.png' style='width:334px; height:306px; float: right;'>
 


### PR DESCRIPTION
Since you aren't using Travis-CI and Appveyor anymore, might as well show GitHub Action badges.

One limitation of the GitHub Action badges is that you can only show status at a workflow level (each yaml file).