### PR TITLE
Make actions run at master and power CI badges

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -6,6 +6,7 @@ on:
     - 'doc/**'
   push:
     branches:
+    - master
     - 'release-*'
 
 jobs:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -3,6 +3,7 @@ name: Release Tests
 on:
   push:
     branches:
+    - master
     - 'release-*'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Quick Tests](https://github.com/capnproto/capnproto/workflows/Quick%20Tests/badge.svg)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Quick+Tests%22)
-[![Release Tests](https://github.com/capnproto/capnproto/workflows/Release%20Tests/badge.svg)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Release+Tests%22)
+[![Quick Tests](https://github.com/capnproto/capnproto/workflows/Quick%20Tests/badge.svg?branch=master)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Quick+Tests%22)
+[![Release Tests](https://github.com/capnproto/capnproto/workflows/Release%20Tests/badge.svg?branch=master)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Release+Tests%22)
 
 <img src='http://kentonv.github.com/capnproto/images/infinity-times-faster.png' style='width:334px; height:306px; float: right;'>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Unix: [![Unix Build Status](https://travis-ci.org/capnproto/capnproto.svg?branch=master)](https://travis-ci.org/capnproto/capnproto) Windows: [![Windows Build Status](https://ci.appveyor.com/api/projects/status/9rxff2tujkae4hte?svg=true)](https://ci.appveyor.com/project/kentonv/capnproto)
+[![Quick Tests](https://github.com/capnproto/capnproto/workflows/Quick%20Tests/badge.svg)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Quick+Tests%22)
+[![Release Tests](https://github.com/capnproto/capnproto/workflows/Release%20Tests/badge.svg)](https://github.com/capnproto/capnproto/actions?query=workflow%3A%22Release+Tests%22)
 
 <img src='http://kentonv.github.com/capnproto/images/infinity-times-faster.png' style='width:334px; height:306px; float: right;'>
 


### PR DESCRIPTION
Based on @haata's #979, but I changed the badges to show specifically the master branch, and made the actions actually run at master -- including the release tests. It'll be nice to find out when the release tests break without having to explicitly ask for them, but also without having to run them on every PR commit.