### PR TITLE
Fix markup of code blocks within lists.

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -403,17 +403,27 @@ Cap'n Proto generics work very similarly to Java generics or C++ templates. Some
   substituting the type parameters manually. For example, `Map(Text, Person)` is encoded exactly
   the same as:
 
-  <div>{% highlight capnp %}
-  struct PersonMap {
-    # Encoded the same as Map(Text, Person).
-    entries @0 :List(Entry);
-    struct Entry {
-      key @0 :Text;
-      value @1 :Person;
+  <figure class="highlight"><pre><code class="language-capnp" data-lang="capnp"><span></span><span class="k">struct</span> <span class="n">PersonMap</span> {
+    <span class="c1"># Encoded the same as Map(Text, Person).</span>
+    <span class="n">entries</span> <span class="nd">@0</span> <span class="nc">:List(Entry)</span>;
+    <span class="k">struct</span> <span class="n">Entry</span> {
+      <span class="n">key</span> <span class="nd">@0</span> <span class="nc">:Text</span>;
+      <span class="n">value</span> <span class="nd">@1</span> <span class="nc">:Person</span>;
     }
-  }
-  {% endhighlight %}
-  </div>
+  }</code></pre></figure>
+
+  {% comment %}
+  Highlighter manually invoked because of: https://github.com/jekyll/jekyll/issues/588
+  Original code was:
+    struct PersonMap {
+      # Encoded the same as Map(Text, Person).
+      entries @0 :List(Entry);
+      struct Entry {
+        key @0 :Text;
+        value @1 :Person;
+      }
+    }
+  {% endcomment %}
 
   Therefore, it is possible to upgrade non-generic types to generic types while retaining
   backwards-compatibility.
@@ -733,29 +743,47 @@ without changing the [canonical](encoding.html#canonicalization) encoding of a m
   be replaced with the new generic parameter so long as all existing users of the type are updated
   to bind that generic parameter to the type it replaced. For example:
 
-  <div>{% highlight capnp %}
-  struct Map {
-    entries @0 :List(Entry);
-    struct Entry {
-      key @0 :Text;
-      value @1 :Text;
+  <figure class="highlight"><pre><code class="language-capnp" data-lang="capnp"><span></span><span class="k">struct</span> <span class="n">Map</span> {
+    <span class="n">entries</span> <span class="nd">@0</span> <span class="nc">:List(Entry)</span>;
+    <span class="k">struct</span> <span class="n">Entry</span> {
+      <span class="n">key</span> <span class="nd">@0</span> <span class="nc">:Text</span>;
+      <span class="n">value</span> <span class="nd">@1</span> <span class="nc">:Text</span>;
     }
-  }
-  {% endhighlight %}
-  </div>
+  }</code></pre></figure>
+
+  {% comment %}
+  Highlighter manually invoked because of: https://github.com/jekyll/jekyll/issues/588
+  Original code was:
+    struct Map {
+      entries @0 :List(Entry);
+      struct Entry {
+        key @0 :Text;
+        value @1 :Text;
+      }
+    }
+  {% endcomment %}
 
   Can change to:
 
-  <div>{% highlight capnp %}
-  struct Map(Key, Value) {
-    entries @0 :List(Entry);
-    struct Entry {
-      key @0 :Key;
-      value @1 :Value;
+  <figure class="highlight"><pre><code class="language-capnp" data-lang="capnp"><span></span><span class="k">struct</span> <span class="n">Map</span>(<span class="n">Key</span>, <span class="n">Value</span>) {
+    <span class="n">entries</span> <span class="nd">@0</span> <span class="nc">:List(Entry)</span>;
+    <span class="k">struct</span> <span class="n">Entry</span> {
+      <span class="n">key</span> <span class="nd">@0</span> <span class="nc">:Key</span>;
+      <span class="n">value</span> <span class="nd">@1</span> <span class="nc">:Value</span>;
     }
-  }
-  {% endhighlight %}
-  </div>
+  }</code></pre></figure>
+
+  {% comment %}
+  Highlighter manually invoked because of: https://github.com/jekyll/jekyll/issues/588
+  Original code was:
+    struct Map(Key, Value) {
+      entries @0 :List(Entry);
+      struct Entry {
+        key @0 :Key;
+        value @1 :Value;
+      }
+    }
+  {% endcomment %}
 
   As long as all existing uses of `Map` are replaced with `Map(Text, Text)` (and any uses of
   `Map.Entry` are replaced with `Map(Text, Text).Entry`).


### PR DESCRIPTION
Properly fixes #897.

It turns out Jekyll just doesn't let you render a highlighted code block inside of a list item anymore. It used to, I guess. Probably my `<div>`s were a work-around to make it work before, but at some point that stopped working.

Solution: Manually embed the highlighted HTML.