### PR TITLE
Fix/complete CMake installation

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -45,21 +45,28 @@ jobs:
         os: ['windows-2016', 'windows-latest']
         include:
           - os: windows-2016
-            target: 'Visual Studio 15 2017'
           - os: windows-latest
-            target: 'Visual Studio 16 2019'
     steps:
       - uses: actions/checkout@v2
+      - name: Include $CONDA in $PATH
+        run: |
+          echo "::add-path::$Env:CONDA\condabin"
+      - name: Install dependencies via Conda
+        run: |
+          conda update -n base -c defaults -q conda
+          conda install -n base -c defaults -q ninja openssl zlib
       - name: Build and test
         shell: cmd
         run: |
+            echo "Activate conda base environment"
+            call activate base
             echo "Building Cap'n Proto with ${{ matrix.target }}"
-            cmake -Hc++ -Bbuild-output -G "${{ matrix.target }}" -DCMAKE_INSTALL_PREFIX=%CD%\capnproto-c++-install
-            cmake --build build-output --config debug --target install
+            cmake -Hc++ -Bbuild-output -G Ninja -DCMAKE_BUILD_TYPE=debug -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%" -DCMAKE_INSTALL_PREFIX=%CD%\capnproto-c++-install
+            cmake --build build-output --target install
 
             echo "Building Cap'n Proto samples with ${{ matrix.target }}"
-            cmake -Hc++/samples -Bbuild-output-samples -G "${{ matrix.target }}" -DCMAKE_PREFIX_PATH=%CD%\capnproto-c++-install
-            cmake --build build-output-samples --config debug
+            cmake -Hc++/samples -Bbuild-output-samples -G Ninja -DCMAKE_BUILD_TYPE=debug -DCMAKE_PREFIX_PATH=%CD%\capnproto-c++-install
+            cmake --build build-output-samples
 
             cd build-output\src
             ctest -V -C debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.4)
 project("Cap'n Proto Root" CXX)
 add_subdirectory(c++)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.4)
 project("Cap'n Proto" CXX)
 set(VERSION 0.9-dev)
 
@@ -39,6 +39,29 @@ if(CAPNP_LITE)
   # This flag is attached as PUBLIC target_compile_definition to kj target
 else()
   set(CAPNP_LITE_FLAG)
+endif()
+
+set(WITH_OPENSSL "AUTO" CACHE STRING
+  "Whether or not to build libkj-tls by linking against openssl")
+# define list of values GUI will offer for the variable
+set_property(CACHE WITH_OPENSSL PROPERTY STRINGS AUTO ON OFF)
+
+# shadow cache variable original value with ON/OFF,
+# so from now on OpenSSL-specific code just has to check:
+#     if (WITH_OPENSSL)
+#         ...
+#     endif()
+if (CAPNP_LITE)
+  set(WITH_OPENSSL OFF)
+elseif (WITH_OPENSSL STREQUAL "AUTO")
+  find_package(OpenSSL COMPONENTS Crypto SSL)
+  if (OPENSSL_FOUND)
+    set(WITH_OPENSSL ON)
+  else()
+    set(WITH_OPENSSL OFF)
+  endif()
+elseif (WITH_OPENSSL)
+  find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
 endif()
 
 if(MSVC)
@@ -134,8 +157,10 @@ if(NOT MSVC)  # Don't install pkg-config files when building with MSVC
   if(NOT CAPNP_LITE)
     list(APPEND CAPNP_PKG_CONFIG_FILES
       pkgconfig/kj-async.pc
+      pkgconfig/kj-gzip.pc
       pkgconfig/kj-http.pc
       pkgconfig/kj-test.pc
+      pkgconfig/kj-tls.pc
       pkgconfig/capnp-rpc.pc
       pkgconfig/capnp-json.pc
     )

--- a/c++/cmake/CapnProtoConfig.cmake.in
+++ b/c++/cmake/CapnProtoConfig.cmake.in
@@ -49,7 +49,18 @@ if(NOT _IMPORT_PREFIX)
   set(_IMPORT_PREFIX ${PACKAGE_PREFIX_DIR})
 endif()
 
-
+if (@WITH_OPENSSL@)  # WITH_OPENSSL
+  include(CMakeFindDependencyMacro)
+  if (CMAKE_VERSION VERSION_LESS 3.9)
+    # find_dependency() did not support COMPONENTS until CMake 3.9
+    #
+    # in practice, this call can be erroneous
+    # if the user has only libcrypto installed, but not libssl
+    find_dependency(OpenSSL)
+  else()
+    find_dependency(OpenSSL COMPONENTS Crypto SSL)
+  endif()
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/CapnProtoTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/CapnProtoMacros.cmake")

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -193,5 +193,8 @@ AS_IF([test "$with_openssl" != no], [
 ])
 AM_CONDITIONAL([BUILD_KJ_TLS], [test "$with_openssl" != no])
 
+# CapnProtoConfig.cmake.in needs this variable.
+AC_SUBST(WITH_OPENSSL, $with_openssl)
+
 AC_CONFIG_FILES([Makefile] CAPNP_PKG_CONFIG_FILES CAPNP_CMAKE_CONFIG_FILES)
 AC_OUTPUT

--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -29,7 +29,6 @@ endif()
 set(capnp_headers
   c++.capnp.h
   common.h
-  compat/std-iterator.h
   blob.h
   endian.h
   layout.h
@@ -55,6 +54,9 @@ set(capnp_headers
   generated-header-support.h
   raw-schema.h
 )
+set(capnp_compat_headers
+  compat/std-iterator.h
+)
 set(capnp_schemas
   c++.capnp
   schema.capnp
@@ -72,6 +74,7 @@ target_include_directories(capnp INTERFACE
 set_target_properties(capnp PROPERTIES VERSION ${VERSION})
 install(TARGETS capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${capnp_headers} ${capnp_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
+install(FILES ${capnp_compat_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp/compat")
 
 set(capnp-rpc_sources
   serialize-async.c++

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -163,6 +163,29 @@ if(NOT CAPNP_LITE)
   install(FILES ${kj-http_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
 endif()
 
+# kj-tls ======================================================================
+set(kj-tls_sources
+  compat/readiness-io.c++
+  compat/tls.c++
+)
+set(kj-tls_headers
+  compat/readiness-io.h
+  compat/tls.h
+)
+if(NOT CAPNP_LITE)
+  add_library(kj-tls ${kj-tls_sources})
+  add_library(CapnProto::kj-tls ALIAS kj-tls)
+  target_link_libraries(kj-tls PUBLIC kj-async)
+  if (WITH_OPENSSL)
+    target_compile_definitions(kj-tls PRIVATE KJ_HAS_OPENSSL)
+    target_link_libraries(kj-tls PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+  endif()
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(kj-tls PROPERTIES VERSION ${VERSION})
+  install(TARGETS kj-tls ${INSTALL_TARGETS_DEFAULT_ARGS})
+  install(FILES ${kj-tls_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
+endif()
+
 # kj-gzip ======================================================================
 
 set(kj-gzip_sources
@@ -236,8 +259,15 @@ if(BUILD_TESTING)
       compat/url-test.c++
       compat/http-test.c++
       compat/gzip-test.c++
+      compat/tls-test.c++
     )
-    target_link_libraries(kj-heavy-tests kj-http kj-gzip kj-async kj-test kj)
+    target_link_libraries(kj-heavy-tests kj-http kj-gzip kj-tls kj-async kj-test kj)
+    if (WITH_OPENSSL)
+      set_source_files_properties(compat/tls-test.c++
+        PROPERTIES
+          COMPILE_DEFINITIONS KJ_HAS_OPENSSL
+      )
+    endif()
     add_dependencies(check kj-heavy-tests)
     add_test(NAME kj-heavy-tests-run COMMAND kj-heavy-tests)
   endif()  # NOT CAPNP_LITE

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -276,7 +276,7 @@ private:
   kj::Promise<size_t> sslCall(Func&& func) {
     if (disconnected) return size_t(0);
 
-    ssize_t result = func();
+    auto result = func();
 
     if (result > 0) {
       return result;


### PR DESCRIPTION
This PR tries to address #973 and also fix an issue with a header installed to the wrong place.
I tried to compare the install trees generated by autotools and CMake to make sure there was no functional differences.

I see that @harrishancock said he will do the CMake part here https://github.com/capnproto/capnproto/pull/978#pullrequestreview-397491907, but seeing the imminent release, I thought it was worth trying to do it before the release is official, in case the merge window was still open.
My apology if this feels inappropriate.