### PR TITLE
expand comments for Brand.Scope.inherit

### DIFF
--- a/c++/src/capnp/schema.capnp
+++ b/c++/src/capnp/schema.capnp
@@ -407,8 +407,8 @@ struct Brand {
       #     struct Inner {
       #       value @0 :T;
       #     }
-      #     innerInherit @0 :Inner;            # Outer scope is `inherit`.
-      #     innerBindSelf @1 :Outer(T).Inner;  # Outer scope explicitly binds T to T.
+      #     innerInherit @0 :Inner;            # Outer Brand.Scope is `inherit`.
+      #     innerBindSelf @1 :Outer(T).Inner;  # Outer Brand.Scope explicitly binds T to T.
       #   }
       #
       # The innerInherit and innerBindSelf fields have equivalent types, but different Brand

--- a/c++/src/capnp/schema.capnp
+++ b/c++/src/capnp/schema.capnp
@@ -399,9 +399,9 @@ struct Brand {
 
       inherit @2 :Void;
       # The place where the Brand appears is within this scope or a sub-scope, and bindings
-      # for this scope are deferred to later Brand applications. This is equivalent to an
-      # identity binding list, where each of this scope's parameters is bound to itself. For
-      # example:
+      # for this scope are deferred to later Brand applications. This is equivalent to a
+      # pass-through binding list, where each of this scope's parameters is bound to itself.
+      # For example:
       #
       #   struct Outer(T) {
       #     struct Inner {

--- a/c++/src/capnp/schema.capnp
+++ b/c++/src/capnp/schema.capnp
@@ -398,8 +398,21 @@ struct Brand {
       # List of parameter bindings.
 
       inherit @2 :Void;
-      # The place where this Brand appears is actually within this scope or a sub-scope,
-      # and the bindings for this scope should be inherited from the reference point.
+      # The place where the Brand appears is within this scope or a sub-scope, and bindings
+      # for this scope are deferred to later Brand applications. This is equivalent to an
+      # identity binding list, where each of this scope's parameters is bound to itself. For
+      # example:
+      #
+      #   struct Outer(T) {
+      #     struct Inner {
+      #       value @0 :T;
+      #     }
+      #     innerInherit @0 :Inner;            # Outer scope is `inherit`.
+      #     innerBindSelf @1 :Outer(T).Inner;  # Outer scope explicitly binds T to T.
+      #   }
+      #
+      # The innerInherit and innerBindSelf fields have equivalent types, but different Brand
+      # styles.
     }
   }
 


### PR DESCRIPTION
The first time I learned about Cap'n Proto generics, and again this weekend while trying to relearn them, I spent a long amount of time trying to understand the meaning of `Brand.Scope.inherit`. I found the existing doc comment to be unhelpful: what exactly is a "reference point" and what does it mean to inherit from one?

What finally made things click was to think of `Brand`s as type substitutions, and to think of `inherit` as an identity substitution -- it just replaces the parameters with themselves.

This pull request expands the documentation and adds an example that should make things more clear.