### PR TITLE
Add a seperate CanceledException type for fiber cancelation.

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1093,17 +1093,13 @@ inline PromiseForResult<Func, void> evalNow(Func&& func) {
 
 template <typename Func>
 inline PromiseForResult<Func, WaitScope&> startFiber(size_t stackSize, Func&& func) {
-  #if KJ_NO_EXCEPTIONS
-    KJ_UNIMPLEMENTED("Fibers require exceptions");
-  #else
-    typedef _::FixVoid<_::ReturnType<Func, WaitScope&>> ResultT;
+  typedef _::FixVoid<_::ReturnType<Func, WaitScope&>> ResultT;
 
-    Own<_::FiberBase> intermediate = kj::heap<_::Fiber<Func>>(stackSize, kj::fwd<Func>(func));
-    intermediate->start();
-    auto result = _::PromiseNode::to<_::ChainPromises<_::ReturnType<Func, WaitScope&>>>(
-        _::maybeChain(kj::mv(intermediate), implicitCast<ResultT*>(nullptr)));
-    return _::maybeReduce(kj::mv(result), false);
-  #endif
+  Own<_::FiberBase> intermediate = kj::heap<_::Fiber<Func>>(stackSize, kj::fwd<Func>(func));
+  intermediate->start();
+  auto result = _::PromiseNode::to<_::ChainPromises<_::ReturnType<Func, WaitScope&>>>(
+      _::maybeChain(kj::mv(intermediate), implicitCast<ResultT*>(nullptr)));
+  return _::maybeReduce(kj::mv(result), false);
 }
 
 template <typename T>

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -937,6 +937,7 @@ KJ_TEST("cancel a fiber") {
         promise.wait(fiberScope);
       } catch (kj::CanceledException) {
         canceled = true;
+        throw;
       }
       return "foo"_kj;
     });

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -819,7 +819,10 @@ FiberBase::FiberBase(size_t stackSizeParam, _::ExceptionOrValue& result)
       impl(Impl::alloc(stackSize)),
 #endif
       result(result) {
-#if _WIN32 || __CYGWIN__
+#if KJ_NO_EXCEPTIONS
+  KJ_UNIMPLEMENTED("Fibers are not implemented because exceptions are disabled");
+
+#elif _WIN32 || __CYGWIN__
   auto& eventLoop = currentEventLoop();
   if (eventLoop.mainFiber == nullptr) {
     // First time we've created a fiber. We need to convert the main stack into a fiber as well
@@ -828,9 +831,6 @@ FiberBase::FiberBase(size_t stackSizeParam, _::ExceptionOrValue& result)
   }
 
   KJ_WIN32(osFiber = CreateFiber(stackSize, &StartRoutine::run, this));
-
-#elif KJ_NO_EXCEPTIONS
-  KJ_UNIMPLEMENTED("Fibers are not implemented because exceptions are disabled");
 
 #elif !__BIONIC__
   // Note: Nothing below here can throw. If that changes then we need to call Impl::free(impl)

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -917,6 +917,7 @@ void FiberBase::switchToMain() {
 }
 
 void FiberBase::run() {
+#if !KJ_NO_EXCEPTIONS
   bool caughtCanceled = false;
   state = RUNNING;
   KJ_DEFER(state = FINISHED);
@@ -943,6 +944,7 @@ void FiberBase::run() {
   }
 
   onReadyEvent.arm();
+#endif
 }
 
 void FiberBase::onReady(_::Event* event) noexcept {

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -733,10 +733,6 @@ String KJ_STRINGIFY(const Exception& e) {
              stringifyStackTrace(e.getStackTrace()));
 }
 
-StringPtr KJ_STRINGIFY(CanceledException e) {
-  return "This fiber is being canceled.";
-}
-
 Exception::Exception(Type type, const char* file, int line, String description) noexcept
     : file(trimSourceFilename(file).cStr()), line(line), type(type), description(mv(description)),
       traceCount(0) {}

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -134,7 +134,7 @@ private:
 
 struct CanceledException { };
   // This exception is thrown to force-unwind a stack in order to immediately cancel whatever that
-  // stack was doing. It is used in the implementation of fibers in praticular. Application code
+  // stack was doing. It is used in the implementation of fibers in particular. Application code
   // should almost never catch this exception, unless you need to modify stack unwinding for some
   // reason. kj::runCatchingExceptions() does not catch it.
 

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -132,8 +132,15 @@ private:
   friend class ExceptionImpl;
 };
 
+struct CanceledException { };
+  // This exception is thrown to force-unwind a stack in order to immediately cancel whatever that
+  // stack was doing. It is used in the implementation of fibers in praticular. Application code
+  // should almost never catch this exception, unless you need to modify stack unwinding for some
+  // reason. kj::runCatchingExceptions() does not catch it.
+
 StringPtr KJ_STRINGIFY(Exception::Type type);
 String KJ_STRINGIFY(const Exception& e);
+StringPtr KJ_STRINGIFY(CanceledException e);
 
 // =======================================================================================
 
@@ -248,7 +255,7 @@ KJ_NOINLINE void throwRecoverableException(kj::Exception&& exception, uint ignor
 namespace _ { class Runnable; }
 
 template <typename Func>
-Maybe<Exception> runCatchingExceptions(Func&& func) noexcept;
+Maybe<Exception> runCatchingExceptions(Func&& func);
 // Executes the given function (usually, a lambda returning nothing) catching any exceptions that
 // are thrown.  Returns the Exception if there was one, or null if the operation completed normally.
 // Non-KJ exceptions will be wrapped.
@@ -303,12 +310,12 @@ private:
   Func func;
 };
 
-Maybe<Exception> runCatchingExceptions(Runnable& runnable) noexcept;
+Maybe<Exception> runCatchingExceptions(Runnable& runnable);
 
 }  // namespace _ (private)
 
 template <typename Func>
-Maybe<Exception> runCatchingExceptions(Func&& func) noexcept {
+Maybe<Exception> runCatchingExceptions(Func&& func) {
   _::RunnableImpl<Decay<Func>> runnable(kj::fwd<Func>(func));
   return _::runCatchingExceptions(runnable);
 }

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -133,14 +133,13 @@ private:
 };
 
 struct CanceledException { };
-  // This exception is thrown to force-unwind a stack in order to immediately cancel whatever that
-  // stack was doing. It is used in the implementation of fibers in particular. Application code
-  // should almost never catch this exception, unless you need to modify stack unwinding for some
-  // reason. kj::runCatchingExceptions() does not catch it.
+// This exception is thrown to force-unwind a stack in order to immediately cancel whatever that
+// stack was doing. It is used in the implementation of fibers in particular. Application code
+// should almost never catch this exception, unless you need to modify stack unwinding for some
+// reason. kj::runCatchingExceptions() does not catch it.
 
 StringPtr KJ_STRINGIFY(Exception::Type type);
 String KJ_STRINGIFY(const Exception& e);
-StringPtr KJ_STRINGIFY(CanceledException e);
 
 // =======================================================================================
 


### PR DESCRIPTION
This may not be suitable since it requires exceptions to be enabled to use fibers as the new exception type isn't a kj exception.