### PR TITLE
Fix build for C++20 via reinterpret_cast

### DIFF
--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -239,7 +239,7 @@ EncodingResult<String> decodeUtf32(ArrayPtr<const char32_t> utf16) {
     }
 
   error:
-    result.addAll(StringPtr(u8"\ufffd"));
+    result.addAll(StringPtr(reinterpret_cast<const char *>(u8"\ufffd")));
     hadErrors = true;
   }
 


### PR DESCRIPTION
Closes https://github.com/capnproto/capnproto/issues/815.

According to [**char8_t backward compatibility remediation**](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r0.html) I tried to implement `reintrerpret_cast` case:

<img width="898" alt="Screenshot 2020-05-12 at 18 16 44" src="https://user-images.githubusercontent.com/6595049/81711898-be6ea800-947c-11ea-92ef-8c6db23029e8.png">

File [encoding.c++:242](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/kj/encoding.c%2B%2B#L242) was changed:
```
-    result.addAll(StringPtr(u8"\ufffd"));
+    result.addAll(StringPtr(reinterpret_cast<const char *>(u8"\ufffd")));
```

It works for me!