### PR TITLE
Add freelisting fibers API

### DIFF
--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -188,6 +188,7 @@ class PromiseNode;
 class ChainPromiseNode;
 template <typename T>
 class ForkHub;
+class FiberStack;
 class FiberBase;
 
 class Event;


### PR DESCRIPTION
This abstracts the fiber stack implementation into a separate `FiberStack` class, allowing stacks to be saved and freelisted via `FiberPool`.