### PR TITLE
kj/encoding.c++: Fix clang warning

### DIFF
--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -852,7 +852,7 @@ typedef enum {
   step_a, step_b, step_c, step_d
 } base64_decodestep;
 
-typedef struct {
+struct base64_decodestate {
   bool hadErrors = false;
   size_t nPaddingBytesSeen = 0;
   // Output state. `nPaddingBytesSeen` is not guaranteed to be correct if `hadErrors` is true. It is
@@ -861,7 +861,7 @@ typedef struct {
 
   base64_decodestep step = step_a;
   char plainchar = 0;
-} base64_decodestate;
+};
 
 int base64_decode_value(char value_in) {
   // Returns either the fragment value or: -1 on whitespace, -2 on padding, -3 on invalid input.


### PR DESCRIPTION
Apparently clang has enabled a warning (`-Wnon-c-typedef-for-linkage`) for when a C-style anonymous struct uses C++ features that make it incompatible with C. We introduced such code in f3e0ed22 when we effectively added a constructor to `base64_decodestate`.  Naming the struct quells the warning.