### PR TITLE
 Extend Executor to gracefully handle remote event loop exits.

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1333,6 +1333,12 @@ private:
   friend class kj::Executor;
 
   void done();
+  // Sets the state to `DONE` and notifies the originating thread that this event is done. Do NOT
+  // call under lock.
+
+  void setDoneState();
+  // Assigns `state` to `DONE`, being careful to use an atomic-release-store if needed. Must be
+  // called under lock.
 
   class DelayedDoneHack;
 

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1269,8 +1269,7 @@ namespace _ {  // (private)
 class XThreadEvent: private Event,         // it's an event in the target thread
                     public PromiseNode {   // it's a PromiseNode in the requesting thread
 public:
-  XThreadEvent(ExceptionOrValue& result, const Executor& targetExecutor)
-      : Event(targetExecutor.loop), result(result), targetExecutor(targetExecutor) {}
+  XThreadEvent(ExceptionOrValue& result, const Executor& targetExecutor);
 
 protected:
   void ensureDoneOrCanceled();
@@ -1288,7 +1287,7 @@ protected:
 private:
   ExceptionOrValue& result;
 
-  const Executor& targetExecutor;
+  kj::Own<const Executor> targetExecutor;
   Maybe<const Executor&> replyExecutor;  // If executeAsync() was used.
 
   kj::Maybe<Own<PromiseNode>> promiseNode;
@@ -1304,12 +1303,17 @@ private:
     // Object was never queued on another thread.
 
     QUEUED,
-    // Target thread has not yet dequeued the event from crossThreadRequests.events. The requesting
+    // Target thread has not yet dequeued the event from the state.start list. The requesting
     // thread can cancel execution by removing the event from the list.
 
     EXECUTING,
-    // Target thread has dequeued the event and is executing it. To cancel, the requesting thread
-    // must add the event to the crossThreadRequests.cancel list.
+    // Target thread has dequeued the event from state.start and moved it to state.executing. To
+    // cancel, the requesting thread must add the event to the state.cancel list and change the
+    // state to CANCELING.
+
+    CANCELING,
+    // Requesting thread is trying to cancel this event. The target thread will change the state to
+    // `DONE` once canceled.
 
     DONE
     // Target thread has completed handling this event and will not touch it again. The requesting
@@ -1336,9 +1340,20 @@ private:
   // Sets the state to `DONE` and notifies the originating thread that this event is done. Do NOT
   // call under lock.
 
+  void sendReply();
+  // Notifies the originating thread that this event is done, but doesn't set the state to DONE
+  // yet. Do NOT call under lock.
+
   void setDoneState();
-  // Assigns `state` to `DONE`, being careful to use an atomic-release-store if needed. Must be
-  // called under lock.
+  // Assigns `state` to `DONE`, being careful to use an atomic-release-store if needed. This must
+  // only be called in the destination thread, and must either be called under lock, or the thread
+  // must take the lock and release it again shortly after setting the state (because some threads
+  // may be waiting on the DONE state using a conditional wait on the mutex). After calling
+  // setDoneState(), the destination thread MUST NOT touch this object ever again; it now belongs
+  // solely to the requesting thread.
+
+  void setDisconnected();
+  // Sets the result to a DISCONNECTED exception indicating that the target event loop exited.
 
   class DelayedDoneHack;
 

--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -565,5 +565,209 @@ KJ_TEST("call own thread's executor") {
   }
 }
 
+KJ_TEST("synchronous cross-thread event disconnected") {
+  MutexGuarded<kj::Maybe<const Executor&>> executor;  // to get the Executor from the other thread
+  Own<PromiseFulfiller<void>> fulfiller;  // accessed only from the subthread
+  thread_local bool isChild = false;  // to assert which thread we're in
+
+  Thread thread([&]() noexcept {
+    isChild = true;
+
+    {
+      KJ_XTHREAD_TEST_SETUP_LOOP;
+
+      auto paf = newPromiseAndFulfiller<void>();
+      fulfiller = kj::mv(paf.fulfiller);
+
+      *executor.lockExclusive() = getCurrentThreadExecutor();
+
+      paf.promise.wait(waitScope);
+
+      // Exit the event loop!
+    }
+
+    // Wait until parent thread sets executor to null, as a way to tell us to quit.
+    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+  });
+
+  ([&]() noexcept {
+    Own<const Executor> exec;
+    {
+      auto lock = executor.lockExclusive();
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      exec = KJ_ASSERT_NONNULL(*lock).addRef();
+    }
+
+    KJ_EXPECT(!isChild);
+
+    KJ_EXPECT(exec->isLive());
+
+    KJ_EXPECT_THROW_MESSAGE(
+        "Executor's event loop exited before cross-thread event could complete",
+        exec->executeSync([&]() -> Promise<void> {
+          fulfiller->fulfill();
+          return kj::NEVER_DONE;
+        }));
+
+    KJ_EXPECT(!exec->isLive());
+
+    KJ_EXPECT_THROW_MESSAGE(
+        "Executor's event loop has exited",
+        exec->executeSync([&]() {}));
+
+    *executor.lockExclusive() = nullptr;
+  })();
+}
+
+KJ_TEST("asynchronous cross-thread event disconnected") {
+  MutexGuarded<kj::Maybe<const Executor&>> executor;  // to get the Executor from the other thread
+  Own<PromiseFulfiller<void>> fulfiller;  // accessed only from the subthread
+  thread_local bool isChild = false;  // to assert which thread we're in
+
+  Thread thread([&]() noexcept {
+    isChild = true;
+
+    {
+      KJ_XTHREAD_TEST_SETUP_LOOP;
+
+      auto paf = newPromiseAndFulfiller<void>();
+      fulfiller = kj::mv(paf.fulfiller);
+
+      *executor.lockExclusive() = getCurrentThreadExecutor();
+
+      paf.promise.wait(waitScope);
+
+      // Exit the event loop!
+    }
+
+    // Wait until parent thread sets executor to null, as a way to tell us to quit.
+    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+  });
+
+  ([&]() noexcept {
+    KJ_XTHREAD_TEST_SETUP_LOOP;
+
+    Own<const Executor> exec;
+    {
+      auto lock = executor.lockExclusive();
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      exec = KJ_ASSERT_NONNULL(*lock).addRef();
+    }
+
+    KJ_EXPECT(!isChild);
+
+    KJ_EXPECT(exec->isLive());
+
+    KJ_EXPECT_THROW_MESSAGE(
+        "Executor's event loop exited before cross-thread event could complete",
+        exec->executeAsync([&]() -> Promise<void> {
+          fulfiller->fulfill();
+          return kj::NEVER_DONE;
+        }).wait(waitScope));
+
+    KJ_EXPECT(!exec->isLive());
+
+    KJ_EXPECT_THROW_MESSAGE(
+        "Executor's event loop has exited",
+        exec->executeAsync([&]() {}).wait(waitScope));
+
+    *executor.lockExclusive() = nullptr;
+  })();
+}
+
+KJ_TEST("cross-thread event disconnected before it runs") {
+  MutexGuarded<kj::Maybe<const Executor&>> executor;  // to get the Executor from the other thread
+  thread_local bool isChild = false;  // to assert which thread we're in
+
+  Thread thread([&]() noexcept {
+    isChild = true;
+
+    KJ_XTHREAD_TEST_SETUP_LOOP;
+
+    *executor.lockExclusive() = getCurrentThreadExecutor();
+
+    // Don't actually run the event loop. Destroy it when the other thread signals us to.
+    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+  });
+
+  ([&]() noexcept {
+    KJ_XTHREAD_TEST_SETUP_LOOP;
+
+    Own<const Executor> exec;
+    {
+      auto lock = executor.lockExclusive();
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      exec = KJ_ASSERT_NONNULL(*lock).addRef();
+    }
+
+    KJ_EXPECT(!isChild);
+
+    KJ_EXPECT(exec->isLive());
+
+    auto promise = exec->executeAsync([&]() {
+      KJ_LOG(ERROR, "shouldn't have executed");
+    });
+    KJ_EXPECT(!promise.poll(waitScope));
+
+    *executor.lockExclusive() = nullptr;
+
+    KJ_EXPECT_THROW_MESSAGE(
+        "Executor's event loop exited before cross-thread event could complete",
+        promise.wait(waitScope));
+
+    KJ_EXPECT(!exec->isLive());
+  })();
+}
+
+KJ_TEST("cross-thread event disconnected without holding Executor ref") {
+  MutexGuarded<kj::Maybe<const Executor&>> executor;  // to get the Executor from the other thread
+  Own<PromiseFulfiller<void>> fulfiller;  // accessed only from the subthread
+  thread_local bool isChild = false;  // to assert which thread we're in
+
+  Thread thread([&]() noexcept {
+    isChild = true;
+
+    {
+      KJ_XTHREAD_TEST_SETUP_LOOP;
+
+      auto paf = newPromiseAndFulfiller<void>();
+      fulfiller = kj::mv(paf.fulfiller);
+
+      *executor.lockExclusive() = getCurrentThreadExecutor();
+
+      paf.promise.wait(waitScope);
+
+      // Exit the event loop!
+    }
+
+    // Wait until parent thread sets executor to null, as a way to tell us to quit.
+    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+  });
+
+  ([&]() noexcept {
+    const Executor* exec;
+    {
+      auto lock = executor.lockExclusive();
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      exec = &KJ_ASSERT_NONNULL(*lock);
+    }
+
+    KJ_EXPECT(!isChild);
+
+    KJ_EXPECT(exec->isLive());
+
+    KJ_EXPECT_THROW_MESSAGE(
+        "Executor's event loop exited before cross-thread event could complete",
+        exec->executeSync([&]() -> Promise<void> {
+          fulfiller->fulfill();
+          return kj::NEVER_DONE;
+        }));
+
+    // Can't check `exec->isLive()` because it's been destroyed by now.
+
+    *executor.lockExclusive() = nullptr;
+  })();
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -441,7 +441,7 @@ struct Executor::Impl {
   void disconnect() {
     state.lockExclusive()->loop = nullptr;
 
-    // Now that `loop` is set null is `state`, other threads will no longer try to manipulate our
+    // Now that `loop` is set null in `state`, other threads will no longer try to manipulate our
     // lists, so we can access them without a lock. That's convenient because a bunch of the things
     // we want to do with them would require dropping the lock to avoid deadlocks. We'd end up
     // copying all the lists over into separate vectors first, dropping the lock, operating on

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -309,6 +309,8 @@ LoggingErrorHandler LoggingErrorHandler::instance = LoggingErrorHandler();
 // =======================================================================================
 
 struct Executor::Impl {
+  Impl(EventLoop& loop): state(loop) {}
+
   typedef Maybe<_::XThreadEvent&> _::XThreadEvent::*NextMember;
   typedef Maybe<_::XThreadEvent&>* _::XThreadEvent::*PrevMember;
 
@@ -359,22 +361,33 @@ struct Executor::Impl {
   struct State {
     // Queues of notifications from other threads that need this thread's attention.
 
-    List<&_::XThreadEvent::targetNext, &_::XThreadEvent::targetPrev> run;
+    State(EventLoop& loop): loop(loop) {}
+
+    kj::Maybe<EventLoop&> loop;
+    // Becomes null when the loop is destroyed.
+
+    List<&_::XThreadEvent::targetNext, &_::XThreadEvent::targetPrev> start;
     List<&_::XThreadEvent::targetNext, &_::XThreadEvent::targetPrev> cancel;
     List<&_::XThreadEvent::replyNext, &_::XThreadEvent::replyPrev> replies;
+    // Lists of events that need actioning by this thread.
+
+    List<&_::XThreadEvent::targetNext, &_::XThreadEvent::targetPrev> executing;
+    // Events that have already been dispatched and are happily executing. This list is maintained
+    // so that they can be canceled if the event loop exits.
 
     bool waitingForCancel = false;
     // True if this thread is currently blocked waiting for some other thread to pump its
     // cancellation queue. If that other thread tries to block on *this* thread, then it could
     // deadlock -- it must take precautions against this.
 
-    bool empty() const {
-      return run.empty() && cancel.empty() && replies.empty();
+    bool isDispatchNeeded() const {
+      return !start.empty() || !cancel.empty() || !replies.empty();
     }
 
     void dispatchAll(Vector<_::XThreadEvent*>& eventsToCancelOutsideLock) {
-      run.forEach([&](_::XThreadEvent& event) {
-        run.erase(event);
+      start.forEach([&](_::XThreadEvent& event) {
+        start.erase(event);
+        executing.insert(event);
         event.state = _::XThreadEvent::EXECUTING;
         event.armBreadthFirst();
       });
@@ -424,9 +437,56 @@ struct Executor::Impl {
       event->setDoneState();
     }
   }
-};
+
+  void disconnect() {
+    state.lockExclusive()->loop = nullptr;
+
+    // Now that `loop` is set null is `state`, other threads will no longer try to manipulate our
+    // lists, so we can access them without a lock. That's convenient because a bunch of the things
+    // we want to do with them would require dropping the lock to avoid deadlocks. We'd end up
+    // copying all the lists over into separate vectors first, dropping the lock, operating on
+    // them, and then locking again.
+    auto& s = state.getWithoutLock();
+
+    // We do, however, take and release the lock on the way out, to make sure anyone performing
+    // a conditional wait for state changes gets a chance to have their wait condition re-checked.
+    KJ_DEFER(state.lockExclusive());
+
+    s.start.forEach([&](_::XThreadEvent& event) {
+      s.start.erase(event);
+      event.setDisconnected();
+      event.sendReply();
+      event.setDoneState();
+    });
+
+    s.executing.forEach([&](_::XThreadEvent& event) {
+      s.executing.erase(event);
+      event.promiseNode = nullptr;
+      event.setDisconnected();
+      event.sendReply();
+      event.setDoneState();
+    });
+
+    s.cancel.forEach([&](_::XThreadEvent& event) {
+      s.executing.erase(event);
+      event.promiseNode = nullptr;
+      event.setDoneState();
+    });
+
+    // The replies list "should" be empty, because any locally-initiated tasks should have been
+    // canceled before destroying the EventLoop.
+    if (!s.replies.empty()) {
+      KJ_LOG(ERROR, "EventLoop destroyed with cross-thread event replies outstanding");
+      s.replies.forEach([&](_::XThreadEvent& event) {
+        s.replies.erase(event);
+      });
+    }
+  }};
 
 namespace _ {  // (private)
+
+XThreadEvent::XThreadEvent(ExceptionOrValue& result, const Executor& targetExecutor)
+    : Event(targetExecutor.getLoop()), result(result), targetExecutor(targetExecutor.addRef()) {}
 
 void XThreadEvent::ensureDoneOrCanceled() {
 #if _MSC_VER
@@ -434,26 +494,39 @@ void XThreadEvent::ensureDoneOrCanceled() {
 #else
   if (__atomic_load_n(&state, __ATOMIC_ACQUIRE) != DONE) {
 #endif
-    auto lock = targetExecutor.impl->state.lockExclusive();
+    auto lock = targetExecutor->impl->state.lockExclusive();
+
+    const EventLoop* loop;
+    KJ_IF_MAYBE(l, lock->loop) {
+      loop = l;
+    } else {
+      // Target event loop is already dead, so we know it's already working on transitioning all
+      // events to the DONE state. We can just wait.
+      lock.wait([&](auto&) { return state == DONE; });
+      return;
+    }
+
     switch (state) {
       case UNUSED:
         // Nothing to do.
         break;
       case QUEUED:
-        lock->run.erase(*this);
+        lock->start.erase(*this);
         // No wake needed since we removed work rather than adding it.
         state = DONE;
         break;
       case EXECUTING: {
+        lock->executing.erase(*this);
         lock->cancel.insert(*this);
-        KJ_IF_MAYBE(p, targetExecutor.loop.port) {
+        state = CANCELING;
+        KJ_IF_MAYBE(p, loop->port) {
           p->wake();
         }
 
         Maybe<Executor&> maybeSelfExecutor = nullptr;
         if (threadLocalEventLoop != nullptr) {
           KJ_IF_MAYBE(e, threadLocalEventLoop->executor) {
-            maybeSelfExecutor = *e;
+            maybeSelfExecutor = **e;
           }
         }
 
@@ -520,7 +593,7 @@ void XThreadEvent::ensureDoneOrCanceled() {
             }
 
             // OK now we can take the original lock again.
-            lock = targetExecutor.impl->state.lockExclusive();
+            lock = targetExecutor->impl->state.lockExclusive();
 
             // OK, now we can wait for the other thread to either process our cancellation or
             // indicate that it is waiting for remote cancellation.
@@ -539,6 +612,8 @@ void XThreadEvent::ensureDoneOrCanceled() {
         KJ_DASSERT(targetPrev == nullptr);
         break;
       }
+      case CANCELING:
+        KJ_FAIL_ASSERT("impossible state: CANCELING should only be set within the above case");
       case DONE:
         // Became done while we waited for lock. Nothing to do.
         break;
@@ -556,28 +631,55 @@ void XThreadEvent::ensureDoneOrCanceled() {
   }
 }
 
-void XThreadEvent::done() {
+void XThreadEvent::sendReply() {
   KJ_IF_MAYBE(e, replyExecutor) {
     // Queue the reply.
+    const EventLoop* replyLoop;
     {
       auto lock = e->impl->state.lockExclusive();
-      lock->replies.insert(*this);
+      KJ_IF_MAYBE(l, lock->loop) {
+        lock->replies.insert(*this);
+        replyLoop = l;
+      } else {
+        // Calling thread exited without cancelling the promise. This is UB. In fact,
+        // `replyExecutor` is probably already destroyed and we are in use-after-free territory
+        // already. Better abort.
+        KJ_LOG(FATAL,
+            "the thread which called kj::Executor::executeAsync() apparently exited its own "
+            "event loop without canceling the cross-thread promise first; this is undefined "
+            "behavior so I will crash now");
+        abort();
+      }
     }
 
-    KJ_IF_MAYBE(p, e->loop.port) {
+    // Note that it's safe to assume `replyLoop` still exists even though we dropped the lock
+    // because that thread would have had to cancel any promises before destroying its own
+    // EventLoop, and when it tries to destroy this promise, it will wait for `state` to become
+    // `DONE`, which we don't set until later on. That's nice because wake() probably makes a
+    // syscall and we'd rather not hold the lock through syscalls.
+    KJ_IF_MAYBE(p, replyLoop->port) {
       p->wake();
     }
   }
+}
+
+void XThreadEvent::done() {
+  sendReply();
 
   {
-    auto lock = targetExecutor.impl->state.lockExclusive();
-    KJ_DASSERT(state == EXECUTING);
+    auto lock = targetExecutor->impl->state.lockExclusive();
 
-    if (targetPrev != nullptr) {
-      // We must be in the cancel list, because we can't be in the run list during EXECUTING state.
-      // We can remove ourselves from the cancel list because at this point we're done anyway, so
-      // whatever.
-      lock->cancel.erase(*this);
+    switch (state) {
+      case EXECUTING:
+        lock->executing.erase(*this);
+        break;
+      case CANCELING:
+        // Sending thread requested cancelation, but we're done anyway, so it doesn't matter at this
+        // point.
+        lock->cancel.erase(*this);
+        break;
+      default:
+        KJ_FAIL_ASSERT("can't call done() from this state", (uint)state);
     }
 
     setDoneState();
@@ -591,6 +693,11 @@ inline void XThreadEvent::setDoneState() {
 #else
   __atomic_store_n(&state, DONE, __ATOMIC_RELEASE);
 #endif
+}
+
+void XThreadEvent::setDisconnected() {
+  result.addException(KJ_EXCEPTION(DISCONNECTED,
+      "Executor's event loop exited before cross-thread event could complete"));
 }
 
 class XThreadEvent::DelayedDoneHack: public Disposer {
@@ -641,16 +748,31 @@ void XThreadEvent::onReady(Event* event) noexcept {
   onReadyEvent.init(event);
 }
 
+class ExecutorImpl: public Executor, public AtomicRefcounted {
+public:
+  using Executor::Executor;
+
+  kj::Own<const Executor> addRef() const override {
+    return kj::atomicAddRef(static_cast<const _::ExecutorImpl&>(*this));
+  }
+};
+
 }  // namespace _
 
-Executor::Executor(EventLoop& loop, Badge<EventLoop>): loop(loop), impl(kj::heap<Impl>()) {}
+Executor::Executor(EventLoop& loop, Badge<EventLoop>): impl(kj::heap<Impl>(loop)) {}
 Executor::~Executor() noexcept(false) {}
+
+bool Executor::isLive() const {
+  return impl->state.lockShared()->loop != nullptr;
+}
 
 void Executor::send(_::XThreadEvent& event, bool sync) const {
   KJ_ASSERT(event.state == _::XThreadEvent::UNUSED);
 
   if (sync) {
-    if (threadLocalEventLoop == &loop) {
+    EventLoop* thisThread = threadLocalEventLoop;
+    if (thisThread != nullptr &&
+        thisThread->executor.map([this](auto& e) { return e == this; }).orDefault(false)) {
       // Invoking a sync request on our own thread. Just execute it directly; if we try to queue
       // it to the loop, we'll deadlock.
       auto promiseNode = event.execute();
@@ -671,10 +793,18 @@ void Executor::send(_::XThreadEvent& event, bool sync) const {
   }
 
   auto lock = impl->state.lockExclusive();
-  event.state = _::XThreadEvent::QUEUED;
-  lock->run.insert(event);
+  const EventLoop* loop;
+  KJ_IF_MAYBE(l, lock->loop) {
+    loop = l;
+  } else {
+    event.setDisconnected();
+    return;
+  }
 
-  KJ_IF_MAYBE(p, loop.port) {
+  event.state = _::XThreadEvent::QUEUED;
+  lock->start.insert(event);
+
+  KJ_IF_MAYBE(p, loop->port) {
     p->wake();
   } else {
     // Event loop will be waiting on executor.wait(), which will be woken when we unlock the mutex.
@@ -692,7 +822,7 @@ void Executor::wait() {
   auto lock = impl->state.lockExclusive();
 
   lock.wait([](const Impl::State& state) {
-    return !state.empty();
+    return state.isDispatchNeeded();
   });
 
   lock->dispatchAll(eventsToCancelOutsideLock);
@@ -703,11 +833,19 @@ bool Executor::poll() {
   KJ_DEFER(impl->processAsyncCancellations(eventsToCancelOutsideLock));
 
   auto lock = impl->state.lockExclusive();
-  if (lock->empty()) {
-    return false;
-  } else {
+  if (lock->isDispatchNeeded()) {
     lock->dispatchAll(eventsToCancelOutsideLock);
     return true;
+  } else {
+    return false;
+  }
+}
+
+EventLoop& Executor::getLoop() const {
+  KJ_IF_MAYBE(l, impl->state.lockShared()->loop) {
+    return *l;
+  } else {
+    kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "Executor's event loop has exited"));
   }
 }
 
@@ -987,6 +1125,11 @@ EventLoop::~EventLoop() noexcept(false) {
   });
 #endif
 
+  KJ_IF_MAYBE(e, executor) {
+    // Cancel all outstanding cross-thread events.
+    e->get()->impl->disconnect();
+  }
+
   // Destroy all "daemon" tasks, noting that their destructors might try to access the EventLoop
   // some more.
   daemons = nullptr;
@@ -1067,9 +1210,9 @@ bool EventLoop::isRunnable() {
 
 const Executor& EventLoop::getExecutor() {
   KJ_IF_MAYBE(e, executor) {
-    return *e;
+    return **e;
   } else {
-    return executor.emplace(*this, Badge<EventLoop>());
+    return *executor.emplace(kj::atomicRefcounted<_::ExecutorImpl>(*this, Badge<EventLoop>()));
   }
 }
 
@@ -1100,11 +1243,11 @@ void EventLoop::wait() {
     if (p->wait()) {
       // Another thread called wake(). Check for cross-thread events.
       KJ_IF_MAYBE(e, executor) {
-        e->poll();
+        e->get()->poll();
       }
     }
   } else KJ_IF_MAYBE(e, executor) {
-    e->wait();
+    e->get()->wait();
   } else {
     KJ_FAIL_REQUIRE("Nothing to wait for; this thread would hang forever.");
   }
@@ -1115,11 +1258,11 @@ void EventLoop::poll() {
     if (p->poll()) {
       // Another thread called wake(). Check for cross-thread events.
       KJ_IF_MAYBE(e, executor) {
-        e->poll();
+        e->get()->poll();
       }
     }
   } else KJ_IF_MAYBE(e, executor) {
-    e->poll();
+    e->get()->poll();
   }
 }
 


### PR DESCRIPTION
In practice, we've found that Executor is hard to use correctly if it's possible that the target event loop might exit while other threads are still trying to queue things to its executor. This change makes handling that case more graceful. Now, if an event loop exits without completing a cross-thread task, the requesting thread gets a DISCONNECTED exception (instead of hanging forever or crashing). It's also now possible to hold on to an Executor reference beyond the lifetime of the destination thread, and to query whether its event loop still lives.