### PR TITLE
Fix -fno-exceptions build.

### DIFF
--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -602,7 +602,7 @@ KJ_TEST("synchronous cross-thread event disconnected") {
 
     KJ_EXPECT(exec->isLive());
 
-    KJ_EXPECT_THROW_MESSAGE(
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(
         "Executor's event loop exited before cross-thread event could complete",
         exec->executeSync([&]() -> Promise<void> {
           fulfiller->fulfill();
@@ -658,7 +658,7 @@ KJ_TEST("asynchronous cross-thread event disconnected") {
 
     KJ_EXPECT(exec->isLive());
 
-    KJ_EXPECT_THROW_MESSAGE(
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(
         "Executor's event loop exited before cross-thread event could complete",
         exec->executeAsync([&]() -> Promise<void> {
           fulfiller->fulfill();
@@ -711,7 +711,7 @@ KJ_TEST("cross-thread event disconnected before it runs") {
 
     *executor.lockExclusive() = nullptr;
 
-    KJ_EXPECT_THROW_MESSAGE(
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(
         "Executor's event loop exited before cross-thread event could complete",
         promise.wait(waitScope));
 
@@ -756,7 +756,7 @@ KJ_TEST("cross-thread event disconnected without holding Executor ref") {
 
     KJ_EXPECT(exec->isLive());
 
-    KJ_EXPECT_THROW_MESSAGE(
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(
         "Executor's event loop exited before cross-thread event could complete",
         exec->executeSync([&]() -> Promise<void> {
           fulfiller->fulfill();


### PR DESCRIPTION
Note that executor disconnects still aren't super-usable when exceptions are disabled as trying to schedule on an executor whose thread is _already_ gone throws a fatal exception. I don't care to put in the effort to fix this because I don't think anyone will use this feature with exceptions disabled. TBH, we should probably define a small subset of KJ/capnp that are expected to work with exceptions disabled and stop trying to test the rest in this configuration...