### PR TITLE
Add const modifier to FiberPool::startFiber

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -342,14 +342,14 @@ struct FiberPool::Impl {
   size_t stackSize;
   MutexGuarded<Maybe<Own<_::FiberStack>>> start;
 
-  void returnStack(Own<_::FiberStack> stack) {
+  void returnStack(Own<_::FiberStack> stack) const {
     stack->reset();
     auto lock = start.lockExclusive();
     stack->freelistNext = kj::mv(*lock);
     *lock = kj::mv(stack);
   }
 
-  Own<_::FiberStack> takeStack() {
+  Own<_::FiberStack> takeStack() const {
     auto lock = start.lockExclusive();
     auto& value = *lock;
     KJ_IF_MAYBE(current, value) {
@@ -1105,7 +1105,7 @@ FiberBase::FiberBase(size_t stackSize, _::ExceptionOrValue& result)
 #endif
 }
 
-FiberBase::FiberBase(FiberPool& pool, _::ExceptionOrValue& result)
+FiberBase::FiberBase(const FiberPool& pool, _::ExceptionOrValue& result)
     : state(WAITING), pool(pool), result(result) {
   stack = pool.impl->takeStack();
   stack->initialize(*this);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -420,7 +420,7 @@ public:
   KJ_DISALLOW_COPY(FiberPool);
 
   template <typename Func>
-  PromiseForResult<Func, WaitScope&> startFiber(Func&& func) KJ_WARN_UNUSED_RESULT;
+  PromiseForResult<Func, WaitScope&> startFiber(Func&& func) const KJ_WARN_UNUSED_RESULT;
   // Executes `func()` in a fiber from this pool, returning a promise for the eventual result.
   // `func()` will be passed a `WaitScope&` as its parameter, allowing it to call `.wait()` on
   // promises. Thus, `func()` can be written in a synchronous, blocking style, instead of


### PR DESCRIPTION
Should've been done originally since `FiberPool` is thread-safe.