### PR TITLE
Extend event loop to support switching stacks while running callbacks. 

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -899,7 +899,6 @@ private:
   _::PromiseNode* currentInner = nullptr;
   OnReadyEvent onReadyEvent;
   Own<FiberStack> stack;
-  Maybe<const FiberPool&> pool;
   _::ExceptionOrValue& result;
 
   void run();

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -972,10 +972,10 @@ KJ_TEST("fiber pool") {
         int i = promise.wait(scope);
         KJ_EXPECT(i == 123);
         if (i1_local == nullptr) {
-            i1_local = &i;
-          } else {
-            KJ_ASSERT(i1_local == &i);
-          }
+          i1_local = &i;
+        } else {
+          KJ_ASSERT(i1_local == &i);
+        }
         return i;
       });
       {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -422,6 +422,10 @@ public:
   ~FiberPool() noexcept(false);
   KJ_DISALLOW_COPY(FiberPool);
 
+  void setMaxFreelist(size_t count);
+  // Set the maximum number of stacks to add to the freelist. If the freelist is full, stacks will
+  // be deleted rather than returned to the freelist.
+
   void useCoreLocalFreelists();
   // EXPERIMENTAL: Call to tell FiberPool to try to use core-local stack freelists, which
   //   in theory should increase L1/L2 cache efficacy for freelisted stacks. In practice, as of
@@ -449,6 +453,9 @@ public:
   //
   // TODO(someday): If func() returns a value, return it from runSynchronously? Current use case
   //   doesn't need it.
+
+  size_t getFreelistSize() const;
+  // Get the number of stacks currently in the freelist. Does not count stacks that are active.
 
 private:
   class Impl;

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -978,10 +978,6 @@ private:
 
   Own<TaskSet> daemons;
 
-#if _WIN32 || __CYGWIN__
-  void* mainFiber = nullptr;
-#endif
-
   bool turn();
   void setRunnable(bool runnable);
   void enterScope();

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -445,7 +445,7 @@ public:
   //   doesn't need it.
 
 private:
-  struct Impl;
+  class Impl;
   Own<Impl> impl;
 
   friend class _::FiberStack;

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -422,6 +422,12 @@ public:
   ~FiberPool() noexcept(false);
   KJ_DISALLOW_COPY(FiberPool);
 
+  void useCoreLocalFreelists();
+  // EXPERIMENTAL: Call to tell FiberPool to try to use core-local stack freelists, which
+  //   in theory should increase L1/L2 cache efficacy for freelisted stacks. In practice, as of
+  //   this writing, no performance advantage has yet been demonstrated. Note that currently this
+  //   feature is only supported on Linux (the flag has no effect on other operating systems).
+
   template <typename Func>
   PromiseForResult<Func, WaitScope&> startFiber(Func&& func) const KJ_WARN_UNUSED_RESULT;
   // Executes `func()` in a fiber from this pool, returning a promise for the eventual result.

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -301,7 +301,7 @@ public:
 template <typename Func>
 class RunnableImpl: public Runnable {
 public:
-  RunnableImpl(Func&& func): func(kj::mv(func)) {}
+  RunnableImpl(Func&& func): func(kj::fwd<Func>(func)) {}
   void run() override {
     func();
   }
@@ -315,7 +315,7 @@ Maybe<Exception> runCatchingExceptions(Runnable& runnable);
 
 template <typename Func>
 Maybe<Exception> runCatchingExceptions(Func&& func) {
-  _::RunnableImpl<Decay<Func>> runnable(kj::fwd<Func>(func));
+  _::RunnableImpl<Func> runnable(kj::fwd<Func>(func));
   return _::runCatchingExceptions(runnable);
 }
 


### PR DESCRIPTION
The event loop will use the main stack while sleeping waiting for I/O, but will switch to a FiberPool stack while running event callbacks. Programs with many threads that spend most of their time sleeping can use this to save memory by sharing a small number of "big stacks" when actually executing.

/cc @ObsidianMinor (would set you as a reviewer but GitHub won't let me...)