### PR TITLE
Consistent checking of __GNUC__ define.

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#ifdef __GNUC__
+#if __GNUC__
 #define KJ_BEGIN_SYSTEM_HEADER _Pragma("GCC system_header")
 #elif defined(_MSC_VER)
 #define KJ_BEGIN_SYSTEM_HEADER __pragma(warning(push, 0))
@@ -55,13 +55,13 @@ KJ_BEGIN_HEADER
 // had it defined to 201300L even with -std=c++14.
 #if __cplusplus < 201300L && !__CDT_PARSER__ && !_MSC_VER
   #error "This code requires C++14. Either your compiler does not support it or it is not enabled."
-  #ifdef __GNUC__
+  #if __GNUC__
     // Compiler claims compatibility with GCC, so presumably supports -std.
     #error "Pass -std=c++14 on the compiler command line to enable C++14."
   #endif
 #endif
 
-#ifdef __GNUC__
+#if __GNUC__
   #if __clang__
     #if __clang_major__ < 5
       #warning "This library requires at least Clang 5.0."
@@ -117,7 +117,7 @@ typedef unsigned char byte;
 // Detect whether RTTI and exceptions are enabled, assuming they are unless we have specific
 // evidence to the contrary.  Clients can always define KJ_NO_RTTI or KJ_NO_EXCEPTIONS explicitly
 // to override these checks.
-#ifdef __GNUC__
+#if __GNUC__
   #if !defined(KJ_NO_RTTI) && !__GXX_RTTI
     #define KJ_NO_RTTI 1
   #endif
@@ -152,7 +152,7 @@ typedef unsigned char byte;
   classname& operator=(const classname&) = delete
 // Deletes the implicit copy constructor and assignment operator.
 
-#ifdef __GNUC__
+#if __GNUC__
 #define KJ_LIKELY(condition) __builtin_expect(condition, true)
 #define KJ_UNLIKELY(condition) __builtin_expect(condition, false)
 // Branch prediction macros.  Evaluates to the condition given, but also tells the compiler that we


### PR DESCRIPTION
The kj/common.h header sometimes checks for if __GNUC__ is defined, and sometimes if it's true, this is changing it to be consistent in checking if it's true.

Specifically, MSVC classifies checking the value of an undefined define as a warning, this header can be included in other projects that have warnings as errors turned on.

My approach to solving this was to manually define these defines as 0, such as ___GNUC__, __CLANG__, __NO_INLINE__, KJ_USE_FUTEX, etc. However doing such for __GNUC__ caused additional problems due to this inconcinstency when it is defined, but set to 0.

This could alternativelly be fixed by consistently checking for all the macro definitions being undefined.