### PR TITLE
Utilities for handling network disconnects

### DIFF
--- a/c++/src/capnp/reconnect-test.c++
+++ b/c++/src/capnp/reconnect-test.c++
@@ -1,0 +1,173 @@
+// Copyright (c) 2020 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "reconnect.h"
+#include "test-util.h"
+#include <kj/debug.h>
+#include <kj/test.h>
+#include <kj/async-io.h>
+#include "rpc-twoparty.h"
+
+namespace capnp {
+namespace _ {
+namespace {
+
+class TestInterfaceImpl final: public test::TestInterface::Server {
+public:
+  TestInterfaceImpl(uint generation): generation(generation) {}
+
+  void setError(kj::Exception e) {
+    error = kj::mv(e);
+  }
+
+  kj::Own<kj::PromiseFulfiller<void>> block() {
+    auto paf = kj::newPromiseAndFulfiller<void>();
+    blocker = paf.promise.fork();
+    return kj::mv(paf.fulfiller);
+  }
+
+protected:
+  kj::Promise<void> foo(FooContext context) override {
+    KJ_IF_MAYBE(e, error) {
+      return kj::cp(*e);
+    }
+    auto params = context.getParams();
+    context.initResults().setX(kj::str(params.getI(), ' ', params.getJ(), ' ', generation));
+    return blocker.addBranch();
+  }
+
+private:
+  uint generation;
+  kj::Maybe<kj::Exception> error;
+  kj::ForkedPromise<void> blocker = kj::Promise<void>(kj::READY_NOW).fork();
+};
+
+void doAutoReconnectTest(kj::WaitScope& ws,
+    kj::Function<test::TestInterface::Client(test::TestInterface::Client)> wrapClient) {
+  TestInterfaceImpl* currentServer = nullptr;
+  uint connectCount = 0;
+
+  test::TestInterface::Client client = wrapClient(autoReconnect([&]() {
+    auto server = kj::heap<TestInterfaceImpl>(connectCount++);
+    currentServer = server;
+    return test::TestInterface::Client(kj::mv(server));
+  }));
+
+  auto testPromise = [&](uint i, bool j) {
+    auto req = client.fooRequest();
+    req.setI(i);
+    req.setJ(j);
+    return req.send();
+  };
+
+  auto test = [&](uint i, bool j) {
+    return testPromise(i, j).wait(ws).getX();
+  };
+
+  KJ_EXPECT(test(123, true) == "123 true 0");
+
+  currentServer->setError(KJ_EXCEPTION(DISCONNECTED, "test1 disconnect"));
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("test1 disconnect", test(456, true));
+
+  KJ_EXPECT(test(789, false) == "789 false 1");
+  KJ_EXPECT(test(21, true) == "21 true 1");
+
+  {
+    // We cause two disconnect promises to be thrown concurrently. This should only cause the
+    // reconnector to reconnect once, not twice.
+    auto fulfiller = currentServer->block();
+    auto promise1 = testPromise(32, false);
+    auto promise2 = testPromise(43, true);
+    KJ_EXPECT(!promise1.poll(ws));
+    KJ_EXPECT(!promise2.poll(ws));
+    fulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "test2 disconnect"));
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("test2 disconnect", promise1.wait(ws));
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("test2 disconnect", promise2.wait(ws));
+  }
+
+  KJ_EXPECT(test(43, false) == "43 false 2");
+
+  // Start a couple calls that will block at the server end, plus an unsent request.
+  auto fulfiller = currentServer->block();
+
+  auto promise1 = testPromise(1212, true);
+  auto promise2 = testPromise(3434, false);
+  auto req3 = client.fooRequest();
+  req3.setI(5656);
+  req3.setJ(true);
+  KJ_EXPECT(!promise1.poll(ws));
+  KJ_EXPECT(!promise2.poll(ws));
+
+  // Now force a reconnect.
+  currentServer->setError(KJ_EXCEPTION(DISCONNECTED, "test3 disconnect"));
+
+  // Initiate a request that will fail with DISCONNECTED.
+  auto promise4 = testPromise(7878, false);
+
+  // And throw away our capability entirely, just to make sure that anyone who needs it is holding
+  // onto their own ref.
+  client = nullptr;
+
+  // Everything we initiated should still finish.
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("test3 disconnect", promise4.wait(ws));
+
+  // Send the request which we created before the disconnect. There are two behaviors we accept
+  // as correct here: it may throw the disconnect exception, or it may automatically redirect to
+  // the newly-reconnected destination.
+  req3.send().then([](Response<test::TestInterface::FooResults> resp) {
+    KJ_EXPECT(resp.getX() == "5656 true 3");
+  }, [](kj::Exception e) {
+    KJ_EXPECT(e.getDescription().endsWith("test3 disconnect"));
+  }).wait(ws);
+
+  KJ_EXPECT(!promise1.poll(ws));
+  KJ_EXPECT(!promise2.poll(ws));
+  fulfiller->fulfill();
+  KJ_EXPECT(promise1.wait(ws).getX() == "1212 true 2");
+  KJ_EXPECT(promise2.wait(ws).getX() == "3434 false 2");
+}
+
+KJ_TEST("autoReconnect() direct call (exercises newCall() / RequestHook)") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  doAutoReconnectTest(ws, [](auto c) {return kj::mv(c);});
+}
+
+KJ_TEST("autoReconnect() through RPC (exercises call() / CallContextHook)") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  auto paf = kj::newPromiseAndFulfiller<test::TestInterface::Client>();
+
+  auto pipe = kj::newTwoWayPipe();
+  TwoPartyClient client(*pipe.ends[0]);
+  TwoPartyClient server(*pipe.ends[1], kj::mv(paf.promise), rpc::twoparty::Side::SERVER);
+
+  doAutoReconnectTest(ws, [&](test::TestInterface::Client c) {
+    paf.fulfiller->fulfill(kj::mv(c));
+    return client.bootstrap().castAs<test::TestInterface>();
+  });
+}
+
+}  // namespace
+}  // namespace _
+}  // namespace capnp

--- a/c++/src/capnp/reconnect.c++
+++ b/c++/src/capnp/reconnect.c++
@@ -1,0 +1,130 @@
+// Copyright (c) 2020 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "reconnect.h"
+
+namespace capnp {
+
+namespace {
+
+class ReconnectHook final: public ClientHook, public kj::Refcounted {
+public:
+  ReconnectHook(kj::Function<Capability::Client()> connectParam)
+      : connect(kj::mv(connectParam)),
+        current(ClientHook::from(connect())) {}
+
+  Request<AnyPointer, AnyPointer> newCall(
+      uint64_t interfaceId, uint16_t methodId, kj::Maybe<MessageSize> sizeHint) override {
+    auto result = current->newCall(interfaceId, methodId, sizeHint);
+    AnyPointer::Builder builder = result;
+    auto hook = kj::heap<RequestImpl>(kj::addRef(*this), RequestHook::from(kj::mv(result)));
+    return { builder, kj::mv(hook) };
+  }
+
+  VoidPromiseAndPipeline call(uint64_t interfaceId, uint16_t methodId,
+                              kj::Own<CallContextHook>&& context) override {
+    auto result = current->call(interfaceId, methodId, kj::mv(context));
+    wrap(result.promise);
+    return result;
+  }
+
+  kj::Maybe<ClientHook&> getResolved() override {
+    // We can't let people resolve to the underlying capability because then we wouldn't be able
+    // to redirect them later.
+    return nullptr;
+  }
+
+  kj::Maybe<kj::Promise<kj::Own<ClientHook>>> whenMoreResolved() override {
+    return nullptr;
+  }
+
+  kj::Own<ClientHook> addRef() override {
+    return kj::addRef(*this);
+  }
+
+  const void* getBrand() override {
+    return nullptr;
+  }
+
+  kj::Maybe<int> getFd() override {
+    // It's not safe to return current->getFd() because normally callers wouldn't expect the FD to
+    // change or go away over time, but this one could whenever we reconnect. If there's a use
+    // case for being able to access the FD here, we'll need a different interface to do it.
+    return nullptr;
+  }
+
+private:
+  kj::Function<Capability::Client()> connect;
+  kj::Own<ClientHook> current;
+  uint generation = 0;
+
+  template <typename T>
+  void wrap(kj::Promise<T>& promise) {
+    promise = promise.catch_(
+        [self = kj::addRef(*this), startGeneration = generation]
+        (kj::Exception&& exception) mutable -> kj::Promise<T> {
+      if (exception.getType() == kj::Exception::Type::DISCONNECTED &&
+          self->generation == startGeneration) {
+        self->generation++;
+        KJ_IF_MAYBE(e2, kj::runCatchingExceptions([&]() {
+          self->current = ClientHook::from(self->connect());
+        })) {
+          self->current = newBrokenCap(kj::mv(*e2));
+        }
+      }
+      return kj::mv(exception);
+    });
+  }
+
+  class RequestImpl final: public RequestHook {
+  public:
+    RequestImpl(kj::Own<ReconnectHook> parent, kj::Own<RequestHook> inner)
+        : parent(kj::mv(parent)), inner(kj::mv(inner)) {}
+
+    RemotePromise<AnyPointer> send() override {
+      auto result = inner->send();
+      parent->wrap(result);
+      return result;
+    }
+
+    kj::Promise<void> sendStreaming() override {
+      auto result = inner->sendStreaming();
+      parent->wrap(result);
+      return result;
+    }
+
+    const void* getBrand() override {
+      return nullptr;
+    }
+
+  private:
+    kj::Own<ReconnectHook> parent;
+    kj::Own<RequestHook> inner;
+  };
+};
+
+}  // namespace
+
+Capability::Client autoReconnect(kj::Function<Capability::Client()> connect) {
+  return Capability::Client(kj::refcounted<ReconnectHook>(kj::mv(connect)));
+}
+
+}  // namespace capnp

--- a/c++/src/capnp/reconnect.h
+++ b/c++/src/capnp/reconnect.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "capability.h"
+#include <kj/function.h>
+
+CAPNP_BEGIN_HEADER
+
+namespace capnp {
+
+template <typename ConnectFunc>
+auto autoReconnect(ConnectFunc&& connect);
+// Creates a capability that reconstructs itself every time it becomes disconnected.
+//
+// `connect()` is a function which is invoked to initially construct the capability, and then
+// invoked again each time the capability is found to be disconnected. `connect()` may return
+// any capability `Client` type.
+//
+// Example usage might look like:
+//
+//     Foo::Client foo = autoReconnect([&rpcSystem, vatId]() {
+//       return rpcSystem.bootstrap(vatId).castAs<RootType>().getFooRequest().send().getFoo();
+//     });
+//
+// The given function is initially called synchronously, and the returned `foo` is a wrapper
+// around what the function returned. But any time this capability becomes disconnected, the
+// function is invoked again, and future calls are directed to the new result.
+//
+// Any call that is in-flight when the capability becomes disconnected still fails with a
+// DISCONNECTED exception. The caller should respond by retrying, as a retry will target the
+// newly-reconnected capability. However, the caller should limit the number of times it retries,
+// to avoid an infinite loop in the case that the DISCONNECTED exception actually represents a
+// permanent problem. Consider using `kj::retryOnDisconnect()` to implement this behavior.
+
+// =======================================================================================
+// inline implementation details
+
+Capability::Client autoReconnect(kj::Function<Capability::Client()> connect);
+template <typename ConnectFunc>
+auto autoReconnect(ConnectFunc&& connect) {
+  return autoReconnect(kj::Function<Capability::Client()>(kj::fwd<ConnectFunc>(connect)))
+      .castAs<FromClient<kj::Decay<decltype(connect())>>>();
+}
+
+}  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -394,6 +394,17 @@ PromiseForResult<Func, void> evalLast(Func&& func) KJ_WARN_UNUSED_RESULT;
 // drained.
 
 template <typename Func>
+PromiseForResult<Func, void> retryOnDisconnect(Func&& func) KJ_WARN_UNUSED_RESULT;
+// Runs `func()`, retrying once if it fails with a DISCONNECTED exception. If the retry also
+// fails, the exception is passed through.
+//
+// `func()` should return a `Promise`. `retryOnDisconnect(func)` returns the same promise, except
+// with the retry logic added.
+//
+// Synchronous exceptions from `func()` are captured and turned into rejected promises (or retries
+// if the failure is a disconnect).
+
+template <typename Func>
 PromiseForResult<Func, WaitScope&> startFiber(size_t stackSize, Func&& func) KJ_WARN_UNUSED_RESULT;
 // Executes `func()` in a fiber, returning a promise for the eventual reseult. `func()` will be
 // passed a `WaitScope&` as its parameter, allowing it to call `.wait()` on promises. Thus, `func()`


### PR DESCRIPTION
Sandstorm has had hackier versions of these for a long time, but lots of Cap'n Proto applications will need these, so I went and wrote clean versions in capnp itself.

@a-robinson