### PR TITLE
Try to fix new MinGW and Cygwin build failures

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Build and test
         shell: cmd
         run: |
+            echo "Deleting broken Postgres install until https://github.com/actions/virtual-environments/issues/1089 is fixed..."
+            rmdir /s /q C:\PROGRA~1\POSTGR~1
+
             echo "Building Cap'n Proto with MinGW"
             cmake -Hc++ -Bbuild-output -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=debug -DCMAKE_INSTALL_PREFIX=%CD%\capnproto-c++-install -DCMAKE_SH="CMAKE_SH-NOTFOUND"
             cmake --build build-output --target install -- -j2

--- a/super-test.sh
+++ b/super-test.sh
@@ -13,10 +13,14 @@ function test_samples() {
   ./addressbook dwrite | ./addressbook dread
   rm -f /tmp/capnp-calculator-example-$$
   ./calculator-server unix:/tmp/capnp-calculator-example-$$ &
+  local SERVER_PID=$!
   sleep 1
   ./calculator-client unix:/tmp/capnp-calculator-example-$$
-  kill %./calculator-server
-  wait %./calculator-server || true
+  # `kill %./calculator-server` doesn't seem to work on recent Cygwins, but we can kill by PID.
+  kill -9 $SERVER_PID
+  # This `fg` will fail if bash happens to have already noticed the quit and reaped the process
+  # before `fg` is invoked, so in that case we just proceed.
+  fg %./calculator-server || true
   rm -f /tmp/capnp-calculator-example-$$
 }
 


### PR DESCRIPTION
Both MinGW and Cygwin builds spontaneously broke in recent weeks for different reasons -- not due to any change to Cap'n Proto, but some external factors.

MinGW seems to have picked up an errant include of `windows.h` which is shitting all over the global namespace and breaking the build.

Cygwin has started hanging after running the calculator demo, just like it used to do on Travis before we switched to GitHub Actions.