### PR TITLE
HTTP 205 responses must have content-length: 0

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -938,6 +938,34 @@ kj::ArrayPtr<const HttpResponseTestCase> responseTestCases() {
     },
 
     {
+      "HTTP/1.1 204 No Content\r\n"
+      "\r\n",
+
+      204, "No Content",
+      {},
+      uint64_t(0), {},
+    },
+
+    {
+      "HTTP/1.1 205 Reset Content\r\n"
+      "Content-Length: 0\r\n"
+      "\r\n",
+
+      205, "Reset Content",
+      {},
+      uint64_t(0), {},
+    },
+
+    {
+      "HTTP/1.1 304 Not Modified\r\n"
+      "\r\n",
+
+      304, "Not Modified",
+      {},
+      uint64_t(0), {},
+    },
+
+    {
       "HTTP/1.1 200 OK\r\n"
       "Content-Length: 8\r\n"
       "Content-Type: text/plain\r\n"


### PR DESCRIPTION
It turns out HTTP 205 is weird. Like 204 or 304, it can't have a body. But unlike those, it must include headers to indicate a body. The body just has to be empty. So we need to add content-length: 0 to these responses.

Spec: https://tools.ietf.org/html/rfc7231#section-6.3.6