### PR TITLE
Make retryOnDisconnect call the provided func asynchronously both times

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -1240,7 +1240,7 @@ KJ_TEST("retryOnDisconnect") {
       i++;
       return 123;
     });
-    KJ_EXPECT(i == 1);
+    KJ_EXPECT(i == 0);
     KJ_EXPECT(promise.wait(waitScope) == 123);
     KJ_EXPECT(i == 1);
   }
@@ -1254,7 +1254,7 @@ KJ_TEST("retryOnDisconnect") {
         return 123;
       }
     });
-    KJ_EXPECT(i == 1);
+    KJ_EXPECT(i == 0);
     KJ_EXPECT(promise.wait(waitScope) == 123);
     KJ_EXPECT(i == 2);
   }
@@ -1269,7 +1269,7 @@ KJ_TEST("retryOnDisconnect") {
         return 123;
       }
     });
-    KJ_EXPECT(i == 1);
+    KJ_EXPECT(i == 0);
     KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("test disconnect; i = 2", promise.wait(waitScope));
     KJ_EXPECT(i == 2);
   }
@@ -1289,7 +1289,7 @@ KJ_TEST("retryOnDisconnect") {
     Func func;
 
     auto promise = retryOnDisconnect(func);
-    KJ_EXPECT(func.i == 1);
+    KJ_EXPECT(func.i == 0);
     KJ_EXPECT(promise.wait(waitScope) == 123);
     KJ_EXPECT(func.i == 2);
   }

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -395,14 +395,11 @@ PromiseForResult<Func, void> evalLast(Func&& func) KJ_WARN_UNUSED_RESULT;
 
 template <typename Func>
 PromiseForResult<Func, void> retryOnDisconnect(Func&& func) KJ_WARN_UNUSED_RESULT;
-// Runs `func()`, retrying once if it fails with a DISCONNECTED exception. If the retry also
-// fails, the exception is passed through.
+// Promises to run `func()` asynchronously, retrying once if it fails with a DISCONNECTED exception.
+// If the retry also fails, the exception is passed through.
 //
 // `func()` should return a `Promise`. `retryOnDisconnect(func)` returns the same promise, except
 // with the retry logic added.
-//
-// Synchronous exceptions from `func()` are captured and turned into rejected promises (or retries
-// if the failure is a disconnect).
 
 template <typename Func>
 PromiseForResult<Func, WaitScope&> startFiber(size_t stackSize, Func&& func) KJ_WARN_UNUSED_RESULT;


### PR DESCRIPTION
Rather than synchronously the first time and async the second, which
makes it tougher to deal with locks.

Minor follow-up to #1017 