### PR TITLE
Get rid of superfluous kj::mv

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -327,7 +327,7 @@ public:
   kj::Promise<kj::Own<kj::AsyncIoStream>> connect() override {
     auto result = KJ_ASSERT_NONNULL(kj::mv(stream));
     stream = nullptr;
-    return kj::mv(result);
+    return result;
   }
 
   kj::Own<kj::ConnectionReceiver> listen() override { KJ_UNIMPLEMENTED("test"); }

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -198,6 +198,7 @@ public:
         return kj::READY_NOW;
       } else {
         // Some other error... propagate it.
+        // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
         return kj::mv(e);
       }
     });
@@ -296,6 +297,7 @@ public:
       // to propagate the problem back to the client. If the error came from the client, then
       // .abort() probably is a noop.
       webSocket.abort();
+      // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
       return kj::mv(e);
     }));
 

--- a/c++/src/capnp/compat/json-rpc.c++
+++ b/c++/src/capnp/compat/json-rpc.c++
@@ -81,7 +81,7 @@ public:
       auto sproto = context.getResultsType().getProto().getStruct();
       MessageSize size { sproto.getDataWordCount(), sproto.getPointerCount() };
       context.initResults(size);
-      return kj::mv(writePromise);
+      return writePromise;
     } else {
       auto paf = kj::newPromiseAndFulfiller<void>();
       parent.awaitedResponses.insert(callId, AwaitedResponse { context, kj::mv(paf.fulfiller) });

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -484,7 +484,7 @@ Orphan<DynamicValue> JsonCodec::decode(
             KJ_REQUIRE(byte(x) == x, "Number in byte array is not an integer in [0, 255]");
             data[i] = x;
           }
-          return kj::mv(orphan);
+          return orphan;
         }
         default:
           KJ_FAIL_REQUIRE("Expected data value");
@@ -509,7 +509,7 @@ Orphan<DynamicValue> JsonCodec::decode(
       auto structType = type.asStruct();
       auto orphan = orphanage.newOrphan(structType);
       decodeObject(input, structType, orphanage, orphan.get());
-      return kj::mv(orphan);
+      return orphan;
     }
     case schema::Type::INTERFACE:
       KJ_FAIL_REQUIRE("don't know how to JSON-decode capabilities; "

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -755,7 +755,7 @@ public:
     if (!quiet) {
       auto result = checkPlausibility(convertFrom, input.getReadBuffer());
       if (result.getError() != nullptr) {
-        return kj::mv(result);
+        return result;
       }
     }
 

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -477,7 +477,7 @@ private:
     if ('a' <= result[0] && result[0] <= 'z') {
       result[0] = result[0] - 'a' + 'A';
     }
-    return kj::mv(result);
+    return result;
   }
 
   CppTypeName typeName(Type type, kj::Maybe<InterfaceSchema::Method> method) {

--- a/c++/src/capnp/compiler/capnpc-capnp.c++
+++ b/c++/src/capnp/compiler/capnpc-capnp.c++
@@ -425,7 +425,7 @@ private:
   kj::Array<decltype(kj::instance<MemberList>()[0])> sortByCodeOrder(MemberList&& list) {
     auto sorted = KJ_MAP(item, list) { return item; };
     std::sort(sorted.begin(), sorted.end(), OrderByCodeOrder());
-    return kj::mv(sorted);
+    return sorted;
   }
 
   kj::Array<kj::StringTree> genStructFields(StructSchema schema, Indent indent) {

--- a/c++/src/capnp/compiler/evolution-test.c++
+++ b/c++/src/capnp/compiler/evolution-test.c++
@@ -493,7 +493,7 @@ Orphan<DynamicValue> makeExampleValue(
             orphanage, ordinal, field.getType(), sharedOrdinalCount));
       }
 
-      return kj::mv(result);
+      return result;
     }
     case schema::Type::ENUM: {
       auto enumerants = type.asEnum().getEnumerants();
@@ -505,7 +505,7 @@ Orphan<DynamicValue> makeExampleValue(
       auto result = orphanage.newOrphan(listType, 1);
       result.get().adopt(0, makeExampleValue(
           orphanage, ordinal, elementType, sharedOrdinalCount));
-      return kj::mv(result);
+      return result;
     }
     default:
       KJ_FAIL_ASSERT("You added a new possible field type!");
@@ -613,7 +613,7 @@ Orphan<DynamicStruct> makeExampleStruct(
     setExampleField(builder, field, sharedOrdinalCount);
   }
 
-  return kj::mv(result);
+  return result;
 }
 
 void checkExampleStruct(DynamicStruct::Reader reader, uint sharedOrdinalCount) {

--- a/c++/src/capnp/compiler/lexer.c++
+++ b/c++/src/capnp/compiler/lexer.c++
@@ -283,7 +283,7 @@ Lexer::Lexer(Orphanage orphanageParam, ErrorReporter& errorReporter)
         }
         builder.setStartByte(loc.begin());
         builder.setEndByte(loc.end());
-        return kj::mv(statement);
+        return statement;
       }));
 
   parsers.statementSequence = arena.copy(sequence(

--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -2734,13 +2734,13 @@ kj::Maybe<Orphan<DynamicValue>> ValueTranslator::compileValue(Expression::Reader
 
     case DynamicValue::VOID:
       if (type.isVoid()) {
-        return kj::mv(result);
+        return result;
       }
       break;
 
     case DynamicValue::BOOL:
       if (type.isBool()) {
-        return kj::mv(result);
+        return result;
       }
       break;
 
@@ -2772,7 +2772,7 @@ kj::Maybe<Orphan<DynamicValue>> ValueTranslator::compileValue(Expression::Reader
           errorReporter.addErrorOn(src, "Integer value out of range.");
           result = minValue;
         }
-        return kj::mv(result);
+        return result;
       }
 
     } // fallthrough -- value is positive, so we can just go on to the uint case below.
@@ -2803,37 +2803,37 @@ kj::Maybe<Orphan<DynamicValue>> ValueTranslator::compileValue(Expression::Reader
         errorReporter.addErrorOn(src, "Integer value out of range.");
         result = maxValue;
       }
-      return kj::mv(result);
+      return result;
     }
 
     case DynamicValue::FLOAT:
       if (type.isFloat32() || type.isFloat64()) {
-        return kj::mv(result);
+        return result;
       }
       break;
 
     case DynamicValue::TEXT:
       if (type.isText()) {
-        return kj::mv(result);
+        return result;
       }
       break;
 
     case DynamicValue::DATA:
       if (type.isData()) {
-        return kj::mv(result);
+        return result;
       }
       break;
 
     case DynamicValue::LIST:
       if (type.isList()) {
         if (result.getReader().as<DynamicList>().getSchema() == type.asList()) {
-          return kj::mv(result);
+          return result;
         }
       } else if (type.isAnyPointer()) {
         switch (type.whichAnyPointerKind()) {
           case schema::Type::AnyPointer::Unconstrained::ANY_KIND:
           case schema::Type::AnyPointer::Unconstrained::LIST:
-            return kj::mv(result);
+            return result;
           case schema::Type::AnyPointer::Unconstrained::STRUCT:
           case schema::Type::AnyPointer::Unconstrained::CAPABILITY:
             break;
@@ -2844,7 +2844,7 @@ kj::Maybe<Orphan<DynamicValue>> ValueTranslator::compileValue(Expression::Reader
     case DynamicValue::ENUM:
       if (type.isEnum()) {
         if (result.getReader().as<DynamicEnum>().getSchema() == type.asEnum()) {
-          return kj::mv(result);
+          return result;
         }
       }
       break;
@@ -2852,13 +2852,13 @@ kj::Maybe<Orphan<DynamicValue>> ValueTranslator::compileValue(Expression::Reader
     case DynamicValue::STRUCT:
       if (type.isStruct()) {
         if (result.getReader().as<DynamicStruct>().getSchema() == type.asStruct()) {
-          return kj::mv(result);
+          return result;
         }
       } else if (type.isAnyPointer()) {
         switch (type.whichAnyPointerKind()) {
           case schema::Type::AnyPointer::Unconstrained::ANY_KIND:
           case schema::Type::AnyPointer::Unconstrained::STRUCT:
-            return kj::mv(result);
+            return result;
           case schema::Type::AnyPointer::Unconstrained::LIST:
           case schema::Type::AnyPointer::Unconstrained::CAPABILITY:
             break;
@@ -3026,7 +3026,7 @@ Orphan<DynamicValue> ValueTranslator::compileValueInner(Expression::Reader src, 
           dstList.adopt(i, kj::mv(*value));
         }
       }
-      return kj::mv(result);
+      return result;
     }
 
     case Expression::TUPLE: {
@@ -3037,7 +3037,7 @@ Orphan<DynamicValue> ValueTranslator::compileValueInner(Expression::Reader src, 
       auto structSchema = type.asStruct();
       Orphan<DynamicStruct> result = orphanage.newOrphan(structSchema);
       fillStructValue(result.get(), src.getTuple());
-      return kj::mv(result);
+      return result;
     }
 
     case Expression::UNKNOWN:

--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -224,6 +224,7 @@ public:
 
   kj::Maybe<Located<Text::Reader>> operator()(Located<Text::Reader>&& text) const {
     if (text.value == expected) {
+      // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
       return kj::mv(text);
     } else {
       return nullptr;
@@ -312,7 +313,7 @@ Orphan<List<T>> arrayToList(Orphanage& orphanage, kj::Array<Orphan<T>>&& element
   for (size_t i = 0; i < elements.size(); i++) {
     builder.adoptWithCaveats(i, kj::mv(elements[i]));
   }
-  return kj::mv(result);
+  return result;
 }
 
 static void initGenericParams(Declaration::Builder builder,
@@ -388,7 +389,7 @@ CapnpParser::CapnpParser(Orphanage orphanageParam, ErrorReporter& errorReporterP
           builder.setUnnamed();
         }
         builder.adoptValue(kj::mv(fieldValue));
-        return kj::mv(result);
+        return result;
       }));
 
   auto& tuple = arena.copy<Parser<Located<Orphan<List<Expression::Param>>>>>(
@@ -571,7 +572,7 @@ CapnpParser::CapnpParser(Orphanage orphanageParam, ErrorReporter& errorReporterP
           builder.setStartByte(startByte);
           base = kj::mv(suffix);
         }
-        return kj::mv(base);
+        return base;
       }));
 
   parsers.annotation = arena.copy(p::transform(
@@ -859,7 +860,7 @@ CapnpParser::CapnpParser(Orphanage orphanageParam, ErrorReporter& errorReporterP
           builder.getDefaultValue().setNone();
         }
 
-        return kj::mv(result);
+        return result;
       }));
 
   auto& paramList = arena.copy(p::oneOf(

--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -878,7 +878,7 @@ Orphan<DynamicValue> DynamicStruct::Builder::disown(StructSchema::Field field) {
         case schema::Type::ENUM: {
           auto result = Orphan<DynamicValue>(get(field), _::OrphanBuilder());
           clear(field);
-          return kj::mv(result);
+          return result;
         }
 
         case schema::Type::TEXT:
@@ -918,7 +918,7 @@ Orphan<DynamicValue> DynamicStruct::Builder::disown(StructSchema::Field field) {
         }
       }
 
-      return kj::mv(result);
+      return result;
     }
   }
 
@@ -1388,7 +1388,7 @@ Orphan<DynamicValue> DynamicList::Builder::disown(uint index) {
         case ElementSize::INLINE_COMPOSITE:
           KJ_UNREACHABLE;
       }
-      return kj::mv(result);
+      return result;
     }
 
     case schema::Type::TEXT:
@@ -1407,7 +1407,7 @@ Orphan<DynamicValue> DynamicList::Builder::disown(uint index) {
       auto element = builder.getStructElement(bounded(index) * ELEMENTS);
       result.get().builder.transferContentFrom(element);
       element.clearAll();
-      return kj::mv(result);
+      return result;
     }
   }
   KJ_UNREACHABLE;

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -398,7 +398,7 @@ public:
     } else {
       auto result = kj::mv(connectionQueue.front());
       connectionQueue.pop();
-      return kj::mv(result);
+      return result;
     }
   }
 

--- a/c++/src/capnp/rpc-twoparty.c++
+++ b/c++/src/capnp/rpc-twoparty.c++
@@ -293,7 +293,7 @@ kj::Promise<void> TwoPartyVatNetwork::shutdown() {
     }
   });
   previousWrite = nullptr;
-  return kj::mv(result);
+  return result;
 }
 
 // =======================================================================================

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -396,6 +396,7 @@ public:
               [](kj::Exception&& e) -> kj::Promise<void> {
           // Don't report disconnects as an error.
           if (e.getType() != kj::Exception::Type::DISCONNECTED) {
+            // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
             return kj::mv(e);
           }
           return kj::READY_NOW;
@@ -1166,7 +1167,7 @@ private:
 
       cap = replacement->addRef();
 
-      return kj::mv(replacement);
+      return replacement;
     }
   };
 
@@ -1451,11 +1452,11 @@ private:
         auto result = kj::refcounted<PromiseClient>(
             *this, kj::mv(importClient), kj::mv(paf.promise), importId);
         import.appClient = *result;
-        return kj::mv(result);
+        return result;
       }
     } else {
       import.appClient = *importClient;
-      return kj::mv(importClient);
+      return importClient;
     }
   }
 
@@ -1566,7 +1567,7 @@ private:
           if (result->getBrand() == this) {
             result = kj::refcounted<TribbleRaceBlocker>(kj::mv(result));
           }
-          return kj::mv(result);
+          return result;
         } else {
           return newBrokenCap("invalid 'receiverHosted' export ID");
         }
@@ -1582,7 +1583,7 @@ private:
                 if (result->getBrand() == this) {
                   result = kj::refcounted<TribbleRaceBlocker>(kj::mv(result));
                 }
-                return kj::mv(result);
+                return result;
               } else {
                 return newBrokenCap("unrecognized pipeline ops");
               }
@@ -1866,7 +1867,7 @@ private:
       }
 
       // Send and return.
-      return kj::mv(result);
+      return result;
     }
 
     kj::Promise<void> sendStreamingInternal(bool isTailCall) {
@@ -2093,7 +2094,7 @@ private:
       if (capTable.size() == 0) {
         return nullptr;
       } else {
-        return kj::mv(exports);
+        return exports;
       }
     }
 

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -539,7 +539,7 @@ kj::Promise<kj::Own<_::VatNetworkBase::Connection>>
     VatNetwork<SturdyRef, ProvisionId, RecipientId, ThirdPartyCapId, JoinResult>::baseAccept() {
   return accept().then(
       [](kj::Own<Connection>&& connection) -> kj::Own<_::VatNetworkBase::Connection> {
-    return kj::mv(connection);
+    return connection;
   });
 }
 

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -144,7 +144,7 @@ kj::Array<word> messageToFlatArray(kj::ArrayPtr<const kj::ArrayPtr<const word>> 
 
   KJ_DASSERT(dst == result.end(), "Buffer overrun/underrun bug in code above.");
 
-  return kj::mv(result);
+  return result;
 }
 
 size_t computeSerializedSizeInWords(kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) {

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -1069,7 +1069,7 @@ kj::Promise<void> TestMoreStuffImpl::neverReturn(NeverReturnContext context) {
   context.getResults().setCapCopy(context.getParams().getCap());
 
   context.allowCancellation();
-  return kj::mv(promise);
+  return promise;
 }
 
 kj::Promise<void> TestMoreStuffImpl::hold(HoldContext context) {

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1439,7 +1439,7 @@ public:
   kj::Maybe<Own<_::PromiseNode>> execute() override {
     auto result = _::PromiseNode::from(func());
     KJ_IREQUIRE(result.get() != nullptr);
-    return kj::mv(result);
+    return result;
   }
 
   // implements PromiseNode ----------------------------------------------------

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -226,7 +226,7 @@ public:
       auto fork = observer.whenWriteDisconnected().fork();
       auto result = fork.addBranch();
       writeDisconnectedPromise = kj::mv(fork);
-      return kj::mv(result);
+      return result;
     }
   }
 
@@ -1234,7 +1234,7 @@ public:
       if (err != 0) {
         KJ_FAIL_SYSCALL("connect()", err) { break; }
       }
-      return kj::mv(stream);
+      return stream;
     }));
   }
   Own<ConnectionReceiver> wrapListenSocketFd(
@@ -1355,7 +1355,7 @@ private:
       }
     }).then([](Own<AsyncIoStream>&& stream) -> Promise<Own<AsyncIoStream>> {
       // Success, pass along.
-      return kj::mv(stream);
+      return stream;
     }, [&lowLevel,&filter,addrs](Exception&& exception) mutable -> Promise<Own<AsyncIoStream>> {
       // Connect failed.
       if (addrs.size() > 1) {
@@ -1363,6 +1363,7 @@ private:
         return connectImpl(lowLevel, filter, addrs.slice(1, addrs.size()));
       } else {
         // No more addresses to try, so propagate the exception.
+        // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
         return kj::mv(exception);
       }
     });

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -900,7 +900,7 @@ private:
             auto promise = pipe.write(retry.data.begin(), retry.data.size());
             if (retry.moreData.size() == 0) {
               // No more pieces so that's it.
-              return kj::mv(promise);
+              return promise;
             } else {
               // Also need to write the remaining pieces.
               auto& pipeRef = pipe;
@@ -2353,6 +2353,7 @@ public:
         if (e.getType() == kj::Exception::Type::DISCONNECTED) {
           return kj::READY_NOW;
         } else {
+          // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
           return kj::mv(e);
         }
       });
@@ -2442,6 +2443,7 @@ public:
         if (e.getType() == kj::Exception::Type::DISCONNECTED) {
           return kj::READY_NOW;
         } else {
+          // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
           return kj::mv(e);
         }
       });
@@ -2659,7 +2661,7 @@ LowLevelAsyncIoProvider::NetworkFilter& LowLevelAsyncIoProvider::NetworkFilter::
 Promise<Own<AsyncIoStream>> CapabilityStreamConnectionReceiver::accept() {
   return inner.receiveStream()
       .then([](Own<AsyncCapabilityStream>&& stream) -> Own<AsyncIoStream> {
-    return kj::mv(stream);
+    return stream;
   });
 }
 
@@ -2677,7 +2679,7 @@ Promise<Own<AsyncIoStream>> CapabilityStreamNetworkAddress::connect() {
   auto result = kj::mv(pipe.ends[0]);
   return inner.sendStream(kj::mv(pipe.ends[1]))
       .then(kj::mvCapture(result, [](Own<AsyncIoStream>&& result) {
-    return kj::mv(result);
+    return result;
   }));
 }
 Own<ConnectionReceiver> CapabilityStreamNetworkAddress::listen() {

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -189,7 +189,7 @@ TEST(Async, DeepChain) {
   // Create a ridiculous chain of promises.
   for (uint i = 0; i < 1000; i++) {
     promise = evalLater(mvCapture(promise, [](Promise<void> promise) {
-      return kj::mv(promise);
+      return promise;
     }));
   }
 
@@ -226,7 +226,7 @@ TEST(Async, DeepChain2) {
   // Create a ridiculous chain of promises.
   for (uint i = 0; i < 1000; i++) {
     promise = evalLater(mvCapture(promise, [](Promise<void> promise) {
-      return kj::mv(promise);
+      return promise;
     }));
   }
 
@@ -268,7 +268,7 @@ Promise<void> makeChain2(uint i, Promise<void> promise) {
       return makeChain2(i - 1, kj::mv(promise));
     }));
   } else {
-    return kj::mv(promise);
+    return promise;
   }
 }
 

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1892,7 +1892,7 @@ static kj::String demangleTypeName(const char* name) {
   char* buf = abi::__cxa_demangle(name, nullptr, nullptr, &status);
   kj::String result = kj::heapString(buf == nullptr ? name : buf);
   free(buf);
-  return kj::mv(result);
+  return result;
 }
 #else
 static kj::String demangleTypeName(const char* name) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1239,6 +1239,7 @@ public:
   }
   T&& orDefault(T&& defaultValue) && {
     if (ptr == nullptr) {
+      // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
       return kj::mv(defaultValue);
     } else {
       return kj::mv(*ptr);
@@ -1246,6 +1247,7 @@ public:
   }
   const T&& orDefault(const T&& defaultValue) const && {
     if (ptr == nullptr) {
+      // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
       return kj::mv(defaultValue);
     } else {
       return kj::mv(*ptr);

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -3906,7 +3906,7 @@ KJ_TEST("HttpClient to capnproto.org") {
     auto promise = addr->connect();
     return promise.attach(kj::mv(addr));
   }).then([](kj::Own<kj::AsyncIoStream>&& connection) -> kj::Maybe<kj::Own<kj::AsyncIoStream>> {
-    return kj::mv(connection);
+    return connection;
   }, [](kj::Exception&& e) -> kj::Maybe<kj::Own<kj::AsyncIoStream>> {
     KJ_LOG(WARNING, "skipping test because couldn't connect to capnproto.org");
     return nullptr;

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1995,7 +1995,7 @@ public:
       });
     }
 
-    return kj::mv(promise);
+    return promise;
   }
 
   Promise<void> whenWriteDisconnected() override {
@@ -2010,7 +2010,7 @@ private:
     if (length == 0) {
       return promise.then([this]() { inner.finishBody(); });
     } else {
-      return kj::mv(promise);
+      return promise;
     }
   }
 };
@@ -2870,6 +2870,7 @@ private:
         canceler.release();
         fulfiller.reject(kj::cp(e));
         pipe.endState(*this);
+        // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
         return kj::mv(e);
       }));
     }
@@ -2928,7 +2929,7 @@ private:
           fulfiller.fulfill();
           pipe.endState(*this);
         }
-        return kj::mv(message);
+        return message;
       }, [this](kj::Exception&& e) -> Message {
         canceler.release();
         fulfiller.reject(kj::cp(e));
@@ -3017,6 +3018,7 @@ private:
         canceler.release();
         fulfiller.reject(kj::cp(e));
         pipe.endState(*this);
+        // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
         return kj::mv(e);
       }));
     }
@@ -3559,6 +3561,7 @@ public:
     result.response = result.response.then(kj::mvCapture(refcounted,
         [](kj::Own<RefcountedClient>&& refcounted, Response&& response) {
       response.body = response.body.attach(kj::mv(refcounted));
+      // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
       return kj::mv(response);
     }));
     return result;
@@ -3583,6 +3586,7 @@ public:
           response.webSocketOrBody = ws.attach(kj::mv(refcounted));
         }
       }
+      // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
       return kj::mv(response);
     }));
   }
@@ -3965,7 +3969,7 @@ public:
 
     pendingRequests.push(kj::mv(paf.fulfiller));
     fireCountChanged();
-    return kj::mv(promise);
+    return promise;
   }
 
 private:
@@ -4226,6 +4230,7 @@ private:
           return result;
         } else {
           // Must have called tryRead() again after we already signaled EOF or threw. Fine.
+          // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
           return kj::mv(e);
         }
       });
@@ -4334,6 +4339,7 @@ private:
           return afterReceiveClosed()
               .then([message = kj::mv(message)]() mutable { return kj::mv(message); });
         }
+        // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
         return kj::mv(message);
       });
     }
@@ -4581,7 +4587,7 @@ public:
         // the exception because it's probably a side-effect of this.
         auto promise = kj::mv(*p);
         webSocketError = nullptr;
-        return kj::mv(promise);
+        return promise;
       }
 
       return sendError(kj::mv(e));
@@ -4646,7 +4652,7 @@ private:
             };
           }));
         }
-        return kj::mv(readHeaders);
+        return readHeaders;
       } else {
         // Client closed connection or pipeline timed out with no bytes received. This is not an
         // error, so don't report one.
@@ -4723,7 +4729,7 @@ private:
               // sendWebSocketError() was called. Finish sending and close the connection.
               auto promise = kj::mv(*p);
               webSocketError = nullptr;
-              return kj::mv(promise);
+              return promise;
             }
 
             if (upgraded) {

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -291,6 +291,7 @@ public:
   kj::Promise<T> wrap(kj::Promise<T>&& promise) {
     return promise.catch_([this](kj::Exception&& e) -> kj::Promise<T> {
       fulfiller->reject(kj::cp(e));
+      // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
       return kj::mv(e);
     }).exclusiveJoin(failurePromise.addBranch().then([]() -> T { KJ_UNREACHABLE; }));
   }

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -663,7 +663,7 @@ kj::Promise<kj::Own<kj::AsyncIoStream>> TlsContext::wrapClient(
   auto promise = conn->connect(expectedServerHostname);
   return promise.then(kj::mvCapture(conn, [](kj::Own<TlsConnection> conn)
       -> kj::Own<kj::AsyncIoStream> {
-    return kj::mv(conn);
+    return conn;
   }));
 }
 
@@ -672,7 +672,7 @@ kj::Promise<kj::Own<kj::AsyncIoStream>> TlsContext::wrapServer(kj::Own<kj::Async
   auto promise = conn->accept();
   return promise.then(kj::mvCapture(conn, [](kj::Own<TlsConnection> conn)
       -> kj::Own<kj::AsyncIoStream> {
-    return kj::mv(conn);
+    return conn;
   }));
 }
 

--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -121,7 +121,7 @@ String percentDecode(ArrayPtr<const char> text, bool& hadErrors, const Url::Opti
   if (options.percentDecode) {
     auto result = decodeUriComponent(text);
     if (result.hadErrors) hadErrors = true;
-    return kj::mv(result);
+    return result;
   }
   return kj::str(text);
 }
@@ -130,7 +130,7 @@ String percentDecodeQuery(ArrayPtr<const char> text, bool& hadErrors, const Url:
   if (options.percentDecode) {
     auto result = decodeWwwForm(text);
     if (result.hadErrors) hadErrors = true;
-    return kj::mv(result);
+    return result;
   }
   return kj::str(text);
 }
@@ -272,7 +272,7 @@ Maybe<Url> Url::tryParse(StringPtr text, Context context, Options options) {
 
   if (err) return nullptr;
 
-  return kj::mv(result);
+  return result;
 }
 
 Url Url::parseRelative(StringPtr url) const {
@@ -419,7 +419,7 @@ Maybe<Url> Url::tryParseRelative(StringPtr text) const {
 
   if (err) return nullptr;
 
-  return kj::mv(result);
+  return result;
 }
 
 String Url::toString(Context context) const {

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -224,6 +224,7 @@ NullableValue<T> readMaybe(EncodingResult<T>&& value) {
   if (value.hadErrors) {
     return nullptr;
   } else {
+    // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
     return kj::mv(value);
   }
 }

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -1086,7 +1086,7 @@ static kj::String demangleTypeName(const char* name) {
   char* buf = abi::__cxa_demangle(name, nullptr, nullptr, &status);
   kj::String result = kj::heapString(buf == nullptr ? name : buf);
   free(buf);
-  return kj::mv(result);
+  return result;
 }
 
 kj::String getCaughtExceptionType() {

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -112,6 +112,7 @@ public:
           default:
             KJ_FAIL_WIN32("CreateDirectoryW", error);
         }
+        // TODO(optimization): Will removing kj::mv still degrade to a move if NVRO isn't possible?
         return kj::mv(candidatePath);
       })) {}
 

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -784,7 +784,7 @@ public:
     setCloexec(result);
 #endif
 
-    return kj::mv(result);
+    return result;
   }
 
   Maybe<Own<const ReadableDirectory>> tryOpenSubdir(PathPtr path) const {
@@ -915,7 +915,7 @@ public:
         return nullptr;
     }
 
-    return kj::mv(path);
+    return path;
   }
 
   bool tryReplaceNode(PathPtr path, WriteMode mode, Function<int(StringPtr)> tryCreate) const {
@@ -1057,7 +1057,7 @@ public:
     setCloexec(result);
 #endif
 
-    return kj::mv(result);
+    return result;
   }
 
   bool tryCommitReplacement(StringPtr toPath, int fromDirFd, StringPtr fromPath, WriteMode mode,
@@ -1363,7 +1363,7 @@ public:
 #endif
       auto result = newDiskFile(kj::mv(newFd));
       KJ_SYSCALL(unlinkat(fd, temp->cStr(), 0)) { break; }
-      return kj::mv(result);
+      return result;
     } else {
       // threw, but exceptions are disabled
       return newInMemoryFile(nullClock());
@@ -1685,7 +1685,7 @@ private:
       } else {
         if (pwdStat.st_ino == dotStat.st_ino &&
             pwdStat.st_dev == dotStat.st_dev) {
-          return kj::mv(result);
+          return result;
         } else {
           KJ_LOG(WARNING, "PWD environment variable doesn't match current directory", pwd);
         }

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -699,7 +699,7 @@ public:
     KJ_WIN32(GetFileInformationByHandle(ownHandle, &info));
 
     KJ_REQUIRE(info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY, "not a directory", path);
-    return kj::mv(ownHandle);
+    return ownHandle;
   }
 
   Maybe<Own<const ReadableDirectory>> tryOpenSubdir(PathPtr path) const {
@@ -822,7 +822,7 @@ public:
         return nullptr;
     }
 
-    return kj::mv(path);
+    return path;
   }
 
   kj::Maybe<Array<wchar_t>> createNamedTemporary(

--- a/c++/src/kj/parse/common.h
+++ b/c++/src/kj/parse/common.h
@@ -613,7 +613,7 @@ public:
 
       if (firstResult != nullptr) {
         subInput.advanceParent();
-        return kj::mv(firstResult);
+        return firstResult;
       }
     }
 

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -293,7 +293,7 @@ String concat(Params&&... params) {
 }
 
 inline String concat(String&& arr) {
-  return kj::mv(arr);
+  return arr;
 }
 
 template <typename First, typename... Rest>


### PR DESCRIPTION
Returning an l-value automatically applies NVRO when possible and
otherwise falls back to calling the move constructor if available. I
tried to be conservative here and only remove the kj::mv that were
obviously superfluous (variables declared & returned within the
function and l-value function parameters returned).

Fixes issue #1022