### PR TITLE
Fix Windows version friendliness with external build

### DIFF
--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -23,6 +23,10 @@
 #define _GNU_SOURCE
 #endif
 
+#if _WIN32
+#include <kj/win32-api-version.h>
+#endif
+
 #include "lexer.h"
 #include "parser.h"
 #include "compiler.h"
@@ -50,10 +54,8 @@
 
 #if _WIN32
 #include <process.h>
-#define WIN32_LEAN_AND_MEAN  // ::eyeroll::
 #include <windows.h>
 #include <kj/windows-sanity.h>
-#undef VOID
 #undef CONST
 #else
 #include <sys/wait.h>

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -21,6 +21,10 @@
 
 // This program is a code generator plugin for `capnp compile` which generates C++ code.
 
+#if _WIN32
+#include <kj/win32-api-version.h>
+#endif
+
 #include <capnp/schema.capnp.h>
 #include "../serialize.h"
 #include <kj/debug.h>
@@ -40,10 +44,8 @@
 #include <capnp/stream.capnp.h>
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN  // ::eyeroll::
 #include <windows.h>
 #include <kj/windows-sanity.h>
-#undef VOID
 #undef CONST
 #else
 #include <sys/time.h>

--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -19,6 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if _WIN32
+#include <kj/win32-api-version.h>
+#endif
+
 #include "parser.h"
 #include "type-id.h"
 #include <capnp/dynamic.h>
@@ -31,10 +35,10 @@
 #include <fcntl.h>
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <wincrypt.h>
-#undef VOID
+#undef CONST
+#include <kj/windows-sanity.h>
 #endif
 
 namespace capnp {

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -25,6 +25,11 @@
 #define _GNU_SOURCE
 #endif
 
+// Includes just for need SOL_SOCKET and SO_SNDBUF
+#if _WIN32
+#include <kj/win32-api-version.h>
+#endif
+
 #include "rpc-twoparty.h"
 #include "test-util.h"
 #include <capnp/rpc.capnp.h>
@@ -33,9 +38,7 @@
 #include <kj/compat/gtest.h>
 #include <kj/miniposix.h>
 
-// Includes just for need SOL_SOCKET and SO_SNDBUF
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN  // ::eyeroll::
 #include <winsock2.h>
 #include <mswsock.h>
 #include <kj/windows-sanity.h>

--- a/c++/src/capnp/rpc-twoparty.c++
+++ b/c++/src/capnp/rpc-twoparty.c++
@@ -19,14 +19,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// Includes just for need SOL_SOCKET and SO_SNDBUF
+#if _WIN32
+#include <kj/win32-api-version.h>
+#endif
+
 #include "rpc-twoparty.h"
 #include "serialize-async.h"
 #include <kj/debug.h>
 #include <kj/io.h>
 
-// Includes just for need SOL_SOCKET and SO_SNDBUF
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN  // ::eyeroll::
 #include <winsock2.h>
 #include <mswsock.h>
 #include <kj/windows-sanity.h>

--- a/c++/src/capnp/serialize-async-test.c++
+++ b/c++/src/capnp/serialize-async-test.c++
@@ -23,6 +23,10 @@
 #define _GNU_SOURCE
 #endif
 
+#if _WIN32
+#include <kj/win32-api-version.h>
+#endif
+
 #include "serialize-async.h"
 #include "serialize.h"
 #include <kj/debug.h>
@@ -33,7 +37,6 @@
 #include <kj/compat/gtest.h>
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <kj/windows-sanity.h>
 namespace kj {

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -21,8 +21,7 @@
 
 #if _WIN32
 // Request Vista-level APIs.
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
+#include "win32-api-version.h"
 #elif !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
 #endif

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -23,8 +23,7 @@
 // For Unix implementation, see async-io-unix.c++.
 
 // Request Vista-level APIs.
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
+#include "win32-api-version.h"
 
 #include "async-io.h"
 #include "async-io-internal.h"

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -21,8 +21,7 @@
 
 #if _WIN32
 // Request Vista-level APIs.
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
+#include "win32-api-version.h"
 #endif
 
 #include "async-io.h"

--- a/c++/src/kj/async-win32.c++
+++ b/c++/src/kj/async-win32.c++
@@ -22,8 +22,7 @@
 #if _WIN32
 
 // Request Vista-level APIs.
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
+#include "win32-api-version.h"
 
 #include "async-win32.h"
 #include "debug.h"

--- a/c++/src/kj/async-win32.h
+++ b/c++/src/kj/async-win32.h
@@ -25,18 +25,16 @@
 #error "This file is Windows-specific. On Unix, include async-unix.h instead."
 #endif
 
+// Include windows.h as lean as possible. (If you need more of the Windows API for your app,
+// #include windows.h yourself before including this header.)
+#include "win32-api-version.h"
+
 #include "async.h"
 #include "timer.h"
 #include "io.h"
 #include <atomic>
 #include <inttypes.h>
 
-// Include windows.h as lean as possible. (If you need more of the Windows API for your app,
-// #include windows.h yourself before including this header.)
-#define WIN32_LEAN_AND_MEAN 1
-#define NOSERVICE 1
-#define NOMCX 1
-#define NOIME 1
 #include <windows.h>
 #include "windows-sanity.h"
 

--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -19,6 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if _WIN32
+#include "win32-api-version.h"
+#endif
+
 #include "async.h"
 #include "debug.h"
 #include "thread.h"
@@ -26,7 +30,6 @@
 #include <kj/test.h>
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN 1  // lolz
 #include <windows.h>
 #include "windows-sanity.h"
 inline void delay() { Sleep(10); }

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -26,7 +26,7 @@
 // so this check isn't appropriate for us.
 
 #if _WIN32 || __CYGWIN__
-#define WIN32_LEAN_AND_MEAN 1  // lolz
+#include "win32-api-version.h"
 #elif __APPLE__
 // getcontext() and friends are marked deprecated on MacOS but seemingly no replacement is
 // provided. It appears as if they deprecated it solely because the standards bodies deprecated it,

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -21,6 +21,10 @@
 
 #if KJ_HAS_OPENSSL
 
+#if _WIN32
+#include <kj/win32-api-version.h>
+#endif
+
 #include "tls.h"
 #include <kj/test.h>
 #include <kj/async-io.h>
@@ -28,7 +32,6 @@
 #include <openssl/opensslv.h>
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <kj/windows-sanity.h>
 #else

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -19,6 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if _WIN32 || __CYGWIN__
+#include "win32-api-version.h"
+#endif
+
 #include "debug.h"
 #include <stdlib.h>
 #include <ctype.h>
@@ -29,11 +33,6 @@
 #if !__CYGWIN__
 #define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
 #endif
-#define NOMINMAX 1
-#define WIN32_LEAN_AND_MEAN 1
-#define NOSERVICE 1
-#define NOMCX 1
-#define NOIME 1
 #include <windows.h>
 #include "windows-sanity.h"
 #include "encoding.h"

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -23,6 +23,10 @@
 #define _GNU_SOURCE
 #endif
 
+#if _WIN32 || __CYGWIN__
+#include "win32-api-version.h"
+#endif
+
 #if (_WIN32 && _M_X64) || (__CYGWIN__ && __x86_64__)
 // Currently the Win32 stack-trace code only supports x86_64. We could easily extend it to support
 // i386 as well but it requires some code changes around how we read the context to start the
@@ -59,7 +63,6 @@
 #endif
 
 #if _WIN32 || __CYGWIN__
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "windows-sanity.h"
 #include <dbghelp.h>

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -23,10 +23,7 @@
 // For Unix implementation, see filesystem-disk-unix.c++.
 
 // Request Vista-level APIs.
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
-
-#define WIN32_LEAN_AND_MEAN  // ::eyeroll::
+#include "win32-api-version.h"
 
 #include "filesystem.h"
 #include "debug.h"

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -23,6 +23,10 @@
 #define _GNU_SOURCE
 #endif
 
+#if _WIN32
+#include "win32-api-version.h"
+#endif
+
 #include "io.h"
 #include "debug.h"
 #include "miniposix.h"
@@ -31,10 +35,6 @@
 #include "vector.h"
 
 #if _WIN32
-#ifndef NOMINMAX
-#define NOMINMAX 1
-#endif
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "windows-sanity.h"
 #else

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -23,6 +23,10 @@
 #define _GNU_SOURCE
 #endif
 
+#if _WIN32
+#include "win32-api-version.h"
+#endif
+
 #include "main.h"
 #include "debug.h"
 #include "arena.h"
@@ -34,10 +38,6 @@
 #include <limits.h>
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#define NOMINMAX 1
-#endif
 #include <windows.h>
 #include "windows-sanity.h"
 #else

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -19,13 +19,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "time.h"
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN 1  // lolz
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
+#include "win32-api-version.h"
 #define NOGDI  // NOGDI is needed to make EXPECT_EQ(123u, *lock) compile for some reason
 #endif
+
+#include "time.h"
 
 #define KJ_MUTEX_TEST 1
 

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -20,9 +20,7 @@
 // THE SOFTWARE.
 
 #if _WIN32 || __CYGWIN__
-#define WIN32_LEAN_AND_MEAN 1  // lolz
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
+#include "win32-api-version.h"
 #endif
 
 #include "mutex.h"

--- a/c++/src/kj/time-test.c++
+++ b/c++/src/kj/time-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN 1  // lolz
+#include "win32-api-version.h"
 #endif
 
 #include "time.h"

--- a/c++/src/kj/time.c++
+++ b/c++/src/kj/time.c++
@@ -21,9 +21,7 @@
 // THE SOFTWARE.
 
 #if _WIN32
-#define WIN32_LEAN_AND_MEAN 1  // lolz
-#define WINVER 0x0600
-#define _WIN32_WINNT 0x0600
+#include "win32-api-version.h"
 #endif
 
 #include "time.h"

--- a/c++/src/kj/win32-api-version.h
+++ b/c++/src/kj/win32-api-version.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2013-2017 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+// Request Vista-level APIs.
+#ifndef WINVER
+#define WINVER 0x0600
+#elif WINVER < 0x0600
+#error "WINVER defined but older than Vista"
+#endif
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#elif _WIN32_WINNT < 0x0600
+#error "_WIN32_WINNT defined but older than Vista"
+#endif
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN  // ::eyeroll::
+#endif
+
+#define NOSERVICE 1
+#define NOMCX 1
+#define NOIME 1
+#define NOMINMAX 1


### PR DESCRIPTION
External build systems may override the minimum windows version when
building to be even newer than Vista. Fix the conflict so that if the
macro is a baked-in parameter for the compiler invocation that
everything still builds.