### PR TITLE
Fix ignored qualifier

### DIFF
--- a/c++/src/kj/time.c++
+++ b/c++/src/kj/time.c++
@@ -72,7 +72,7 @@ class Win32PreciseClock: public Clock {
   typedef VOID WINAPI GetSystemTimePreciseAsFileTimeFunc(LPFILETIME);
 public:
   Date now() const override {
-    static const GetSystemTimePreciseAsFileTimeFunc* getSystemTimePreciseAsFileTimePtr =
+    static GetSystemTimePreciseAsFileTimeFunc* const getSystemTimePreciseAsFileTimePtr =
         getGetSystemTimePreciseAsFileTime();
     FILETIME ft;
     if (getSystemTimePreciseAsFileTimePtr == nullptr) {


### PR DESCRIPTION
clang-cl rightly points out that the const in its current spot doesn't
do anything as it's applying the const to the function type. Instead
make the pointer itself const which is what's intended.