### PR TITLE
Fix unqualified friend declaration

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -907,7 +907,6 @@ private:
   Maybe<Own<Event>> fire() override;
   // Implements Event. Each time the event is fired, switchToFiber() is called.
 
-  friend class WaitScope;
   friend class FiberStack;
   friend void _::waitImpl(Own<_::PromiseNode>&& node, _::ExceptionOrValue& result,
                           WaitScope& waitScope);


### PR DESCRIPTION
clang-cl warns about this as a Microsoft extension:
```
async-inl.h(922,16): warning: unqualified friend declaration referring
to type outside of the nearest enclosing namespace is a Microsoft
extension; add a nested name specifier [-Wmicrosoft-unq
ualified-friend]
  friend class WaitScope;
               ^
               ::kj::
```