### PR TITLE
Add lock timeout support to MutexGuarded

### DIFF
--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -59,7 +59,7 @@ TEST(Mutex, MutexGuarded) {
     EXPECT_EQ(123u, *lock);
     EXPECT_EQ(123u, value.getAlreadyLockedExclusive());
 
-#if !(_WIN32 || __CYGWIN__)
+#if KJ_USE_FUTEX
     EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) == nullptr);
     EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) == nullptr);
 #endif
@@ -76,7 +76,7 @@ TEST(Mutex, MutexGuarded) {
     auto earlyRelease = kj::mv(lock);
   }
 
-#if !(_WIN32 || __CYGWIN__)
+#if KJ_USE_FUTEX
   EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) != nullptr);
   EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) != nullptr);
 #endif

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -59,6 +59,9 @@ TEST(Mutex, MutexGuarded) {
     EXPECT_EQ(123u, *lock);
     EXPECT_EQ(123u, value.getAlreadyLockedExclusive());
 
+    EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) == nullptr);
+    EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) == nullptr);
+
     Thread thread([&]() {
       Locked<uint> threadLock = value.lockExclusive();
       EXPECT_EQ(456u, *threadLock);
@@ -71,6 +74,8 @@ TEST(Mutex, MutexGuarded) {
     auto earlyRelease = kj::mv(lock);
   }
 
+  EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) != nullptr);
+  EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) != nullptr);
   EXPECT_EQ(789u, *value.lockExclusive());
 
   {

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -59,8 +59,10 @@ TEST(Mutex, MutexGuarded) {
     EXPECT_EQ(123u, *lock);
     EXPECT_EQ(123u, value.getAlreadyLockedExclusive());
 
+#if !(_WIN32 || __CYGWIN__)
     EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) == nullptr);
     EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) == nullptr);
+#endif
 
     Thread thread([&]() {
       Locked<uint> threadLock = value.lockExclusive();
@@ -74,9 +76,13 @@ TEST(Mutex, MutexGuarded) {
     auto earlyRelease = kj::mv(lock);
   }
 
+#if !(_WIN32 || __CYGWIN__)
   EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) != nullptr);
   EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) != nullptr);
+#endif
+
   EXPECT_EQ(789u, *value.lockExclusive());
+
 
   {
     auto rlock1 = value.lockShared();

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include "time.h"
 #if _WIN32
 #define WIN32_LEAN_AND_MEAN 1  // lolz
 #define WINVER 0x0600
@@ -60,8 +61,26 @@ TEST(Mutex, MutexGuarded) {
     EXPECT_EQ(123u, value.getAlreadyLockedExclusive());
 
 #if KJ_USE_FUTEX
-    EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) == nullptr);
-    EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) == nullptr);
+    auto timeout = MILLISECONDS * 50;
+
+    auto startTime = systemPreciseMonotonicClock().now();
+    EXPECT_TRUE(value.lockExclusiveWithTimeout(timeout) == nullptr);
+    auto duration = startTime - systemPreciseMonotonicClock().now();
+    EXPECT_TRUE(duration < timeout);
+
+    startTime = systemPreciseMonotonicClock().now();
+    EXPECT_TRUE(value.lockSharedWithTimeout(timeout) == nullptr);
+    duration = startTime - systemPreciseMonotonicClock().now();
+    EXPECT_TRUE(duration < timeout);
+
+    // originally, upon timing out, the exclusive requested flag would be removed
+    // from the futex state. if we did remove the exclusive request flag this test
+    // would hang.
+    Thread lockTimeoutThread([&]() {
+      // try to timeout during 10 ms delay
+      Maybe<Locked<uint>> maybeLock = value.lockExclusiveWithTimeout(MILLISECONDS * 8);
+      EXPECT_TRUE(maybeLock == nullptr);
+    });
 #endif
 
     Thread thread([&]() {
@@ -77,12 +96,11 @@ TEST(Mutex, MutexGuarded) {
   }
 
 #if KJ_USE_FUTEX
-  EXPECT_TRUE(value.lockExclusiveWithTimeout(MILLISECONDS * 50) != nullptr);
-  EXPECT_TRUE(value.lockSharedWithTimeout(MILLISECONDS * 50) != nullptr);
+  EXPECT_EQ(789u, *KJ_ASSERT_NONNULL(value.lockExclusiveWithTimeout(MILLISECONDS * 50)));
+  EXPECT_EQ(789u, *KJ_ASSERT_NONNULL(value.lockSharedWithTimeout(MILLISECONDS * 50)));
 #endif
 
   EXPECT_EQ(789u, *value.lockExclusive());
-
 
   {
     auto rlock1 = value.lockShared();

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -159,9 +159,9 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout) {
 
         auto result = syscall(SYS_futex, &futex, FUTEX_WAIT_PRIVATE, state, specp, nullptr, 0);
         if (result < 0) {
-          // We timed out, we can't remove the exclusive request flag (since others might be waiting)
-          // so we just return false.
           if (errno == ETIMEDOUT) {
+            // We timed out, we can't remove the exclusive request flag (since others might be waiting)
+            // so we just return false.
             return false;
           }
         }

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -733,30 +733,30 @@ void Mutex::lock(Exclusivity exclusivity) {
 }
 
 bool Mutex::lockWithTimeout(Exclusivity exclusivity, Duration timeout) {
-  struct timespec duration = toRelativeTimespec(timeout);
+  struct timespec absTime = toAbsoluteTimespec(now() + timeout);
   int result;
   switch (exclusivity) {
     case EXCLUSIVE:
-      result = pthread_rwlock_timed_wrlock(&mutex, &duration);
+      result = pthread_rwlock_timed_wrlock(&mutex, &absTime);
       switch (result) {
         case 0:
           break;
         case ETIMEDOUT:
           return false;
         default:
-          KJ_FAIL_SYSCALL("pthread_rwlock_timed_wrlock(&mutex, &duration)", result);
+          KJ_FAIL_SYSCALL("pthread_rwlock_timed_wrlock(&mutex, &absTime)", result);
           break;
       }
       break;
     case SHARED:
-      result = pthread_rwlock_timedrdlock(&mutex, &duration);
+      result = pthread_rwlock_timedrdlock(&mutex, &absTime);
       switch (result) {
         case 0:
           break;
         case ETIMEDOUT:
           return false;
         default:
-          KJ_FAIL_SYSCALL("pthread_rwlock_timedrdlock(&mutex, &duration)", result);
+          KJ_FAIL_SYSCALL("pthread_rwlock_timedrdlock(&mutex, &absTime)", result);
           break;
       }
       break;

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -67,8 +67,7 @@ public:
     SHARED
   };
 
-  void lock(Exclusivity exclusivity);
-  bool lockWithTimeout(Exclusivity exclusivity, Duration timeout);
+  bool lock(Exclusivity exclusivity, Maybe<Duration> timeout = nullptr);
   void unlock(Exclusivity exclusivity, Waiter* waiterToSkip = nullptr);
 
   void assertLockedByCaller(Exclusivity exclusivity);
@@ -509,7 +508,7 @@ inline Locked<const T> MutexGuarded<T>::lockShared() const {
 
 template <typename T>
 inline Maybe<Locked<T>> MutexGuarded<T>::lockExclusiveWithTimeout(Duration timeout) const {
-  if (mutex.lockWithTimeout(_::Mutex::EXCLUSIVE, timeout)) {
+  if (mutex.lock(_::Mutex::EXCLUSIVE, timeout)) {
     return Locked<T>(mutex, value);
   } else {
     return nullptr;
@@ -518,7 +517,7 @@ inline Maybe<Locked<T>> MutexGuarded<T>::lockExclusiveWithTimeout(Duration timeo
 
 template <typename T>
 inline Maybe<Locked<const T>> MutexGuarded<T>::lockSharedWithTimeout(Duration timeout) const {
-  if (mutex.lockWithTimeout(_::Mutex::SHARED, timeout)) {
+  if (mutex.lock(_::Mutex::SHARED, timeout)) {
     return Locked<const T>(mutex, value);
   } else {
     return nullptr;

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -68,6 +68,7 @@ public:
   };
 
   void lock(Exclusivity exclusivity);
+  bool lockWithTimeout(Exclusivity exclusivity, Duration timeout);
   void unlock(Exclusivity exclusivity, Waiter* waiterToSkip = nullptr);
 
   void assertLockedByCaller(Exclusivity exclusivity);
@@ -330,6 +331,14 @@ public:
   // Lock the value for shared access.  Multiple shared locks can be taken concurrently, but cannot
   // be held at the same time as a non-shared lock.
 
+  Maybe<Locked<T>> lockExclusiveWithTimeout(Duration timeout) const;
+  // Attempts to exclusively lock the object. If the timeout elapses before the lock is aquired,
+  // this returns null.
+
+  Maybe<Locked<const T>> lockSharedWithTimeout(Duration timeout) const;
+  // Attempts to lock the value for shared access. If the timeout elapses before the lock is aquired,
+  // this returns null.
+
   inline const T& getWithoutLock() const { return value; }
   inline T& getWithoutLock() { return value; }
   // Escape hatch for cases where some external factor guarantees that it's safe to get the
@@ -496,6 +505,24 @@ template <typename T>
 inline Locked<const T> MutexGuarded<T>::lockShared() const {
   mutex.lock(_::Mutex::SHARED);
   return Locked<const T>(mutex, value);
+}
+
+template <typename T>
+inline Maybe<Locked<T>> MutexGuarded<T>::lockExclusiveWithTimeout(Duration timeout) const {
+  if (mutex.lockWithTimeout(_::Mutex::EXCLUSIVE, timeout)) {
+    return Locked<T>(mutex, value);
+  } else {
+    return nullptr;
+  }
+}
+
+template <typename T>
+inline Maybe<Locked<const T>> MutexGuarded<T>::lockSharedWithTimeout(Duration timeout) const {
+  if (mutex.lockWithTimeout(_::Mutex::SHARED, timeout)) {
+    return Locked<const T>(mutex, value);
+  } else {
+    return nullptr;
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
Not supported on Windows since slim rw locks don't support timeouts.