### PR TITLE
Improve clang cl support

### DIFF
--- a/c++/src/capnp/any-test.c++
+++ b/c++/src/capnp/any-test.c++
@@ -130,7 +130,7 @@ TEST(Any, AnyStruct) {
   EXPECT_EQ(48, b.getDataSection().size());
   EXPECT_EQ(20, b.getPointerSection().size());
 
-#if !_MSC_VER  // TODO(msvc): ICE on the necessary constructor; see any.h.
+#if !_MSC_VER || defined(__clang__) // TODO(msvc): ICE on the necessary constructor; see any.h.
   b = root.getAnyPointerField().getAs<TestAllTypes>();
   EXPECT_EQ(48, b.getDataSection().size());
   EXPECT_EQ(20, b.getPointerSection().size());
@@ -144,7 +144,7 @@ TEST(Any, AnyStruct) {
   EXPECT_EQ(48, r.getDataSection().size());
   EXPECT_EQ(20, r.getPointerSection().size());
 
-#if !_MSC_VER  // TODO(msvc): ICE on the necessary constructor; see any.h.
+#if !_MSC_VER || defined(__clang__)  // TODO(msvc): ICE on the necessary constructor; see any.h.
   r = root.getAnyPointerField().getAs<TestAllTypes>().asReader();
   EXPECT_EQ(48, r.getDataSection().size());
   EXPECT_EQ(20, r.getPointerSection().size());
@@ -201,7 +201,7 @@ TEST(Any, AnyList) {
   EXPECT_EQ(48, alb.as<List<AnyStruct>>()[0].getDataSection().size());
   EXPECT_EQ(20, alb.as<List<AnyStruct>>()[0].getPointerSection().size());
 
-#if !_MSC_VER  // TODO(msvc): ICE on the necessary constructor; see any.h.
+#if !_MSC_VER || defined(__clang__) // TODO(msvc): ICE on the necessary constructor; see any.h.
   alb = root.getAnyPointerField().getAs<List<TestAllTypes>>();
   EXPECT_EQ(2, alb.size());
   EXPECT_EQ(48, alb.as<List<AnyStruct>>()[0].getDataSection().size());
@@ -218,7 +218,7 @@ TEST(Any, AnyList) {
   EXPECT_EQ(48, alr.as<List<AnyStruct>>()[0].getDataSection().size());
   EXPECT_EQ(20, alr.as<List<AnyStruct>>()[0].getPointerSection().size());
 
-#if !_MSC_VER  // TODO(msvc): ICE on the necessary constructor; see any.h.
+#if !_MSC_VER || defined(__clang__) // TODO(msvc): ICE on the necessary constructor; see any.h.
   alr = root.getAnyPointerField().getAs<List<TestAllTypes>>().asReader();
   EXPECT_EQ(2, alr.size());
   EXPECT_EQ(48, alr.as<List<AnyStruct>>()[0].getDataSection().size());

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -508,7 +508,7 @@ public:
   inline Builder(decltype(nullptr)) {}
   inline Builder(_::StructBuilder builder): _builder(builder) {}
 
-#if !_MSC_VER  // TODO(msvc): MSVC ICEs on this. Try restoring when compiler improves.
+#if !_MSC_VER || defined(__clang__) // TODO(msvc): MSVC ICEs on this. Try restoring when compiler improves.
   template <typename T, typename = kj::EnableIf<CAPNP_KIND(FromBuilder<T>) == Kind::STRUCT>>
   inline Builder(T&& value)
       : _builder(_::PointerHelpers<FromBuilder<T>>::getInternalBuilder(kj::fwd<T>(value))) {}
@@ -640,7 +640,7 @@ public:
   inline Reader(): _reader(ElementSize::VOID) {}
   inline Reader(_::ListReader reader): _reader(reader) {}
 
-#if !_MSC_VER  // TODO(msvc): MSVC ICEs on this. Try restoring when compiler improves.
+#if !_MSC_VER || defined(__clang__) // TODO(msvc): MSVC ICEs on this. Try restoring when compiler improves.
   template <typename T, typename = kj::EnableIf<CAPNP_KIND(FromReader<T>) == Kind::LIST>>
   inline Reader(T&& value)
       : _reader(_::PointerHelpers<FromReader<T>>::getInternalReader(kj::fwd<T>(value))) {}
@@ -680,7 +680,7 @@ public:
   inline Builder(decltype(nullptr)): _builder(ElementSize::VOID) {}
   inline Builder(_::ListBuilder builder): _builder(builder) {}
 
-#if !_MSC_VER  // TODO(msvc): MSVC ICEs on this. Try restoring when compiler improves.
+#if !_MSC_VER || defined(__clang__) // TODO(msvc): MSVC ICEs on this. Try restoring when compiler improves.
   template <typename T, typename = kj::EnableIf<CAPNP_KIND(FromBuilder<T>) == Kind::LIST>>
   inline Builder(T&& value)
       : _builder(_::PointerHelpers<FromBuilder<T>>::getInternalBuilder(kj::fwd<T>(value))) {}

--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -173,7 +173,7 @@ inline constexpr Kind kind() {
   return k;
 }
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 
 #define CAPNP_KIND(T) ::capnp::_::Kind_<T>::kind
 // Avoid constexpr methods in MSVC (it remains buggy in many situations).
@@ -199,7 +199,7 @@ inline constexpr Style style() {
 template <typename T, Kind k = CAPNP_KIND(T)>
 struct List;
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 
 template <typename T, Kind k>
 struct List {};
@@ -314,7 +314,7 @@ namespace _ {  // private
 template <typename T, Kind k = CAPNP_KIND(T)>
 struct PointerHelpers;
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 
 template <typename T, Kind k>
 struct PointerHelpers {};

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -1383,7 +1383,7 @@ class JsonCodec::JsonValueHandler final: public JsonCodec::Handler<DynamicStruct
 public:
   void encode(const JsonCodec& codec, DynamicStruct::Reader input,
               JsonValue::Builder output) const override {
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
     // TODO(msvc): Hack to work around missing AnyStruct::Builder constructor on MSVC.
     rawCopy(input, toDynamic(output));
 #else

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1785,7 +1785,7 @@ private:
             "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(),
-                "#ifndef _MSC_VER\n"
+                "#if !defined(_MSC_VER) || defined(__clang__)\n"
                 "// Excluded under MSVC because bugs may make it unable to compile this method.\n"),
             templateContext.allDecls(),
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
@@ -1793,7 +1793,7 @@ private:
             "  return ::capnp::_::PointerHelpers<", type, ">::disown(_builder.getPointerField(\n"
             "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
-            COND(type.hasDisambiguatedTemplate(), "#endif  // !_MSC_VER\n"),
+            COND(type.hasDisambiguatedTemplate(), "#endif  // !_MSC_VER || __clang__\n"),
             COND(shouldExcludeInLiteMode, "#endif  // !CAPNP_LITE\n"),
             "\n")
       };
@@ -2573,7 +2573,7 @@ private:
           scope.size() == 0 ? kj::strTree() : kj::strTree(
               // TODO(msvc): MSVC doesn't like definitions of constexprs, but other compilers and
               //   the standard require them.
-              "#ifndef _MSC_VER\n"
+              "#if !defined(_MSC_VER) || defined(__clang__)\n"
               "constexpr ", typeName_, ' ', scope, upperCase, ";\n"
               "#endif\n")
         };

--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -315,7 +315,7 @@ inline constexpr uint sizeInWords() {
 
 }  // namespace capnp
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 // MSVC doesn't understand floating-point constexpr yet.
 //
 // TODO(msvc): Remove this hack when MSVC is fixed.
@@ -326,7 +326,7 @@ inline constexpr uint sizeInWords() {
 #define CAPNP_NON_INT_CONSTEXPR_DEF_INIT(value)
 #endif
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 // TODO(msvc): A little hack to allow MSVC to use C++14 return type deduction in cases where the
 // explicit type exposes bugs in the compiler.
 #define CAPNP_AUTO_IF_MSVC(...) auto
@@ -349,7 +349,7 @@ inline constexpr uint sizeInWords() {
       static inline ::capnp::word const* encodedSchema() { return bp_##id; } \
     }
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 // TODO(msvc): MSVC doesn't expect constexprs to have definitions.
 #define CAPNP_DEFINE_ENUM(type, id)
 #else

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -41,7 +41,7 @@ static BrokenCapFactory* brokenCapFactory = nullptr;
 void setGlobalBrokenCapFactoryForLayoutCpp(BrokenCapFactory& factory) {
   // Called from capability.c++ when the capability API is used, to make sure that layout.c++
   // is ready for it.  May be called multiple times but always with the same value.
-#if __GNUC__
+#if __GNUC__ || defined(__clang__)
   __atomic_store_n(&brokenCapFactory, &factory, __ATOMIC_RELAXED);
 #elif _MSC_VER
   *static_cast<BrokenCapFactory* volatile*>(&brokenCapFactory) = &factory;

--- a/c++/src/capnp/raw-schema.h
+++ b/c++/src/capnp/raw-schema.h
@@ -23,7 +23,7 @@
 
 #include "common.h"  // for uint and friends
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 #include <atomic>
 #endif
 
@@ -145,7 +145,7 @@ struct RawBrandedSchema {
     // is required in particular when traversing the dependency list.  RawSchemas for compiled-in
     // types are always initialized; only dynamically-loaded schemas may be lazy.
 
-#if __GNUC__
+#if __GNUC__ || defined(__clang__)
     const Initializer* i = __atomic_load_n(&lazyInitializer, __ATOMIC_ACQUIRE);
 #elif _MSC_VER
     const Initializer* i = *static_cast<Initializer const* const volatile*>(&lazyInitializer);
@@ -211,7 +211,7 @@ struct RawSchema {
     // is required in particular when traversing the dependency list.  RawSchemas for compiled-in
     // types are always initialized; only dynamically-loaded schemas may be lazy.
 
-#if __GNUC__
+#if __GNUC__ || defined(__clang__)
     const Initializer* i = __atomic_load_n(&lazyInitializer, __ATOMIC_ACQUIRE);
 #elif _MSC_VER
     const Initializer* i = *static_cast<Initializer const* const volatile*>(&lazyInitializer);

--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -31,7 +31,7 @@
 #include <kj/map.h>
 #include <capnp/stream.capnp.h>
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 #include <atomic>
 #endif
 
@@ -1295,7 +1295,7 @@ _::RawSchema* SchemaLoader::Impl::load(const schema::Node::Reader& reader, bool 
     // If this schema is not newly-allocated, it may already be in the wild, specifically in the
     // dependency list of other schemas.  Once the initializer is null, it is live, so we must do
     // a release-store here.
-#if __GNUC__
+#if __GNUC__ || defined(__clang__)
     __atomic_store_n(&schema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
     __atomic_store_n(&schema->defaultBrand.lazyInitializer, nullptr, __ATOMIC_RELEASE);
 #elif _MSC_VER
@@ -1392,7 +1392,7 @@ _::RawSchema* SchemaLoader::Impl::loadNative(const _::RawSchema* nativeSchema) {
     // If this schema is not newly-allocated, it may already be in the wild, specifically in the
     // dependency list of other schemas.  Once the initializer is null, it is live, so we must do
     // a release-store here.
-#if __GNUC__
+#if __GNUC__ || defined(__clang__)
     __atomic_store_n(&schema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
     __atomic_store_n(&schema->defaultBrand.lazyInitializer, nullptr, __ATOMIC_RELEASE);
 #elif _MSC_VER
@@ -1912,7 +1912,7 @@ void SchemaLoader::InitializerImpl::init(const _::RawSchema* schema) const {
               "A schema not belonging to this loader used its initializer.");
 
     // Disable the initializer.
-#if __GNUC__
+#if __GNUC__ || defined(__clang__)
     __atomic_store_n(&mutableSchema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
     __atomic_store_n(&mutableSchema->defaultBrand.lazyInitializer, nullptr, __ATOMIC_RELEASE);
 #elif _MSC_VER
@@ -1949,7 +1949,7 @@ void SchemaLoader::BrandedInitializerImpl::init(const _::RawBrandedSchema* schem
   mutableSchema->dependencyCount = deps.size();
 
   // It's initialized now, so disable the initializer.
-#if __GNUC__
+#if __GNUC__ || defined(__clang__)
   __atomic_store_n(&mutableSchema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
 #elif _MSC_VER
   std::atomic_thread_fence(std::memory_order_release);

--- a/c++/src/capnp/schema.capnp.c++
+++ b/c++/src/capnp/schema.capnp.c++
@@ -3647,7 +3647,7 @@ constexpr ::capnp::Kind Field::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* Field::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || defined(__clang__)
 constexpr  ::uint16_t Field::NO_DISCRIMINANT;
 #endif
 // Field::Slot

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -28,7 +28,7 @@
 namespace kj {
 namespace {
 
-#if !_MSC_VER
+#if !_MSC_VER || defined(__clang__)
 // TODO(msvc): GetFunctorStartAddress is not supported on MSVC currently, so skip the test.
 TEST(Async, GetFunctorStartAddress) {
   EXPECT_TRUE(nullptr != _::GetFunctorStartAddress<>::apply([](){return 0;}));

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -775,7 +775,7 @@ XThreadEvent::XThreadEvent(ExceptionOrValue& result, const Executor& targetExecu
     : Event(targetExecutor.getLoop()), result(result), targetExecutor(targetExecutor.addRef()) {}
 
 void XThreadEvent::ensureDoneOrCanceled() {
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   {  // TODO(perf): TODO(msvc): Implement the double-checked lock optimization on MSVC.
 #else
   if (__atomic_load_n(&state, __ATOMIC_ACQUIRE) != DONE) {
@@ -973,7 +973,7 @@ void XThreadEvent::done() {
 }
 
 inline void XThreadEvent::setDoneState() {
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   // TODO(perf): TODO(msvc): Implement the double-checked lock optimization on MSVC.
   state = DONE;
 #else

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -40,7 +40,7 @@
 #include <sys/wait.h>
 #endif
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 #pragma warning(disable: 4996)
 // Warns that sprintf() is buffer-overrunny. Yeah, I know, it's cool.
 #endif

--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -114,7 +114,7 @@ KJ_BEGIN_HEADER
 
 namespace kj {
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 // MSVC does __VA_ARGS__ differently from GCC:
 // - A trailing comma before an empty __VA_ARGS__ is removed automatically, whereas GCC wants
 //   you to request this behavior with "##__VA_ARGS__".

--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -171,7 +171,7 @@ TEST(Exception, ScopeSuccessFail) {
 }
 #endif
 
-#if __GNUG__
+#if __GNUG__ || defined(__clang__)
 kj::String testStackTrace() __attribute__((noinline));
 #elif _MSC_VER
 __declspec(noinline) kj::String testStackTrace();

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -298,7 +298,7 @@ protected:
   }
 };
 
-#if _MSC_VER && _MSC_VER < 1910
+#if _MSC_VER && _MSC_VER < 1910 && !defined(__clang__)
 // TODO(msvc): MSVC 2015 can't initialize a constexpr's vtable correctly.
 const MmapDisposer mmapDisposer = MmapDisposer();
 #else

--- a/c++/src/kj/parse/char.h
+++ b/c++/src/kj/parse/char.h
@@ -156,7 +156,7 @@ constexpr inline CharGroup_ charRange(char first, char last) {
   return CharGroup_().orRange(first, last);
 }
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 #define anyOfChars(chars) CharGroup_().orAny(chars)
 // TODO(msvc): MSVC ICEs on the proper definition of `anyOfChars()`, which in turn prevents us from
 //   building the compiler or schema parser. We don't know why this happens, but Harris found that

--- a/c++/src/kj/refcount.c++
+++ b/c++/src/kj/refcount.c++
@@ -22,7 +22,7 @@
 #include "refcount.h"
 #include "debug.h"
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 // Annoyingly, MSVC only implements the C++ atomic libs, not the C libs, so the only useful
 // thing we can get from <atomic> seems to be atomic_thread_fence... but that one function is
 // indeed not implemented by the intrinsics, so...
@@ -52,7 +52,7 @@ AtomicRefcounted::~AtomicRefcounted() noexcept(false) {
 }
 
 void AtomicRefcounted::disposeImpl(void* pointer) const {
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   if (KJ_MSVC_INTERLOCKED(Decrement, rel)(&refcount) == 0) {
     std::atomic_thread_fence(std::memory_order_acquire);
     delete this;
@@ -66,7 +66,7 @@ void AtomicRefcounted::disposeImpl(void* pointer) const {
 }
 
 bool AtomicRefcounted::addRefWeakInternal() const {
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   long orig = refcount;
 
   for (;;) {

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -117,7 +117,7 @@ Own<T> Refcounted::addRefInternal(T* object) {
 //
 // Warning: Atomic ops are SLOW.
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 #if _M_ARM
 #define KJ_MSVC_INTERLOCKED(OP, MEM) _Interlocked##OP##_##MEM
 #else
@@ -132,7 +132,7 @@ public:
   KJ_DISALLOW_COPY(AtomicRefcounted);
 
   inline bool isShared() const {
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
     return KJ_MSVC_INTERLOCKED(Or, acq)(&refcount, 0) > 1;
 #else
     return __atomic_load_n(&refcount, __ATOMIC_ACQUIRE) > 1;
@@ -140,7 +140,7 @@ public:
   }
 
 private:
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   mutable volatile long refcount = 0;
 #else
   mutable volatile uint refcount = 0;
@@ -203,7 +203,7 @@ kj::Maybe<kj::Own<const T>> atomicAddRefWeak(const T& object) {
 template <typename T>
 kj::Own<T> AtomicRefcounted::addRefInternal(T* object) {
   AtomicRefcounted* refcounted = object;
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   KJ_MSVC_INTERLOCKED(Increment, nf)(&refcounted->refcount);
 #else
   __atomic_add_fetch(&refcounted->refcount, 1, __ATOMIC_RELAXED);
@@ -214,7 +214,7 @@ kj::Own<T> AtomicRefcounted::addRefInternal(T* object) {
 template <typename T>
 kj::Own<const T> AtomicRefcounted::addRefInternal(const T* object) {
   const AtomicRefcounted* refcounted = object;
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   KJ_MSVC_INTERLOCKED(Increment, nf)(&refcounted->refcount);
 #else
   __atomic_add_fetch(&refcounted->refcount, 1, __ATOMIC_RELAXED);

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -29,7 +29,7 @@
 
 namespace kj {
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 #pragma warning(disable: 4996)
 // Warns that sprintf() is buffer-overrunny. We know that, it's cool.
 #endif

--- a/c++/src/kj/table.c++
+++ b/c++/src/kj/table.c++
@@ -30,7 +30,7 @@ static inline uint lg(uint value) {
   // Compute floor(log2(value)).
   //
   // Undefined for value = 0.
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   unsigned long i;
   auto found = _BitScanReverse(&i, value);
   KJ_DASSERT(found);  // !found means value = 0

--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -892,7 +892,7 @@ uint chooseBucket(uint hash, uint count);
 template <typename Callbacks>
 class HashIndex {
 public:
-  HashIndex() KJ_DEFAULT_CONSTRUCTOR_VS2015_BUGGY
+  HashIndex() = default;
   template <typename... Params>
   HashIndex(Params&&... params): cb(kj::fwd<Params>(params)...) {}
 
@@ -1436,7 +1436,7 @@ inline BTreeImpl::Iterator BTreeImpl::end() const {
 template <typename Callbacks>
 class TreeIndex {
 public:
-  TreeIndex() KJ_DEFAULT_CONSTRUCTOR_VS2015_BUGGY
+  TreeIndex() = default;
   template <typename... Params>
   TreeIndex(Params&&... params): cb(kj::fwd<Params>(params)...) {}
 

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -60,7 +60,7 @@ private:
   } KJ_UNIQUE_NAME(testCase); \
   void KJ_UNIQUE_NAME(TestCase)::run()
 
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
 #define KJ_INDIRECT_EXPAND(m, vargs) m vargs
 #define KJ_FAIL_EXPECT(...) \
   KJ_INDIRECT_EXPAND(KJ_LOG, (ERROR , __VA_ARGS__));

--- a/c++/src/kj/thread.c++
+++ b/c++/src/kj/thread.c++
@@ -117,7 +117,7 @@ Thread::ThreadState::ThreadState(Function<void()> func)
       refcount(2) {}
 
 void Thread::ThreadState::unref() {
-#if _MSC_VER
+#if _MSC_VER && !defined(__clang__)
   if (_InterlockedDecrement(&refcount) == 0) {
 #else
   if (__atomic_sub_fetch(&refcount, 1, __ATOMIC_RELEASE) == 0) {

--- a/c++/src/kj/tuple.h
+++ b/c++/src/kj/tuple.h
@@ -91,7 +91,7 @@ struct TupleElement {
   // from a TupleElement for each element, which is more efficient than a recursive definition.
 
   T value;
-  TupleElement() KJ_DEFAULT_CONSTRUCTOR_VS2015_BUGGY
+  TupleElement() = default;
   constexpr inline TupleElement(const T& value): value(value) {}
   constexpr inline TupleElement(T&& value): value(kj::mv(value)) {}
 };
@@ -121,7 +121,7 @@ struct TupleImpl<Indexes<indexes...>, Types...>
 
   static_assert(sizeof...(indexes) == sizeof...(Types), "Incorrect use of TupleImpl.");
 
-  TupleImpl() KJ_DEFAULT_CONSTRUCTOR_VS2015_BUGGY
+  TupleImpl() = default;
 
   template <typename... Params>
   inline TupleImpl(Params&&... params)
@@ -151,7 +151,7 @@ class Tuple {
   // The actual Tuple class (used for tuples of size other than 1).
 
 public:
-  Tuple() KJ_DEFAULT_CONSTRUCTOR_VS2015_BUGGY
+  Tuple() = default;
 
   template <typename... U>
   constexpr inline Tuple(Tuple<U...>&& other): impl(kj::mv(other)) {}


### PR DESCRIPTION
clang-cl defines a really old version of _MSC_VER which trips up some of
the version detection and also would trigger unnecessary workarounds
that clang is able to handle.

Additionally remove a MSVC 2015 workaround since 2017 is the minimum
version anyway.

Audit all _MSC_VER usage throughout codebase to try to handle it
correctly. There are still places that access _MSC_VER when they
probably mean to check if building for Windows - those places are
untouched.

Not sure how to integrate this into automated build support. Will be testing it
on my own build farm but I don't run the capnp unit tests so there could be a potential
gap there.