### PR TITLE
Add option to reject decoding of JSON messages with unrecognized fields

### DIFF
--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -647,6 +647,18 @@ KJ_TEST("maximum nesting depth") {
   }
 }
 
+KJ_TEST("unrecognized fields") {
+  JsonCodec json;
+  MallocMessageBuilder message;
+  auto root = message.initRoot<TestJsonAnnotations>();
+  auto valid = R"({"foo": "a"})"_kj;
+  auto unrecognized = R"({"foo": "a", "unrecognize-bar": "pun"})"_kj;
+  json.decode(valid, root);
+  json.decode(unrecognized, root);
+  json.setIgnoreUnrecognizedFields(false);
+  KJ_EXPECT_THROW_MESSAGE("Unrecognized field", json.decode(valid, root));
+}
+
 class TestCallHandler: public JsonCodec::Handler<Text> {
 public:
   void encode(const JsonCodec& codec, Text::Reader input,

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -647,17 +647,17 @@ KJ_TEST("maximum nesting depth") {
   }
 }
 
-KJ_TEST("unrecognized fields") {
+KJ_TEST("unknown fields") {
   JsonCodec json;
   MallocMessageBuilder message;
   auto root = message.initRoot<TestJsonAnnotations2>();
   auto valid = R"({"foo": "a"})"_kj;
-  auto unrecognized = R"({"foo": "a", "unrecognize-bar": "pun"})"_kj;
+  auto unknown = R"({"foo": "a", "unknown-field": "b"})"_kj;
   json.decode(valid, root);
-  json.decode(unrecognized, root);
-  json.setIgnoreUnrecognizedFields(false);
+  json.decode(unknown, root);
+  json.setRejectUnknownFields(true);
   json.decode(valid, root);
-  KJ_EXPECT_THROW_MESSAGE("Unrecognized field", json.decode(unrecognized, root));
+  KJ_EXPECT_THROW_MESSAGE("Unknown field", json.decode(unknown, root));
 }
 
 class TestCallHandler: public JsonCodec::Handler<Text> {

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -650,13 +650,14 @@ KJ_TEST("maximum nesting depth") {
 KJ_TEST("unrecognized fields") {
   JsonCodec json;
   MallocMessageBuilder message;
-  auto root = message.initRoot<TestJsonAnnotations>();
+  auto root = message.initRoot<TestJsonAnnotations2>();
   auto valid = R"({"foo": "a"})"_kj;
   auto unrecognized = R"({"foo": "a", "unrecognize-bar": "pun"})"_kj;
   json.decode(valid, root);
   json.decode(unrecognized, root);
   json.setIgnoreUnrecognizedFields(false);
-  KJ_EXPECT_THROW_MESSAGE("Unrecognized field", json.decode(valid, root));
+  json.decode(valid, root);
+  KJ_EXPECT_THROW_MESSAGE("Unrecognized field", json.decode(unrecognized, root));
 }
 
 class TestCallHandler: public JsonCodec::Handler<Text> {

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -389,7 +389,7 @@ void JsonCodec::decodeObject(JsonValue::Reader input, StructSchema type, Orphana
     KJ_IF_MAYBE(fieldSchema, type.findFieldByName(field.getName())) {
       decodeField(*fieldSchema, field.getValue(), orphanage, output);
     } else {
-      KJ_REQUIRE(impl->ignoreUnrecognizedFields, "Unrecognized field.", field.getName());
+      KJ_REQUIRE(impl->ignoreUnrecognizedFields, "Unrecognized field", field.getName());
     }
   }
 }

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -37,7 +37,7 @@ struct JsonCodec::Impl {
   bool prettyPrint = false;
   HasMode hasMode = HasMode::NON_NULL;
   size_t maxNestingDepth = 64;
-  bool ignoreUnrecognizedFields = true;
+  bool rejectUnknownFields = false;
 
   kj::HashMap<Type, HandlerBase*> typeHandlers;
   kj::HashMap<StructSchema::Field, HandlerBase*> fieldHandlers;
@@ -186,7 +186,7 @@ void JsonCodec::setMaxNestingDepth(size_t maxNestingDepth) {
 
 void JsonCodec::setHasMode(HasMode mode) { impl->hasMode = mode; }
 
-void JsonCodec::setIgnoreUnrecognizedFields(bool ignore) { impl->ignoreUnrecognizedFields = ignore; }
+void JsonCodec::setRejectUnknownFields(bool enabled) { impl->rejectUnknownFields = enabled; }
 
 kj::String JsonCodec::encode(DynamicValue::Reader value, Type type) const {
   MallocMessageBuilder message;
@@ -389,7 +389,7 @@ void JsonCodec::decodeObject(JsonValue::Reader input, StructSchema type, Orphana
     KJ_IF_MAYBE(fieldSchema, type.findFieldByName(field.getName())) {
       decodeField(*fieldSchema, field.getValue(), orphanage, output);
     } else {
-      KJ_REQUIRE(impl->ignoreUnrecognizedFields, "Unrecognized field", field.getName());
+      KJ_REQUIRE(!impl->rejectUnknownFields, "Unknown field", field.getName());
     }
   }
 }

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -84,9 +84,9 @@ public:
   // omitted as well.
 
   void setIgnoreUnrecognizedFields(bool ignore);
-  // Choose whether decoding JSON with unrecognized field names results in an error. You may trade
-  // allowing schema evolution against a guarantee that all data is preserved depending on this
-  // option. The default is to ignore unrecognized fields.
+  // Choose whether decoding JSON with unrecognized fields should produce an error. You may trade
+  // allowing schema evolution against a guarantee that all data is preserved when decoding JSON
+  // by toggling this option. The default is to ignore unrecognized fields.
 
   template <typename T>
   kj::String encode(T&& value) const;

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -60,9 +60,7 @@ class JsonCodec {
   //   different ways people do this.
   // - Encoding/decoding capabilities and AnyPointers requires registering a Handler, since there's
   //   no obvious default behavior.
-  // - When decoding, unrecognized field names are ignored. Note: This means that JSON is NOT a
-  //   good format for receiving input from a human. Consider `capnp eval` or the SchemaParser
-  //   library for human input.
+  // - When decoding, unrecognized field names are ignored by default to allow schema evolution.
 
 public:
   JsonCodec();
@@ -84,6 +82,11 @@ public:
   // value (HasMode::NON_NULL -- only null pointers are omitted). You can use
   // setHasMode(HasMode::NON_DEFAULT) to specify that default-valued primitive fields should be
   // omitted as well.
+
+  void setIgnoreUnrecognizedFields(bool ignore);
+  // Choose whether decoding JSON with unrecognized field names results in an error. You may trade
+  // allowing schema evolution against a guarantee that all data is preserved depending on this
+  // option. The default is to ignore unrecognized fields.
 
   template <typename T>
   kj::String encode(T&& value) const;

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -60,7 +60,7 @@ class JsonCodec {
   //   different ways people do this.
   // - Encoding/decoding capabilities and AnyPointers requires registering a Handler, since there's
   //   no obvious default behavior.
-  // - When decoding, unrecognized field names are ignored by default to allow schema evolution.
+  // - When decoding, unknown field names are ignored by default to allow schema evolution.
 
 public:
   JsonCodec();
@@ -83,10 +83,10 @@ public:
   // setHasMode(HasMode::NON_DEFAULT) to specify that default-valued primitive fields should be
   // omitted as well.
 
-  void setIgnoreUnrecognizedFields(bool ignore);
-  // Choose whether decoding JSON with unrecognized fields should produce an error. You may trade
+  void setRejectUnknownFields(bool enable);
+  // Choose whether decoding JSON with unknown fields should produce an error. You may trade
   // allowing schema evolution against a guarantee that all data is preserved when decoding JSON
-  // by toggling this option. The default is to ignore unrecognized fields.
+  // by toggling this option. The default is to ignore unknown fields.
 
   template <typename T>
   kj::String encode(T&& value) const;

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -60,7 +60,7 @@ class JsonCodec {
   //   different ways people do this.
   // - Encoding/decoding capabilities and AnyPointers requires registering a Handler, since there's
   //   no obvious default behavior.
-  // - When decoding, unknown field names are ignored by default to allow schema evolution.
+  // - When decoding, fields with unknown names are ignored by default to allow schema evolution.
 
 public:
   JsonCodec();


### PR DESCRIPTION
Hi kentonv,

I would like to propose the attached change to libcapnp-json. It adds an opt-in flag to make JsonCodec's decoding fail when encountering unknown fields.

My use case, which I believe requires this change, involves a tool for preserving/archiving an inbound JSON data stream in Cap'n Proto's wire format. A failure scenario exists where a client is changed to provide data not yet known to the archival tool (and thus not yet approved by the archive owner). Given my philosophy of "fail early", I would like the tool to reject messages unless it is sure that no data is lost in the conversion process. Forward compatibility is of insignificant importance compared to a risk of data loss or maintenance cost of storing inbound data in multiple formats.

An alternative to this change would involve checking inbound data using tools such as json-schema prior to processing it with libcapnp. However, this would require that I maintain two schema files and formats with basically the same logical content, which is not an attractive option.

Thank you for your consideration and time to look into this change!

Best

Oliver