### PR TITLE
Remove obsolete strtod includes from json.c++

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -20,9 +20,6 @@
 // THE SOFTWARE.
 
 #include "json.h"
-#include <math.h>    // for HUGEVAL to check for overflow in strtod
-#include <stdlib.h>  // strtod
-#include <errno.h>   // for strtod errors
 #include <capnp/orphan.h>
 #include <kj/debug.h>
 #include <kj/function.h>


### PR DESCRIPTION
I noticed that json.c++ references unneeded headers for strtod, which is no longer used directly. This merge request removes the obsolete includes.