### PR TITLE
Check if fufiller is waiting before asserting that the fulfiller exists

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -290,7 +290,11 @@ kj::String TaskSet::trace() {
 }
 
 Promise<void> TaskSet::onEmpty() {
-  KJ_REQUIRE(emptyFulfiller == nullptr, "onEmpty() can only be called once at a time");
+  KJ_IF_MAYBE(fulfiller, emptyFulfiller) {
+    if (fulfiller->get()->isWaiting()) {
+      KJ_FAIL_REQUIRE("onEmpty() can only be called once at a time");
+    }
+  }
 
   if (tasks == nullptr) {
     return READY_NOW;


### PR DESCRIPTION
This can prevent issues where `drain` is called and the promise is destroyed, preventing further `drain`s from being done.