### PR TITLE
Fix use-after-free in reconnect-test.

### DIFF
--- a/c++/src/capnp/reconnect-test.c++
+++ b/c++/src/capnp/reconnect-test.c++
@@ -79,7 +79,7 @@ void doAutoReconnectTest(kj::WaitScope& ws,
   };
 
   auto test = [&](uint i, bool j) {
-    return testPromise(i, j).wait(ws).getX();
+    return kj::str(testPromise(i, j).wait(ws).getX());
   };
 
   KJ_EXPECT(test(123, true) == "123 true 0");


### PR DESCRIPTION
This is a bug in the test, not in the code it is testing.