### PR TITLE
Set TCP_NODELAY on servers as well as on clients

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1101,6 +1101,20 @@ public:
         // Ignore disallowed address.
         return acceptImpl(authenticated);
       } else {
+        // TODO(perf):  As a hack for the 0.4 release we are always setting
+        //   TCP_NODELAY because Nagle's algorithm pretty much kills Cap'n Proto's
+        //   RPC protocol.  Later, we should extend the interface to provide more
+        //   control over this.  Perhaps write() should have a flag which
+        //   specifies whether to pass MSG_MORE.
+        int one = 1;
+        KJ_SYSCALL_HANDLE_ERRORS(::setsockopt(
+              ownFd.get(), IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(one))) {
+          case EOPNOTSUPP:
+            break;
+          default:
+            KJ_FAIL_SYSCALL("setsocketopt(IPPROTO_TCP, TCP_NODELAY)", error);
+        }
+
         AuthenticatedStream result;
         result.stream = heap<AsyncStreamFd>(eventPort, ownFd.release(), NEW_FD_FLAGS);
         if (authenticated) {


### PR DESCRIPTION
SocketAddress::socket() has long (since 2013) put newly created socket streams into
TCP_NODELAY mode to get around the performance problems caused by the
combination of capnproto making a lot of small writes and Nagle's
algorithm not playing nicely with all those small writes.

I've found that when using capnproto over high latency links it's
important to also set TCP_NODELAY on the server side, since the server
can make lots of small writes as well, and without this an extra TCP
round trip can often be needed for the client to ack the server's first
packet before the server's second packet is sent (and thus before the
client can start doing any useful work).

It's very possible there's a better place to put this, but this works and as far as I can tell all sockets handled here are indeed TCP sockets. Suggestions on where it should go instead would be great.

Along the lines of lots of small writes, though, it does appear that the behavior of kj when writing capnproto messages to TCP sockets is pretty pessimized. Assuming I'm interpeting the series of writes correctly, for each message it first writes 8 bytes (or more, presumably, but I only ever saw 8 locally) that contain the length of the actual message, and then separately writes the actual message. That first write of 8 bytes can get sent out over the network immediately before the actual body of the message is written, causing two packets to be sent when there really only needs to be one. It doesn't seem like it'd be terribly hard to improve this if you're interested.