### PR TITLE
Combine small writes together in TLS compatibility layer

### DIFF
--- a/c++/src/kj/compat/readiness-io.c++
+++ b/c++/src/kj/compat/readiness-io.c++
@@ -147,6 +147,9 @@ kj::Promise<void> ReadyOutputStreamWrapper::pump() {
       return pump();
     } else {
       isPumping = false;
+      // As a small optimization, reset to the start of the buffer when it's empty so we can provide
+      // the underlying layer just one contiguous chunk of memory instead of two when possible.
+      start = 0;
       return kj::READY_NOW;
     }
   });

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -185,7 +185,8 @@ public:
   }
 
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
-    return writeInternal(pieces[0], pieces.slice(1, pieces.size()));
+    auto cork = writeBuffer.cork();
+    return writeInternal(pieces[0], pieces.slice(1, pieces.size())).attach(kj::mv(cork));
   }
 
   Promise<void> whenWriteDisconnected() override {


### PR DESCRIPTION
This is a bit hacky, but it's a quick fix that makes a noticeable
difference in the number of small packets we send over the wire,
especially now that TCP_NODELAY is enabled on the server side.

If you'd prefer a different approach, let me know.

I also added a tiny little second commit that's mostly unrelated, which I can remove if you don't care about it.