### PR TITLE
cmake: set CAPNP_INCLUDE_DIR

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -168,6 +168,9 @@ if(NOT CAPNP_LITE)
   set_target_properties(capnp_tool PROPERTIES CAPNP_INCLUDE_DIRECTORY
     $<JOIN:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>,$<INSTALL_INTERFACE:${CMAKE_INSTALL_BINDIR}/..>>
   )
+  set_target_properties(capnp_tool PROPERTIES
+    COMPILE_DEFINITIONS CAPNP_INCLUDE_DIR=\"${CMAKE_INSTALL_FULL_INCLUDEDIR}\"
+  )
 
   add_executable(capnpc_cpp
     compiler/capnpc-c++.c++


### PR DESCRIPTION
when installing capnp to a non-standard location (out of `/usr` or `/usr/local`), the `capnp compile` must be issued with the `-I` option even for the standard `/capnp/c++.capnp` import. Some projects that use `capnp compile` directly, not via cmake (e.g. [capnproto-java](https://github.com/capnproto/capnproto-java/blob/b60bc1e7148893ad584e369b7bd3c1717f1d2cb0/compiler/pom.xml#L87)) cannot be built in this configuration.