### PR TITLE
Disable clang unreachable code warnings for known-unreachable code

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1110,6 +1110,7 @@ public:
         KJ_SYSCALL_HANDLE_ERRORS(::setsockopt(
               ownFd.get(), IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(one))) {
           case EOPNOTSUPP:
+          case ENOPROTOOPT: // (returned for AF_UNIX in cygwin)
             break;
           default:
             KJ_FAIL_SYSCALL("setsocketopt(IPPROTO_TCP, TCP_NODELAY)", error);

--- a/c++/src/kj/common.c++
+++ b/c++/src/kj/common.c++
@@ -44,7 +44,7 @@ void unreachable() {
   KJ_FAIL_ASSERT("Supposedly-unreachable branch executed.");
 
   // Really make sure we abort.
-  abort();
+  KJ_KNOWN_UNREACHABLE(abort());
 }
 
 }  // namespace _ (private)

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -278,6 +278,20 @@ KJ_NORETURN(void unreachable());
 #define KJ_CLANG_KNOWS_THIS_IS_UNREACHABLE_BUT_GCC_DOESNT KJ_UNREACHABLE
 #endif
 
+#if __clang__
+#define KJ_KNOWN_UNREACHABLE(code) \
+    do { \
+      _Pragma("clang diagnostic push") \
+      _Pragma("clang diagnostic ignored \"-Wunreachable-code\"") \
+      code; \
+      _Pragma("clang diagnostic pop") \
+    } while (false)
+// Suppress "unreachable code" warnings on intentionally unreachable code.
+#else
+// TODO(someday): Add support for non-clang compilers.
+#define KJ_KNOWN_UNREACHABLE(code) do {code;} while(false)
+#endif
+
 // #define KJ_STACK_ARRAY(type, name, size, minStack, maxStack)
 //
 // Allocate an array, preferably on the stack, unless it is too big.  On GCC this will use

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -322,7 +322,7 @@ TEST(Debug, Catch) {
     // Catch as std::exception.
     try {
       line = __LINE__; KJ_FAIL_ASSERT("foo");
-      ADD_FAILURE() << "Expected exception.";
+      KJ_KNOWN_UNREACHABLE(ADD_FAILURE() << "Expected exception.");
     } catch (const std::exception& e) {
       kj::StringPtr what = e.what();
       std::string text;

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -340,7 +340,7 @@ void Debug::Fault::fatal() {
   delete exception;
   exception = nullptr;
   throwFatalException(mv(copy), 2);
-  abort();
+  KJ_KNOWN_UNREACHABLE(abort());
 }
 
 void Debug::Fault::init(

--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -71,10 +71,10 @@ TEST(OneOf, Basic) {
   EXPECT_EQ("foo", var.get<String>());
   EXPECT_EQ("", var2.get<String>());
 
-  if (false) {
+  auto canCompile KJ_UNUSED = [&]() {
     var.allHandled<3>();
     // var.allHandled<2>();  // doesn't compile
-  }
+  };
 }
 
 TEST(OneOf, Copy) {


### PR DESCRIPTION
This change cleans up compiler output when building capnproto in a project that is using clang with `-Wunreachable-code`.  I'm not sure if there is a cleaner way to do this, or one that could be applied to more compilers.

(Since these are `#pragma`s, I assume there's no way to substitute them via macros, so I assume we'd otherwise have to resort to tiny `#include` files, which seemed kind of messy?)