### PR TITLE
fastCaseCmp: workaround gcc -Wtautological-compare

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1617,10 +1617,8 @@ template <char first, char... rest>
 struct FastCaseCmp<first, rest...> {
   static constexpr bool apply(const char* actual) {
     return
-      'a' <= first && first <= 'z'
-        ? (*actual | 0x20) == first && FastCaseCmp<rest...>::apply(actual + 1)
-      : 'A' <= first && first <= 'Z'
-        ? (*actual & ~0x20) == first && FastCaseCmp<rest...>::apply(actual + 1)
+      ('a' <= first && first <= 'z') || ('A' <= first && first <= 'Z')
+        ? (*actual | 0x20) == (first | 0x20) && FastCaseCmp<rest...>::apply(actual + 1)
         : *actual == first && FastCaseCmp<rest...>::apply(actual + 1);
   }
 };


### PR DESCRIPTION
https://godbolt.org/z/nP5fcc

```
In instantiation of 'static constexpr bool FastCaseCmp<first, rest ...>::apply(const char*) [with char first = 'f'; char ...rest = {'O', 'o', 'B', '1'}]':
<source>:25:38:   required from 'constexpr bool fastCaseCmp(const char*) [with char ...chars = {'f', 'O', 'o', 'B', '1'}]'
<source>:29:47:   required from here
<source>:11:29: error: bitwise comparison always evaluates to false [-Werror=tautological-compare]
   11 |         ? (*actual & ~0x20) == first && FastCaseCmp<rest...>::apply(actual + 1)
      |           ~~~~~~~~~~~~~~~~~~^~~~~~~~
```