### PR TITLE
Fix TextCodec parse error formatting.

### DIFF
--- a/c++/src/capnp/serialize-text-test.c++
+++ b/c++/src/capnp/serialize-text-test.c++
@@ -126,6 +126,22 @@ KJ_TEST("raw text") {
   KJ_EXPECT(reader.getAnotherUnion().getCorge()[2] == 9);
 }
 
+KJ_TEST("TextCodec parse error") {
+  auto message = "\n  (,)"_kj;
+
+  MallocMessageBuilder builder;
+  auto root = builder.initRoot<TestAllTypes>();
+
+  TextCodec codec;
+  auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions(
+      [&]() { codec.decode(message, root); }));
+
+  KJ_EXPECT(exception.getFile() == "(capnp text input)"_kj);
+  KJ_EXPECT(exception.getLine() == 2);
+  KJ_EXPECT(exception.getDescription() == "3-6: Parse error: Empty list item.",
+            exception.getDescription());
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp

--- a/c++/src/capnp/serialize-text-test.c++
+++ b/c++/src/capnp/serialize-text-test.c++
@@ -32,7 +32,7 @@ namespace capnp {
 namespace _ {  // private
 namespace {
 
-KJ_TEST("TestAllTypes") {
+KJ_TEST("TextCodec TestAllTypes") {
   MallocMessageBuilder builder;
   initTestMessage(builder.initRoot<TestAllTypes>());
 
@@ -66,7 +66,7 @@ KJ_TEST("TestAllTypes") {
   }
 }
 
-KJ_TEST("TestDefaults") {
+KJ_TEST("TextCodec TestDefaults") {
   MallocMessageBuilder builder;
   initTestMessage(builder.initRoot<TestDefaults>());
 
@@ -79,7 +79,7 @@ KJ_TEST("TestDefaults") {
   checkTestMessage(structReader);
 }
 
-KJ_TEST("TestListDefaults") {
+KJ_TEST("TextCodec TestListDefaults") {
   MallocMessageBuilder builder;
   initTestMessage(builder.initRoot<TestListDefaults>());
 
@@ -92,7 +92,7 @@ KJ_TEST("TestListDefaults") {
   checkTestMessage(structReader);
 }
 
-KJ_TEST("raw text") {
+KJ_TEST("TextCodec raw text") {
   using TestType = capnproto_test::capnp::test::TestLateUnion;
 
   kj::String message =

--- a/c++/src/capnp/serialize-text.c++
+++ b/c++/src/capnp/serialize-text.c++
@@ -29,6 +29,8 @@
 #include "compiler/node-translator.h"
 #include "compiler/parser.h"
 
+namespace capnp {
+
 namespace {
 
 class ThrowingErrorReporter final: public capnp::compiler::ErrorReporter {
@@ -107,8 +109,6 @@ void lexAndParseExpression(kj::StringPtr input, Function f) {
 }
 
 }  // namespace
-
-namespace capnp {
 
 TextCodec::TextCodec() : prettyPrint(false) {}
 TextCodec::~TextCodec() noexcept(true) {}

--- a/c++/src/capnp/serialize-text.c++
+++ b/c++/src/capnp/serialize-text.c++
@@ -34,11 +34,29 @@ namespace {
 class ThrowingErrorReporter final: public capnp::compiler::ErrorReporter {
   // Throws all errors as assertion failures.
 public:
+  ThrowingErrorReporter(kj::StringPtr input): input(input) {}
+
   void addError(uint32_t startByte, uint32_t endByte, kj::StringPtr message) override {
-    KJ_FAIL_REQUIRE(kj::str(message, " (", startByte, ":", endByte, ")."));
+    // Note: Line and column numbers are usually 1-based.
+    uint line = 1;
+    uint32_t lineStart = 0;
+    for (auto i: kj::zeroTo(startByte)) {
+      if (input[i] == '\n') {
+        ++line;
+        lineStart = i;  // Omit +1 so that column is 1-based.
+      }
+    }
+
+    kj::throwRecoverableException(kj::Exception(
+      kj::Exception::Type::FAILED, "(capnp text input)", line,
+      kj::str(startByte - lineStart, "-", endByte - lineStart, ": ", message)
+    ));
   }
 
   bool hadErrors() override { return false; }
+
+private:
+  kj::StringPtr input;
 };
 
 class ExternalResolver final: public capnp::compiler::ValueTranslator::Resolver {
@@ -59,7 +77,7 @@ template <typename Function>
 void lexAndParseExpression(kj::StringPtr input, Function f) {
   // Parses a single expression from the input and calls `f(expression)`.
 
-  ThrowingErrorReporter errorReporter;
+  ThrowingErrorReporter errorReporter(input);
 
   capnp::MallocMessageBuilder tokenArena;
   auto lexedTokens = tokenArena.initRoot<capnp::compiler::LexedTokens>();
@@ -112,10 +130,10 @@ kj::String TextCodec::encode(DynamicValue::Reader value) const {
 }
 
 void TextCodec::decode(kj::StringPtr input, DynamicStruct::Builder output) const {
-  lexAndParseExpression(input, [&output](compiler::Expression::Reader expression) {
+  lexAndParseExpression(input, [&](compiler::Expression::Reader expression) {
     KJ_REQUIRE(expression.isTuple(), "Input does not contain a struct.");
 
-    ThrowingErrorReporter errorReporter;
+    ThrowingErrorReporter errorReporter(input);
     ExternalResolver nullResolver;
 
     Orphanage orphanage = Orphanage::getForMessageContaining(output);
@@ -126,9 +144,9 @@ void TextCodec::decode(kj::StringPtr input, DynamicStruct::Builder output) const
 
 Orphan<DynamicValue> TextCodec::decode(kj::StringPtr input, Type type, Orphanage orphanage) const {
   Orphan<DynamicValue> output;
-  
-  lexAndParseExpression(input, [&type, &orphanage, &output](compiler::Expression::Reader expression) {
-    ThrowingErrorReporter errorReporter;
+
+  lexAndParseExpression(input, [&](compiler::Expression::Reader expression) {
+    ThrowingErrorReporter errorReporter(input);
     ExternalResolver nullResolver;
 
     compiler::ValueTranslator translator(nullResolver, errorReporter, orphanage);
@@ -138,7 +156,7 @@ Orphan<DynamicValue> TextCodec::decode(kj::StringPtr input, Type type, Orphanage
       // An error should have already been given to the errorReporter.
     }
   });
-  
+
   return output;
 }
 


### PR DESCRIPTION
The error messages always started with `kj::str(message, " (", startByte, ":", endByte, ").") =` due to the use of KJ_FAIL_ASSERT. This garbage clearly wasn't intended to be part of the error message.

I also went a little further and computed the line number and column numbers, which is usually nicer than a byte span.