### PR TITLE
Fix canceler.isEmpty() check in http-over-capnp

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -46,7 +46,7 @@ public:
 
   void cancel() {
     if (tasks != nullptr) {
-      if (canceler.isEmpty()) {
+      if (!canceler.isEmpty()) {
         canceler.cancel(KJ_EXCEPTION(DISCONNECTED, "request canceled"));
       }
       tasks = nullptr;

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -643,7 +643,7 @@ public:
   // happens to this Canceler.
 
   bool isEmpty() const { return list == nullptr; }
-  // Indicates if any previously-wrapped promises are still executing. (If this returns false, then
+  // Indicates if any previously-wrapped promises are still executing. (If this returns true, then
   // cancel() would be a no-op.)
 
 private:


### PR DESCRIPTION
Additionally, the documentation for the bool result from Canceler.isEmpty was reversed.

---

All credit to @harrishancock 