### PR TITLE
Clarify canonicalization behavior on zero-sized values.

### DIFF
--- a/doc/encoding.md
+++ b/doc/encoding.md
@@ -374,7 +374,10 @@ A canonical Cap'n Proto message must adhere to the following rules:
 * Similarly, for a struct list, if a trailing word in a section of all structs in the list is zero,
   then it must be truncated from all structs in the list. (All structs in a struct list must have
   equal sizes, hence a trailing zero can only be removed if it is zero in all elements.)
-* Any struct pointer pointing to a zero-sized struct should have an offset of -1.
+* Any struct pointer pointing to a zero-sized struct should have an
+  offset of -1.
+  * Note that this applies _only_ to structs; other zero-sized values should have offsets
+    allocated in preorder, as normal.
 * Canonical messages are not packed. However, packing can still be applied for transmission
   purposes; the message must simply be unpacked before checking signatures.
 


### PR DESCRIPTION
Fixes #1085.

This is what the implementation already does, and you can make the
argument that it is implied by the previous description, but this makes
it unambiguous.