### PR TITLE
Add support for List(Capability)

### DIFF
--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -313,36 +313,36 @@ CppTypeName whichKind(Type type) {
   // instantiation.
 
   switch (type.which()) {
-      case schema::Type::VOID: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::VOID: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
 
-      case schema::Type::BOOL: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::INT8: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::INT16: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::INT32: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::INT64: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::UINT8: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::UINT16: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::UINT32: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::UINT64: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::FLOAT32: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
-      case schema::Type::FLOAT64: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::BOOL: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::INT8: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::INT16: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::INT32: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::INT64: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::UINT8: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::UINT16: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::UINT32: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::UINT64: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::FLOAT32: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
+    case schema::Type::FLOAT64: return CppTypeName::makePrimitive(" ::capnp::Kind::PRIMITIVE");
 
-      case schema::Type::TEXT: return CppTypeName::makePrimitive(" ::capnp::Kind::BLOB");
-      case schema::Type::DATA: return CppTypeName::makePrimitive(" ::capnp::Kind::BLOB");
+    case schema::Type::TEXT: return CppTypeName::makePrimitive(" ::capnp::Kind::BLOB");
+    case schema::Type::DATA: return CppTypeName::makePrimitive(" ::capnp::Kind::BLOB");
 
-      case schema::Type::ENUM: return CppTypeName::makePrimitive(" ::capnp::Kind::ENUM");
-      case schema::Type::STRUCT: return CppTypeName::makePrimitive(" ::capnp::Kind::STRUCT");
-      case schema::Type::INTERFACE: return CppTypeName::makePrimitive(" ::capnp::Kind::INTERFACE");
+    case schema::Type::ENUM: return CppTypeName::makePrimitive(" ::capnp::Kind::ENUM");
+    case schema::Type::STRUCT: return CppTypeName::makePrimitive(" ::capnp::Kind::STRUCT");
+    case schema::Type::INTERFACE: return CppTypeName::makePrimitive(" ::capnp::Kind::INTERFACE");
 
-      case schema::Type::LIST: return CppTypeName::makePrimitive(" ::capnp::Kind::LIST");
-      case schema::Type::ANY_POINTER: {
-        switch (type.whichAnyPointerKind()) {
-          case schema::Type::AnyPointer::Unconstrained::CAPABILITY:
-            return CppTypeName::makePrimitive(" ::capnp::Kind::INTERFACE");
-          default:
-            return CppTypeName::makePrimitive(" ::capnp::Kind::OTHER");
-        }
+    case schema::Type::LIST: return CppTypeName::makePrimitive(" ::capnp::Kind::LIST");
+    case schema::Type::ANY_POINTER: {
+      switch (type.whichAnyPointerKind()) {
+        case schema::Type::AnyPointer::Unconstrained::CAPABILITY:
+          return CppTypeName::makePrimitive(" ::capnp::Kind::INTERFACE");
+        default:
+          return CppTypeName::makePrimitive(" ::capnp::Kind::OTHER");
       }
+    }
   }
 
   KJ_UNREACHABLE;

--- a/c++/src/capnp/compiler/generics.c++
+++ b/c++/src/capnp/compiler/generics.c++
@@ -131,10 +131,19 @@ bool BrandedDecl::compileAsType(
         }
 
         if (elementType.isAnyPointer()) {
-          addError(errorReporter, "'List(AnyPointer)' is not supported.");
-          // Seeing List(AnyPointer) later can mess things up, so change the type to Void.
-          elementType.setVoid();
-          return false;
+          auto unconstrained = elementType.getAnyPointer().getUnconstrained();
+
+          if (unconstrained.isAnyKind()) {
+            addError(errorReporter, "'List(AnyPointer)' is not supported.");
+            // Seeing List(AnyPointer) later can mess things up, so change the type to Void.
+            elementType.setVoid();
+            return false;
+          } else if (unconstrained.isStruct()) {
+            addError(errorReporter, "'List(AnyStruct)' is not supported.");
+            // Seeing List(AnyStruct) later can mess things up, so change the type to Void.
+            elementType.setVoid();
+            return false;
+          }
         }
 
         return true;

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -763,7 +763,6 @@ struct TestAnyPointerConstants {
   anyStructAsStruct @1 :AnyStruct;
   anyKindAsList @2 :AnyPointer;
   anyListAsList @3 :AnyList;
-
 }
 
 const anyPointerConstants :TestAnyPointerConstants = (
@@ -772,6 +771,11 @@ const anyPointerConstants :TestAnyPointerConstants = (
   anyKindAsList = TestConstants.int32ListConst,
   anyListAsList = TestConstants.int32ListConst,
 );
+
+struct TestListOfAny {
+  capList @0 :List(Capability);
+  #listList @1 :List(AnyList); # TODO(soon): Make List(AnyList) work correctly in C++ generated code.
+}
 
 interface TestInterface {
   foo @0 (i :UInt32, j :Bool) -> (x :Text);

--- a/c++/src/capnp/testdata/errors.capnp.nobuild
+++ b/c++/src/capnp/testdata/errors.capnp.nobuild
@@ -97,6 +97,7 @@ struct Foo {
   listWithoutParam @31 :List;
   listWithTooManyParams @32 :List(Int32, Int64);
   listAnyPointer @33 :List(AnyPointer);
+  listAnyStruct @48 :List(AnyStruct);
   notAType @34 :notType;
   noParams @35 :Foo(Int32);
 

--- a/c++/src/capnp/testdata/errors.txt
+++ b/c++/src/capnp/testdata/errors.txt
@@ -2,7 +2,7 @@ file:74:30-32: error: As of Cap'n Proto v0.3, it is no longer necessary to assig
 file:74:30-32: error: As of Cap'n Proto v0.3, the 'union' keyword should be prefixed with a colon for named unions, e.g. `foo :union {`.
 file:79:23-25: error: As of Cap'n Proto v0.3, it is no longer necessary to assign numbers to unions. However, removing the number will break binary compatibility. If this is an old protocol and you need to retain compatibility, please add an exclamation point after the number to indicate that it is really needed, e.g. `foo @1! :union {`. If this is a new protocol or compatibility doesn't matter, just remove the @n entirely. Sorry for the inconvenience, and thanks for being an early adopter!  :)
 file:84:17-19: error: As of Cap'n Proto v0.3, the 'union' keyword should be prefixed with a colon for named unions, e.g. `foo :union {`.
-file:132:7-10: error: 'using' declaration without '=' must specify a named declaration from a different scope.
+file:133:7-10: error: 'using' declaration without '=' must specify a named declaration from a different scope.
 file:37:3-10: error: 'dupName' is already defined in this scope.
 file:36:3-10: error: 'dupName' previously defined here.
 file:52:5-12: error: 'dupName' is already defined in this scope.
@@ -21,42 +21,43 @@ file:39:15-16: error: Duplicate ordinal number.
 file:38:15-16: error: Ordinal @2 originally used here.
 file:41:18-19: error: Skipped ordinal @3.  Ordinals must be sequential with no holes.
 file:69:15-17: error: Union ordinal, if specified, must be greater than no more than one of its member ordinals (i.e. there can only be one field retroactively unionized).
-file:116:31-50: error: Import failed: noshuchfile.capnp
-file:118:26-32: error: Not defined: NoSuch
-file:119:28-34: error: 'Foo' has no member named 'NoSuch'
+file:117:31-50: error: Import failed: noshuchfile.capnp
+file:119:26-32: error: Not defined: NoSuch
+file:120:28-34: error: 'Foo' has no member named 'NoSuch'
 file:97:25-29: error: 'List' requires exactly one parameter.
 file:98:30-48: error: Too many generic parameters.
 file:98:30-34: error: 'List' requires exactly one parameter.
 file:99:23-39: error: 'List(AnyPointer)' is not supported.
-file:100:17-24: error: 'notType' is not a type.
-file:101:17-27: error: Declaration does not accept generic parameters.
-file:103:34-41: error: Integer value out of range.
-file:104:37-38: error: Integer value out of range.
-file:105:32-35: error: Type mismatch; expected Text.
-file:106:33-38: error: Type mismatch; expected Text.
-file:107:33-55: error: Type mismatch; expected Text.
-file:108:43-61: error: Integer is too big to be negative.
-file:109:35-39: error: '.Foo' does not refer to a constant.
-file:110:44-51: error: Constant names must be qualified to avoid confusion.  Please replace 'notType' with '.notType', if that's what you intended.
-file:117:28-34: error: Not defined: NoSuch
-file:112:29-32: error: 'Foo' is not an annotation.
-file:113:29-47: error: 'notFieldAnnotation' cannot be applied to this kind of declaration.
-file:114:33-48: error: 'fieldAnnotation' requires a value.
-file:126:35-46: error: Struct has no field named 'nosuchfield'.
-file:127:49-52: error: Type mismatch; expected group.
-file:125:52-55: error: Missing field name.
-file:136:3-10: error: 'dupName' is already defined in this scope.
-file:135:3-10: error: 'dupName' previously defined here.
-file:138:15-16: error: Duplicate ordinal number.
-file:137:15-16: error: Ordinal @2 originally used here.
-file:141:7-16: error: Declaration recursively depends on itself.
-file:147:14-27: error: Not enough generic parameters.
-file:148:15-47: error: Too many generic parameters.
-file:149:18-49: error: Double-application of generic parameters.
-file:150:38-43: error: Sorry, only pointer types can be used as generic parameters.
-file:153:30-44: error: Embeds can only be used when Text, Data, or a struct is expected.
-file:154:37-51: error: Couldn't read file for embed: no-such-file
-file:160:23-27: error: Only pointer parameters can declare their default as 'null'.
-file:161:10-16: error: 'stream' can only appear after '->', not before.
-file:161:10-16: error: A method declaration uses streaming, but '/capnp/stream.capnp' is not found in the import path. This is a standard file that should always be installed with the Cap'n Proto compiler.
-file:156:20-45: error: Import failed: nosuchfile-unused.capnp
+file:101:17-24: error: 'notType' is not a type.
+file:102:17-27: error: Declaration does not accept generic parameters.
+file:104:34-41: error: Integer value out of range.
+file:105:37-38: error: Integer value out of range.
+file:106:32-35: error: Type mismatch; expected Text.
+file:107:33-38: error: Type mismatch; expected Text.
+file:108:33-55: error: Type mismatch; expected Text.
+file:109:43-61: error: Integer is too big to be negative.
+file:110:35-39: error: '.Foo' does not refer to a constant.
+file:111:44-51: error: Constant names must be qualified to avoid confusion.  Please replace 'notType' with '.notType', if that's what you intended.
+file:118:28-34: error: Not defined: NoSuch
+file:100:22-37: error: 'List(AnyStruct)' is not supported.
+file:113:29-32: error: 'Foo' is not an annotation.
+file:114:29-47: error: 'notFieldAnnotation' cannot be applied to this kind of declaration.
+file:115:33-48: error: 'fieldAnnotation' requires a value.
+file:127:35-46: error: Struct has no field named 'nosuchfield'.
+file:128:49-52: error: Type mismatch; expected group.
+file:126:52-55: error: Missing field name.
+file:137:3-10: error: 'dupName' is already defined in this scope.
+file:136:3-10: error: 'dupName' previously defined here.
+file:139:15-16: error: Duplicate ordinal number.
+file:138:15-16: error: Ordinal @2 originally used here.
+file:142:7-16: error: Declaration recursively depends on itself.
+file:148:14-27: error: Not enough generic parameters.
+file:149:15-47: error: Too many generic parameters.
+file:150:18-49: error: Double-application of generic parameters.
+file:151:38-43: error: Sorry, only pointer types can be used as generic parameters.
+file:154:30-44: error: Embeds can only be used when Text, Data, or a struct is expected.
+file:155:37-51: error: Couldn't read file for embed: no-such-file
+file:161:23-27: error: Only pointer parameters can declare their default as 'null'.
+file:162:10-16: error: 'stream' can only appear after '->', not before.
+file:162:10-16: error: A method declaration uses streaming, but '/capnp/stream.capnp' is not found in the import path. This is a standard file that should always be installed with the Cap'n Proto compiler.
+file:157:20-45: error: Import failed: nosuchfile-unused.capnp


### PR DESCRIPTION
This is hoping to solve #1089. This time I managed to get to a point where it works for me, with a small example using a list of capabilities defined as:

```
fetchCapabilities @0 () -> (caps :List(Capability));
```

With those changes, I can pass a list of capabilities through `fetchCapabilities` by modifying the calculator example, and it works. I finally realized that I should handle the `AnyPointer` type further in the pipeline. I was first trying to do that in `schema.h`, but I think that it did not work because an `Unconstrained::Capability` is not an `InterfaceSchema`, though both are `INTERFACE`s in the end.

Resolves #1089.