### PR TITLE
Fix for `make check` in an out-of-source build directory

### DIFF
--- a/c++/src/capnp/compiler/capnp-test.sh
+++ b/c++/src/capnp/compiler/capnp-test.sh
@@ -79,10 +79,10 @@ $CAPNP convert json:binary $SCHEMA TestAllTypes < $TESTDATA/short.json | cmp $TE
 $CAPNP convert json:binary $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated.json | cmp $TESTDATA/annotated-json.binary || fail annotated json to binary
 $CAPNP convert binary:json $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated-json.binary | cmp $TESTDATA/annotated.json || fail annotated json to binary
 
-[ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text src/capnp/test.capnp BrandedAlias)" = '(foo = (text = "abc"), uv = void)' ]  || fail branded alias
-[ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text src/capnp/test.capnp BrandedAlias.Inner)" = '(foo = (text = "abc"))' ]  || fail branded alias
-[ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text src/capnp/test.capnp 'TestGenerics(BoxedText, Text)')" = '(foo = (text = "abc"), uv = void)' ]  || fail branded alias
-[ "$(echo '(baz = (text = "abc"))' | $CAPNP convert text:text src/capnp/test.capnp 'TestGenerics(TestAllTypes, List(Int32)).Inner2(BoxedText)')" = '(baz = (text = "abc"))' ]  || fail branded alias
+[ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" BrandedAlias)" = '(foo = (text = "abc"), uv = void)' ]  || fail branded alias
+[ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" BrandedAlias.Inner)" = '(foo = (text = "abc"))' ]  || fail branded alias
+[ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" 'TestGenerics(BoxedText, Text)')" = '(foo = (text = "abc"), uv = void)' ]  || fail branded alias
+[ "$(echo '(baz = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" 'TestGenerics(TestAllTypes, List(Int32)).Inner2(BoxedText)')" = '(baz = (text = "abc"))' ]  || fail branded alias
 
 # ========================================================================================
 # DEPRECATED encode/decode


### PR DESCRIPTION
 src/capnp/compiler/capnp-test.sh was failing `make check` for me when building in an out-of-source build. This fixes that.