### PR TITLE
Support constexpr `kj::nan()` under MSVC

### DIFF
--- a/c++/src/kj/common.c++
+++ b/c++/src/kj/common.c++
@@ -22,9 +22,6 @@
 #include "common.h"
 #include "debug.h"
 #include <stdlib.h>
-#ifdef _MSC_VER
-#include <limits>
-#endif
 
 namespace kj {
 namespace _ {  // private
@@ -48,11 +45,5 @@ void unreachable() {
 }
 
 }  // namespace _ (private)
-
-#if _MSC_VER && !__clang__
-
-float nan() { return std::numeric_limits<float>::quiet_NaN(); }
-
-#endif
 
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -705,25 +705,9 @@ struct ThrowOverflow {
   void operator()() const;
 };
 
-#if __GNUC__ || __clang__
+#if __GNUC__ || __clang__ || _MSC_VER
 inline constexpr float inf() { return __builtin_huge_valf(); }
 inline constexpr float nan() { return __builtin_nanf(""); }
-
-#elif _MSC_VER
-
-// Do what MSVC math.h does
-#pragma warning(push)
-#pragma warning(disable: 4756)  // "overflow in constant arithmetic"
-inline constexpr float inf() { return (float)(1e300 * 1e300); }
-#pragma warning(pop)
-
-float nan();
-// Unfortunately, inf() * 0.0f produces a NaN with the sign bit set, whereas our preferred
-// canonical NaN should not have the sign bit set. std::numeric_limits<float>::quiet_NaN()
-// returns the correct NaN, but we don't want to #include that here. So, we give up and make
-// this out-of-line on MSVC.
-//
-// TODO(msvc): Can we do better?
 
 #else
 #error "Not sure how to support your compiler."


### PR DESCRIPTION
I noticed the comments around this when at work today and (because of reasons\*) I wanted to look into it a little more when I got off of work (as it's irrelevant to my actual job).

Recent MSVCs support a handful of clang/gcc-like `__builtin` functions so I figured I'd check, and it seems these two are totally supported, even as far back as libkj's min supported MSVC version (_MSC_VER >= 1910 is checked elsewhere in common.h). Godbolt proof that it works on that old of a MSVC: https://gcc.godbolt.org/z/7q6rsn

This simplifies and reduces the amount of code (compiler-specific code no less), and removes another use of the c++ stdlib (which appears to be one of libkj's aspirations).

The drawback is that I... can't find much in the way of docs about MSVC supporting these... I could have sworn it was mentioned (that they added support for certain clang/gcc-like `__builtin`s) in a post on the Visual C++ blog, but I can't find it now, unfortunately...

It's also not exactly like the "try just see if it works" approach I described is, uh, particularly great engineering practice (especially when it comes to avoiding unstable compiler features) so I'd understand if you don't want to take it for fear that it's an internal/unstable MSVC api.

Still, seemed worth PRing either way.

---

(skippable rambling tangent below)

\* I had to look into this because compilers doing weird things to NaN is relevant to some [spelunking](https://bugs.llvm.org/show_bug.cgi?id=43907#c8) I did last month — investigating a bug in LLVM's APFloat type.

The negative qNaN MSVC here ofc is unrelated, but I'm glad I looked at it, since while MSVC is behaving as I'd expect, it seems like LLVM is doing the wrong\*\* thing again.

\*\* Okay, "wrong" is debatable — certainly IEEE754 allows these deviations, and C++'s standard very likely does too.

I'm considering MSVC (and GCC) "right" and LLVM "wrong" in that they agree/disagree (respectively) with what `inf() * 0.0f` would evaluate to on the target hardware, if the operations all happened at runtime.

That is, on x86, `-qNaN` is right for `inf() * 0.0f`, but LLVM gives `+qNaN` on all targets (which *would* be right for some stuff, like ARM, but really by accident...).

Rust cares about this since it lets if "did we constant fold this" be something code can detect, and it would rather optimizations not change program behavior for well defined programs (although it's an uphill battle for floats...). So, I'm glad I saw this even if you don't take the patch.
