### PR TITLE
CMake: append cmake folder into CMAKE_MODULE_PATH instead of set

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.4)
 project("Cap'n Proto" CXX)
 set(VERSION 0.9-dev)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(CheckIncludeFileCXX)
 include(GNUInstallDirs)


### PR DESCRIPTION
Paths defined in `CMAKE_MODULE_PATH` by callers are lost with current CMakeLists. Best practice is to always append new values in CMAKE_MODULE_PATH. For conan package manager, it leads to issues because it injects specific paths in this variable.