### PR TITLE
Fix leak when an RPC tail call is canceled.

### DIFF
--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -673,6 +673,107 @@ TEST(Rpc, TailCall) {
   EXPECT_EQ(1, context.restorer.callCount);
 }
 
+class TestHangingTailCallee final: public test::TestTailCallee::Server {
+public:
+  TestHangingTailCallee(int& callCount, int& cancelCount)
+      : callCount(callCount), cancelCount(cancelCount) {}
+
+  kj::Promise<void> foo(FooContext context) override {
+    context.allowCancellation();
+    ++callCount;
+    return kj::Promise<void>(kj::NEVER_DONE)
+        .attach(kj::defer([&cancelCount = cancelCount]() { ++cancelCount; }));
+  }
+
+private:
+  int& callCount;
+  int& cancelCount;
+};
+
+class TestRacingTailCaller final: public test::TestTailCaller::Server {
+public:
+  TestRacingTailCaller(kj::Promise<void> unblock): unblock(kj::mv(unblock)) {}
+
+  kj::Promise<void> foo(FooContext context) override {
+    return unblock.then([context]() mutable {
+      auto tailRequest = context.getParams().getCallee().fooRequest();
+      return context.tailCall(kj::mv(tailRequest));
+    });
+  }
+
+private:
+  kj::Promise<void> unblock;
+};
+
+TEST(Rpc, TailCallCancel) {
+  TestContext context;
+
+  auto caller = context.connect(test::TestSturdyRefObjectId::Tag::TEST_TAIL_CALLER)
+      .castAs<test::TestTailCaller>();
+
+  int callCount = 0, cancelCount = 0;
+
+  test::TestTailCallee::Client callee(kj::heap<TestHangingTailCallee>(callCount, cancelCount));
+
+  {
+    auto request = caller.fooRequest();
+    request.setCallee(callee);
+
+    auto promise = request.send();
+
+    KJ_ASSERT(callCount == 0);
+    KJ_ASSERT(cancelCount == 0);
+
+    KJ_ASSERT(!promise.poll(context.waitScope));
+
+    KJ_ASSERT(callCount == 1);
+    KJ_ASSERT(cancelCount == 0);
+  }
+
+  kj::Promise<void>(kj::NEVER_DONE).poll(context.waitScope);
+
+  KJ_ASSERT(callCount == 1);
+  KJ_ASSERT(cancelCount == 1);
+}
+
+TEST(Rpc, TailCallCancelRace) {
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  TestContext context(kj::heap<TestRacingTailCaller>(kj::mv(paf.promise)));
+
+  MallocMessageBuilder serverHostIdBuilder;
+  auto serverHostId = serverHostIdBuilder.getRoot<test::TestSturdyRefHostId>();
+  serverHostId.setHost("server");
+
+  auto caller = context.rpcClient.bootstrap(serverHostId).castAs<test::TestTailCaller>();
+
+  int callCount = 0, cancelCount = 0;
+
+  test::TestTailCallee::Client callee(kj::heap<TestHangingTailCallee>(callCount, cancelCount));
+
+  {
+    auto request = caller.fooRequest();
+    request.setCallee(callee);
+
+    auto promise = request.send();
+
+    KJ_ASSERT(callCount == 0);
+    KJ_ASSERT(cancelCount == 0);
+
+    KJ_ASSERT(!promise.poll(context.waitScope));
+
+    KJ_ASSERT(callCount == 0);
+    KJ_ASSERT(cancelCount == 0);
+
+    // Unblock the server and at the same time cancel the client.
+    paf.fulfiller->fulfill();
+  }
+
+  kj::Promise<void>(kj::NEVER_DONE).poll(context.waitScope);
+
+  KJ_ASSERT(callCount == 1);
+  KJ_ASSERT(cancelCount == 1);
+}
+
 TEST(Rpc, Cancelation) {
   // Tests allowCancellation().
 


### PR DESCRIPTION
Consider this situation:
* Client makes call to server.
* The server method tail-calls back to a capability hosted by the client.
* While the server is doing this, the client cancels the original call.

In this situation, the server ends up sending the client messages saying "start this new call, and then use the results to satisfy this other outstanding call you made to me".

However, in the case where the client has already canceled the original call, the code failed to clean up properly. As a result, it ended up never sending a return message for the server -> client call. This would leak some resources, especially including the RPC object to which the tail call was directed on the client side.

In addition to this bug, cancellation was not propagated correctly through these tail calls. This was true whether the cancellation occurred on the client side before or after the server notified it of the tail call.