### PR TITLE
mutex: Fix build on 32-bit architectures using 64-bit time_t

### DIFF
--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -39,7 +39,13 @@
 
 #ifndef SYS_futex
 // Missing on Android/Bionic.
+#ifdef __NR_futex
 #define SYS_futex __NR_futex
+#elif defined(SYS_futex_time64)
+#define SYS_futex SYS_futex_time64
+#else
+#error "Need working SYS_futex"
+#endif
 #endif
 
 #ifndef FUTEX_WAIT_PRIVATE


### PR DESCRIPTION
mutex code uses SYS_futex, which it expects from system C library.
in glibc (/usr/include/bits/syscall.h defines it in terms of of NR_futex)
rv32 is using 64bit time_t from get go unlike other 32bit architectures
in glibc, therefore it wont have NR_futex defined but just NR_futex_time64
this aliases it to NR_futex so that SYS_futex is then defined for rv32

Signed-off-by: Khem Raj <raj.khem@gmail.com>