### PR TITLE
Add Coroutines TS support

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -499,6 +499,7 @@ endif
 heavy_tests =                                                  \
   src/kj/async-test.c++                                        \
   src/kj/async-xthread-test.c++                                \
+  src/kj/async-coroutine-test.c++                              \
   src/kj/async-unix-test.c++                                   \
   src/kj/async-unix-xthread-test.c++                           \
   src/kj/async-win32-test.c++                                  \

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -245,6 +245,7 @@ if(BUILD_TESTING)
     add_executable(kj-heavy-tests
       async-test.c++
       async-xthread-test.c++
+      async-coroutine-test.c++
       async-unix-test.c++
       async-unix-xthread-test.c++
       async-win32-test.c++

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -1,0 +1,496 @@
+// Copyright (c) 2020 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <kj/async.h>
+#include <kj/array.h>
+#include <kj/compat/http.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+
+namespace kj {
+namespace {
+
+#ifdef KJ_HAS_COROUTINE
+
+template <typename T>
+Promise<kj::Decay<T>> identity(T&& value) {
+  co_return kj::fwd<T>(value);
+}
+// Work around a bonkers MSVC ICE with a separate overload.
+Promise<const char*> identity(const char* value) {
+  co_return value;
+}
+
+KJ_TEST("Identity coroutine") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  KJ_EXPECT(identity(123).wait(waitScope) == 123);
+  KJ_EXPECT(*identity(kj::heap(456)).wait(waitScope) == 456);
+
+  {
+    auto p = identity("we can cancel the coroutine");
+  }
+}
+
+template <typename T>
+Promise<T> simpleCoroutine(kj::Promise<T> result, kj::Promise<bool> dontThrow = true) {
+  KJ_ASSERT(co_await dontThrow);
+  co_return co_await result;
+}
+
+KJ_TEST("Simple coroutine test") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  simpleCoroutine(kj::Promise<void>(kj::READY_NOW)).wait(waitScope);
+
+  KJ_EXPECT(simpleCoroutine(kj::Promise<int>(123)).wait(waitScope) == 123);
+}
+
+struct Counter {
+  size_t& count;
+  Counter(size_t& count): count(count) {}
+  ~Counter() { ++count; }
+  KJ_DISALLOW_COPY(Counter);
+};
+
+kj::Promise<void> countDtorsAroundAwait(size_t& count, kj::Promise<void> promise) {
+  Counter counter1(count);
+  co_await promise;
+  Counter counter2(count);
+  co_return;
+};
+
+KJ_TEST("co_awaiting an immediate promise does not suspend if the event loop is empty and running") {
+  // The coroutine PromiseNode implementation contains an optimization which allows us to avoid
+  // suspending the coroutine and instead immediately call PromiseNode::get() and proceed with
+  // execution.
+
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  // The immediate-execution optimization is only enabled when the event loop is running, so use an
+  // eagerly-evaluated evalLater() to perform the test from within the event loop. (If we didn't
+  // eagerly-evaluate the promise, the result would be extracted after the loop finished.)
+  kj::evalLater([&]() {
+    size_t count = 0;
+
+    auto promise = kj::Promise<void>(kj::READY_NOW);
+    auto coroPromise = countDtorsAroundAwait(count, kj::READY_NOW);
+
+    // `coro` has not been destroyed yet, but it completed and unwound its frame.
+    KJ_EXPECT(count == 2);
+  }).eagerlyEvaluate(nullptr).wait(waitScope);
+
+  kj::evalLater([&]() {
+    // If there are no background tasks in the queue, coroutines execute through an evalLater()
+    // without suspending.
+
+    size_t count = 0;
+    bool evalLaterRan = false;
+
+    auto promise = kj::evalLater([&]() { evalLaterRan = true; });
+    auto coroPromise = countDtorsAroundAwait(count, kj::mv(promise));
+
+    KJ_EXPECT(evalLaterRan == true);
+    KJ_EXPECT(count == 2);
+  }).eagerlyEvaluate(nullptr).wait(waitScope);
+}
+
+KJ_TEST("co_awaiting an immediate promise suspends if the event loop is not running") {
+  // We only want to enable the immediate-execution optimization if the event loop is running, or
+  // else a whole bunch of RPC tests break, because some .then()s get evaluated on promise
+  // construction, before any .wait() call.
+
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  size_t count = 0;
+
+  auto promise = kj::Promise<void>(kj::READY_NOW);
+  auto coroPromise = countDtorsAroundAwait(count, kj::READY_NOW);
+
+  // In the previous test, this exact same code executed immediately because the event loop was
+  // running.
+  KJ_EXPECT(count == 0);
+}
+
+KJ_TEST("co_awaiting immediate promises suspends if the event loop is not empty") {
+  // We want to make sure that we can still return to the event loop when we need to.
+
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  // The immediate-execution optimization is only enabled when the event loop is running, so use an
+  // eagerly-evaluated evalLater() to perform the test from within the event loop. (If we didn't
+  // eagerly-evaluate the promise, the result would be extracted after the loop finished.)
+  kj::evalLater([&]() {
+    size_t count = 0;
+
+    // We need to enqueue an Event on the event loop to inhibit the immediate-execution
+    // optimization. Creating and then immediately fulfilling an EagerPromiseNode is a convenient
+    // way to do so.
+    auto paf = newPromiseAndFulfiller<void>();
+    paf.promise = paf.promise.eagerlyEvaluate(nullptr);
+    paf.fulfiller->fulfill();
+
+    auto promise = kj::Promise<void>(kj::READY_NOW);
+    auto coroPromise = countDtorsAroundAwait(count, kj::READY_NOW);
+
+    // We didn't immediately extract the READY_NOW.
+    KJ_EXPECT(count == 0);
+  }).eagerlyEvaluate(nullptr).wait(waitScope);
+
+  kj::evalLater([&]() {
+    size_t count = 0;
+    bool evalLaterRan = false;
+
+    // We need to enqueue an Event on the event loop to inhibit the immediate-execution
+    // optimization. Creating and then immediately fulfilling an EagerPromiseNode is a convenient
+    // way to do so.
+    auto paf = newPromiseAndFulfiller<void>();
+    paf.promise = paf.promise.eagerlyEvaluate(nullptr);
+    paf.fulfiller->fulfill();
+
+    auto promise = kj::evalLater([&]() { evalLaterRan = true; });
+    auto coroPromise = countDtorsAroundAwait(count, kj::mv(promise));
+
+    // We didn't continue through the evalLater() promise, because the background promise's
+    // continuation was next in the event loop's queue.
+    KJ_EXPECT(evalLaterRan == false);
+    // No Counter destructor has run.
+    KJ_EXPECT(count == 0, count);
+  }).eagerlyEvaluate(nullptr).wait(waitScope);
+}
+
+KJ_TEST("Exceptions propagate through layered coroutines") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  auto throwy = simpleCoroutine(kj::Promise<int>(kj::NEVER_DONE), false);
+
+  KJ_EXPECT_THROW_RECOVERABLE(FAILED, simpleCoroutine(kj::mv(throwy)).wait(waitScope));
+}
+
+KJ_TEST("Exceptions before the first co_await don't escape, but reject the promise") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  auto throwEarly = []() -> Promise<void> {
+    KJ_FAIL_ASSERT("test exception");
+#ifdef __GNUC__
+// Yes, this `co_return` is unreachable. But without it, this function is no longer a coroutine.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif  // __GNUC__
+    co_return;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
+  };
+
+  auto throwy = throwEarly();
+
+  KJ_EXPECT_THROW_RECOVERABLE(FAILED, throwy.wait(waitScope));
+}
+
+KJ_TEST("Coroutines can catch exceptions from co_await") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  kj::String description;
+
+  auto tryCatch = [&](kj::Promise<void> promise) -> kj::Promise<kj::String> {
+    try {
+      co_await promise;
+    } catch (const kj::Exception& exception) {
+      co_return kj::str(exception.getDescription());
+    }
+    KJ_FAIL_EXPECT("should have thrown");
+    KJ_UNREACHABLE;
+  };
+
+  {
+    // Immediately ready case.
+    auto promise = kj::Promise<void>(KJ_EXCEPTION(FAILED, "catch me"));
+    KJ_EXPECT(tryCatch(kj::mv(promise)).wait(waitScope) == "catch me");
+  }
+
+  {
+    // Ready later case.
+    auto promise = kj::evalLater([]() -> kj::Promise<void> {
+      return KJ_EXCEPTION(FAILED, "catch me");
+    });
+    KJ_EXPECT(tryCatch(kj::mv(promise)).wait(waitScope) == "catch me");
+  }
+}
+
+KJ_TEST("Coroutines can be canceled while suspended") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  size_t count = 0;
+
+  auto coro = [&](kj::Promise<int> promise) -> kj::Promise<void> {
+    Counter counter1(count);
+    co_await kj::evalLater([](){});
+    Counter counter2(count);
+    co_await promise;
+  };
+
+  {
+    auto neverDone = kj::Promise<int>(kj::NEVER_DONE);
+    neverDone = neverDone.attach(kj::heap<Counter>(count));
+    auto promise = coro(kj::mv(neverDone));
+    KJ_EXPECT(!promise.poll(waitScope));
+  }
+
+  // Stack variables on both sides of a co_await, plus coroutine arguments are destroyed.
+  KJ_EXPECT(count == 3);
+}
+
+kj::Promise<void> deferredThrowCoroutine(kj::Promise<void> awaitMe) {
+  KJ_DEFER(kj::throwFatalException(KJ_EXCEPTION(FAILED, "thrown during unwind")));
+  co_await awaitMe;
+  co_return;
+};
+
+KJ_TEST("Exceptions during suspended coroutine frame-unwind propagate via destructor") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
+    deferredThrowCoroutine(kj::NEVER_DONE);
+  }));
+
+  KJ_EXPECT(exception.getDescription() == "thrown during unwind");
+};
+
+KJ_TEST("Exceptions during suspended coroutine frame-unwind do not cause a memory leak") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  // We can't easily test for memory leaks without hooking operator new and delete. However, we can
+  // arrange for the test to crash on failure, by having the coroutine suspend at a promise that we
+  // later fulfill, thus arming the Coroutine's Event. If we fail to destroy the coroutine in this
+  // state, EventLoop will throw on destruction because it can still see the Event in its list.
+
+  auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
+    auto paf = kj::newPromiseAndFulfiller<void>();
+
+    auto coroPromise = deferredThrowCoroutine(kj::mv(paf.promise));
+
+    // Arm the Coroutine's Event.
+    paf.fulfiller->fulfill();
+
+    // If destroying `coroPromise` does not run ~Event(), then ~EventLoop() will crash later.
+  }));
+
+  KJ_EXPECT(exception.getDescription() == "thrown during unwind");
+};
+
+KJ_TEST("Exceptions during completed coroutine frame-unwind propagate via returned Promise") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  {
+    // First, prove that exceptions don't escape the destructor of a completed coroutine.
+    auto promise = deferredThrowCoroutine(kj::READY_NOW);
+    KJ_EXPECT(promise.poll(waitScope));
+  }
+
+  {
+    // Next, prove that they show up via the returned Promise.
+    auto promise = deferredThrowCoroutine(kj::READY_NOW);
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("thrown during unwind", promise.wait(waitScope));
+  }
+}
+
+KJ_TEST("Coroutine destruction exceptions are ignored if there is another exception in flight") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
+    auto promise = deferredThrowCoroutine(kj::NEVER_DONE);
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "thrown before destroying throwy promise"));
+  }));
+
+  KJ_EXPECT(exception.getDescription() == "thrown before destroying throwy promise");
+}
+
+KJ_TEST("co_await only sees coroutine destruction exceptions if promise was not rejected") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  // throwyDtorPromise is an immediate void promise that will throw when it's destroyed, which
+  // we expect to be able to catch from a coroutine which co_awaits it.
+  auto throwyDtorPromise = kj::Promise<void>(kj::READY_NOW)
+      .attach(kj::defer([]() {
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "thrown during unwind"));
+  }));
+
+  // rejectedThrowyDtorPromise is a rejected promise. When co_awaited in a coroutine,
+  // Awaiter::await_resume() will throw that exception for us to catch, but before we can catch it,
+  // the temporary promise will be destroyed. The exception it throws during unwind will be ignored,
+  // and the caller of the coroutine will see only the "thrown during execution" exception.
+  auto rejectedThrowyDtorPromise = kj::evalNow([&]() -> kj::Promise<void> {
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "thrown during execution"));
+  }).attach(kj::defer([]() {
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "thrown during unwind"));
+  }));
+
+  auto awaitPromise = [](kj::Promise<void> promise) -> kj::Promise<void> {
+    co_await promise;
+  };
+
+  KJ_EXPECT_THROW_MESSAGE("thrown during unwind",
+      awaitPromise(kj::mv(throwyDtorPromise)).wait(waitScope));
+
+  KJ_EXPECT_THROW_MESSAGE("thrown during execution",
+      awaitPromise(kj::mv(rejectedThrowyDtorPromise)).wait(waitScope));
+}
+
+uint countLines(StringPtr s) {
+  uint lines = 0;
+  for (char c: s) {
+    lines += c == '\n';
+  }
+  return lines;
+}
+
+#if !_MSC_VER || defined(__clang__)
+// TODO(msvc): This test relies on GetFunctorStartAddress, which is not supported on MSVC currently,
+//   so skip the test.
+KJ_TEST("Can trace through coroutines") {
+  // This verifies that async traces, generated either from promises or from events, can see through
+  // coroutines.
+  //
+  // This test may be a bit brittle because it depends on specific trace counts.
+
+  // Enable stack traces, even in release mode.
+  class EnableFullStackTrace: public ExceptionCallback {
+  public:
+    StackTraceMode stackTraceMode() override { return StackTraceMode::FULL; }
+  };
+  EnableFullStackTrace exceptionCallback;
+
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  auto paf = newPromiseAndFulfiller<void>();
+
+  // Get an async trace when the promise is fulfilled. We eagerlyEvaluate() to make sure the
+  // continuation executes while the event loop is running.
+  paf.promise = paf.promise.then([]() {
+    auto trace = getAsyncTrace();
+    // We expect one entry for waitImpl(), one for the coroutine, and one for this continuation.
+    // When building in debug mode with CMake, I observed this count can be 2. The missing frame is
+    // probably this continuation. Let's just expect a range.
+    auto count = countLines(trace);
+    KJ_EXPECT(0 < count && count <= 3);
+  }).eagerlyEvaluate(nullptr);
+
+  auto coroPromise = [&]() -> kj::Promise<void> {
+    co_await paf.promise;
+  }();
+
+  {
+    auto trace = coroPromise.trace();
+    // One for the Coroutine PromiseNode, one for paf.promise.
+    KJ_EXPECT(countLines(trace) >= 2);
+  }
+
+  paf.fulfiller->fulfill();
+
+  coroPromise.wait(waitScope);
+}
+#endif  // !_MSC_VER || defined(__clang__)
+
+Promise<void> sendData(Promise<Own<NetworkAddress>> addressPromise) {
+  auto address = co_await addressPromise;
+  auto client = co_await address->connect();
+  co_await client->write("foo", 3);
+}
+
+Promise<String> receiveDataCoroutine(Promise<Own<NetworkAddress>> addressPromise) {
+  auto address = co_await addressPromise;
+  auto listener = address->listen();
+  auto server = co_await listener->accept();
+  char buffer[4];
+  auto n = co_await server->read(buffer, 3, 4);
+  KJ_EXPECT(3u == n);
+  co_return heapString(buffer, n);
+}
+
+KJ_TEST("Simple network test with coroutine") {
+  auto io = setupAsyncIo();
+  auto& network = io.provider->getNetwork();
+
+  constexpr uint port = 5500;
+
+  sendData(network.parseAddress("localhost", port)).detach([](Exception&& exception) {
+    KJ_FAIL_EXPECT(exception);
+  });
+
+  String result = receiveDataCoroutine(network.parseAddress("*", port)).wait(io.waitScope);
+
+  KJ_EXPECT("foo" == result);
+}
+
+Promise<Own<AsyncIoStream>> httpClientConnect(AsyncIoContext& io) {
+  auto addr = co_await io.provider->getNetwork().parseAddress("capnproto.org", 80);
+  co_return co_await addr->connect();
+}
+
+Promise<void> httpClient(Own<AsyncIoStream> connection) {
+  // Borrowed and rewritten from compat/http-test.c++.
+
+  HttpHeaderTable table;
+  auto client = newHttpClient(table, *connection);
+
+  HttpHeaders headers(table);
+  headers.set(HttpHeaderId::HOST, "capnproto.org");
+
+  auto response = co_await client->request(HttpMethod::GET, "/", headers).response;
+  KJ_EXPECT(response.statusCode / 100 == 3);
+  auto location = KJ_ASSERT_NONNULL(response.headers->get(HttpHeaderId::LOCATION));
+  KJ_EXPECT(location == "https://capnproto.org/");
+
+  auto body = co_await response.body->readAllText();
+}
+
+KJ_TEST("HttpClient to capnproto.org with a coroutine") {
+  auto io = setupAsyncIo();
+
+  auto promise = httpClientConnect(io).then([](Own<AsyncIoStream> connection) {
+    return httpClient(kj::mv(connection));
+  }, [](Exception&&) {
+    KJ_LOG(WARNING, "skipping test because couldn't connect to capnproto.org");
+  });
+
+  promise.wait(io.waitScope);
+}
+
+#endif  // KJ_HAS_COROUTINE
+
+}  // namespace
+}  // namespace kj

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -27,6 +27,24 @@
 #include "exception.h"
 #include "tuple.h"
 
+// Detect whether or not we should enable kj::Promise<T> coroutine integration.
+//
+// TODO(someday): Support coroutines with -fno-exceptions.
+#if !KJ_NO_EXCEPTIONS
+#ifdef __has_include
+// For now, we only support the Coroutines TS.
+//
+// TODO(someday): Also support standardized C++20 Coroutines. The latest VS2019 and GCC 10 both have
+//   support, though MSVC hides it behind /std:c++latest, which brings an ICE with it.
+#if __cpp_coroutines && __has_include(<experimental/coroutine>)
+// Coroutines TS detected.
+#include <experimental/coroutine>
+#define KJ_HAS_COROUTINE 1
+#define KJ_COROUTINE_STD_NAMESPACE std::experimental
+#endif
+#endif
+#endif
+
 KJ_BEGIN_HEADER
 
 namespace kj {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2044,6 +2044,10 @@ void Event::armLast() {
   }
 }
 
+bool Event::isNext() {
+  return loop.running && loop.head == this;
+}
+
 void Event::disarm() {
   if (prev != nullptr) {
     if (threadLocalEventLoop != &loop && threadLocalEventLoop != nullptr) {
@@ -2709,4 +2713,202 @@ namespace _ {  // (private)
 Promise<void> IdentityFunc<Promise<void>>::operator()() const { return READY_NOW; }
 
 }  // namespace _ (private)
+
+// -------------------------------------------------------------------
+
+#if KJ_HAS_COROUTINE
+
+namespace _ {  // (private)
+
+CoroutineBase::CoroutineBase(stdcoro::coroutine_handle<> coroutine, ExceptionOrValue& resultRef)
+    : coroutine(coroutine),
+      resultRef(resultRef) {}
+CoroutineBase::~CoroutineBase() noexcept(false) {
+  readMaybe(maybeDisposalResults)->destructorRan = true;
+}
+
+void CoroutineBase::unhandled_exception() {
+  // Pretty self-explanatory, we propagate the exception to the promise which owns us, unless
+  // we're being destroyed, in which case we propagate it back to our disposer. Note that all
+  // unhandled exceptions end up here, not just ones after the first co_await.
+
+  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([] { throw; })) {
+    KJ_IF_MAYBE(disposalResults, maybeDisposalResults) {
+      // Exception during coroutine destruction. Only record the first one.
+      if (disposalResults->exception == nullptr) {
+        disposalResults->exception = kj::mv(*exception);
+      }
+    } else if (isWaiting()) {
+      // Exception during coroutine execution.
+      resultRef.addException(kj::mv(*exception));
+      scheduleResumption();
+    } else {
+      // Okay, what could this mean? We've already been fulfilled or rejected, but we aren't being
+      // destroyed yet. The only possibility is that we are unwinding the coroutine frame due to a
+      // successful completion, and something in the frame threw. We can't already be rejected,
+      // because rejecting a coroutine involves throwing, which would have unwound the frame prior
+      // to setting `waiting = false`.
+      //
+      // Since we know we're unwinding due to a successful completion, we also know that whatever
+      // Event we may have armed has not yet fired, because we haven't had a chance to return to
+      // the event loop.
+
+      // final_suspend() has not been called.
+      KJ_IASSERT(!coroutine.done());
+
+      // Since final_suspend() hasn't been called, whatever Event is waiting on us has not fired,
+      // and will see this exception.
+      resultRef.addException(kj::mv(*exception));
+    }
+  } else {
+    KJ_UNREACHABLE;
+  }
+}
+
+void CoroutineBase::onReady(Event* event) noexcept {
+  onReadyEvent.init(event);
+}
+
+void CoroutineBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
+  if (stopAtNextEvent) return;
+
+  KJ_IF_MAYBE(promise, promiseNodeForTrace) {
+    promise->tracePromise(builder, stopAtNextEvent);
+  }
+
+  // Maybe returning the address of coroutine() will give us a function name with meaningful type
+  // information. (Narrator: It doesn't.)
+  builder.add(GetFunctorStartAddress<>::apply(coroutine));
+};
+
+Maybe<Own<Event>> CoroutineBase::fire() {
+  // Call Awaiter::await_resume() and proceed with the coroutine. Note that this will not destroy
+  // the coroutine if control flows off the end of it, because we return suspend_always() from
+  // final_suspend().
+  //
+  // It's tempting to arrange to check for exceptions right now and reject the promise that owns
+  // us without resuming the coroutine, which would save us from throwing an exception when we
+  // already know where it's going. But, we don't really know: unlike in the KJ_NO_EXCEPTIONS
+  // case, the `co_await` might be in a try-catch block, so we have no choice but to resume and
+  // throw later.
+  //
+  // TODO(someday): If we ever support coroutines with -fno-exceptions, we'll need to reject the
+  //   enclosing coroutine promise here, if the Awaiter's result is exceptional.
+
+  promiseNodeForTrace = nullptr;
+
+  coroutine.resume();
+
+  return nullptr;
+}
+
+void CoroutineBase::traceEvent(TraceBuilder& builder) {
+  KJ_IF_MAYBE(promise, promiseNodeForTrace) {
+    promise->tracePromise(builder, true);
+  }
+
+  // Maybe returning the address of coroutine() will give us a function name with meaningful type
+  // information. (Narrator: It doesn't.)
+  builder.add(GetFunctorStartAddress<>::apply(coroutine));
+
+  onReadyEvent.traceEvent(builder);
+}
+
+void CoroutineBase::disposeImpl(void* pointer) const {
+  KJ_IASSERT(pointer == this);
+
+  // const_cast okay -- every Own<PromiseNode> that we build in get_return_object() uses itself
+  // as the disposer, thus every disposer is unique and there are no thread-safety concerns.
+  const_cast<CoroutineBase&>(*this).destroy();
+}
+
+void CoroutineBase::destroy() {
+  // Mutable helper function for disposeImpl(). Basically a wrapper around coroutine.destroy()
+  // with some stuff to propagate exceptions appropriately.
+
+  // Objects in the coroutine frame might throw from their destructors, so unhandled_exception()
+  // will need some way to communicate those exceptions back to us. Separately, we also want
+  // confirmation that our own ~Coroutine() destructor ran. To solve this, we put a
+  // DisposalResults object on the stack and set a pointer to it in the Coroutine object. This
+  // indicates to unhandled_exception() and ~Coroutine() where to store the results of the
+  // destruction operation.
+  DisposalResults disposalResults;
+  maybeDisposalResults = &disposalResults;
+
+  // Need to save this while `unwindDetector` is still valid.
+  bool shouldRethrow = !unwindDetector.isUnwinding();
+
+  do {
+    // Clang's implementation of the Coroutines TS does not destroy the Coroutine object or
+    // deallocate the coroutine frame if a destructor of an object on the frame threw an
+    // exception. This is despite the fact that it delivered the exception to _us_ via
+    // unhandled_exception(). Anyway, it appears we can work around this by running
+    // coroutine.destroy() a second time.
+    //
+    // On Clang, `disposalResults.exception != nullptr` implies `!disposalResults.destructorRan`.
+    // We could optimize out the separate `destructorRan` flag if we verify that other compilers
+    // behave the same way.
+    coroutine.destroy();
+  } while (!disposalResults.destructorRan);
+
+  // WARNING: `this` is now a dangling pointer.
+
+  KJ_IF_MAYBE(exception, disposalResults.exception) {
+    if (shouldRethrow) {
+      kj::throwFatalException(kj::mv(*exception));
+    } else {
+      // An exception is already unwinding the stack, so throwing this secondary exception would
+      // call std::terminate().
+    }
+  }
+}
+
+CoroutineBase::AwaiterBase::AwaiterBase(Own<PromiseNode> node): node(kj::mv(node)) {}
+CoroutineBase::AwaiterBase::AwaiterBase(AwaiterBase&&) = default;
+CoroutineBase::AwaiterBase::~AwaiterBase() noexcept(false) {
+  // Make sure it's safe to generate an async stack trace between now and when the Coroutine is
+  // destroyed.
+  KJ_IF_MAYBE(coroutineEvent, maybeCoroutineEvent) {
+    coroutineEvent->promiseNodeForTrace = nullptr;
+  }
+
+  unwindDetector.catchExceptionsIfUnwinding([this]() {
+    // No need to check for a moved-from state, node will just ignore the nullification.
+    node = nullptr;
+  });
+}
+
+void CoroutineBase::AwaiterBase::getImpl(ExceptionOrValue& result) {
+  node->get(result);
+
+  KJ_IF_MAYBE(exception, result.exception) {
+    kj::throwFatalException(kj::mv(*exception));
+  }
+}
+
+bool CoroutineBase::AwaiterBase::awaitSuspendImpl(CoroutineBase& coroutineEvent) {
+  node->setSelfPointer(&node);
+  node->onReady(&coroutineEvent);
+
+  if (coroutineEvent.isNext()) {
+    // The result is immediately ready! Let's cancel our event.
+    coroutineEvent.disarm();
+
+    // We can resume ourselves by returning false. This accomplishes the same thing as if we had
+    // returned true from await_ready().
+    return false;
+  } else {
+    // Otherwise, we must suspend. Store a reference to the promise we're waiting on for tracing
+    // purposes; coroutineEvent.fire() and/or ~Adapter() will null this out.
+    coroutineEvent.promiseNodeForTrace = *node;
+    maybeCoroutineEvent = coroutineEvent;
+
+    return true;
+  }
+}
+
+}  // namespace _ (private)
+
+#endif  // KJ_HAS_COROUTINE
+
 }  // namespace kj


### PR DESCRIPTION
This adds support for the Coroutines TS to libkj. Specifically, you can now co_await kj::Promise<T> objects from inside functions which themselves return kj::Promise<U> objects.

The integration is header-only, so the only difference in a Cap'n Proto build is that we might conditionally compile the coroutine tests, if the compiler and standard library both support the Coroutines TS.

I tested this with Clang/libc++ 12 and the latest VS2019.

* For Clang with autotools / CMake it should be sufficient to configure the toolchain like so, then configure and build like normal:
  export CC=clang
  export CXX=clang++
  export CXXFLAGS="-std=gnu++17 -fcoroutines-ts -stdlib=libc++"
  export LDFLAGS="-fcoroutines-ts -stdlib=libc++"
  ./configure && make check

* For VS2019, add -DCMAKE_CXX_FLAGS="/std:c++17 /await /EHsc" to your regular CMake command line. (The /EHsc shuts up a compiler warning...)

VS2019 and GCC both apparently support C++20-standardized coroutines, but VS2019's version seems ICE-y, and I'm too lazy to figure out how to install GCC 10 on Debian Buster.