### PR TITLE
Change Canceler's default exception type to DISCONNECTED

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -136,7 +136,7 @@ Canceler::~Canceler() noexcept(false) {
 
 void Canceler::cancel(StringPtr cancelReason) {
   if (isEmpty()) return;
-  cancel(Exception(Exception::Type::FAILED, __FILE__, __LINE__, kj::str(cancelReason)));
+  cancel(Exception(Exception::Type::DISCONNECTED, __FILE__, __LINE__, kj::str(cancelReason)));
 }
 
 void Canceler::cancel(const Exception& exception) {


### PR DESCRIPTION
I wasn't sure what the message should actually say...