### PR TITLE
Fix `List<List<T>>` `adopt()` and `disown()`.

### DIFF
--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -396,13 +396,13 @@ struct List<List<T>, Kind::LIST> {
         l.set(i++, element);
       }
     }
-    inline void adopt(uint index, Orphan<T>&& value) {
+    inline void adopt(uint index, Orphan<List<T>>&& value) {
       KJ_IREQUIRE(index < size());
       builder.getPointerElement(bounded(index) * ELEMENTS).adopt(kj::mv(value.builder));
     }
-    inline Orphan<T> disown(uint index) {
+    inline Orphan<List<T>> disown(uint index) {
       KJ_IREQUIRE(index < size());
-      return Orphan<T>(builder.getPointerElement(bounded(index) * ELEMENTS).disown());
+      return Orphan<List<T>>(builder.getPointerElement(bounded(index) * ELEMENTS).disown());
     }
 
     typedef _::IndexingIterator<Builder, typename List<T>::Builder> Iterator;


### PR DESCRIPTION
These should be using `Orphan<List<T>>`, not `Orphan<T>`.

A bug as old as time, apparently.

I noticed this while reviewing #1112.