### PR TITLE
Redesign async trace code

### DIFF
--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -393,6 +393,12 @@ PromiseForResult<Func, void> evalLast(Func&& func) KJ_WARN_UNUSED_RESULT;
 // callback enqueues new events, then latter callbacks will not execute until those events are
 // drained.
 
+ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space);
+kj::String getAsyncTrace();
+// If the event loop is currently running in this thread, get a trace back through the promise
+// chain leading to the currently-executing event. The format is the same as kj::getStackTrace()
+// from exception.c++.
+
 template <typename Func>
 PromiseForResult<Func, void> retryOnDisconnect(Func&& func) KJ_WARN_UNUSED_RESULT;
 // Promises to run `func()` asynchronously, retrying once if it fails with a DISCONNECTED exception.
@@ -993,6 +999,8 @@ private:
 
   Own<TaskSet> daemons;
 
+  _::Event* currentlyFiring = nullptr;
+
   bool turn();
   void setRunnable(bool runnable);
   void enterScope();
@@ -1011,6 +1019,7 @@ private:
   friend class _::XThreadEvent;
   friend class _::FiberBase;
   friend class _::FiberStack;
+  friend ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space);
 };
 
 class WaitScope {


### PR DESCRIPTION
The old Event::trace() in particular was nonsense -- it didn't actually trace back to the next event and so on, instead it would trace _forwards_ through `PromiseNode`s.

Additionally, the output of the old traces was not particularly useful, as it would tell you the types of the promises but not line numbers.

The new tracing code produces a list of instruction addresses, just like regular stack traces. It can be passed into all the regular stack tracing tools.

Additionally, a new global function `kj::getAsyncTrace()` gets a trace of the promises leading up to the currently-executing code. Previously, such traces were generated when you threw an exception and it actually passed through the promise chain, but there was no way to get a meaningful async trace e.g. in a crash handler. Now there is.