### PR TITLE
Implement magic assert stringification.

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -391,7 +391,7 @@ void runEndToEndTests(kj::Timer& timer, kj::HttpHeaderTable& headerTable,
   clientPipe.ends[0] = nullptr;
   auto lastRead = serverPipe.ends[1]->readAllText();
   KJ_ASSERT(lastRead.poll(waitScope), "last read hung");
-  KJ_EXPECT(lastRead.wait(waitScope) == 0);
+  KJ_EXPECT(lastRead.wait(waitScope) == nullptr);
 }
 
 KJ_TEST("HTTP-over-Cap'n-Proto E2E, no path shortening") {

--- a/c++/src/kj/filesystem-test.c++
+++ b/c++/src/kj/filesystem-test.c++
@@ -155,10 +155,6 @@ KJ_TEST("Path exceptions") {
   KJ_EXPECT_THROW_MESSAGE("root path has no parent", Path(nullptr).parent());
 }
 
-static inline bool operator==(const Array<wchar_t>& arr, const wchar_t* expected) {
-  return wcscmp(arr.begin(), expected) == 0;
-}
-
 constexpr kj::ArrayPtr<const wchar_t> operator "" _a(const wchar_t* str, size_t n) {
   return { str, n };
 }

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -61,6 +61,12 @@
 namespace kj {
 namespace _ {  // private
 
+#if KJ_USE_FUTEX
+constexpr uint Mutex::EXCLUSIVE_HELD;
+constexpr uint Mutex::EXCLUSIVE_REQUESTED;
+constexpr uint Mutex::SHARED_COUNT_MASK;
+#endif
+
 inline void Mutex::addWaiter(Waiter& waiter) {
 #ifdef KJ_DEBUG
   assertLockedByCaller(EXCLUSIVE);

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -231,6 +231,15 @@ KJ_TEST("parsing 'nan' returns canonical NaN value") {
   }
 }
 
+KJ_TEST("stringify array-of-array") {
+  int arr1[] = {1, 23};
+  int arr2[] = {456, 7890};
+  ArrayPtr<int> arr3[] = {arr1, arr2};
+  ArrayPtr<ArrayPtr<int>> array = arr3;
+
+  KJ_EXPECT(str(array) == "1, 23, 456, 7890");
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -65,12 +65,14 @@ private:
 #define KJ_FAIL_EXPECT(...) \
   KJ_INDIRECT_EXPAND(KJ_LOG, (ERROR , __VA_ARGS__));
 #define KJ_EXPECT(cond, ...) \
-  if (cond); else KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("failed: expected " #cond , __VA_ARGS__))
+  if (auto _kjCondition = ::kj::_::MAGIC_ASSERT << cond); \
+  else KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("failed: expected " #cond , _kjCondition, __VA_ARGS__))
 #else
 #define KJ_FAIL_EXPECT(...) \
   KJ_LOG(ERROR, ##__VA_ARGS__);
 #define KJ_EXPECT(cond, ...) \
-  if (cond); else KJ_FAIL_EXPECT("failed: expected " #cond, ##__VA_ARGS__)
+  if (auto _kjCondition = ::kj::_::MAGIC_ASSERT << cond); \
+  else KJ_FAIL_EXPECT("failed: expected " #cond, _kjCondition, ##__VA_ARGS__)
 #endif
 
 #define KJ_EXPECT_THROW_RECOVERABLE(type, code) \


### PR DESCRIPTION
When `KJ_ASSERT(foo == bar)` fails, `foo` and `bar`'s actual values will be stringified in the error message. How does it work? We use template magic and operator precedence. The assertion actually evaluates something like this:

    if (auto _kjCondition = kj::_::MAGIC_ASSERT << foo == bar)

`<<` has operator precedence slightly above `==`, so `kj::_::MAGIC_ASSERT << foo` gets evaluated first. This wraps `foo` in a little wrapper that captures the comparison operators and keeps enough information around to be able to stringify the left and right sides of the comparison independently. As always, the stringification only actually occurs if the assert fails.

You might ask why we use operator `<<` and not e.g. operator `<=`, since operators of the same precedence are evaluated left-to-right. The answer is that some compilers trigger all sorts of warnings when you seem to be using a comparison as the input to another comparison. The particular warning GCC produces is its general "-Wparentheses" warning which is broadly useful, so we don't want to disable it. `<<` also produces some warnings, but only on Clang and the specific warning is one we're comfortable disabling (see below). This does mean that we have to explicitly overload `operator<<` ourselves to make sure using it in an assert still works.

You might also ask, if we're using operator `<<` anyway, why not start it from the right, in which case it would bind after computing any `<<` operators that were actually in the user's code? I tried this, but it resulted in a somewhat broader warning from clang that I felt worse about disabling (a warning about `<<` precedence not applying specifically to overloads) and also created ambiguous overload errors in the KJ units code.
