### PR TITLE
Provide compat layer for atfile libc calls

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -27,6 +27,7 @@ set(kj_sources_heavy
   filesystem-disk-unix.c++
   filesystem-disk-win32.c++
   parse/char.c++
+  compat/atfile.c++
 )
 if(NOT CAPNP_LITE)
   set(kj_sources ${kj_sources_lite} ${kj_sources_heavy})

--- a/c++/src/kj/compat/atfile.c++
+++ b/c++/src/kj/compat/atfile.c++
@@ -1,0 +1,98 @@
+#include "atfile.h"
+
+#ifdef __linux
+
+#include <linux/limits.h> // PATH_MAX
+#include <errno.h>        // EBADF and other error constants
+#include <cstdio>         // snprintf (emulate libc only in terms of libc)
+#include <unistd.h>       // non-*at versions of emulated functions, e.g. readlink
+
+// Attempt to get path from file descriptor
+inline static int path_from_fd(int fd, char *buf, size_t buf_sz) {
+  if (fd < 0) return EBADF;
+  // Attempt to get path from file descriptor using proc fs.
+  // This is a best-effort approach: proc fs may be unavailable and
+  // this method may not work on every type of fds.
+  char pfs_path[PATH_MAX];
+  snprintf(pfs_path, PATH_MAX, "/proc/self/fd/%d", fd);
+  return ::readlink(pfs_path, buf, buf_sz);
+}
+
+// -- Compatibility mappings for supported functions ---
+#if KJ_COMPAT_ATFILE_EMULATE_READLINKAT == 1
+int kj::readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz) {
+  if (pathname == nullptr) return EINVAL;
+  if (*pathname != '/') {    // glibc's way of determining path relativeness
+    if (dirfd != AT_FDCWD) {
+      if (dirfd < 0) return EBADF;
+      char cwd_path[PATH_MAX];
+      path_from_fd(dirfd, cwd_path, PATH_MAX);
+      char path[PATH_MAX];
+      snprintf(path, PATH_MAX, "%s/%s", cwd_path, pathname);
+      return ::readlink(path, buf, bufsiz);
+    }
+  }
+  return ::readlink(pathname, buf, bufsiz);
+}
+#endif // KJ_COMPAT_ATFILE_EMULATE_READLINKAT
+
+#if KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT == 1
+int kj::symlinkat(const char *oldpath, int newdirfd, const char *newpath) {
+  if ((oldpath == nullptr) || (newpath == nullptr)) return EINVAL;
+  if (*oldpath != '/') {
+    if (newdirfd != AT_FDCWD) {
+      if (newdirfd < 0) return EBADF;
+      char cwd_path[PATH_MAX];
+      char path[PATH_MAX];
+      path_from_fd(newdirfd, cwd_path, PATH_MAX);
+      snprintf(path, PATH_MAX, "%s/%s", cwd_path, newpath);
+      return ::symlink(oldpath, path);
+    }
+  }
+  return ::symlink(oldpath, newpath);
+}
+#endif // KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT
+
+#if KJ_COMPAT_ATFILE_EMULATE_LINKAT == 1
+int kj::linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int) {
+  // This implementation ignores flags, similar to old Linux kernels
+  if ((oldpath == nullptr) || (newpath == nullptr)) return EINVAL;
+  char cwd_path[PATH_MAX];
+  char src_path[PATH_MAX];
+  char dst_path[PATH_MAX];
+  if ((*oldpath != '/') && (olddirfd != AT_FDCWD)) {
+    if (olddirfd < 0) return EBADF;
+    path_from_fd(olddirfd, cwd_path, PATH_MAX);
+    snprintf(src_path, PATH_MAX, "%s/%s", cwd_path, oldpath);
+  } else {
+    snprintf(src_path, PATH_MAX, "%s", oldpath);
+  }
+  if ((*newpath != '/') && (newdirfd != AT_FDCWD)) {
+    if (newdirfd < 0) return EBADF;
+    path_from_fd(newdirfd, cwd_path, PATH_MAX);
+    snprintf(dst_path, PATH_MAX, "%s/%s", cwd_path, newpath);
+  } else {
+    snprintf(dst_path, PATH_MAX, "%s", newpath);
+  }
+  return ::link(src_path, dst_path);
+}
+#endif // KJ_COMPAT_ATFILE_EMULATE_LINKAT
+
+#if KJ_COMPAT_ATFILE_EMULATE_MKNODAT == 1
+int kj::mknodat(int dirfd, const char *pathname, mode_t mode, dev_t dev) {
+  if (pathname == nullptr) return EINVAL;
+  if (*pathname != '/') {
+    if (dirfd != AT_FDCWD) {
+      if (dirfd < 0) return EBADF;
+      char cwd_path[PATH_MAX];
+      path_from_fd(dirfd, cwd_path, PATH_MAX);
+      char path[PATH_MAX];
+      snprintf(path, PATH_MAX, "%s/%s", cwd_path, pathname);
+      return ::mknod(path, mode, dev);
+    }
+  }
+  return ::mknod(pathname, mode, dev);
+}
+#endif // KJ_COMPAT_ATFILE_EMULATE_MKNODAT
+
+#endif // __linux

--- a/c++/src/kj/compat/atfile.h
+++ b/c++/src/kj/compat/atfile.h
@@ -1,0 +1,98 @@
+#pragma once
+
+// libc compatibility layer for target platforms that do not fully implement
+// expected APIs, like older versions of Android
+
+// -- Flags to inidicate that a compat layer for a particular function is required. --
+#define KJ_COMPAT_ATFILE_EMULATE_READLINKAT 0
+#define KJ_COMPAT_ATFILE_EMULATE_MKNODAT 0
+#define KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT 0
+#define KJ_COMPAT_ATFILE_EMULATE_LINKAT 0
+
+// -- Compatibility layer requirement checks. A single positive test is sufficient to set a flag above --
+
+// Glibc feature test macros checks
+#ifdef __GLIBC__
+
+#if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 10)  // Condition: glibc >= 2.10
+#if (!(_XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L))
+  #undef KJ_COMPAT_ATFILE_EMULATE_READLINKAT
+  #define KJ_COMPAT_ATFILE_EMULATE_READLINKAT 1
+  #undef KJ_COMPAT_ATFILE_EMULATE_LINKAT
+  #define KJ_COMPAT_ATFILE_EMULATE_LINKAT 1
+  #undef KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT
+  #define KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT 1
+#endif
+#else  // Condition: glibc < 2.10
+#ifndef _ATFILE_SOURCE
+  #undef KJ_COMPAT_ATFILE_EMULATE_READLINKAT
+  #define KJ_COMPAT_ATFILE_EMULATE_READLINKAT 1
+  #undef KJ_COMPAT_ATFILE_EMULATE_LINKAT
+  #define KJ_COMPAT_ATFILE_EMULATE_LINKAT 1
+  #undef KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT
+  #define KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT 1
+#endif
+#endif
+
+#if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 19)  // Condition: glibc >= 2.19
+#if (!(defined(_DEFAULT_SOURCE) || (_XOPEN_SOURCE >= 500)))
+  #undefine KJ_COMPAT_ATFILE_EMULATE_MKNODAT
+  #define KJ_COMPAT_ATFILE_EMULATE_MKNODAT 1
+#endif
+#else // Condition: glibc < 2.19
+#if (!(defined(_BSD_SOURCE) || defined(_SVID_SOURCE))
+  #undefine KJ_COMPAT_ATFILE_EMULATE_MKNODAT
+  #define KJ_COMPAT_ATFILE_EMULATE_MKNODAT 1
+#endif
+#endif
+
+#endif // __GLIBC__
+
+// Android API version checks
+#ifdef __ANDROID__
+#if (__ANDROID_API < 21) // Condition: Android API < 21
+#undef KJ_COMPAT_ATFILE_EMULATE_READLINKAT
+#define KJ_COMPAT_ATFILE_EMULATE_READLINKAT 1
+#undef KJ_COMPAT_ATFILE_EMULATE_LINKAT
+#define KJ_COMPAT_ATFILE_EMULATE_LINKAT 1
+#undef KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT
+#define KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT 1
+#undef KJ_COMPAT_ATFILE_EMULATE_MKNODAT
+#define KJ_COMPAT_ATFILE_EMULATE_MKNODAT 1
+#endif
+#endif // __ANDROID__
+
+// -- Includes, depending on emulation's dependencies
+#if (KJ_COMPAT_ATFILE_EMULATE_READLINKAT == 1)
+#include <stddef.h>   // size_t
+#endif
+#if KJ_COMPAT_ATFILE_EMULATE_MKNODAT == 1
+#include <sys/stat.h>  // mode_t, dev_t
+#endif
+
+// -- Additional atfile constants, activated if one of emulations is required ---
+#if (KJ_COMPAT_ATFILE_EMULATE_READLINKAT == 1) ||       \
+  (KJ_COMPAT_ATFILE_EMULATE_MKNODAT == 1) ||            \
+  (KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT == 1) ||          \
+  (KJ_COMPAT_ATFILE_EMULATE_LINKAT == 1)
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+#endif
+
+
+namespace kj {
+  #if (KJ_COMPAT_ATFILE_EMULATE_READLINKAT == 1)
+  #include <stddef.h>
+  int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
+  #endif
+  #if (KJ_COMPAT_ATFILE_EMULATE_SYMLINKAT == 1)
+  int symlinkat(const char *oldpath, int newdirfd, const char *newpath);
+  #endif
+  #if KJ_COMPAT_ATFILE_EMULATE_LINKAT == 1
+  int linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int flags);
+  #endif
+  #if KJ_COMPAT_ATFILE_EMULATE_MKNODAT == 1
+  int mknodat(int dirfd, const char *pathname, mode_t mode, dev_t dev);
+  #endif
+}

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -27,6 +27,7 @@
 
 #include "filesystem.h"
 #include "debug.h"
+#include "compat/atfile.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -383,7 +383,7 @@ public:
   }
 
   void zero(uint64_t offset, uint64_t size) const {
-#ifdef FALLOC_FL_PUNCH_HOLE
+#if (FALLOC_FL_PUNCH_HOLE && (!(defined(__ANDROID__) && __ANDROID_API__ < 21)))
     KJ_SYSCALL_HANDLE_ERRORS(
         fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, size)) {
       case EOPNOTSUPP:

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -384,7 +384,12 @@ public:
   }
 
   void zero(uint64_t offset, uint64_t size) const {
-#if (FALLOC_FL_PUNCH_HOLE && (!(defined(__ANDROID__) && __ANDROID_API__ < 21)))
+// If FALLOC_FL_PUNCH_HOLE is defined, use it to efficiently zero the area.
+//
+// A fallocate() wrapper was only added to Android's Bionic C library as of API level 21,
+// but FALLOC_FL_PUNCH_HOLE is apparently defined in the headers before that, so we'll
+// have to explicitly test for that case.
+#if defined(FALLOC_FL_PUNCH_HOLE) && !(__ANDROID__ && __BIONIC__ && __ANDROID_API__ < 21)
     KJ_SYSCALL_HANDLE_ERRORS(
         fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, size)) {
       case EOPNOTSUPP:


### PR DESCRIPTION
Atfile libc calls became available on Android since API21. This patch provides a best effort compatbility layer for older Android versions by declaring proxy functions with same interface in kj namespace. Additionally this compatibility layer is activated by glibc defines, if provided with.