### PR TITLE
Minor speedup for miniposix::iovMax

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -8,6 +8,7 @@ set(kj_sources_lite
   exception.c++
   io.c++
   memory.c++
+  miniposix.c++
   mutex.c++
   string.c++
   hash.c++

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -471,7 +471,7 @@ private:
   Promise<void> writeInternal(ArrayPtr<const byte> firstPiece,
                               ArrayPtr<const ArrayPtr<const byte>> morePieces,
                               ArrayPtr<const int> fds) {
-    const size_t iovmax = kj::miniposix::iovMax(1 + morePieces.size());
+    const size_t iovmax = kj::miniposix::iovMax();
     // If there are more than IOV_MAX pieces, we'll only write the first IOV_MAX for now, and
     // then we'll loop later.
     KJ_STACK_ARRAY(struct iovec, iov, kj::min(1 + morePieces.size(), iovmax), 16, 128);
@@ -1544,7 +1544,7 @@ Promise<size_t> DatagramPortImpl::send(
   msg.msg_name = const_cast<void*>(implicitCast<const void*>(addr.getRaw()));
   msg.msg_namelen = addr.getRawSize();
 
-  const size_t iovmax = kj::miniposix::iovMax(pieces.size());
+  const size_t iovmax = kj::miniposix::iovMax();
   KJ_STACK_ARRAY(struct iovec, iov, kj::min(pieces.size(), iovmax), 16, 64);
 
   for (size_t i: kj::indices(pieces)) {
@@ -1557,7 +1557,7 @@ Promise<size_t> DatagramPortImpl::send(
     // Too many pieces, but we can't use multiple syscalls because they'd send separate
     // datagrams. We'll have to copy the trailing pieces into a temporary array.
     //
-    // TODO(perf): On Linux we could use multiple syscalls via MSG_MORE.
+    // TODO(perf): On Linux we could use multiple syscalls via MSG_MORE or sendmsg/sendmmsg.
     size_t extraSize = 0;
     for (size_t i = iovmax - 1; i < pieces.size(); i++) {
       extraSize += pieces[i].size();
@@ -1568,8 +1568,8 @@ Promise<size_t> DatagramPortImpl::send(
       memcpy(extra.begin() + extraSize, pieces[i].begin(), pieces[i].size());
       extraSize += pieces[i].size();
     }
-    iov[iovmax - 1].iov_base = extra.begin();
-    iov[iovmax - 1].iov_len = extra.size();
+    iov.back().iov_base = extra.begin();
+    iov.back().iov_len = extra.size();
   }
 
   msg.msg_iov = iov.begin();

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -414,7 +414,7 @@ public:
 #else
     // Use a 4k buffer of zeros amplified by iov to write zeros with as few syscalls as possible.
     size_t count = (size + sizeof(ZEROS) - 1) / sizeof(ZEROS);
-    const size_t iovmax = miniposix::iovMax(count);
+    const size_t iovmax = miniposix::iovMax();
     KJ_STACK_ARRAY(struct iovec, iov, kj::min(iovmax, count), 16, 256);
 
     for (auto& item: iov) {

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -377,7 +377,7 @@ void FdOutputStream::write(ArrayPtr<const ArrayPtr<const byte>> pieces) {
   OutputStream::write(pieces);
 
 #else
-  const size_t iovmax = miniposix::iovMax(pieces.size());
+  const size_t iovmax = miniposix::iovMax();
   while (pieces.size() > iovmax) {
     write(pieces.slice(0, iovmax));
     pieces = pieces.slice(iovmax, pieces.size());

--- a/c++/src/kj/miniposix.c++
+++ b/c++/src/kj/miniposix.c++
@@ -34,7 +34,7 @@ size_t iovMax() {
     if (iovmax == -1) {
       if (errno == 0) {
         // The -1 return value was the actual value, not an error. This means there's no limit.
-        return kj::MaxValue;
+        return kj::maxValue;
       } else {
         return _XOPEN_IOV_MAX;
       }

--- a/c++/src/kj/miniposix.c++
+++ b/c++/src/kj/miniposix.c++
@@ -32,8 +32,12 @@ size_t iovMax() {
     errno = 0;
     iovmax = sysconf(_SC_IOV_MAX);
     if (iovmax == -1) {
-      // Assume iovmax == -1 && errno == 0 means "unbounded".
-      return errno ? _XOPEN_IOV_MAX : kj::maxValue;
+      if (errno == 0) {
+        // The -1 return value was the actual value, not an error. This means there's no limit.
+        return kj::MaxValue;
+      } else {
+        return _XOPEN_IOV_MAX;
+      }
     }
 
     return (size_t) iovmax;

--- a/c++/src/kj/miniposix.c++
+++ b/c++/src/kj/miniposix.c++
@@ -1,0 +1,45 @@
+// Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "miniposix.h"
+
+namespace kj {
+namespace miniposix {
+#if !defined(_WIN32) && !defined(IOV_MAX) && !defined(UIO_MAX_IOV)
+size_t iovMax() {
+  // Thread-safe & lazily initialized only on first use.
+  static const size_t KJ_IOV_MAX = [] () -> size_t {
+    long iovmax;
+
+    errno = 0;
+    iovmax = sysconf(_SC_IOV_MAX);
+    if (iovmax == -1) {
+      // Assume iovmax == -1 && errno == 0 means "unbounded".
+      return errno ? _XOPEN_IOV_MAX : kj::maxValue;
+    }
+
+    return (size_t) iovmax;
+  }();
+  return KJ_IOV_MAX;
+}
+#endif
+}  // namespace miniposix
+}  // namespace kj

--- a/c++/src/kj/miniposix.h
+++ b/c++/src/kj/miniposix.h
@@ -43,6 +43,9 @@
 #include <sys/uio.h>
 #endif
 
+// To get KJ_BEGIN_HEADER/KJ_END_HEADER
+#include "common.h"
+
 KJ_BEGIN_HEADER
 
 namespace kj {
@@ -110,36 +113,29 @@ inline int mkdir(const char* path, int mode) {
 using ::pipe;
 using ::mkdir;
 
-inline size_t iovMax(size_t count) {
-  // Apparently, there is a maximum number of iovecs allowed per call.  I don't understand why.
-  // Most platforms define IOV_MAX but Linux defines only UIO_MAXIOV and others, like Hurd,
-  // define neither.
-  //
-  // On platforms where both IOV_MAX and UIO_MAXIOV are undefined, we poke sysconf(_SC_IOV_MAX),
-  // then try to fall back to the POSIX-mandated minimum of _XOPEN_IOV_MAX if that fails.
-  //
-  // http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html#tag_13_23_03_01
 
+// Apparently, there is a maximum number of iovecs allowed per call.  I don't understand why.
+// Most platforms define IOV_MAX but Linux defines only UIO_MAXIOV and others, like Hurd,
+// define neither.
+//
+// On platforms where both IOV_MAX and UIO_MAXIOV are undefined, we poke sysconf(_SC_IOV_MAX),
+// then try to fall back to the POSIX-mandated minimum of _XOPEN_IOV_MAX if that fails.
+//
+// http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html#tag_13_23_03_01
 #if defined(IOV_MAX)
-  // Solaris (and others?)
+// Solaris, MacOS (& all other BSD-variants?) (and others?)
+static constexpr inline size_t iovMax() {
   return IOV_MAX;
-#elif defined(UIO_MAXIOV)
-  // Linux
-  return UIO_MAXIOV;
-#else
-  // POSIX mystery meat
-
-  long iovmax;
-
-  errno = 0;
-  if ((iovmax = sysconf(_SC_IOV_MAX)) == -1) {
-    // assume iovmax == -1 && errno == 0 means "unbounded"
-    return errno ? _XOPEN_IOV_MAX : count;
-  } else {
-    return (size_t) iovmax;
-  }
-#endif
 }
+#elif defined(UIO_MAX_IOV)
+// Linux
+static constexpr inline size_t iovMax() {
+  return UIO_MAX_IOV;
+}
+#else
+// POSIX mystery meat
+size_t iovMax();
+#endif
 
 #endif
 


### PR DESCRIPTION
On platforms that need iovMax to be queried via sysconf, iovMax
does an unnecessary syscall on every call to `iovMax`. This value isn't
going to change during runtime though. Move this to a constant that's
initialized only once and remove the `count` argument into iovMax since
it's actually superfluous to the API. The more correct action is to just return
`std::numeric_limits<size_t>::max()` and let the caller figure out what
the value is.

Open question is whether this should be just an implementation detail of
`iovMax` (i.e. hide the lazy initialization of the runtime value there) or to
make it the responsibility of the caller. My personal preference is to hide
it within `iovMax` but figured that may be more controversial.