### PR TITLE
Fix large writes

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -277,7 +277,7 @@ libkj_la_SOURCES=                                              \
   src/kj/thread.c++                                            \
   src/kj/time.c++                                              \
   src/kj/filesystem.c++                                        \
-  src/kj/filesystem-disk-unix.c++                                   \
+  src/kj/filesystem-disk-unix.c++                              \
   src/kj/filesystem-disk-win32.c++                             \
   src/kj/test-helpers.c++                                      \
   src/kj/main.c++                                              \
@@ -285,7 +285,10 @@ libkj_la_SOURCES=                                              \
 
 libkj_test_la_LIBADD = libkj.la $(PTHREAD_LIBS)
 libkj_test_la_LDFLAGS = -release $(VERSION) -no-undefined
-libkj_test_la_SOURCES = src/kj/test.c++
+libkj_test_la_SOURCES =                                        \
+  src/kj/test.c++                                              \
+  src/kj/test-util.c++                                         \
+  src/kj/test-util.h
 
 if !LITE_MODE
 libkj_async_la_LIBADD = libkj.la $(ASYNC_LIBS) $(PTHREAD_LIBS)

--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -696,7 +696,6 @@ void NodeTranslator::compileNode(Declaration::Reader decl, schema::Node::Builder
 }
 
 static kj::StringPtr getExpressionTargetName(Expression::Reader exp) {
-  kj::StringPtr targetName;
   switch (exp.which()) {
     case Expression::ABSOLUTE_NAME:
       return exp.getAbsoluteName().getValue();

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -376,8 +376,7 @@ TEST(Serialize, WriteMessageEvenSegmentCount) {
 }
 
 TEST(Serialize, FileDescriptors) {
-  char filename[] = KJ_TEMP_FILE_TEMPLATE("capnproto-serialize-test");
-  kj::AutoCloseFd tmpfile = kj::test::mkstempAutoErased(filename);
+  kj::AutoCloseFd tmpfile = kj::test::mkstempAutoErased();
   ASSERT_GE(tmpfile.get(), 0);
 
   {

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -18,6 +18,7 @@ set(kj_sources_lite
   test-helpers.c++
   units.c++
   encoding.c++
+  miniposix.c++
 )
 set(kj_sources_heavy
   refcount.c++
@@ -61,6 +62,7 @@ set(kj_headers
   time.h
   main.h
   windows-sanity.h
+  miniposix.h
 )
 set(kj-parse_headers
   parse/common.h

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -93,9 +93,11 @@ install(FILES ${kj-std_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/std"
 
 set(kj-test_sources
   test.c++
+  test-util.c++
 )
 set(kj-test_headers
   test.h
+  test-util.h
 )
 set(kj-test-compat_headers
   compat/gtest.h

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -183,11 +183,11 @@ public:
   template <typename U>
   inline bool operator!=(const U& other) const { return asPtr() != other; }
 
-  inline ArrayPtr<T> slice(size_t start, size_t end) {
+  inline constexpr ArrayPtr<T> slice(size_t start, size_t end) {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().");
     return ArrayPtr<T>(ptr + start, end - start);
   }
-  inline ArrayPtr<const T> slice(size_t start, size_t end) const {
+  inline constexpr ArrayPtr<const T> slice(size_t start, size_t end) const {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().");
     return ArrayPtr<const T>(ptr + start, end - start);
   }

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1449,31 +1449,31 @@ public:
     static_assert(!isSameType<T, const char32_t>(), "see above");
   }
 
-  inline operator ArrayPtr<const T>() const {
+  inline constexpr operator ArrayPtr<const T>() const {
     return ArrayPtr<const T>(ptr, size_);
   }
-  inline ArrayPtr<const T> asConst() const {
+  inline constexpr ArrayPtr<const T> asConst() const {
     return ArrayPtr<const T>(ptr, size_);
   }
 
   inline constexpr size_t size() const { return size_; }
-  inline const T& operator[](size_t index) const {
+  inline constexpr const T& operator[](size_t index) const {
     KJ_IREQUIRE(index < size_, "Out-of-bounds ArrayPtr access.");
     return ptr[index];
   }
-  inline T& operator[](size_t index) {
+  inline constexpr T& operator[](size_t index) {
     KJ_IREQUIRE(index < size_, "Out-of-bounds ArrayPtr access.");
     return ptr[index];
   }
 
-  inline T* begin() { return ptr; }
-  inline T* end() { return ptr + size_; }
-  inline T& front() { return *ptr; }
-  inline T& back() { return *(ptr + size_ - 1); }
+  inline constexpr T* begin() { return ptr; }
+  inline constexpr T* end() { return ptr + size_; }
+  inline constexpr T& front() { return *ptr; }
+  inline constexpr T& back() { return *(ptr + size_ - 1); }
   inline constexpr const T* begin() const { return ptr; }
   inline constexpr const T* end() const { return ptr + size_; }
-  inline const T& front() const { return *ptr; }
-  inline const T& back() const { return *(ptr + size_ - 1); }
+  inline constexpr const T& front() const { return *ptr; }
+  inline constexpr const T& back() const { return *(ptr + size_ - 1); }
 
   inline ArrayPtr<const T> slice(size_t start, size_t end) const {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds ArrayPtr::slice().");

--- a/c++/src/kj/io-test.c++
+++ b/c++/src/kj/io-test.c++
@@ -75,10 +75,6 @@ static void setPrefix(char* ptr, int gb) {
   KJ_ASSERT(gb < ONE_GB_ALIGNED_PREFIXES.size());
   strcpy(ptr + gb * ONE_GB, (ONE_GB_ALIGNED_PREFIXES.begin() + gb)->cStr());
 };
-
-static void clearPrefix(char* ptr, int gb) {
-  memset(ptr + gb * ONE_GB, 0, (ONE_GB_ALIGNED_PREFIXES.begin() + gb)->size());
-};
 #endif
 
 TEST(Io, WriteLarge) {
@@ -168,7 +164,7 @@ TEST(Io, WriteVecLarge) {
     setPrefix(toWrite.begin(), 1);
     setPrefix(toWrite.begin(), 2);
 
-    ArrayPtr<const byte> pieces[5] = {
+    ArrayPtr<const byte> pieces[] = {
       arrayPtr(const_cast<const byte*>(toWrite.asBytes().begin()), ONE_GB),
       arrayPtr(const_cast<const byte*>(toWrite.asBytes().begin()), 3 * ONE_GB),
       arrayPtr(const_cast<const byte*>(toWrite.asBytes().begin() + 2 * ONE_GB), ONE_GB),

--- a/c++/src/kj/io-test.c++
+++ b/c++/src/kj/io-test.c++
@@ -86,8 +86,7 @@ TEST(Io, WriteLarge) {
   // Have to thunk through a temporary file since pipes would block on write trying to push this
   // much data (i.e. would never get to read anything);
 
-  char filename [] = KJ_TEMP_FILE_TEMPLATE("kj-io-write-large-test");
-  AutoCloseFd file = test::mkstemp_auto_erased(filename);
+  AutoCloseFd file = test::mkstemp_auto_erased();
 
   {
     FdOutputStream out(file.get());
@@ -154,8 +153,7 @@ TEST(Io, WriteVecLarge) {
   // pose a problem).
 
 #if INTPTR_MAX == INT64_MAX
-  char filename [] = KJ_TEMP_FILE_TEMPLATE("kj-io-writevec-large-test");
-  AutoCloseFd file = test::mkstemp_auto_erased(filename);
+  AutoCloseFd file = test::mkstemp_auto_erased();
 
   {
     auto toWrite = heapArray<char>(BUFFER_SIZE);

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -402,7 +402,7 @@ void FdOutputStream::write(ArrayPtr<const ArrayPtr<const byte>> pieces) {
   while (current < iov.end()) {
     // Issue the write.
     ssize_t n = 0;
-    KJ_SYSCALL(n = ::writev(fd, current, iov.end() - current), fd);
+    KJ_SYSCALL(n = miniposix::writev(fd, current, iov.end() - current), fd);
     KJ_ASSERT(n > 0, "writev() returned zero.");
 
     // Advance past all buffers that were fully-written.

--- a/c++/src/kj/miniposix.c++
+++ b/c++/src/kj/miniposix.c++
@@ -1,0 +1,71 @@
+// Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "miniposix.h"
+
+namespace kj {
+namespace miniposix {
+#if __APPLE__
+ssize_t writev(int fd, struct iovec* iov, size_t iovcnt) {
+  // Workaround for writev POSIX bug on Apple (filed as FB8934446) that prevents writes > 2GB.
+  // The process for doing this is:
+  //   1. We find the iov entry that causes us to exceed a 2GB write.
+  //   2. We truncate that entry to only have a length that would get us to 2GB
+  //   3. We do the actual write.
+  //   4. We restore the original length in the modified iovec entry before returning the result.
+  // This is a bit suboptimal for very large vectored I/O. This could be optimized at the cost of
+  // complicating the I/O on all other platforms + adding a bit of overhead (or providing a
+  // dedicated pessimizatioin path for MacO) in kj/io.c++, but this seems like enough of a corner
+  // case within kj/cap'n'proto for now that the simpler approach is more warranted. It seems
+  // unlikely to me that relative cost of doing large I/O doesn't absolutely dominate the CPU cost
+  // of finding this boundary.
+  ssize_t total = 0;
+  size_t originalTruncatedEntryLen;
+  size_t numEntriesToWrite;
+
+  for (numEntriesToWrite = 0; numEntriesToWrite < iovcnt; ++numEntriesToWrite) {
+    // Step 1: Find the iov entry that would cause us to exceed a 2GB write.
+    total += iov[numEntriesToWrite].iov_len;
+
+    if (total > INT_MAX) {
+      // Step 2: Truncate the entry so that we only consume the part of it that gets us up to 2GB.
+       originalTruncatedEntryLen = iov[numEntriesToWrite].iov_len;
+       iov[numEntriesToWrite].iov_len = INT_MAX - (total - originalTruncatedEntryLen);
+
+       // Increment 1 final time since the break will skip the increment in the for loop but we
+       // still intend for this entry to be written (e.g. it might be the first one).
+       ++numEntriesToWrite;
+       break;
+    }
+  }
+
+  // Step 3: Do the write.
+  ssize_t result = ::writev(fd, iov, numEntriesToWrite);
+
+  // Step 4: Restore the original length of the iovec so that the caller 
+  if (numEntriesToWrite != iovcnt) {
+    iov[numEntriesToWrite - 1].iov_len = originalTruncatedEntryLen;
+  }
+  return result;
+}
+#endif
+}  // namespace miniposix
+}  // namespace kj

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -67,24 +67,24 @@ namespace kj {
 
 class StringPtr {
 public:
-  inline StringPtr(): content("", 1) {}
-  inline StringPtr(decltype(nullptr)): content("", 1) {}
+  inline constexpr StringPtr(): content("", 1) {}
+  inline constexpr StringPtr(decltype(nullptr)): content("", 1) {}
   inline StringPtr(const char* value): content(value, strlen(value) + 1) {}
-  inline StringPtr(const char* value, size_t size): content(value, size + 1) {
+  inline constexpr StringPtr(const char* value, size_t size): content(value, size + 1) {
     KJ_IREQUIRE(value[size] == '\0', "StringPtr must be NUL-terminated.");
   }
-  inline StringPtr(const char* begin, const char* end): StringPtr(begin, end - begin) {}
+  inline constexpr StringPtr(const char* begin, const char* end): StringPtr(begin, end - begin) {}
   inline StringPtr(const String& value);
 
 #if KJ_COMPILER_SUPPORTS_STL_STRING_INTEROP
   template <typename T, typename = decltype(instance<T>().c_str())>
-  inline StringPtr(const T& t): StringPtr(t.c_str()) {}
+  inline constexpr StringPtr(const T& t): StringPtr(t.c_str()) {}
   // Allow implicit conversion from any class that has a c_str() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for
   // those who don't want it.
 
   template <typename T, typename = decltype(instance<T>().c_str())>
-  inline operator T() const { return cStr(); }
+  inline constexpr operator T() const { return cStr(); }
   // Allow implicit conversion to any class that has a c_str() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for
   // those who don't want it.
@@ -95,19 +95,19 @@ public:
   inline ArrayPtr<const byte> asBytes() const { return asArray().asBytes(); }
   // Result does not include NUL terminator.
 
-  inline const char* cStr() const { return content.begin(); }
+  inline constexpr const char* cStr() const { return content.begin(); }
   // Returns NUL-terminated string.
 
-  inline size_t size() const { return content.size() - 1; }
+  inline constexpr size_t size() const { return content.size() - 1; }
   // Result does not include NUL terminator.
 
-  inline char operator[](size_t index) const { return content[index]; }
+  inline constexpr char operator[](size_t index) const { return content[index]; }
 
-  inline const char* begin() const { return content.begin(); }
-  inline const char* end() const { return content.end() - 1; }
+  inline constexpr const char* begin() const { return content.begin(); }
+  inline constexpr const char* end() const { return content.end() - 1; }
 
-  inline bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
-  inline bool operator!=(decltype(nullptr)) const { return content.size() > 1; }
+  inline constexpr bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
+  inline constexpr bool operator!=(decltype(nullptr)) const { return content.size() > 1; }
 
   inline bool operator==(const StringPtr& other) const;
   inline bool operator!=(const StringPtr& other) const { return !(*this == other); }

--- a/c++/src/kj/test-util.c++
+++ b/c++/src/kj/test-util.c++
@@ -29,9 +29,21 @@
 #include <io.h>
 #endif
 
+#if _WIN32 || __ANDROID__
+// TODO(cleanup): Find the Windows temp directory? Seems overly difficult pre C++17.
+// https://en.cppreference.com/w/cpp/filesystem/temp_directory_path
+// would require refactoring the mkstemp code a bit to take into account the types
+// needed to do this at runtime.
+#define KJ_TMPDIR_PREFIX ""
+#else
+#define KJ_TMPDIR_PREFIX "/tmp/"
+#endif
+
 namespace kj {
 namespace test {
-AutoCloseFd mkstempAutoErased(char *tpl) {
+AutoCloseFd mkstempAutoErased() {
+  char tpl[] = KJ_TMPDIR_PREFIX "kj-testfile-XXXXXX.tmp"
+
 #if _WIN32
   char* end = tpl + strlen(tpl);
   while (end > tpl && *(end-1) == 'X') --end;

--- a/c++/src/kj/test-util.c++
+++ b/c++/src/kj/test-util.c++
@@ -1,0 +1,62 @@
+// Copyright (c) 2020-2021 Cap'n Proto Contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "debug.h"
+#include "test-util.h"
+#include <stdlib.h>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#else
+#include <io.h>
+#endif
+
+namespace kj {
+namespace test {
+AutoCloseFd mkstempAutoErased(char *tpl) {
+#if _WIN32
+  char* end = tpl + strlen(tpl);
+  while (end > tpl && *(end-1) == 'X') --end;
+
+  for (;;) {
+    KJ_ASSERT(_mktemp(tpl) == tpl);
+
+    int fd = open(tpl, O_RDWR | O_CREAT | O_EXCL | O_TEMPORARY | O_BINARY | O_SHORT_LIVED | O_NOINHERET, 0700);
+    if (fd >= 0) {
+      return fd;
+    }
+
+    int error = errno;
+    if (error != EEXIST && error != EINTR) {
+      KJ_FAIL_SYSCALL("open(mktemp())", error, tpl);
+    }
+
+    memset(end, 'X', strlen(end));
+  }
+#else
+  int fd;
+  KJ_SYSCALL(fd = ::mkstemp(tpl), tpl);
+  KJ_SYSCALL(::unlink(tpl), tpl);
+  return AutoCloseFd{fd};
+#endif
+}
+}  // namespace test
+}  // namespace kj

--- a/c++/src/kj/test-util.h
+++ b/c++/src/kj/test-util.h
@@ -23,19 +23,9 @@
 
 #include "io.h"
 
-#if _WIN32 || __ANDROID__
-// TODO(cleanup): Find the Windows temp directory? Seems overly difficult pre C++17.
-// https://en.cppreference.com/w/cpp/filesystem/temp_directory_path
-// would require refactoring the mkstemp code a bit to take into account the types
-// needed to do this at runtime.
-#define KJ_TEMP_FILE_TEMPLATE(tpl) tpl "-XXXXXX"
-#else
-#define KJ_TEMP_FILE_TEMPLATE(tpl) "/tmp/" tpl "-XXXXXX"
-#endif
-
 namespace kj {
 namespace test {
-AutoCloseFd mkstempAutoErased(char *tpl);
+AutoCloseFd mkstempAutoErased();
 // Equivalent to mkstemp but guaranteed to have the temporary file cleaned up
 // on or before close. *NIX platforms unlink the temporary file from the
 // filesystem before returning. Windows will delete the file when the handle

--- a/c++/src/kj/test-util.h
+++ b/c++/src/kj/test-util.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2020-2021 Cap'n Proto Contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "io.h"
+
+#if _WIN32 || __ANDROID__
+// TODO(cleanup): Find the Windows temp directory? Seems overly difficult pre C++17.
+// https://en.cppreference.com/w/cpp/filesystem/temp_directory_path
+// would require refactoring the mkstemp code a bit to take into account the types
+// needed to do this at runtime.
+#define KJ_TEMP_FILE_TEMPLATE(tpl) tpl "-XXXXXX"
+#else
+#define KJ_TEMP_FILE_TEMPLATE(tpl) "/tmp/" tpl "-XXXXXX"
+#endif
+
+namespace kj {
+namespace test {
+AutoCloseFd mkstempAutoErased(char *tpl);
+// Equivalent to mkstemp but guaranteed to have the temporary file cleaned up
+// on or before close. *NIX platforms unlink the temporary file from the
+// filesystem before returning. Windows will delete the file when the handle
+// is closed.
+}  // namespace test
+}  // namespace kj


### PR DESCRIPTION
This fixes write on Windows & write/writev on MacOS for very large writes (#1128). Still left todo is a cap'n'proto serialization
test of a large message to double-check but maybe that's not needed?

This is based on #1129 so the diff will be a bit messed up until that diff lands & this one is rebased.