### PR TITLE
Introduce CallConetxt::setPipeline().

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -168,6 +168,11 @@ public:
     }
     return responseBuilder;
   }
+  void setPipeline(kj::Own<PipelineHook>&& pipeline) override {
+    KJ_IF_MAYBE(f, tailCallPipelineFulfiller) {
+      f->get()->fulfill(AnyPointer::Pipeline(kj::mv(pipeline)));
+    }
+  }
   kj::Promise<void> tailCall(kj::Own<RequestHook>&& request) override {
     auto result = directTailCall(kj::mv(request));
     KJ_IF_MAYBE(f, tailCallPipelineFulfiller) {

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -277,6 +277,11 @@ public:
     }
   }
 
+  void setPipeline(kj::Own<PipelineHook>&& pipeline) override {
+    inner->setPipeline(kj::refcounted<MembranePipelineHook>(
+        kj::mv(pipeline), policy->addRef(), !reverse));
+  }
+
   kj::Promise<void> tailCall(kj::Own<RequestHook>&& request) override {
     return inner->tailCall(MembraneRequestHook::wrap(kj::mv(request), *policy, !reverse));
   }

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -2337,6 +2337,11 @@ private:
         return results;
       }
     }
+    void setPipeline(kj::Own<PipelineHook>&& pipeline) override {
+      KJ_IF_MAYBE(f, tailCallPipelineFulfiller) {
+        f->get()->fulfill(AnyPointer::Pipeline(kj::mv(pipeline)));
+      }
+    }
     kj::Promise<void> tailCall(kj::Own<RequestHook>&& request) override {
       auto result = directTailCall(kj::mv(request));
       KJ_IF_MAYBE(f, tailCallPipelineFulfiller) {

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -981,6 +981,14 @@ kj::Promise<void> TestPipelineImpl::getAnyCap(GetAnyCapContext context) {
       });
 }
 
+kj::Promise<void> TestPipelineImpl::getCapPipelineOnly(GetCapPipelineOnlyContext context) {
+  ++callCount;
+  PipelineBuilder<GetCapPipelineOnlyResults> pb;
+  pb.initOutBox().setCap(kj::heap<TestExtendsImpl>(callCount));
+  context.setPipeline(pb.build());
+  return kj::NEVER_DONE;
+}
+
 kj::Promise<void> TestCallOrderImpl::getCallSequence(GetCallSequenceContext context) {
   auto result = context.getResults();
   result.setN(count++);

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -212,6 +212,7 @@ public:
 
   kj::Promise<void> getCap(GetCapContext context) override;
   kj::Promise<void> getAnyCap(GetAnyCapContext context) override;
+  kj::Promise<void> getCapPipelineOnly(GetCapPipelineOnlyContext context) override;
 
 private:
   int& callCount;

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -796,6 +796,9 @@ interface TestPipeline {
   testPointers @1 (cap :TestInterface, obj :AnyPointer, list :List(TestInterface)) -> ();
   getAnyCap @2 (n: UInt32, inCap :Capability) -> (s: Text, outBox :AnyBox);
 
+  getCapPipelineOnly @3 () -> (outBox :Box);
+  # Never returns, but uses setPipeline() to make the pipeline work.
+
   struct Box {
     cap @0 :TestInterface;
   }


### PR DESCRIPTION
This makes it possible, when an RPC forwards to another RPC, to start forward pipelined calls on the first to the second, before the first RPC actually completes.