### PR TITLE
Retain stack traces on exception thas disconnect the RPC.

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -82,6 +82,10 @@
 #include "dlfcn.h"
 #endif
 
+#if _MSC_VER
+#include <intrin.h>
+#endif
+
 namespace kj {
 
 StringPtr KJ_STRINGIFY(LogSeverity severity) {
@@ -836,6 +840,16 @@ void Exception::addTrace(void* ptr) {
   if (traceCount < kj::size(trace)) {
     trace[traceCount++] = ptr;
   }
+}
+
+void Exception::addTraceHere() {
+#if __GNUC__
+  addTrace(__builtin_return_address(0));
+#elif _MSC_VER
+  addTrace(_ReturnAddress());
+#else
+  #error "please implement for your compiler"
+#endif
 }
 
 #if !KJ_NO_EXCEPTIONS

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -128,6 +128,9 @@ public:
   // Append the given pointer to the backtrace, if it is not already full. This is used by the
   // async library to trace through the promise chain that led to the exception.
 
+  KJ_NOINLINE void addTraceHere();
+  // Adds the location that called this method to the stack trace.
+
 private:
   String ownFile;
   const char* file;


### PR DESCRIPTION
This makes it easier to figure out why RPC became disconnected, based on having the exception thrown at you later when you try to use the connection.