### PR TITLE
Remove a redundant static_cast.

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1103,7 +1103,7 @@ public:
   using Executor::Executor;
 
   kj::Own<const Executor> addRef() const override {
-    return kj::atomicAddRef(static_cast<const _::ExecutorImpl&>(*this));
+    return kj::atomicAddRef(*this);
   }
 };
 


### PR DESCRIPTION
This `static_cast` is casting the value to the type it already is. I think it may have been a copy-pasto from a version of the code that actually had to do a downcast here.

This is just something I noticed while reading. This change has absolutely no effect on actual behavior.