### PR TITLE
Pretty-print binary blobs (aka Data) properly.

### DIFF
--- a/c++/src/capnp/stringify.c++
+++ b/c++/src/capnp/stringify.c++
@@ -139,17 +139,14 @@ static kj::StringTree print(const DynamicValue::Reader& value,
       } else {
         return kj::strTree(value.as<double>());
       }
-    case DynamicValue::TEXT:
+    case DynamicValue::TEXT: {
+      kj::ArrayPtr<const char> chars = value.as<Text>();
+      return kj::strTree('"', kj::encodeCEscape(chars), '"');
+    }
     case DynamicValue::DATA: {
       // TODO(someday): Maybe data should be printed as binary literal.
-      kj::ArrayPtr<const char> chars;
-      if (value.getType() == DynamicValue::DATA) {
-        chars = value.as<Data>().asChars();
-      } else {
-        chars = value.as<Text>();
-      }
-
-      return kj::strTree('"', kj::encodeCEscape(chars), '"');
+      kj::ArrayPtr<const byte> bytes = value.as<Data>().asBytes();
+      return kj::strTree('"', kj::encodeCEscape(bytes), '"');
     }
     case DynamicValue::LIST: {
       auto listValue = value.as<DynamicList>();

--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -362,10 +362,12 @@ KJ_TEST("application/x-www-form-urlencoded encoding/decoding") {
 }
 
 KJ_TEST("C escape encoding/decoding") {
-  KJ_EXPECT(encodeCEscape("fooo\a\b\f\n\r\t\v\'\"\\bar") ==
-      "fooo\\a\\b\\f\\n\\r\\t\\v\\\'\\\"\\\\bar");
+  KJ_EXPECT(encodeCEscape("fooo\a\b\f\n\r\t\v\'\"\\barПривет, Мир! Ж=О") ==
+      "fooo\\a\\b\\f\\n\\r\\t\\v\\\'\\\"\\\\bar\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82\x2c\x20\xd0\x9c\xd0\xb8\xd1\x80\x21\x20\xd0\x96\x3d\xd0\x9e");
   KJ_EXPECT(encodeCEscape("foo\x01\x7fxxx") ==
       "foo\\001\\177xxx");
+  byte bytes[] = {'f', 'o', 'o', 0, '\x01', '\x7f', 'x', 'x', 'x', 128, 254, 255};
+  KJ_EXPECT(encodeCEscape(bytes) == "foo\\000\\001\\177xxx\\200\\376\\377");
 
   expectRes(decodeCEscape("fooo\\a\\b\\f\\n\\r\\t\\v\\\'\\\"\\\\bar"),
       "fooo\a\b\f\n\r\t\v\'\"\\bar");

--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -536,7 +536,9 @@ EncodingResult<Array<byte>> decodeBinaryUriComponent(
 
 // =======================================================================================
 
-String encodeCEscape(ArrayPtr<const byte> bytes) {
+namespace _ { // private
+
+String encodeCEscapeImpl(ArrayPtr<const byte> bytes, bool isBinary) {
   Vector<char> escaped(bytes.size());
 
   for (byte b: bytes) {
@@ -552,7 +554,7 @@ String encodeCEscape(ArrayPtr<const byte> bytes) {
       case '\"': escaped.addAll(StringPtr("\\\"")); break;
       case '\\': escaped.addAll(StringPtr("\\\\")); break;
       default:
-        if (b < 0x20 || b == 0x7f) {
+        if (b < 0x20 || b == 0x7f || (isBinary && b > 0x7f)) {
           // Use octal escape, not hex, because hex escapes technically have no length limit and
           // so can create ambiguity with subsequent characters.
           escaped.add('\\');
@@ -569,6 +571,8 @@ String encodeCEscape(ArrayPtr<const byte> bytes) {
   escaped.add(0);
   return String(escaped.releaseAsArray());
 }
+
+} // namespace
 
 EncodingResult<Array<byte>> decodeBinaryCEscape(ArrayPtr<const char> text, bool nulTerminate) {
   Vector<byte> result(text.size() + nulTerminate);

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -246,6 +246,8 @@ const T* readMaybe(const EncodingResult<T>& value) {
   }
 }
 
+String encodeCEscapeImpl(ArrayPtr<const byte> bytes, bool isBinary);
+
 }  // namespace _ (private)
 
 inline String encodeUriComponent(ArrayPtr<const char> text) {
@@ -276,8 +278,13 @@ inline EncodingResult<String> decodeWwwForm(ArrayPtr<const char> text) {
 }
 
 inline String encodeCEscape(ArrayPtr<const char> text) {
-  return encodeCEscape(text.asBytes());
+  return _::encodeCEscapeImpl(text.asBytes(), false);
 }
+
+inline String encodeCEscape(ArrayPtr<const byte> bytes) {
+  return _::encodeCEscapeImpl(bytes, true);
+}
+
 inline EncodingResult<String> decodeCEscape(ArrayPtr<const char> text) {
   auto result = decodeBinaryCEscape(text, true);
   return { String(result.releaseAsChars()), result.hadErrors };


### PR DESCRIPTION
Adjust encodeCEscape() to generate encoding that is compatible with utf-8 which is used in python3 when presented with a binary blob, which means escaping upper half of the code space. Without this attempt to make printable representation of the valid otherwise binary data in python would sometimes fail with something like this:

```
Traceback (most recent call last):
  File "./tools/lib/logreader.py", line 147, in <module>
    print(msg)
  File "capnp/lib/capnp.pyx", line 1092, in capnp.lib.capnp._DynamicStructReader.__str__
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9d in position 118: invalid start byte
```
The structure in question is:
```
struct CanData {
  address @0 :UInt32;
  busTime @1 :UInt16;
  dat     @2 :Data;
  src     @3 :UInt8;
}
```
The data:
```
( logMonoTime = 166125304492147,
  sendcan = [
    ( address = 832,
      busTime = 0,
      dat = "\004\000\000$d\000\235\021",
      src = 0 ) ],
  valid = true )
```

I've also tried to fix it at pycapnp level [here](https://github.com/sobomax/pycapnp/commit/18401754222bb3de2840029f6503558f2f04c4da) using "backslashreplace" mechanism, however that produces awfully inconsistently escaped output, so I think this is the best place to fix it.

```
        ( key = "PandaFirmware",
          value = "\021\001[\026|GSe\xd5\032+\x94\xff\f|" ),
```
(note both octal and hex escaping).