### PR TITLE
Add writeMessages for serializing multiple messages to an output stream

### DIFF
--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -252,37 +252,82 @@ struct WriteArrays {
   kj::Array<kj::ArrayPtr<const byte>> pieces;
 };
 
+inline size_t tableSizeForSegments(size_t segmentsSize) {
+  return (segmentsSize + 2) & ~size_t(1);
+}
+
+// Helper function that allocates and fills the pointed-to table with info about the segments and
+// populates the pieces array with pointers to the segments.
+void fillWriteArraysWithMessage(kj::ArrayPtr<const kj::ArrayPtr<const word>> segments,
+                                kj::ArrayPtr<_::WireValue<uint32_t>> table,
+                                kj::ArrayPtr<kj::ArrayPtr<const byte>> pieces) {
+  KJ_REQUIRE(segments.size() > 0, "Tried to serialize uninitialized message.");
+
+  // We write the segment count - 1 because this makes the first word zero for single-segment
+  // messages, improving compression.  We don't bother doing this with segment sizes because
+  // one-word segments are rare anyway.
+  table[0].set(segments.size() - 1);
+  for (uint i = 0; i < segments.size(); i++) {
+    table[i + 1].set(segments[i].size());
+  }
+  if (segments.size() % 2 == 0) {
+    // Set padding byte.
+    table[segments.size() + 1].set(0);
+  }
+
+  KJ_ASSERT(pieces.size() == segments.size() + 1, "incorrectly sized pieces array during write");
+  pieces[0] = table.asBytes();
+  for (uint i = 0; i < segments.size(); i++) {
+    pieces[i + 1] = segments[i].asBytes();
+  }
+}
+
 template <typename WriteFunc>
 kj::Promise<void> writeMessageImpl(kj::ArrayPtr<const kj::ArrayPtr<const word>> segments,
                                    WriteFunc&& writeFunc) {
   KJ_REQUIRE(segments.size() > 0, "Tried to serialize uninitialized message.");
 
   WriteArrays arrays;
-  arrays.table = kj::heapArray<_::WireValue<uint32_t>>((segments.size() + 2) & ~size_t(1));
-
-  // We write the segment count - 1 because this makes the first word zero for single-segment
-  // messages, improving compression.  We don't bother doing this with segment sizes because
-  // one-word segments are rare anyway.
-  arrays.table[0].set(segments.size() - 1);
-  for (uint i = 0; i < segments.size(); i++) {
-    arrays.table[i + 1].set(segments[i].size());
-  }
-  if (segments.size() % 2 == 0) {
-    // Set padding byte.
-    arrays.table[segments.size() + 1].set(0);
-  }
-
+  arrays.table = kj::heapArray<_::WireValue<uint32_t>>(tableSizeForSegments(segments.size()));
   arrays.pieces = kj::heapArray<kj::ArrayPtr<const byte>>(segments.size() + 1);
-  arrays.pieces[0] = arrays.table.asBytes();
-
-  for (uint i = 0; i < segments.size(); i++) {
-    arrays.pieces[i + 1] = segments[i].asBytes();
-  }
+  fillWriteArraysWithMessage(segments, arrays.table, arrays.pieces);
 
   auto promise = writeFunc(arrays.pieces);
 
   // Make sure the arrays aren't freed until the write completes.
   return promise.then(kj::mvCapture(arrays, [](WriteArrays&&) {}));
+}
+
+template <typename WriteFunc>
+kj::Promise<void> writeMessagesImpl(
+    kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages, WriteFunc&& writeFunc) {
+  KJ_REQUIRE(messages.size() > 0, "Tried to serialize zero messages.");
+
+  // Determine how large the shared table and pieces arrays needs to be.
+  size_t tableSize = 0;
+  size_t piecesSize = 0;
+  for (auto& segments : messages) {
+    tableSize += tableSizeForSegments(segments.size());
+    piecesSize += segments.size() + 1;
+  }
+  auto table = kj::heapArray<_::WireValue<uint32_t>>(tableSize);
+  auto pieces = kj::heapArray<kj::ArrayPtr<const byte>>(piecesSize);
+
+  size_t tableValsWritten = 0;
+  size_t piecesWritten = 0;
+  for (int i = 0; i < messages.size(); ++i) {
+    const size_t tableValsToWrite = tableSizeForSegments(messages[i].size());
+    const size_t piecesToWrite = messages[i].size() + 1;
+    fillWriteArraysWithMessage(
+        messages[i],
+        table.slice(tableValsWritten, tableValsWritten + tableValsToWrite),
+        pieces.slice(piecesWritten, piecesWritten + piecesToWrite));
+    tableValsWritten += tableValsToWrite;
+    piecesWritten += piecesToWrite;
+  }
+
+  auto promise = writeFunc(pieces);
+  return promise.attach(kj::mv(table), kj::mv(pieces));
 }
 
 }  // namespace
@@ -301,6 +346,32 @@ kj::Promise<void> writeMessage(kj::AsyncCapabilityStream& output, kj::ArrayPtr<c
       [&](kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) {
     return output.writeWithFds(pieces[0], pieces.slice(1, pieces.size()), fds);
   });
+}
+
+kj::Promise<void> writeMessages(
+    kj::AsyncOutputStream& output,
+    kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages) {
+  return writeMessagesImpl(messages,
+      [&](kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) {
+    return output.write(pieces);
+  });
+}
+
+kj::Promise<void> writeMessages(
+    kj::AsyncOutputStream& output, kj::ArrayPtr<MessageBuilder*> builders) {
+  auto messages = kj::heapArray<kj::ArrayPtr<const kj::ArrayPtr<const word>>>(builders.size());
+  for (int i = 0; i < builders.size(); ++i) {
+    messages[i] = builders[i]->getSegmentsForOutput();
+  }
+  return writeMessages(output, messages);
+}
+
+kj::Promise<void> MessageStream::writeMessages(kj::ArrayPtr<MessageBuilder*> builders) {
+  auto messages = kj::heapArray<kj::ArrayPtr<const kj::ArrayPtr<const word>>>(builders.size());
+  for (int i = 0; i < builders.size(); ++i) {
+    messages[i] = builders[i]->getSegmentsForOutput();
+  }
+  return writeMessages(messages);
 }
 
 AsyncIoMessageStream::AsyncIoMessageStream(kj::AsyncIoStream& stream)
@@ -324,6 +395,11 @@ kj::Promise<void> AsyncIoMessageStream::writeMessage(
     kj::ArrayPtr<const int> fds,
     kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) {
   return capnp::writeMessage(stream, segments);
+}
+
+kj::Promise<void> AsyncIoMessageStream::writeMessages(
+    kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages) {
+  return capnp::writeMessages(stream, messages);
 }
 
 kj::Maybe<int> getSendBufferSize(kj::AsyncIoStream& stream) {
@@ -371,6 +447,11 @@ kj::Promise<void> AsyncCapabilityMessageStream::writeMessage(
     kj::ArrayPtr<const int> fds,
     kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) {
   return capnp::writeMessage(stream, fds, segments);
+}
+
+kj::Promise<void> AsyncCapabilityMessageStream::writeMessages(
+    kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages) {
+  return capnp::writeMessages(stream, messages);
 }
 
 kj::Maybe<int> AsyncCapabilityMessageStream::getSendBufferSize() {

--- a/c++/src/capnp/serialize-async.h
+++ b/c++/src/capnp/serialize-async.h
@@ -76,6 +76,13 @@ public:
       KJ_WARN_UNUSED_RESULT;
   // Equivalent to the above with fds = nullptr.
 
+  virtual kj::Promise<void> writeMessages(
+      kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages)
+    KJ_WARN_UNUSED_RESULT = 0;
+  kj::Promise<void> writeMessages(kj::ArrayPtr<MessageBuilder*> builders)
+      KJ_WARN_UNUSED_RESULT;
+  // Similar to the above, but for writing multiple messages at a time in a batch.
+
   virtual kj::Maybe<int> getSendBufferSize() = 0;
   // Get the size of the underlying send buffer, if applicable. The RPC
   // system uses this as a hint for flow control purposes; see:
@@ -103,6 +110,8 @@ public:
   kj::Promise<void> writeMessage(
       kj::ArrayPtr<const int> fds,
       kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) override;
+  kj::Promise<void> writeMessages(
+      kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages) override;
   kj::Maybe<int> getSendBufferSize() override;
 
   kj::Promise<void> end() override;
@@ -122,6 +131,8 @@ public:
   kj::Promise<void> writeMessage(
       kj::ArrayPtr<const int> fds,
       kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) override;
+  kj::Promise<void> writeMessages(
+      kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages) override;
   kj::Maybe<int> getSendBufferSize() override;
   kj::Promise<void> end() override;
 private:
@@ -171,6 +182,18 @@ kj::Promise<void> writeMessage(kj::AsyncCapabilityStream& output, kj::ArrayPtr<c
     KJ_WARN_UNUSED_RESULT;
 kj::Promise<void> writeMessage(kj::AsyncCapabilityStream& output, kj::ArrayPtr<const int> fds,
                                MessageBuilder& builder)
+    KJ_WARN_UNUSED_RESULT;
+
+
+// -----------------------------------------------------------------------------
+// Stand-alone functions for writing multiple messages at once on AsyncOutputStreams.
+
+kj::Promise<void> writeMessages(kj::AsyncOutputStream& output,
+                                kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages)
+    KJ_WARN_UNUSED_RESULT;
+
+kj::Promise<void> writeMessages(
+    kj::AsyncOutputStream& output, kj::ArrayPtr<MessageBuilder*> builders)
     KJ_WARN_UNUSED_RESULT;
 
 // =======================================================================================

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -149,7 +149,7 @@ public:
 };
 
 class AsyncCapabilityStream: public AsyncIoStream {
-  // An AsyncIoStream that also allows transmitting new stream objects and file descirptors
+  // An AsyncIoStream that also allows transmitting new stream objects and file descriptors
   // (capabilities, in the object-capability model sense), in addition to bytes.
   //
   // Capabilities can be attached to bytes when they are written. On the receiving end, the read()
@@ -158,7 +158,7 @@ class AsyncCapabilityStream: public AsyncIoStream {
   // Note that AsyncIoStream's regular byte-oriented methods can be used on AsyncCapabilityStream,
   // with the effect of silently dropping any capabilities attached to the respective bytes. E.g.
   // using `AsyncIoStream::tryRead()` to read bytes that had been sent with `writeWithFds()` will
-  // silently drop the FDs (closing them if appropriate). Also note that puming a stream with
+  // silently drop the FDs (closing them if appropriate). Also note that pumping a stream with
   // `pumpTo()` always drops all capabilities attached to the pumped data. (TODO(someday): Do we
   // want a version of pumpTo() that preserves capabilities?)
   //


### PR DESCRIPTION
In order to support batching up some of the small writes that capnproto
tends to do in practice when you're sending lots of pipelined RPCs.

---

This could use unit tests, and perhaps should also have versions of the methods added onto the `MessageStream` type, but I wanted to get your feedback on the core approach before going the rest of the way.