### PR TITLE
Change exception for 'pipe ended prematurely' to DISCONNECTED.

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -1638,7 +1638,8 @@ private:
     if (limit == 0) {
       inner = nullptr;
     } else if (amount < requested) {
-      KJ_FAIL_REQUIRE("pipe ended prematurely") { break; }
+      kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED,
+          "fixed-length pipe ended prematurely"));
     }
   }
 };


### PR DESCRIPTION
This seems like the easiest way to get it to stop showing up in our error logs when Workers don't write as much data as they promised.