### PR TITLE
Add `kj::arrOf<T>()`, similar to `kj::arr()` but with explicit type.

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -383,6 +383,20 @@ KJ_TEST("kj::arr()") {
   kj::Array<kj::String> array = kj::arr(kj::str("foo"), kj::str(123));
   KJ_EXPECT(array == kj::ArrayPtr<const kj::StringPtr>({"foo", "123"}));
 }
+
+struct ImmovableInt {
+  ImmovableInt(int i): i(i) {}
+  KJ_DISALLOW_COPY(ImmovableInt);
+  int i;
+};
+
+KJ_TEST("kj::arrOf()") {
+  kj::Array<ImmovableInt> array = kj::arrOf<ImmovableInt>(123, 456, 789);
+  KJ_ASSERT(array.size() == 3);
+  KJ_EXPECT(array[0].i == 123);
+  KJ_EXPECT(array[1].i == 456);
+  KJ_EXPECT(array[2].i == 789);
+}
 #endif
 
 struct DestructionOrderRecorder {

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -853,6 +853,12 @@ inline Array<Decay<T>> arr(T&& param1, Params&&... params) {
   (builder.add(kj::fwd<T>(param1)), ... , builder.add(kj::fwd<Params>(params)));
   return builder.finish();
 }
+template <typename T, typename... Params>
+inline Array<Decay<T>> arrOf(Params&&... params) {
+  ArrayBuilder<Decay<T>> builder = heapArrayBuilder<Decay<T>>(sizeof...(params));
+  (... , builder.add(kj::fwd<Params>(params)));
+  return builder.finish();
+}
 #endif
 
 namespace _ {  // private


### PR DESCRIPTION
This is useful when creating an array of an immovable type, where the constructor takes one parameter.

I don't actually need this for anything. I thought I did, but then it turned out I didn't. But I wrote it and it seems useful.