### PR TITLE
Bump max header size 64k -> 128k.

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1036,7 +1036,7 @@ kj::String HttpHeaders::toString() const {
 namespace {
 
 static constexpr size_t MIN_BUFFER = 4096;
-static constexpr size_t MAX_BUFFER = 65536;
+static constexpr size_t MAX_BUFFER = 128 * 1024;
 static constexpr size_t MAX_CHUNK_HEADER_SIZE = 32;
 
 class HttpInputStreamImpl final: public HttpInputStream {


### PR DESCRIPTION
For Workers, our ingress proxy should already be guarding against oversized headers, but we're seeing a trickle of errors, probably because of internal headers that have been added to the request after the early check.