### PR TITLE
Document additional valid backwards-compatible schema transformations

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -801,6 +801,14 @@ this list, but most apps can safely use them:
   As a special exception to this rule, `List(Bool)` may **not** be upgraded to a list of structs,
   because implementing this for bit lists has proven unreasonably expensive.
 
+* A integer field may be promoted to an integer field of larger width while keeping the sign
+* A boolean field may be promoted to an integer field
+* A `Text` field may be promoted to `Data`
+* A `Data` field may be promoted to `List(UInt8)`
+* An enumeration may be promoted to `Uint16`, `UInt32`, or `UInt64`
+* An unsigned integer may be promoted to a signed integer if the positive part of the signed integer 
+  is wide enough to contain the unsigned integer
+
 Any change not listed above should be assumed NOT to be safe.  In particular:
 
 * You cannot change a field, method, or enumerant's number.


### PR DESCRIPTION
I have been running a set of schema evolution experiments using Cap'n
Proto and I believe that the schema transformations I'm documenting in
this commit are all backwards-compatible, at least as far as my
experiments went.

Please let me know your thoughts! I can double check from my side (and provide examples) if you think some of these transformations sound odd. I'm also not sure if you want to mention the enumeration constant to integer transformation given that the documentation explicitly asks the reader to not think about enumeration constants as numeric types.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>