### PR TITLE
`kj::defer`: allow lvalue lambda reference

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -596,5 +596,33 @@ KJ_TEST("kj::range()") {
   KJ_EXPECT(expected == 8);
 }
 
+KJ_TEST("kj::defer()") {
+  bool executed;
+
+  // rvalue reference
+  {
+    executed = false;
+    auto deferred = kj::defer([&executed]() {
+      executed = true;
+    });
+    KJ_EXPECT(!executed);
+  }
+
+  KJ_EXPECT(executed);
+
+  // lvalue reference
+  auto executor = [&executed]() {
+    executed = true;
+  };
+
+  {
+    executed = false;
+    auto deferred = kj::defer(executor);
+    KJ_EXPECT(!executed);
+  }
+
+  KJ_EXPECT(executed);
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1604,7 +1604,7 @@ public:
   KJ_DISALLOW_COPY(Deferred);
 
   // This move constructor is usually optimized away by the compiler.
-  inline Deferred(Deferred&& other): func(kj::mv(other.func)), canceled(false) {
+  inline Deferred(Deferred&& other): func(kj::fwd<Func>(other.func)), canceled(false) {
     other.canceled = true;
   }
 private:


### PR DESCRIPTION
This allows for the usage of named / reusable lambdas with `kj::defer()`, which is especially helpful in testing functions.