### PR TITLE
Expose RpcSystemBase's accept loop promise

### DIFF
--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -87,6 +87,8 @@ public:
 
   void setTraceEncoder(kj::Function<kj::String(const kj::Exception&)> func);
 
+  kj::Promise<void> run();
+
 private:
   class Impl;
   kj::Own<Impl> impl;

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -151,6 +151,16 @@ public:
   //
   // Stack traces can sometimes contain sensitive information, so you should think carefully about
   // what information you are willing to reveal to the remote party.
+
+  kj::Promise<void> run() { return RpcSystemBase::run(); }
+  // Listens for incoming RPC connections and handles them. Never returns normally, but could throw
+  // an exception if the system becomes unable to accept new connections (e.g. because the
+  // underlying listen socket becomes broken somehow).
+  //
+  // For historical reasons, the RpcSystem will actually run itself even if you do not call this.
+  // However, if an exception is thrown, the RpcSystem will log the exception to the console and
+  // then cease accepting new connections. In this case, your server may be in a broken state, but
+  // without restarting. All servers should therefore call run() and handle failures in some way.
 };
 
 template <typename VatId, typename ProvisionId, typename RecipientId,


### PR DESCRIPTION
This allows users of the RPC system to detect when the accept loop stops
for some reason.

---

An alternative would be to have people manually start the RPC system and own the actual promise. It was a bit surprising to me (but not necessarily bad) that the system runs itself on construction.