### PR TITLE
Create better exceptions when default-canceling a `kj::Canceler`.

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -423,6 +423,16 @@ private:
 
 #endif  // !KJ_NO_EXCEPTIONS
 
+kj::Exception getDestructionReason(void* traceSeparator,
+    kj::Exception::Type defaultType, const char* defaultFile, int defaultLine,
+    kj::StringPtr defaultDescription);
+// Returns an exception that attempts to capture why a destructor has been invoked. If a KJ
+// exception is currently in-flight (see InFlightExceptionIterator), then that exception is
+// returned. Otherwise, an exception is constructed using the current stack trace and the type,
+// file, line, and description provided. In the latter case, `traceSeparator` is appended to the
+// stack trace; this should be a pointer to some dummy symbol which acts as a separator between the
+// original stack trace and any new trace frames added later.
+
 kj::ArrayPtr<void* const> computeRelativeTrace(
     kj::ArrayPtr<void* const> trace, kj::ArrayPtr<void* const> relativeTo);
 // Given two traces expected to have started from the same root, try to find the part of `trace`


### PR DESCRIPTION
We give this the same treatment as we did PromiseFulfillerPair: If a `Canceler` is canceled because it is simply destroyed, we propagate the in-flight exception if there is one, otherwise we produce an exception that includes a stack trace to the destructor, in addition to the trace to the canceled operation.