### PR TITLE
[WIP] fix `KJ_CLEAN_SHUTDOWN` behavior

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -40,6 +40,7 @@
 #include "threadlocal.h"
 #include "miniposix.h"
 #include "function.h"
+#include "main.h"
 #include <stdlib.h>
 #include <exception>
 #include <new>
@@ -1260,6 +1261,8 @@ Maybe<Exception> runCatchingExceptions(Runnable& runnable) {
   } catch (std::exception& e) {
     return Exception(Exception::Type::FAILED,
                      "(unknown)", -1, str("std::exception: ", e.what()));
+  } catch (TopLevelProcessContext::CleanShutdownException) {
+    throw;
   } catch (...) {
 #if __GNUC__ && !KJ_NO_RTTI
     return Exception(Exception::Type::FAILED, "(unknown)", -1, str(


### PR DESCRIPTION
Prior to these changes, using KJ_CLEAN_SHUTDOWN results in the following error:

```
failed: unknown non-KJ exception of type:
kj::TopLevelProcessContext::CleanShutdownException
```