### PR TITLE
Move `getDestructionReason()` to correct file.

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2731,31 +2731,6 @@ void WeakFulfillerBase::disposeImpl(void* pointer) const {
 
 }  // namespace _ (private)
 
-kj::Exception getDestructionReason(void* traceSeparator, kj::Exception::Type defaultType,
-    const char* defaultFile, int defaultLine, kj::StringPtr defaultDescription) {
-#if !KJ_NO_EXCEPTIONS
-  InFlightExceptionIterator iter;
-  KJ_IF_MAYBE(e, iter.next()) {
-    auto copy = kj::cp(*e);
-    copy.truncateCommonTrace();
-    return copy;
-  } else {
-#endif
-    // Darn, use a generic exception.
-    kj::Exception exception(defaultType, __FILE__, __LINE__, kj::heapString(defaultDescription));
-
-    // Let's give some context on where the PromiseFulfiller was destroyed.
-    exception.extendTrace(2, 16);
-
-    // Add a separator that hopefully makes this understandable...
-    exception.addTrace(traceSeparator);
-
-    return exception;
-#if !KJ_NO_EXCEPTIONS
-  }
-#endif
-}
-
 // -------------------------------------------------------------------
 
 namespace _ {  // (private)

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -915,6 +915,31 @@ Maybe<const Exception&> InFlightExceptionIterator::next() {
 
 #endif  // !KJ_NO_EXCEPTIONS
 
+kj::Exception getDestructionReason(void* traceSeparator, kj::Exception::Type defaultType,
+    const char* defaultFile, int defaultLine, kj::StringPtr defaultDescription) {
+#if !KJ_NO_EXCEPTIONS
+  InFlightExceptionIterator iter;
+  KJ_IF_MAYBE(e, iter.next()) {
+    auto copy = kj::cp(*e);
+    copy.truncateCommonTrace();
+    return copy;
+  } else {
+#endif
+    // Darn, use a generic exception.
+    kj::Exception exception(defaultType, __FILE__, __LINE__, kj::heapString(defaultDescription));
+
+    // Let's give some context on where the PromiseFulfiller was destroyed.
+    exception.extendTrace(2, 16);
+
+    // Add a separator that hopefully makes this understandable...
+    exception.addTrace(traceSeparator);
+
+    return exception;
+#if !KJ_NO_EXCEPTIONS
+  }
+#endif
+}
+
 // =======================================================================================
 
 namespace {


### PR DESCRIPTION
When I previously factored out `getDestructionReason()` from `WeakFulfillerBase::disposeImpl()` (in #1176), I had intended to move it to `exception.c++`. I even declared the prototype in `exception.h`. But I forgot to move it.

This PR just moves the code without changing anything else.