### PR TITLE
JSON: Fix inflexibilities with unions

### DIFF
--- a/c++/src/capnp/compat/json-test.capnp
+++ b/c++/src/capnp/compat/json-test.capnp
@@ -104,8 +104,40 @@ struct TestJsonAnnotations3 $Json.discriminator(name = "type") {
   }
 }
 
+struct TestUnionTag $Json.discriminator(name = "type") {
+  union {
+    foo @0 :TestFlattenedStruct $Json.flatten();
+    ref @1 :TestUnionTypeReference $Json.flatten();
+    ren @2 :TestUnionTypeReference $Json.name("renamed-ref") $Json.flatten();
+  }
+}
+
+struct TestBogusGroup $Json.discriminator(name = "type") {
+  aGroup :group $Json.flatten() {
+    foo @0 :TestFlattenedStruct;
+    ref @1 :TestUnionTypeReference $Json.flatten();
+  }
+}
+
+struct TestIllegalTagType $Json.discriminator(name = "type") {
+  union {
+    foo @0 :TestFlattenedStruct $Json.flatten();
+    ref @1 :TestTypeUInt32 $Json.flatten();
+  }
+}
+
 struct TestFlattenedStruct {
   value @0 :Text;
+}
+
+struct TestUnionTypeReference {
+  type @0 :Text;
+  value @1 :Text;
+}
+
+struct TestTypeUInt32 {
+  type @0 :UInt32;
+  value @1 :Text;
 }
 
 enum TestJsonAnnotatedEnum {

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -253,7 +253,7 @@ private:
   AnnotatedHandler& loadAnnotatedHandler(
       StructSchema schema,
       kj::Maybe<json::DiscriminatorOptions::Reader> discriminator,
-      kj::Maybe<kj::StringPtr> unionDeclName,
+      kj::StringPtr unionDeclName,
       kj::Vector<Schema>& dependencies);
 };
 


### PR DESCRIPTION
This pull request addresses two minor shortcomings of the current JSON implementation that I stumbled over recently. This first part is probably an oversight and trivial, the second part is a feature that removes a limitation. All changes are backwards-compatible.

### 1. Flattening anonymous unions

The following construct was so far rejected by the JSON en-/decoder:

```capnp
struct TestAnonymousUnion $Json.flatten() $Json.discriminator(name = "type") {
  union {
    foo @0 :Foo $Json.flatten();
    ref @1 :Bar $Json.flatten();
  }
}
```

However, the following was always legal:

```capnp
struct TestUnion {
  u :union $Json.flatten() $Json.discriminator(name = "type") {
    foo @0 :Foo $Json.flatten();
    bar @1 :Bar $Json.flatten();
  }
}
```

I believe that's totally unfair, anonymous unions deserve love too, and thus this merge request makes the first one legal too. No code changes are required apart from modifying the schema. I however added a test for it.

### 2. Allow referencing union tags from flattened member structs

A union tag, defined via `Json.discriminator`, configures which union member the JSON en-/decoder should pick. It is registered as internal field that so far could no longer appear in the structs below it if they were flattened. For example, the following was illegal:

```capnp
struct TestTagReference $Json.flatten() $Json.discriminator(name = "type") {
  union {
    foo @0 :Foo $Json.flatten();
    ref @1 :Ref $Json.flatten();
  }
}

struct Bar {
  type @0 :Text; #<- error: name already reserved by discriminator field
  value @1 :Text;
}
```

This pull request makes the JSON implementation accept the above construct and do the obvious: The discriminator field's value is simply copied into Bar. Thus, Bar's "type" will always equal "bar" when decoded from JSON as union member. This adds a good deal of flexibility. For example, it allows Bar to be reused in the schema where a "type" field must still explicitly appear. The encoding of Bar to JSON also happens to be a valid TestTagReference. 

My use case for both changes is being able to use Cap'n Proto's JSON decoder as ingress for messages that come in a fixed, legacy format that I have no control over. They can now be parsed seamlessly to Cap'n Proto structs and forwarded via RPC.