### PR TITLE
Undefined behavior sanitizer on FileKeyHash()

### DIFF
--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -115,7 +115,7 @@ struct FileKeyHash {
           key.size * 103 + (key.lastModified - kj::UNIX_EPOCH) / kj::MILLISECONDS * 73;
     } else {
       return key.hashCode + key.size * 103 +
-          (key.lastModified - kj::UNIX_EPOCH) / kj::NANOSECONDS * 73;
+          (key.lastModified - kj::UNIX_EPOCH) / kj::NANOSECONDS * 73ull;
     }
   }
 };


### PR DESCRIPTION
Multiply signed by unsigned number would get unsigned.
```
$ capnp_tool compile -oc++ a20.capnp base.capnp
../third/capnproto/c++/src/capnp/compiler/module-loader.c++:118:65: runtime error: signed integer overflow: 1613965689944811244 * 73 cannot be represented in type 'long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../third/capnproto/c++/src/capnp/compiler/module-loader.c++:118:65 in
```