### PR TITLE
Add ability to check if a promise is valid.

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -85,6 +85,29 @@ TEST(Async, ThereVoid) {
   EXPECT_EQ(123, value);
 }
 
+TEST(Async, PromiseMove) {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Promise<int> a = 123;
+
+  int value = 0;
+  Promise<int> promise = a.then([&](int ai) { value = ai; return 0; });
+
+  EXPECT_TRUE(a.isConsumed());
+  EXPECT_FALSE(promise.isConsumed());
+
+  Promise<int> b = kj::mv(promise);
+  EXPECT_TRUE(promise.isConsumed());
+  EXPECT_FALSE(b.isConsumed());
+
+  EXPECT_EQ(0, value);
+  b.wait(waitScope);
+  EXPECT_EQ(123, value);
+
+  EXPECT_TRUE(b.isConsumed());
+}
+
 TEST(Async, Exception) {
   EventLoop loop;
   WaitScope waitScope(loop);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -314,6 +314,11 @@ public:
   // Returns a dump of debug info about this promise.  Not for production use.  Requires RTTI.
   // This method does NOT consume the promise as other methods do.
 
+  bool isConsumed() const {
+    // Returns true if this instance represents a consumed promise. Primarily useful for asserts.
+    return node == nullptr;
+  }
+
 private:
   Promise(bool, Own<_::PromiseNode>&& node): PromiseBase(kj::mv(node)) {}
   // Second parameter prevent ambiguity with immediate-value constructor.


### PR DESCRIPTION
Useful as an assert if using a cross-thread promise fulfiller pair if we want to enforce that we only take the promise once.