### PR TITLE
Make sigset safe to use in memcmp

### DIFF
--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -324,6 +324,8 @@ UnixEventPort::UnixEventPort()
   KJ_SYSCALL(fd = epoll_create1(EPOLL_CLOEXEC));
   epollFd = AutoCloseFd(fd);
 
+  memset(&signalFdSigset, 0, sizeof(signalFdSigset));
+
   KJ_SYSCALL(sigemptyset(&signalFdSigset));
   KJ_SYSCALL(fd = signalfd(-1, &signalFdSigset, SFD_NONBLOCK | SFD_CLOEXEC));
   signalFd = AutoCloseFd(fd);
@@ -569,6 +571,7 @@ static siginfo_t toRegularSiginfo(const struct signalfd_siginfo& siginfo) {
 
 bool UnixEventPort::doEpollWait(int timeout) {
   sigset_t newMask;
+  memset(&newMask, 0, sizeof(newMask));
   sigemptyset(&newMask);
 
   {


### PR DESCRIPTION
sigemptyset isn't guaranteed to clear the structure to a level where a
byte-level comparison is safe (e.g. padding, unused fields, etc).
Explicitly 0-initialize the structs before comparison.

This was found by running async-unix-test under valgrind 3.16.1 on Arch
running 5.10.23-1-lts and glibc 2.33. Didn't happen always, but like
80-90% of the time. After this change confirmed that valgrind doesn't
complain about use of uninitialized memory.