### PR TITLE
Fix logging tests, context filename trimming

### DIFF
--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -174,8 +174,19 @@ public:
     this->text += "log message: ";
     text = str(file, ":", line, ":+", contextDepth, ": ", severity, ": ", mv(text));
     this->text.append(text.begin(), text.end());
+    this->text.append("\n");
   }
 };
+
+#define EXPECT_LOG_EQ(f, expText) do { \
+  std::string text; \
+  { \
+    MockExceptionCallback mockCallback; \
+    f(); \
+    text = kj::mv(mockCallback.text); \
+  } \
+  EXPECT_EQ(expText, text); \
+} while(0)
 
 #if KJ_NO_EXCEPTIONS
 #define EXPECT_FATAL(code) if (mockCallback.forkForDeathTest()) { code; abort(); }
@@ -197,47 +208,44 @@ std::string fileLine(std::string file, int line) {
 }
 
 TEST(Debug, Log) {
-  MockExceptionCallback mockCallback;
   int line;
 
-  KJ_LOG(WARNING, "Hello world!"); line = __LINE__;
-  EXPECT_EQ("log message: " + fileLine(__FILE__, line) + ":+0: warning: Hello world!\n",
-            mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    KJ_LOG(WARNING, "Hello world!"); line = __LINE__;
+  }, "log message: " + fileLine(__FILE__, line) + ":+0: warning: Hello world!\n");
 
   int i = 123;
   const char* str = "foo";
 
-  KJ_LOG(ERROR, i, str); line = __LINE__;
-  EXPECT_EQ("log message: " + fileLine(__FILE__, line) + ":+0: error: i = 123; str = foo\n",
-            mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    KJ_LOG(ERROR, i, str); line = __LINE__;
+  }, "log message: " + fileLine(__FILE__, line) + ":+0: error: i = 123; str = foo\n");
 
-  KJ_DBG("Some debug text."); line = __LINE__;
-  EXPECT_EQ("log message: " + fileLine(__FILE__, line) + ":+0: debug: Some debug text.\n",
-            mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    KJ_DBG("Some debug text."); line = __LINE__;
+  }, "log message: " + fileLine(__FILE__, line) + ":+0: debug: Some debug text.\n");
 
   // INFO logging is disabled by default.
-  KJ_LOG(INFO, "Info."); line = __LINE__;
-  EXPECT_EQ("", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    KJ_LOG(INFO, "Info."); line = __LINE__;
+  }, "");
 
   // Enable it.
   Debug::setLogLevel(Debug::Severity::INFO);
-  KJ_LOG(INFO, "Some text."); line = __LINE__;
-  EXPECT_EQ("log message: " + fileLine(__FILE__, line) + ":+0: info: Some text.\n",
-            mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    KJ_LOG(INFO, "Some text."); line = __LINE__;
+  }, "log message: " + fileLine(__FILE__, line) + ":+0: info: Some text.\n");
 
   // Back to default.
   Debug::setLogLevel(Debug::Severity::WARNING);
 
-  KJ_ASSERT(1 == 1);
-  EXPECT_FATAL(KJ_ASSERT(1 == 2)); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) + ": failed: expected "
-            "1 == 2\n", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    KJ_ASSERT(1 == 1);
+  }, "");
+
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_ASSERT(1 == 2)); line = __LINE__;
+  }, "fatal exception: " + fileLine(__FILE__, line) + ": failed: expected 1 == 2 [1 == 2]\n");
 
   KJ_ASSERT(1 == 1) {
     ADD_FAILURE() << "Shouldn't call recovery code when check passes.";
@@ -245,26 +253,31 @@ TEST(Debug, Log) {
   };
 
   bool recovered = false;
-  KJ_ASSERT(1 == 2, "1 is not 2") { recovered = true; break; } line = __LINE__;
-  EXPECT_EQ("recoverable exception: " + fileLine(__FILE__, line) + ": failed: expected "
-            "1 == 2; 1 is not 2\n", mockCallback.text);
+  EXPECT_LOG_EQ([&](){
+    KJ_ASSERT(1 == 2, "1 is not 2") { recovered = true; break; } line = __LINE__;
+  }, (
+    "recoverable exception: " + fileLine(__FILE__, line) + ": "
+    "failed: expected 1 == 2 [1 == 2]; 1 is not 2\n"
+  ));
   EXPECT_TRUE(recovered);
-  mockCallback.text.clear();
 
-  EXPECT_FATAL(KJ_ASSERT(1 == 2, i, "hi", str)); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) + ": failed: expected "
-            "1 == 2; i = 123; hi; str = foo\n", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_ASSERT(1 == 2, i, "hi", str)); line = __LINE__;
+  }, (
+    "fatal exception: " + fileLine(__FILE__, line) + ": "
+        "failed: expected 1 == 2 [1 == 2]; i = 123; hi; str = foo\n"
+  ));
 
-  EXPECT_FATAL(KJ_REQUIRE(1 == 2, i, "hi", str)); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) + ": failed: expected "
-            "1 == 2; i = 123; hi; str = foo\n", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_REQUIRE(1 == 2, i, "hi", str)); line = __LINE__;
+  }, (
+    "fatal exception: " + fileLine(__FILE__, line) + ": "
+        "failed: expected 1 == 2 [1 == 2]; i = 123; hi; str = foo\n"
+  ));
 
-  EXPECT_FATAL(KJ_FAIL_ASSERT("foo")); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) + ": failed: foo\n",
-            mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_FAIL_ASSERT("foo")); line = __LINE__;
+  }, "fatal exception: " + fileLine(__FILE__, line) + ": failed: foo\n");
 }
 
 TEST(Debug, Exception) {
@@ -343,91 +356,110 @@ int mockSyscall(int i, int error = 0) {
 }
 
 TEST(Debug, Syscall) {
-  MockExceptionCallback mockCallback;
   int line;
 
   int i = 123;
   const char* str = "foo";
 
-  KJ_SYSCALL(mockSyscall(0));
-  KJ_SYSCALL(mockSyscall(1));
+  EXPECT_LOG_EQ([&](){
+    KJ_SYSCALL(mockSyscall(0));
+    KJ_SYSCALL(mockSyscall(1));
+  }, "");
 
-  EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, EBADF), i, "bar", str)); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) +
-            ": failed: mockSyscall(-1, EBADF): " + strerror(EBADF) +
-            "; i = 123; bar; str = foo\n", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, EBADF), i, "bar", str)); line = __LINE__;
+  }, (
+    "fatal exception: " + fileLine(__FILE__, line) +
+        ": failed: mockSyscall(-1, EBADF): " + strerror(EBADF) +
+        "; i = 123; bar; str = foo\n"
+  ));
 
-  EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, ECONNRESET), i, "bar", str)); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) +
-            ": disconnected: mockSyscall(-1, ECONNRESET): " + strerror(ECONNRESET) +
-            "; i = 123; bar; str = foo\n", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, ECONNRESET), i, "bar", str)); line = __LINE__;
+  }, (
+    "fatal exception: " + fileLine(__FILE__, line) +
+        ": disconnected: mockSyscall(-1, ECONNRESET): " + strerror(ECONNRESET) +
+        "; i = 123; bar; str = foo\n"
+  ));
 
-  EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, ENOMEM), i, "bar", str)); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) +
-            ": overloaded: mockSyscall(-1, ENOMEM): " + strerror(ENOMEM) +
-            "; i = 123; bar; str = foo\n", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, ENOMEM), i, "bar", str)); line = __LINE__;
+  }, (
+    "fatal exception: " + fileLine(__FILE__, line) +
+        ": overloaded: mockSyscall(-1, ENOMEM): " + strerror(ENOMEM) +
+        "; i = 123; bar; str = foo\n"
+  ));
 
-  EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, ENOSYS), i, "bar", str)); line = __LINE__;
-  EXPECT_EQ("fatal exception: " + fileLine(__FILE__, line) +
-            ": unimplemented: mockSyscall(-1, ENOSYS): " + strerror(ENOSYS) +
-            "; i = 123; bar; str = foo\n", mockCallback.text);
-  mockCallback.text.clear();
+  EXPECT_LOG_EQ([&](){
+    EXPECT_FATAL(KJ_SYSCALL(mockSyscall(-1, ENOSYS), i, "bar", str)); line = __LINE__;
+  }, (
+    "fatal exception: " + fileLine(__FILE__, line) +
+        ": unimplemented: mockSyscall(-1, ENOSYS): " + strerror(ENOSYS) +
+        "; i = 123; bar; str = foo\n"
+  ));
 
   int result = 0;
   bool recovered = false;
-  KJ_SYSCALL(result = mockSyscall(-2, EBADF), i, "bar", str) { recovered = true; break; } line = __LINE__;
-  EXPECT_EQ("recoverable exception: " + fileLine(__FILE__, line) +
-            ": failed: mockSyscall(-2, EBADF): " + strerror(EBADF) +
-            "; i = 123; bar; str = foo\n", mockCallback.text);
+  EXPECT_LOG_EQ([&](){
+    KJ_SYSCALL(result = mockSyscall(-2, EBADF), i, "bar", str) { recovered = true; break; } line = __LINE__;
+  }, (
+    "recoverable exception: " + fileLine(__FILE__, line) +
+        ": failed: mockSyscall(-2, EBADF): " + strerror(EBADF) +
+        "; i = 123; bar; str = foo\n"
+  ));
   EXPECT_EQ(-2, result);
   EXPECT_TRUE(recovered);
 }
 
 TEST(Debug, Context) {
-  MockExceptionCallback mockCallback;
+  int line;
+  int line2;
+  int cline;
+  int cline2;
 
-  {
-    KJ_CONTEXT("foo"); int cline = __LINE__;
+  EXPECT_LOG_EQ([&](){
+    KJ_CONTEXT("foo"); cline = __LINE__;
 
-    KJ_LOG(WARNING, "blah"); int line = __LINE__;
-    EXPECT_EQ("log message: " + fileLine(__FILE__, cline) + ":+0: context: foo\n"
-              "log message: " + fileLine(__FILE__, line) + ":+1: warning: blah\n",
-              mockCallback.text);
-    mockCallback.text.clear();
+    KJ_LOG(WARNING, "blah"); line = __LINE__;
+    EXPECT_FATAL(KJ_FAIL_ASSERT("bar")); line2 = __LINE__;
+  }, (
+    "log message: " + fileLine(__FILE__, cline) + ":+0: info: context: foo\n\n"
+        "log message: " + fileLine(__FILE__, line) + ":+1: warning: blah\n"
+        "fatal exception: " + fileLine(__FILE__, cline) + ": context: foo\n"
+         + fileLine(__FILE__, line2) + ": failed: bar\n"
+  ));
 
-    EXPECT_FATAL(KJ_FAIL_ASSERT("bar")); line = __LINE__;
-    EXPECT_EQ("fatal exception: " + fileLine(__FILE__, cline) + ": context: foo\n"
-              + fileLine(__FILE__, line) + ": failed: bar\n",
-              mockCallback.text);
-    mockCallback.text.clear();
-
+  EXPECT_LOG_EQ([&](){
+    KJ_CONTEXT("foo"); cline = __LINE__;
     {
       int i = 123;
       const char* str = "qux";
-      KJ_CONTEXT("baz", i, "corge", str); int cline2 = __LINE__;
+      KJ_CONTEXT("baz", i, "corge", str); cline2 = __LINE__;
+
       EXPECT_FATAL(KJ_FAIL_ASSERT("bar")); line = __LINE__;
-
-      EXPECT_EQ("fatal exception: " + fileLine(__FILE__, cline) + ": context: foo\n"
-                + fileLine(__FILE__, cline2) + ": context: baz; i = 123; corge; str = qux\n"
-                + fileLine(__FILE__, line) + ": failed: bar\n",
-                mockCallback.text);
-      mockCallback.text.clear();
     }
+  }, (
+    "fatal exception: " + fileLine(__FILE__, cline) + ": context: foo\n"
+        + fileLine(__FILE__, cline2) + ": context: baz; i = 123; corge; str = qux\n"
+        + fileLine(__FILE__, line) + ": failed: bar\n"
+  ));
 
+  EXPECT_LOG_EQ([&](){
+    KJ_CONTEXT("foo"); cline = __LINE__;
     {
-      KJ_CONTEXT("grault"); int cline2 = __LINE__;
-      EXPECT_FATAL(KJ_FAIL_ASSERT("bar")); line = __LINE__;
-
-      EXPECT_EQ("fatal exception: " + fileLine(__FILE__, cline) + ": context: foo\n"
-                + fileLine(__FILE__, cline2) + ": context: grault\n"
-                + fileLine(__FILE__, line) + ": failed: bar\n",
-                mockCallback.text);
-      mockCallback.text.clear();
+      int i = 123;
+      const char* str = "qux";
+      KJ_CONTEXT("baz", i, "corge", str); cline2 = __LINE__;
     }
-  }
+    {
+      KJ_CONTEXT("grault"); cline2 = __LINE__;
+      EXPECT_FATAL(KJ_FAIL_ASSERT("bar")); line = __LINE__;
+    }
+  }, (
+    "fatal exception: " + fileLine(__FILE__, cline) + ": context: foo\n"
+        + fileLine(__FILE__, cline2) + ": context: grault\n"
+        + fileLine(__FILE__, line) + ": failed: bar\n"
+  ));
 }
 
 KJ_TEST("magic assert stringification") {

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -460,7 +460,7 @@ void Debug::Context::logMessage(LogSeverity severity, const char* file, int line
                                 String&& text) {
   if (!logged) {
     Value v = ensureInitialized();
-    next.logMessage(LogSeverity::INFO, v.file, v.line, 0,
+    next.logMessage(LogSeverity::INFO, trimSourceFilename(v.file).cStr(), v.line, 0,
                     str("context: ", mv(v.description), '\n'));
     logged = true;
   }

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -726,7 +726,7 @@ String KJ_STRINGIFY(const Exception& e) {
   for (;;) {
     KJ_IF_MAYBE(c, contextPtr) {
       contextText[contextDepth++] =
-          str(c->file, ":", c->line, ": context: ", c->description, "\n");
+          str(trimSourceFilename(c->file), ":", c->line, ": context: ", c->description, "\n");
       contextPtr = c->next;
     } else {
       break;


### PR DESCRIPTION
It seems that the mechanism for capturing logs in the logging tests also ate
the exceptions that the asserts rely upon, so many of the test assertions had
no effect.