### PR TITLE
Fix OOB array access in compiler.

### DIFF
--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -130,6 +130,11 @@ public:
         // No expansion requested.
         return true;
       }
+      if (oldLgSize == kj::size(holes)) {
+        // Old value is already a full word. Further expansion is impossible.
+        return false;
+      }
+      KJ_ASSERT(oldLgSize < kj::size(holes));
       if (holes[oldLgSize] != oldOffset + 1) {
         // The space immediately after the location is not a hole.
         return false;


### PR DESCRIPTION
The "holes" array tracks the location of padding in the layout of a struct's data section. At any time, there can be at most one hole of each power-of-2 size up to 32 bits: 1-bit, 2-bit, 4-bit, 8-bit, 16-bit, 32-bit. The algorithm never creates more than one hole of any size: a new hole only needs to be created as the result of splitting a larger hole in order to allocate space for a field of the same size or smaller, but if a hole already exists, then the existing hole would just be used.

Hence, we end up with a holes array of size 6.

`HoleSet::tryExpand()` attempts to expand an existing non-hole of a particular size by merging it with holes appearing immediately after it. This can be needed in particular when allocating fields that are part of groups nested within unions -- it's complicated. Long story short, sometimes a caller will say "I have this location in the union with is already a 64-bit value, and I'd like to add another 64-bit value, so let's try to expand the existing 64-bit value into a 128-bit value. Then I can use the second half for the new value. So I need to check if there's a 64-bit hole immediately after the existing 64-bit value." However, there's no such thing as a 64-bit hole, and there's also no need for group allocation to be trying to merge two 64-bit values together like this, because there's no down side to allocating them separately. (Whereas, merging to 32-bit value into a 64-bit value can be useful, because a later union member might simply be a 64-bit value, and then it can overlap the same space as the two-32-bit group.)

In any case, `tryExpand()` gets called with `oldLgSize = 6`. It then tries to access `holes[6]`, which is out-of-bounds. The question it is trying to ask is, "is there a hole of this size that happens to be in the position I want it in?", so it compares the member of the hole array with a specific value. Luckily, the out-of-bounds access is extremely likely to fail this comparison, resulting in the whole algorithm saying "nope, can't expand", which happens to be the right answer. In theory, though, if the space immediately after the holes array happened to contain just the right content, then the comparison could succeed and the expansion could be incorrectly approved.

Luckily, it turns out that if this comparison were to accidentally succeed, the compiler will always hit an assert shortly thereafter. We can therefore conclude that the compiler has never produced incorrect output because of this bug, only failed to produce output at all. Moreover, I have never seen this happen in practice -- even though some schemas, including `test.capnp` and `schema.capnp`(!), actually exercise the OOB access. It makes sense that it's extremely unlikely for the OOB read to produce exactly the value that the code is looking for, particularly as it is never looking for zero.

So, this bug probably never hurt anyone.

The bug was discovered by someone building capnp with Clang's UB sanitizer, reported here: https://github.com/google/oss-fuzz/pull/5202#issuecomment-809222101

It would probably have been discovered by Valgrind if we had been running the compiler itself under Valgrind. However, our release tests don't do this -- they only run all the unit tests under Valgrind.