### PR TITLE
Omit label when logging kj::str(...) expression parameters

### DIFF
--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -221,6 +221,11 @@ TEST(Debug, Log) {
     KJ_LOG(ERROR, i, str); line = __LINE__;
   }, "log message: " + fileLine(__FILE__, line) + ":+0: error: i = 123; str = foo\n");
 
+  // kj::str() expressions are included literally.
+  EXPECT_LOG_EQ([&](){
+    KJ_LOG(ERROR, kj::str(i, str), "x"); line = __LINE__;
+  }, "log message: " + fileLine(__FILE__, line) + ":+0: error: 123foo; x\n");
+
   EXPECT_LOG_EQ([&](){
     KJ_DBG("Some debug text."); line = __LINE__;
   }, "log message: " + fileLine(__FILE__, line) + ":+0: debug: Some debug text.\n");

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -285,6 +285,11 @@ static String makeDescriptionImpl(DescriptionStyle style, const char* code, int 
         break;
     }
 
+    auto needsLabel = [](ArrayPtr<const char> &argName) -> bool {
+      return (argName.size() > 0 && argName[0] != '\"' &&
+          !(argName.size() >= 8 && memcmp(argName.begin(), "kj::str(", 8) == 0));
+    };
+
     for (size_t i = 0; i < argValues.size(); i++) {
       if (argNames[i] == "_kjCondition"_kj) {
         // Special handling: don't output delimiter, we want to append this to the previous item,
@@ -299,7 +304,7 @@ static String makeDescriptionImpl(DescriptionStyle style, const char* code, int 
       if (i > 0 || style != LOG) {
         totalSize += delim.size();
       }
-      if (argNames[i].size() > 0 && argNames[i][0] != '\"') {
+      if (needsLabel(argNames[i])) {
         totalSize += argNames[i].size() + sep.size();
       }
       totalSize += argValues[i].size();
@@ -333,7 +338,7 @@ static String makeDescriptionImpl(DescriptionStyle style, const char* code, int 
       if (i > 0 || style != LOG) {
         pos = _::fill(pos, delim);
       }
-      if (argNames[i].size() > 0 && argNames[i][0] != '\"') {
+      if (needsLabel(argNames[i])) {
         pos = _::fill(pos, argNames[i], sep);
       }
       pos = _::fill(pos, argValues[i]);


### PR DESCRIPTION
Omits the value label when the logged expression starts with `kj::str(`, mimicking the handling of literal strings.  This gives us a way to log dynamic content without including an expression label.

Of course, this is not foolproof... Doing something like `KJ_DBG(kj::str("yes") == "no");` will just log `false`.  But of course, the current handling of literal strings has the same drawback.