### PR TITLE
Fix for VS2017 Builds and CI.

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -45,8 +45,8 @@ jobs:
         os: ['windows-2016', 'windows-latest']
         include:
           - os: windows-2016
-            target: 'Ninja'
-            arch:
+            target: 'Visual Studio 15 2017'
+            arch: -A x64
           - os: windows-latest
             target: 'Visual Studio 16 2019'
             arch: -A x64

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1147,7 +1147,7 @@ void XThreadPaf::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
 }
 
 XThreadPaf::FulfillScope::FulfillScope(XThreadPaf** pointer) {
-  obj = __atomic_exchange_n(pointer, reinterpret_cast<XThreadPaf*>(nullptr), __ATOMIC_ACQUIRE);
+  obj = __atomic_exchange_n(pointer, static_cast<XThreadPaf*>(nullptr), __ATOMIC_ACQUIRE);
   auto oldState = WAITING;
   if (obj == nullptr) {
     // Already fulfilled (possibly by another thread).

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1147,7 +1147,7 @@ void XThreadPaf::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
 }
 
 XThreadPaf::FulfillScope::FulfillScope(XThreadPaf** pointer) {
-  obj = __atomic_exchange_n(pointer, nullptr, __ATOMIC_ACQUIRE);
+  obj = __atomic_exchange_n(pointer, reinterpret_cast<XThreadPaf*>(nullptr), __ATOMIC_ACQUIRE);
   auto oldState = WAITING;
   if (obj == nullptr) {
     // Already fulfilled (possibly by another thread).


### PR DESCRIPTION
Fix for #1209, and also CI issue identified in #1025.

VS2017 apparently doesn't properly coerce from nullptr, and it was difficult to solve this in the __atomic_exchange_n macro since the VS2017 template engine didn't seem capable of template deduction either.