### PR TITLE
Tweak cross-thread promise fulfiller interfaces

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1744,7 +1744,7 @@ public:
 }  // namespace _ (private)
 
 template <typename T>
-PromiseFulfillerPair<T> newCrossThreadPromiseAndFulfiller() {
+PromiseFulfillerPair<T> newPromiseAndCrossThreadFulfiller() {
   kj::Own<_::XThreadPafImpl<T>> node(new _::XThreadPafImpl<T>, _::XThreadPaf::DISPOSER);
   auto fulfiller = kj::heap<_::XThreadFulfiller<T>>(node);
   return { _::PromiseNode::to<_::ReducePromises<T>>(kj::mv(node)), kj::mv(fulfiller) };

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1693,7 +1693,7 @@ private:
 };
 
 template <typename T>
-class XThreadFulfiller final: public PromiseFulfiller<T> {
+class XThreadFulfiller final: public CrossThreadPromiseFulfiller<T> {
 public:
   XThreadFulfiller(XThreadPafImpl<T>* target): target(target) {}
 
@@ -1702,19 +1702,19 @@ public:
       reject(XThreadPaf::unfulfilledException());
     }
   }
-  void fulfill(FixVoid<T>&& value) override {
+  void fulfill(FixVoid<T>&& value) const override {
     XThreadPaf::FulfillScope scope(&target);
     if (scope.shouldFulfill()) {
       scope.getTarget<T>()->result = kj::mv(value);
     }
   }
-  void reject(Exception&& exception) override {
+  void reject(Exception&& exception) const override {
     XThreadPaf::FulfillScope scope(&target);
     if (scope.shouldFulfill()) {
       scope.getTarget<T>()->result.addException(kj::mv(exception));
     }
   }
-  bool isWaiting() override {
+  bool isWaiting() const override {
     KJ_IF_MAYBE(t, target) {
 #if _MSC_VER && !__clang__
       // Just assume 1-byte loads are atomic... on what kind of absurd platform would they not be?
@@ -1728,7 +1728,7 @@ public:
   }
 
 private:
-  XThreadPaf* target;
+  mutable XThreadPaf* target;  // accessed using atomic ops
 };
 
 template <typename T>
@@ -1744,7 +1744,7 @@ public:
 }  // namespace _ (private)
 
 template <typename T>
-PromiseFulfillerPair<T> newPromiseAndCrossThreadFulfiller() {
+PromiseCrossThreadFulfillerPair<T> newPromiseAndCrossThreadFulfiller() {
   kj::Own<_::XThreadPafImpl<T>> node(new _::XThreadPafImpl<T>, _::XThreadPaf::DISPOSER);
   auto fulfiller = kj::heap<_::XThreadFulfiller<T>>(node);
   return { _::PromiseNode::to<_::ReducePromises<T>>(kj::mv(node)), kj::mv(fulfiller) };

--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -889,7 +889,7 @@ KJ_TEST("cross-thread fulfiller") {
   Thread thread([&]() noexcept {
     KJ_XTHREAD_TEST_SETUP_LOOP;
 
-    auto paf = kj::newCrossThreadPromiseAndFulfiller<int>();
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<int>();
     *fulfillerMutex.lockExclusive() = kj::mv(paf.fulfiller);
 
     int result = paf.promise.wait(waitScope);
@@ -916,7 +916,7 @@ KJ_TEST("cross-thread fulfiller rejects") {
   Thread thread([&]() noexcept {
     KJ_XTHREAD_TEST_SETUP_LOOP;
 
-    auto paf = kj::newCrossThreadPromiseAndFulfiller<void>();
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
     *fulfillerMutex.lockExclusive() = kj::mv(paf.fulfiller);
 
     KJ_EXPECT_THROW_MESSAGE("foo exception", paf.promise.wait(waitScope));
@@ -942,7 +942,7 @@ KJ_TEST("cross-thread fulfiller destroyed") {
   Thread thread([&]() noexcept {
     KJ_XTHREAD_TEST_SETUP_LOOP;
 
-    auto paf = kj::newCrossThreadPromiseAndFulfiller<void>();
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
     *fulfillerMutex.lockExclusive() = kj::mv(paf.fulfiller);
 
     KJ_EXPECT_THROW_MESSAGE(
@@ -971,7 +971,7 @@ KJ_TEST("cross-thread fulfiller canceled") {
   Thread thread([&]() noexcept {
     KJ_XTHREAD_TEST_SETUP_LOOP;
 
-    auto paf = kj::newCrossThreadPromiseAndFulfiller<void>();
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
     {
       auto lock = fulfillerMutex.lockExclusive();
       *lock = kj::mv(paf.fulfiller);
@@ -1014,7 +1014,7 @@ KJ_TEST("cross-thread fulfiller multiple fulfills") {
   Thread thread([&]() noexcept {
     KJ_XTHREAD_TEST_SETUP_LOOP;
 
-    auto paf = kj::newCrossThreadPromiseAndFulfiller<int>();
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<int>();
     *fulfillerMutex.lockExclusive() = kj::mv(paf.fulfiller);
 
     int result = paf.promise.wait(waitScope);

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1178,7 +1178,7 @@ XThreadPaf::FulfillScope::~FulfillScope() noexcept(false) {
       }
     } else {
       KJ_LOG(FATAL,
-          "the thread which called kj::newCrossThreadPromiseAndFulfiller<T>() apparently exited "
+          "the thread which called kj::newPromiseAndCrossThreadFulfiller<T>() apparently exited "
           "its own event loop without canceling the cross-thread promise first; this is "
           "undefined behavior so I will crash now");
       abort();

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -611,9 +611,11 @@ PromiseFulfillerPair<T> newPromiseAndFulfiller();
 // `fulfill()` callback, and the promises are chained.
 
 template <typename T>
-PromiseFulfillerPair<T> newCrossThreadPromiseAndFulfiller();
+PromiseFulfillerPair<T> newPromiseAndCrossThreadFulfiller();
 // Like `newPromiseAndFulfiller()`, but the fulfiller is allowed to be invoked from any thread,
-// not just the one that called this method.
+// not just the one that called this method. Note that the Promise is still tied to the calling
+// thread's event loop and *cannot* be used from another thread -- only the PromiseFulfiller is
+// cross-thread.
 
 // =======================================================================================
 // Canceler

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -611,7 +611,49 @@ PromiseFulfillerPair<T> newPromiseAndFulfiller();
 // `fulfill()` callback, and the promises are chained.
 
 template <typename T>
-PromiseFulfillerPair<T> newPromiseAndCrossThreadFulfiller();
+class CrossThreadPromiseFulfiller: public kj::PromiseFulfiller<T> {
+  // Like PromiseFulfiller<T> but the methods are `const`, indicating they can safely be called
+  // from another thread.
+
+public:
+  virtual void fulfill(T&& value) const = 0;
+  virtual void reject(Exception&& exception) const = 0;
+  virtual bool isWaiting() const = 0;
+
+  void fulfill(T&& value) override { return constThis()->fulfill(kj::fwd<T>(value)); }
+  void reject(Exception&& exception) override { return constThis()->reject(kj::mv(exception)); }
+  bool isWaiting() override { return constThis()->isWaiting(); }
+
+private:
+  const CrossThreadPromiseFulfiller* constThis() { return this; }
+};
+
+template <>
+class CrossThreadPromiseFulfiller<void>: public kj::PromiseFulfiller<void> {
+  // Specialization of CrossThreadPromiseFulfiller for void promises.  See
+  // CrossThreadPromiseFulfiller<T>.
+
+public:
+  virtual void fulfill(_::Void&& value = _::Void()) const = 0;
+  virtual void reject(Exception&& exception) const = 0;
+  virtual bool isWaiting() const = 0;
+
+  void fulfill(_::Void&& value) override { return constThis()->fulfill(kj::mv(value)); }
+  void reject(Exception&& exception) override { return constThis()->reject(kj::mv(exception)); }
+  bool isWaiting() override { return constThis()->isWaiting(); }
+
+private:
+  const CrossThreadPromiseFulfiller* constThis() { return this; }
+};
+
+template <typename T>
+struct PromiseCrossThreadFulfillerPair {
+  _::ReducePromises<T> promise;
+  Own<CrossThreadPromiseFulfiller<T>> fulfiller;
+};
+
+template <typename T>
+PromiseCrossThreadFulfillerPair<T> newPromiseAndCrossThreadFulfiller();
 // Like `newPromiseAndFulfiller()`, but the fulfiller is allowed to be invoked from any thread,
 // not just the one that called this method. Note that the Promise is still tied to the calling
 // thread's event loop and *cannot* be used from another thread -- only the PromiseFulfiller is


### PR DESCRIPTION
* Rename newCrossThreadPromiseAndFulfiller -> newPromiseAndCrossThreadFulfiller.

    At least one user of this interface did not realize that it's only the fulfiller that is cross-thread-safe, no the promise. Hopefully this helps.

* Define CrossThreadPromiseFulfiller with a const interface.

    This further helps people understand that the fulfiller is cross-thread but the promise is not. It's also helpful for people who are using cross-thread fulfillers in code that uses `const` for checking thread safety, as KJ style recommends.