### PR TITLE
Add `ForkedPromise::hasBranches()`.

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1126,6 +1126,11 @@ Promise<T> ForkedPromise<T>::addBranch() {
 }
 
 template <typename T>
+bool ForkedPromise<T>::hasBranches() {
+  return hub->isShared();
+}
+
+template <typename T>
 _::SplitTuplePromise<T> Promise<T>::split() {
   return refcounted<_::ForkHub<_::FixVoid<T>>>(kj::mv(node))->split();
 }

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -478,14 +478,23 @@ TEST(Async, Fork) {
 
   auto fork = promise.fork();
 
+  KJ_ASSERT(!fork.hasBranches());
+  {
+    auto cancelBranch = fork.addBranch();
+    KJ_ASSERT(fork.hasBranches());
+  }
+  KJ_ASSERT(!fork.hasBranches());
+
   auto branch1 = fork.addBranch().then([](int i) {
     EXPECT_EQ(123, i);
     return 456;
   });
+  KJ_ASSERT(fork.hasBranches());
   auto branch2 = fork.addBranch().then([](int i) {
     EXPECT_EQ(123, i);
     return 789;
   });
+  KJ_ASSERT(fork.hasBranches());
 
   {
     auto releaseFork = kj::mv(fork);

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -478,6 +478,11 @@ TEST(Async, Fork) {
 
   auto fork = promise.fork();
 
+#if __GNUC__ && !__clang__ && __GNUC__ >= 7
+// GCC 7 decides the open-brace below is "misleadingly indented" as if it were guarded by the `for`
+// that appears in the implementation of KJ_REQUIRE(). Shut up shut up shut up.
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#endif
   KJ_ASSERT(!fork.hasBranches());
   {
     auto cancelBranch = fork.addBranch();

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -332,6 +332,9 @@ public:
   Promise<T> addBranch();
   // Add a new branch to the fork.  The branch is equivalent to the original promise.
 
+  bool hasBranches();
+  // Returns true if there are any branches that haven't been canceled.
+
 private:
   Own<_::ForkHub<_::FixVoid<T>>> hub;
 


### PR DESCRIPTION
I ended up not needing this, but figured I'd merge the code anyway in case it's useful in the future.