### PR TITLE
Add pkgconfig/capnp-websocket.pc.in

### DIFF
--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -120,6 +120,7 @@ AC_DEFUN([CAPNP_PKG_CONFIG_FILES], [ \
   pkgconfig/capnpc.pc \
   pkgconfig/capnp-rpc.pc \
   pkgconfig/capnp-json.pc \
+  pkgconfig/capnp-websocket.pc \
   pkgconfig/kj.pc \
   pkgconfig/kj-async.pc \
   pkgconfig/kj-http.pc \

--- a/c++/pkgconfig/capnp-websocket.pc.in
+++ b/c++/pkgconfig/capnp-websocket.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Cap'n Proto WebSocket RPC
+Description: WebSocket MessageStream for Cap'n Proto
+Version: @VERSION@
+Libs: -L${libdir} -lcapnp-websocket
+Requires: capnp = @VERSION@ capnp-rpc = @VERSION@ kj = @VERSION@ kj-async = @VERSION@ kj-http = @VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
I didn't test the new capnp-websocket.pc.in, just copied and modified capnp-json.pc.in. Note that the CMake build enumerates over all its targets to find .pc.in files, meaning adding a target without a corresponding .pc.in file breaks the CMake build, which is how I noticed.