### PR TITLE
Fix build error in websocket-rpc.c++.

### DIFF
--- a/c++/src/capnp/compat/websocket-rpc.c++
+++ b/c++/src/capnp/compat/websocket-rpc.c++
@@ -99,7 +99,7 @@ kj::Promise<void> WebSocketMessageStream::writeMessages(
     return kj::READY_NOW;
   }
   return writeMessage(nullptr, messages[0])
-      .then([this, messages = messages.slice(1, messages.size())]() -> kj::Promise<void> {
+      .then([this, messages = messages.slice(1, messages.size())]() mutable -> kj::Promise<void> {
     return writeMessages(messages);
   });
 }


### PR DESCRIPTION
The error is:

    websocket-rpc.c++:103:26: error: no matching constructor for initialization of 'kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>>'

Bizarrely, the error only seems to manifest with certain compiler flags. It happens in our (CF Workers) debug build, but not our release build. And it didn't happen in Cap'n Proto's own CI.

/cc @zenhack 