### PR TITLE
Add a getFd() method to AsyncIoStream

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -268,6 +268,10 @@ public:
     *length = socklen;
   }
 
+  kj::Maybe<int> getFd() const override {
+    return fd;
+  }
+
   Promise<void> waitConnected() {
     // Wait until initial connection has completed. This actually just waits until it is writable.
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -503,7 +503,7 @@ private:
         KJ_SWITCH_ONEOF(capBuffer) {
           KJ_CASE_ONEOF(fds, ArrayPtr<const int>) {
             if (fds.size() > 0 && maxStreams > 0) {
-              // TODO(someday): Maybe AsyncIoStream should have a `Maybe<int> getFd()` method?
+              // TODO(someday): Use AsyncIoStream's `Maybe<int> getFd()` method?
               KJ_FAIL_REQUIRE(
                   "async pipe message was written with FDs attached, but corresponding read "
                   "asked for streams, and we don't know how to convert here");
@@ -969,7 +969,7 @@ private:
           }
           KJ_CASE_ONEOF(streamBuffer, ArrayPtr<Own<AsyncCapabilityStream>>) {
             if (streamBuffer.size() > 0 && fds.size() > 0) {
-              // TODO(someday): Maybe AsyncIoStream should have a `Maybe<int> getFd()` method?
+              // TODO(someday): Use AsyncIoStream's `Maybe<int> getFd()` method?
               KJ_FAIL_REQUIRE(
                   "async pipe message was written with FDs attached, but corresponding read "
                   "asked for streams, and we don't know how to convert here");
@@ -2405,6 +2405,14 @@ public:
       tasks.add(promise.addBranch().then([this]() {
         return KJ_ASSERT_NONNULL(stream)->abortRead();
       }));
+    }
+  }
+
+  kj::Maybe<int> getFd() const override {
+    KJ_IF_MAYBE(s, stream) {
+      return s->get()->getFd();
+    } else {
+      return nullptr;
     }
   }
 

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -146,6 +146,10 @@ public:
   // Note that we don't provide methods that return NetworkAddress because it usually wouldn't
   // be useful. You can't connect() to or listen() on these addresses, obviously, because they are
   // ephemeral addresses for a single connection.
+
+  virtual kj::Maybe<int> getFd() const { return nullptr; }
+  // Get the underlying Unix file descriptor, if any. Returns nullptr if this object actually
+  // isn't wrapping a file descriptor.
 };
 
 class AsyncCapabilityStream: public AsyncIoStream {

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -227,6 +227,10 @@ public:
     inner.getpeername(addr, length);
   }
 
+  kj::Maybe<int> getFd() const override {
+    return inner.getFd();
+  }
+
 private:
   SSL* ssl;
   kj::AsyncIoStream& inner;


### PR DESCRIPTION
To enable users of IO streams that correspond to underlying sockets to
use the sockets directly for special cases.

I didn't bother providing an implemention that returns non-null on
AsyncPipe or any of its variants, but let me know if you think I should.

I also didn't add a similar method to ConnectionReceiver and its
child classes given I don't have any particular need for it, although
you could easily put one there as well.