### PR TITLE
Mutex tracking

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -25,6 +25,23 @@ jobs:
       - name: super-test
         run: |
             ./super-test.sh quick ${{ matrix.compiler }}
+  Linux-lock-tracking:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [clang-9]
+        features: ["-DKJ_TRACK_LOCK_BLOCKING=1 -DKJ_SAVE_ACQUIRED_LOCK_INFO=1"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get install -y build-essential git zlib1g-dev cmake libssl-dev ${{ matrix.compiler }}
+      - name: super-test
+        run: |
+            # librt is used for timer_create in the unit tests for lock tracking (mutex-test.c++).
+            ./super-test.sh quick ${{ matrix.compiler }} cpp-features "${{matrix.features}}" extra-libs "-lrt"
   MacOS:
     runs-on: macos-latest
     strategy:

--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -162,6 +162,7 @@ includekj_HEADERS =                                            \
   src/kj/one-of.h                                              \
   src/kj/function.h                                            \
   src/kj/mutex.h                                               \
+  src/kj/source-location.h                                     \
   src/kj/thread.h                                              \
   src/kj/threadlocal.h                                         \
   src/kj/filesystem.h                                          \
@@ -269,6 +270,7 @@ libkj_la_SOURCES=                                              \
   src/kj/list.c++                                              \
   src/kj/string.c++                                            \
   src/kj/string-tree.c++                                       \
+  src/kj/source-location.c++                                   \
   src/kj/hash.c++                                              \
   src/kj/table.c++                                             \
   src/kj/encoding.c++                                          \

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -11,6 +11,7 @@ set(kj_sources_lite
   memory.c++
   mutex.c++
   string.c++
+  source-location.c++
   hash.c++
   table.c++
   thread.c++
@@ -45,6 +46,7 @@ set(kj_headers
   vector.h
   string.h
   string-tree.h
+  source-location.h
   hash.h
   table.h
   map.h

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -214,6 +214,28 @@ typedef unsigned char byte;
 #define KJ_UNUSED_MEMBER
 #endif
 
+#if __cplusplus > 201703L || (__clang__  && __clang_major__ >= 9 && __cplusplus >= 201103L)
+// Technically this was only added to C++20 but Clang allows it for >= C++11 and spelunking the
+// attributes manual indicates it first came in with Clang 9.
+#define KJ_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define KJ_NO_UNIQUE_ADDRESS
+#endif
+
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define KJ_SANITIZE_THREAD 1
+#endif
+#elif __SANITIZE_THREAD__
+#define KJ_SANITIZE_THREAD 1
+#endif
+
+#if KJ_SANITIZE_THREAD
+#define KJ_DISABLE_TSAN __attribute__((no_sanitize("thread"), noinline))
+#else
+#define KJ_DISABLE_TSAN
+#endif
+
 #if __clang__
 #define KJ_DEPRECATED(reason) \
     __attribute__((deprecated(reason)))

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -857,20 +857,21 @@ KJ_TEST("tracking blocked on Once::init") {
 KJ_TEST("get location of exclusive mutex") {
   _::Mutex mutex;
   static constexpr auto lockLine = __LINE__ + 1;
-  mutex.lock(_::Mutex::EXCLUSIVE, nullptr, SourceLocation::current());
+  mutex.lock(_::Mutex::EXCLUSIVE, nullptr, SourceLocation{});
   KJ_DEFER(mutex.unlock(_::Mutex::EXCLUSIVE));
 
   const auto& lockedInfo = mutex.lockedInfo();
   const auto& lockInfo = lockedInfo.get<_::HoldingExclusively>();
   EXPECT_EQ(gettid(), lockInfo.threadHoldingLock());
-  KJ_EXPECT(kj::StringPtr{lockInfo.lockAcquiredAt().fileName}.endsWith("/mutex-test.c++"));
+  KJ_EXPECT(kj::StringPtr{lockInfo.lockAcquiredAt().fileName}.endsWith("/mutex-test.c++"),
+      lockInfo.lockAcquiredAt().fileName);
   EXPECT_EQ(lockInfo.lockAcquiredAt().lineNumber, lockLine);
 }
 
 KJ_TEST("get location of shared mutex") {
   _::Mutex mutex;
   static constexpr auto lockLine = __LINE__ + 1;
-  mutex.lock(_::Mutex::SHARED, nullptr, SourceLocation::current());
+  mutex.lock(_::Mutex::SHARED, nullptr, SourceLocation{});
   KJ_DEFER(mutex.unlock(_::Mutex::SHARED));
 
   const auto& lockedInfo = mutex.lockedInfo();

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -42,6 +42,13 @@
 #include <unistd.h>
 #endif
 
+#if KJ_TRACK_LOCK_BLOCKING
+#include <syscall.h>
+#include <signal.h>
+#include <time.h>
+#include <atomic>
+#endif
+
 namespace kj {
 namespace {
 
@@ -625,6 +632,227 @@ KJ_TEST("condvar wait with flapping predicate") {
     });
   }
 }
+
+#if KJ_TRACK_LOCK_BLOCKING
+#if !__GLIBC_PREREQ(2, 30)
+#ifndef SYS_gettid
+#error SYS_gettid is unavailable on this system
+#endif
+
+#define gettid() ((pid_t)syscall(SYS_gettid))
+#endif
+
+KJ_TEST("tracking blocking on mutex acquisition") {
+  // SIGEV_THREAD is supposed to be "private" to the pthreads implementation, but, as
+  // usual, the higher-level POSIX API that we're supposed to use sucks: the "handler" runs on
+  // some other thread, which means the stack trace it prints won't be useful.
+  //
+  // So, we cheat and work around libc.
+  MutexGuarded<int> foo(5);
+  auto lock = foo.lockExclusive();
+
+  struct BlockDetected {
+    volatile bool blockedOnMutexAcquisition;
+    SourceLocation blockLocation;
+  } blockingInfo = {};
+
+  struct sigaction handler;
+  memset(&handler, 0, sizeof(handler));
+  handler.sa_sigaction = [](int, siginfo_t* info, void*) {
+    auto& blockage = *reinterpret_cast<BlockDetected *>(info->si_value.sival_ptr);
+    KJ_IF_MAYBE(r, blockedReason()) {
+      KJ_SWITCH_ONEOF(*r) {
+        KJ_CASE_ONEOF(b, BlockedOnMutexAcquisition) {
+          blockage.blockedOnMutexAcquisition = true;
+          blockage.blockLocation = b.origin;
+        }
+        KJ_CASE_ONEOF_DEFAULT {}
+      }
+    }
+  };
+  handler.sa_flags = SA_SIGINFO | SA_RESTART;
+
+  sigaction(SIGINT, &handler, nullptr);
+
+  timer_t timer;
+  struct sigevent event;
+  memset(&event, 0, sizeof(event));
+  event.sigev_notify = SIGEV_THREAD_ID;
+  event.sigev_signo = SIGINT;
+  event.sigev_value.sival_ptr = &blockingInfo;
+  KJ_SYSCALL(event._sigev_un._tid = gettid());
+  KJ_SYSCALL(timer_create(CLOCK_MONOTONIC, &event, &timer));
+
+  kj::Duration timeout = 50 * MILLISECONDS;
+  struct itimerspec spec;
+  memset(&spec, 0, sizeof(spec));
+  spec.it_value.tv_sec = timeout / kj::SECONDS;
+  spec.it_value.tv_nsec = timeout % kj::SECONDS / kj::NANOSECONDS;
+  // We can't use KJ_SYSCALL() because it is not async-signal-safe.
+  KJ_REQUIRE(-1 != timer_settime(timer, 0, &spec, nullptr));
+
+  static constexpr int blockedLine = __LINE__ + 1;
+  KJ_REQUIRE(foo.lockSharedWithTimeout(100 * MILLISECONDS) == nullptr);
+
+  KJ_EXPECT(blockingInfo.blockedOnMutexAcquisition);
+  KJ_EXPECT(kj::StringPtr{blockingInfo.blockLocation.fileName}.endsWith("/mutex-test.c++"),
+      blockingInfo.blockLocation.fileName);
+  EXPECT_EQ(blockingInfo.blockLocation.lineNumber, blockedLine);
+}
+
+KJ_TEST("tracking blocked on CondVar::wait") {
+  // SIGEV_THREAD is supposed to be "private" to the pthreads implementation, but, as
+  // usual, the higher-level POSIX API that we're supposed to use sucks: the "handler" runs on
+  // some other thread, which means the stack trace it prints won't be useful.
+  //
+  // So, we cheat and work around libc.
+  MutexGuarded<int> foo(5);
+  auto lock = foo.lockExclusive();
+
+  struct BlockDetected {
+    volatile bool blockedOnCondVar;
+    SourceLocation blockLocation;
+  } blockingInfo = {};
+
+  struct sigaction handler;
+  memset(&handler, 0, sizeof(handler));
+  handler.sa_sigaction = [](int, siginfo_t* info, void*) {
+    auto& blockage = *reinterpret_cast<BlockDetected *>(info->si_value.sival_ptr);
+    KJ_IF_MAYBE(r, blockedReason()) {
+      KJ_SWITCH_ONEOF(*r) {
+        KJ_CASE_ONEOF(b, BlockedOnCondVarWait) {
+          blockage.blockedOnCondVar = true;
+          blockage.blockLocation = b.origin;
+        }
+        KJ_CASE_ONEOF_DEFAULT {}
+      }
+    }
+  };
+  handler.sa_flags = SA_SIGINFO | SA_RESTART;
+
+  sigaction(SIGINT, &handler, nullptr);
+
+  timer_t timer;
+  struct sigevent event;
+  memset(&event, 0, sizeof(event));
+  event.sigev_notify = SIGEV_THREAD_ID;
+  event.sigev_signo = SIGINT;
+  event.sigev_value.sival_ptr = &blockingInfo;
+  KJ_SYSCALL(event._sigev_un._tid = gettid());
+  KJ_SYSCALL(timer_create(CLOCK_MONOTONIC, &event, &timer));
+
+  kj::Duration timeout = 50 * MILLISECONDS;
+  struct itimerspec spec;
+  memset(&spec, 0, sizeof(spec));
+  spec.it_value.tv_sec = timeout / kj::SECONDS;
+  spec.it_value.tv_nsec = timeout % kj::SECONDS / kj::NANOSECONDS;
+  // We can't use KJ_SYSCALL() because it is not async-signal-safe.
+  KJ_REQUIRE(-1 != timer_settime(timer, 0, &spec, nullptr));
+
+  static constexpr int blockedLine = __LINE__ + 1;
+  lock.wait([](const int& value) {
+    return false;
+  }, 100 * MILLISECONDS);
+
+  KJ_EXPECT(blockingInfo.blockedOnCondVar);
+  KJ_EXPECT(kj::StringPtr{blockingInfo.blockLocation.fileName}.endsWith("/mutex-test.c++"),
+      blockingInfo.blockLocation.fileName);
+
+#if __clang__
+  static constexpr int lineCorrection = 0;
+#else
+  static constexpr int lineCorrection = 2;
+  // GCC apparently captures the caller's line number as the line number of the argument location
+  // rather than the start of the expression like clang does, so in this case we have to adjust an
+  // extra 2 lines to account for the lambda body (since the location is captured as the last arg).
+#endif
+
+  EXPECT_EQ(blockingInfo.blockLocation.lineNumber, blockedLine + lineCorrection);
+}
+
+KJ_TEST("tracking blocked on Once::init") {
+  // SIGEV_THREAD is supposed to be "private" to the pthreads implementation, but, as
+  // usual, the higher-level POSIX API that we're supposed to use sucks: the "handler" runs on
+  // some other thread, which means the stack trace it prints won't be useful.
+  //
+  // So, we cheat and work around libc.
+  struct BlockDetected {
+    volatile bool blockedOnOnceInit;
+    SourceLocation blockLocation;
+  } blockingInfo = {};
+
+  struct sigaction handler;
+  memset(&handler, 0, sizeof(handler));
+  handler.sa_sigaction = [](int, siginfo_t* info, void*) {
+    auto& blockage = *reinterpret_cast<BlockDetected *>(info->si_value.sival_ptr);
+    KJ_IF_MAYBE(r, blockedReason()) {
+      KJ_SWITCH_ONEOF(*r) {
+        KJ_CASE_ONEOF(b, BlockedOnOnceInit) {
+          blockage.blockedOnOnceInit = true;
+          blockage.blockLocation = b.origin;
+        }
+        KJ_CASE_ONEOF_DEFAULT {}
+      }
+    }
+  };
+  handler.sa_flags = SA_SIGINFO | SA_RESTART;
+
+  sigaction(SIGINT, &handler, nullptr);
+
+  timer_t timer;
+  struct sigevent event;
+  memset(&event, 0, sizeof(event));
+  event.sigev_notify = SIGEV_THREAD_ID;
+  event.sigev_signo = SIGINT;
+  event.sigev_value.sival_ptr = &blockingInfo;
+  KJ_SYSCALL(event._sigev_un._tid = gettid());
+  KJ_SYSCALL(timer_create(CLOCK_MONOTONIC, &event, &timer));
+
+  Lazy<int> once;
+  MutexGuarded<bool> onceInitializing(false);
+
+  Thread backgroundInit([&] {
+    once.get([&](SpaceFor<int>& x) {
+      *onceInitializing.lockExclusive() = true;
+      usleep(100 * 1000);  // 100 ms
+      return x.construct(5);
+    });
+  });
+
+  kj::Duration timeout = 50 * MILLISECONDS;
+  struct itimerspec spec;
+  memset(&spec, 0, sizeof(spec));
+  spec.it_value.tv_sec = timeout / kj::SECONDS;
+  spec.it_value.tv_nsec = timeout % kj::SECONDS / kj::NANOSECONDS;
+  // We can't use KJ_SYSCALL() because it is not async-signal-safe.
+  KJ_REQUIRE(-1 != timer_settime(timer, 0, &spec, nullptr));
+
+  onceInitializing.lockExclusive().wait([](const bool& initializing) {
+    return initializing;
+  });
+
+  static constexpr int blockedLine = __LINE__ + 1;
+  once.get([](SpaceFor<int>& x) {
+      return x.construct(5);
+  });
+
+  KJ_EXPECT(blockingInfo.blockedOnOnceInit);
+  KJ_EXPECT(kj::StringPtr{blockingInfo.blockLocation.fileName}.endsWith("/mutex-test.c++"),
+      blockingInfo.blockLocation.fileName);
+
+#if __clang__
+  static constexpr int lineCorrection = 0;
+#else
+  static constexpr int lineCorrection = 2;
+  // GCC apparently captures the caller's line number as the line number of the argument location
+  // rather than the start of the expression like clang does, so in this case we have to adjust an
+  // extra 2 lines to account for the lambda body (since the location is captured as the last arg).
+#endif
+
+
+  EXPECT_EQ(blockingInfo.blockLocation.lineNumber, blockedLine + lineCorrection);
+}
+#endif
 
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -911,7 +911,7 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
   // currently.
   bool currentlyLocked = true;
   KJ_DEFER({
-    if (!currentlyLocked) lock(EXCLUSIVE, nullptr, NoopSourceLocation::current());
+    if (!currentlyLocked) lock(EXCLUSIVE, nullptr, NoopSourceLocation{});
     removeWaiter(waiter);
 
     // Destroy pthread objects.
@@ -979,7 +979,7 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
     // because we've already been signaled.
     KJ_PTHREAD_CALL(pthread_mutex_unlock(&waiter.stupidMutex));
 
-    lock(EXCLUSIVE, nullptr, NoopSourceLocation::current());
+    lock(EXCLUSIVE, nullptr, NoopSourceLocation{});
     currentlyLocked = true;
 
     KJ_IF_MAYBE(exception, waiter.exception) {

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -356,7 +356,7 @@ public:
 
   template <typename Cond>
   void wait(Cond&& condition, Maybe<Duration> timeout = nullptr,
-      LockSourceLocationArg location = LockSourceLocation::current()) {
+      LockSourceLocationArg location = {}) {
     // Unlocks the lock until `condition(state)` evaluates true (where `state` is type `const T&`
     // referencing the object protected by the lock).
 
@@ -419,7 +419,7 @@ public:
   explicit MutexGuarded(Params&&... params);
   // Initialize the mutex-bounded object by passing the given parameters to its constructor.
 
-  Locked<T> lockExclusive(LockSourceLocationArg location = LockSourceLocation::current()) const;
+  Locked<T> lockExclusive(LockSourceLocationArg location = {}) const;
   // Exclusively locks the object and returns it.  The returned `Locked<T>` can be passed by
   // move, similar to `Own<T>`.
   //
@@ -429,17 +429,17 @@ public:
   // be shared between threads, its methods should be const, even though locking it produces a
   // non-const pointer to the contained object.
 
-  Locked<const T> lockShared(LockSourceLocationArg location = LockSourceLocation::current()) const;
+  Locked<const T> lockShared(LockSourceLocationArg location = {}) const;
   // Lock the value for shared access.  Multiple shared locks can be taken concurrently, but cannot
   // be held at the same time as a non-shared lock.
 
   Maybe<Locked<T>> lockExclusiveWithTimeout(Duration timeout,
-      LockSourceLocationArg location = LockSourceLocation::current()) const;
+      LockSourceLocationArg location = {}) const;
   // Attempts to exclusively lock the object. If the timeout elapses before the lock is aquired,
   // this returns null.
 
   Maybe<Locked<const T>> lockSharedWithTimeout(Duration timeout,
-      LockSourceLocationArg location = LockSourceLocation::current()) const;
+      LockSourceLocationArg location = {}) const;
   // Attempts to lock the value for shared access. If the timeout elapses before the lock is aquired,
   // this returns null.
 
@@ -455,7 +455,7 @@ public:
 
   template <typename Cond, typename Func>
   auto when(Cond&& condition, Func&& callback, Maybe<Duration> timeout = nullptr,
-      LockSourceLocationArg location = LockSourceLocation::current()) const
+      LockSourceLocationArg location = {}) const
       -> decltype(callback(instance<T&>())) {
     // Waits until condition(state) returns true, then calls callback(state) under lock.
     //
@@ -516,7 +516,7 @@ class ExternalMutexGuarded {
   // is compiled out. Once the minimum C++ standard for the KJ library is C++20, this optimization
   // could be replaced by a member variable with a [[no_unique_address]] annotation.
 public:
-  ExternalMutexGuarded(LockSourceLocationArg location = LockSourceLocation::current())
+  ExternalMutexGuarded(LockSourceLocationArg location = {})
       : location(location) {}
 
   ~ExternalMutexGuarded() noexcept(false) {
@@ -580,9 +580,9 @@ class Lazy {
 
 public:
   template <typename Func>
-  T& get(Func&& init, LockSourceLocationArg location = LockSourceLocation::current());
+  T& get(Func&& init, LockSourceLocationArg location = {});
   template <typename Func>
-  const T& get(Func&& init, LockSourceLocationArg location = LockSourceLocation::current()) const;
+  const T& get(Func&& init, LockSourceLocationArg location = {}) const;
   // The first thread to call get() will invoke the given init function to construct the value.
   // Other threads will block until construction completes, then return the same value.
   //

--- a/c++/src/kj/source-location.c++
+++ b/c++/src/kj/source-location.c++
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if __cplusplus > 201703L
+
+#include "source-location.h"
+
+namespace kj {
+kj::String KJ_STRINGIFY(const SourceLocation& l) {
+  return kj::str(l.fileName, ":", l.lineNumber, ":", l.columnNumber, " in ", l.function);
+}
+}  // namespace kj
+
+#endif

--- a/c++/src/kj/source-location.h
+++ b/c++/src/kj/source-location.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "string.h"
+
+#if __clang__ && __clang_major__ >= 9
+#define KJ_CALLER_COLUMN() __builtin_COLUMN()
+// GCC does not implement __builtin_COLUMN() as that's non-standard but MSVC & clang do.
+// MSVC does as of version https://github.com/microsoft/STL/issues/54) but there's currently not any
+// pressing need for this for MSVC & writing the write compiler version check is annoying.
+#else
+#define KJ_CALLER_COLUMN() 0
+#endif
+
+#if __cplusplus > 201703L
+#define KJ_COMPILER_SUPPORTS_SOURCE_LOCATION 1
+#elif __clang__ && __clang_major__ >= 9
+// Clang 9 added these builtins: https://releases.llvm.org/9.0.0/tools/clang/docs/LanguageExtensions.html
+#define KJ_COMPILER_SUPPORTS_SOURCE_LOCATION 1
+#elif __GNUC__ >= 5
+// GCC 5 supports the required builtins: https://gcc.gnu.org/onlinedocs/gcc-5.1.0/gcc/Other-Builtins.html
+#define KJ_COMPILER_SUPPORTS_SOURCE_LOCATION 1
+#endif
+
+namespace kj {
+class SourceLocation {
+  // libc++ doesn't seem to implement <source_location> (or even <experimental/source_location>), so
+  // this is a non-STL wrapper over the compiler primitives (these are the same across MSVC/clang/
+  // gcc). Additionally this uses kj::StringPtr for holding the strings instead of const char* which
+  // makes it integrate a little more nicely into KJ.
+public:
+#if KJ_COMPILER_SUPPORTS_SOURCE_LOCATION
+  static constexpr SourceLocation current(
+      const char* file = __builtin_FILE(), const char* function = __builtin_FUNCTION(),
+      uint line = __builtin_LINE(), uint column = KJ_CALLER_COLUMN()) {
+    // When invoked with no arguments returns a SourceLocation that points at the caller of the
+    // function.
+    return SourceLocation(file, function, line, column);
+  }
+#endif
+
+  constexpr SourceLocation() : SourceLocation("??", "??", 0, 0) {}
+  // Constructs a dummy source location that's not pointing at anything.
+
+  const char* fileName;
+  const char* function;
+  uint lineNumber;
+  uint columnNumber;
+
+private:
+  constexpr SourceLocation(const char* file, const char* func, uint line, uint column)
+    : fileName(file), function(func), lineNumber(line), columnNumber(column)
+  {}
+};
+
+kj::String KJ_STRINGIFY(const SourceLocation& l);
+
+class NoopSourceLocation {
+  // This is used in places where we want to conditionally compile out tracking the source location.
+  // As such it intentionally lacks all the features but the static `::current()` function so that
+  // the API isn't accidentally used in the wrong compilation context.
+public:
+  static constexpr NoopSourceLocation current() {
+    return NoopSourceLocation{};
+  }
+};
+
+KJ_UNUSED static kj::String KJ_STRINGIFY(const NoopSourceLocation& l) {
+  return kj::String();
+}
+}  // namespace kj

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -155,6 +155,7 @@ private:
   ArrayPtr<const char> content;
 
   friend constexpr kj::StringPtr (::operator "" _kj)(const char* str, size_t n);
+  friend class SourceLocation;
 };
 
 #if !__cpp_impl_three_way_comparison

--- a/kjdoc/tour.md
+++ b/kjdoc/tour.md
@@ -532,6 +532,9 @@ This section describes KJ APIs that control process execution and low-level inte
 
 `kj::Lazy<T>` is an instance of `T` that is constructed on first access in a thread-safe way.
 
+Macros `KJ_TRACK_LOCK_BLOCKING` and `KJ_SAVE_ACQUIRED_LOCK_INFO` can be used to enable support utilities to implement deadlock detection & analysis.
+* `KJ_TRACK_LOCK_BLOCKING`: When the current thread is doing a blocking synchronous KJ operation, that operation is available via `kj::blockedReason()` (intention is for this to be invoked from the signal handler running on the thread that's doing the synchronous operation).
+* `KJ_SAVE_ACQUIRED_LOCK_INFO`: When enabled, lock acquisition will save state about the location of the acquired lock. When combined with `KJ_TRACK_LOCK_BLOCKING` this can be particularly helpful because any watchdog can just forward the signal to the thread that's holding the lock.
 ## Asynchronous Event Loop
 
 ### Promises


### PR DESCRIPTION
This adds two tracking operations:

* Async signal safe TLS variables to track when a thread is blocked on a lock primitive.
* Per-mutex contextual information pointing to the locked mutex.

These should be sufficient for deadlock detection with the notable exception that I don't know what to do about shared mutexes. By their very nature, I can only track one random acquisition point. If a shared mutex is part of a deadlock chain, it can't be found. To try to track that data seems cost-prohibitive: needs some kind of array per mutex & maybe hope that lock acquisition/release can be reflected with atomics (otherwise it also implies an acquisition of an exclusive mutex to record the TID holding the shared lock).

I added a `kj::SourceLocation` object when building against c++20 since all compilers support it but not all STL provide `source_location` yet (+ more convenient when everything is a `kj::StringPtr`).

Putting up the PR to get some early feedback on what to do about shared mutexes.