### PR TITLE
Add methods to WebSocket to return bytes sent and received

### DIFF
--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -583,6 +583,9 @@ public:
   // if this WebSocket implementation is able to perform the pump in an optimized way, better than
   // the default implementation of pumpTo(). The default implementation of pumpTo() always tries
   // calling this first, and the default implementation of tryPumpFrom() always returns null.
+
+  virtual uint64_t sentByteCount() = 0;
+  virtual uint64_t receivedByteCount() = 0;
 };
 
 class HttpClient {


### PR DESCRIPTION
~~The functions send(), close(), disconnect(), pumpTo() and tryPumpFrom() are modified to return a promise for the number of bytes sent by the respective operations.~~

~~One possible problem with this approach is that if the promise after bytes, we'll lose the count. I wonder if it might be better to store the bytes sent as some field on the WebSocket object itself.~~

Updated the PR to add new methods to the WebSocket interface for returning the number of bytes sent and received. This is still quite a work in progress. Issues:

1) The accounting in::receive() isn't right. It looks at the payload length in the header, but doesn't work if the sender disconnects before sending the entire payload. This is why the new test is currently failing. I haven't figured out exactly how to count properly here yet.
2) The implementation in WebSocketPipeImpl is not tested, and might still be incomplete. 