### PR TITLE
Fix kj/parse/common.h not compiling in MSVC's C++20 mode

### DIFF
--- a/c++/src/kj/parse/common.h
+++ b/c++/src/kj/parse/common.h
@@ -40,7 +40,12 @@
 #include "../array.h"
 #include "../tuple.h"
 #include "../vector.h"
-#if _MSC_VER && !__clang__
+
+#if _MSC_VER && _MSC_VER < 1920 && !__clang__
+#define KJ_MSVC_BROKEN_DECLTYPE 1
+#endif
+
+#if KJ_MSVC_BROKEN_DECLTYPE
 #include <type_traits>  // result_of_t
 #endif
 
@@ -101,10 +106,9 @@ template <typename T> struct OutputType_;
 template <typename T> struct OutputType_<Maybe<T>> { typedef T Type; };
 template <typename Parser, typename Input>
 using OutputType = typename OutputType_<
-#if _MSC_VER && !__clang__
+#if KJ_MSVC_BROKEN_DECLTYPE
     std::result_of_t<Parser(Input)>
-    // The instance<T&>() based version below results in:
-    //   C2064: term does not evaluate to a function taking 1 arguments
+    // The instance<T&>() based version below results in many compiler errors on MSVC2017.
 #else
     decltype(instance<Parser&>()(instance<Input&>()))
 #endif


### PR DESCRIPTION
"kj/parse/common.h" currently special-cases MSVC to use `std::result_of_t`, but it was removed in C++20. Consequently, if you try compiling with MSVC 2019 in C++20 mode, the build fails because the variable is not found. However, I can't easily test if `result_of_t` was removed, because on MSVC, `__cplusplus` is always `199711L`, and the removal has no corresponding feature flag.

This PR removes the special case for MSVC. The resulting code compiles successfully in the latest MSVC shipping with VS2019, and no longer results in a C2064 error. Testing older MSVC versions on Godbolt, it also successfully compiles on MSVC 19.10 (VS2017, the earliest supported version) and newer. Nonetheless it's possible that that specific older versions of VS2017 not on Godbolt will fail to build.

Fixes #1233. This reverts commit 34031907426f9e8595d764834bb328eada03a6b1.