### PR TITLE
Fix String/StringPtr compilation on MinGW/MSVC C++20

### DIFF
--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -76,7 +76,7 @@ public:
   inline StringPtr(const char* begin, const char* end): StringPtr(begin, end - begin) {}
   inline StringPtr(const String& value);
 
-#if __cplusplus >= 202000L
+#if __cpp_char8_t
   inline StringPtr(const char8_t* value): StringPtr(reinterpret_cast<const char*>(value)) {}
   inline StringPtr(const char8_t* value, size_t size)
       : StringPtr(reinterpret_cast<const char*>(value), size) {}
@@ -152,7 +152,7 @@ private:
   friend constexpr kj::StringPtr (::operator "" _kj)(const char* str, size_t n);
 };
 
-#if __cplusplus < 202000L
+#if !__cpp_impl_three_way_comparison
 inline bool operator==(const char* a, const StringPtr& b) { return b == a; }
 inline bool operator!=(const char* a, const StringPtr& b) { return b != a; }
 #endif
@@ -254,7 +254,7 @@ private:
   Array<char> content;
 };
 
-#if __cplusplus < 202000L
+#if !__cpp_impl_three_way_comparison
 inline bool operator==(const char* a, const String& b) { return b == a; }
 inline bool operator!=(const char* a, const String& b) { return b != a; }
 #endif
@@ -366,7 +366,7 @@ struct Stringifier {
   template<size_t n>
   inline ArrayPtr<const char> operator*(const FixedArray<char, n>& s) const { return s; }
   inline ArrayPtr<const char> operator*(const char* s) const { return arrayPtr(s, strlen(s)); }
-#if __cplusplus >= 202000L
+#if __cpp_char8_t
   inline ArrayPtr<const char> operator*(const char8_t* s) const {
     return operator*(reinterpret_cast<const char*>(s));
   }


### PR DESCRIPTION
When CMake passes MinGW `-std=gnu++2a`, then MinGW GCC defines `__cplusplus` as `201709L` even though C++20 features are active. This causes Cap'n Proto's conditional compilation to think the compiler is in C++17 mode, despite the compiler running in C++20 mode, resulting in build errors (in the case of `char8_t`) or miscompilations and infinite recursion (in the case of `operator==`).

MSVC is even worse, since it unconditionally reports __cplusplus = 199711L, unless you pass in /Zc:__cplusplus in addition to /std:c++xyz ([source](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/)).

This pull request feature-tests C++20 features by name (rather by compiler version) when conditionally compiling code based on those features. This PR fixes "kj/string.h" and makes Cap'n Proto's lite mode and generated headers compile, but I haven't looked at other usages of `__cplusplus` in the rest of kj. (There are no occurrences of `__cplusplus ` in "c++/src/capnp".)

TBH it's probably a good idea to add a `/std:c++latest` MSVC build to CI, to flush out the remaining issues in C++20 mode.

Fixes #1232.