### PR TITLE
Refactor: Move header table building out of HttpOverCapnpFactory's constructor

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.h
+++ b/c++/src/capnp/compat/http-over-capnp.h
@@ -31,15 +31,33 @@ namespace capnp {
 
 class HttpOverCapnpFactory {
 public:
-  HttpOverCapnpFactory(ByteStreamFactory& streamFactory,
-                       kj::HttpHeaderTable::Builder& headerTableBuilder);
+  class HeaderIdBundle {
+  public:
+    HeaderIdBundle(kj::HttpHeaderTable::Builder& builder);
+
+    HeaderIdBundle clone() const;
+
+  private:
+    HeaderIdBundle(const kj::HttpHeaderTable& table, kj::Array<kj::HttpHeaderId> nameCapnpToKj,
+        size_t maxHeaderId);
+    // Constructor for clone().
+
+    const kj::HttpHeaderTable& table;
+
+    kj::Array<kj::HttpHeaderId> nameCapnpToKj;
+    size_t maxHeaderId = 0;
+
+    friend class HttpOverCapnpFactory;
+  };
+
+  HttpOverCapnpFactory(ByteStreamFactory& streamFactory, HeaderIdBundle headerIds);
 
   kj::Own<kj::HttpService> capnpToKj(capnp::HttpService::Client rpcService);
   capnp::HttpService::Client kjToCapnp(kj::Own<kj::HttpService> service);
 
 private:
   ByteStreamFactory& streamFactory;
-  kj::HttpHeaderTable& headerTable;
+  const kj::HttpHeaderTable& headerTable;
   kj::Array<capnp::CommonHeaderName> nameKjToCapnp;
   kj::Array<kj::HttpHeaderId> nameCapnpToKj;
   kj::Array<kj::StringPtr> valueCapnpToKj;

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1041,7 +1041,7 @@ static constexpr size_t MAX_CHUNK_HEADER_SIZE = 32;
 
 class HttpInputStreamImpl final: public HttpInputStream {
 public:
-  explicit HttpInputStreamImpl(AsyncInputStream& inner, HttpHeaderTable& table)
+  explicit HttpInputStreamImpl(AsyncInputStream& inner, const HttpHeaderTable& table)
       : inner(inner), headerBuffer(kj::heapArray<char>(MIN_BUFFER)), headers(table) {
   }
 
@@ -1743,7 +1743,8 @@ kj::Own<kj::AsyncInputStream> HttpInputStreamImpl::getEntityBody(
 
 }  // namespace
 
-kj::Own<HttpInputStream> newHttpInputStream(kj::AsyncInputStream& input, HttpHeaderTable& table) {
+kj::Own<HttpInputStream> newHttpInputStream(
+    kj::AsyncInputStream& input, const HttpHeaderTable& table) {
   return kj::heap<HttpInputStreamImpl>(input, table);
 }
 
@@ -3325,7 +3326,7 @@ namespace {
 class HttpClientImpl final: public HttpClient,
                             private HttpClientErrorHandler {
 public:
-  HttpClientImpl(HttpHeaderTable& responseHeaderTable, kj::Own<kj::AsyncIoStream> rawStream,
+  HttpClientImpl(const HttpHeaderTable& responseHeaderTable, kj::Own<kj::AsyncIoStream> rawStream,
                  HttpClientSettings settings)
       : httpInput(*rawStream, responseHeaderTable),
         httpOutput(*rawStream),
@@ -3617,7 +3618,7 @@ kj::Promise<kj::Own<kj::AsyncIoStream>> HttpClient::connect(kj::StringPtr host) 
 }
 
 kj::Own<HttpClient> newHttpClient(
-    HttpHeaderTable& responseHeaderTable, kj::AsyncIoStream& stream,
+    const HttpHeaderTable& responseHeaderTable, kj::AsyncIoStream& stream,
     HttpClientSettings settings) {
   return kj::heap<HttpClientImpl>(responseHeaderTable,
       kj::Own<kj::AsyncIoStream>(&stream, kj::NullDisposer::instance),
@@ -3644,7 +3645,7 @@ namespace {
 
 class NetworkAddressHttpClient final: public HttpClient {
 public:
-  NetworkAddressHttpClient(kj::Timer& timer, HttpHeaderTable& responseHeaderTable,
+  NetworkAddressHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
                            kj::Own<kj::NetworkAddress> address, HttpClientSettings settings)
       : timer(timer),
         responseHeaderTable(responseHeaderTable),
@@ -3701,7 +3702,7 @@ public:
 
 private:
   kj::Timer& timer;
-  HttpHeaderTable& responseHeaderTable;
+  const HttpHeaderTable& responseHeaderTable;
   kj::Own<kj::NetworkAddress> address;
   HttpClientSettings settings;
 
@@ -3868,7 +3869,7 @@ private:
 
 class NetworkHttpClient final: public HttpClient, private kj::TaskSet::ErrorHandler {
 public:
-  NetworkHttpClient(kj::Timer& timer, HttpHeaderTable& responseHeaderTable,
+  NetworkHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
                     kj::Network& network, kj::Maybe<kj::Network&> tlsNetwork,
                     HttpClientSettings settings)
       : timer(timer),
@@ -3910,7 +3911,7 @@ public:
 
 private:
   kj::Timer& timer;
-  HttpHeaderTable& responseHeaderTable;
+  const HttpHeaderTable& responseHeaderTable;
   kj::Network& network;
   kj::Maybe<kj::Network&> tlsNetwork;
   HttpClientSettings settings;
@@ -4000,13 +4001,13 @@ private:
 
 }  // namespace
 
-kj::Own<HttpClient> newHttpClient(kj::Timer& timer, HttpHeaderTable& responseHeaderTable,
+kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
                                   kj::NetworkAddress& addr, HttpClientSettings settings) {
   return kj::heap<NetworkAddressHttpClient>(timer, responseHeaderTable,
       kj::Own<kj::NetworkAddress>(&addr, kj::NullDisposer::instance), kj::mv(settings));
 }
 
-kj::Own<HttpClient> newHttpClient(kj::Timer& timer, HttpHeaderTable& responseHeaderTable,
+kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
                                   kj::Network& network, kj::Maybe<kj::Network&> tlsNetwork,
                                   HttpClientSettings settings) {
   return kj::heap<NetworkHttpClient>(
@@ -5133,17 +5134,17 @@ private:
   }
 };
 
-HttpServer::HttpServer(kj::Timer& timer, HttpHeaderTable& requestHeaderTable, HttpService& service,
-                       Settings settings)
+HttpServer::HttpServer(kj::Timer& timer, const HttpHeaderTable& requestHeaderTable,
+                       HttpService& service, Settings settings)
     : HttpServer(timer, requestHeaderTable, &service, settings,
                  kj::newPromiseAndFulfiller<void>()) {}
 
-HttpServer::HttpServer(kj::Timer& timer, HttpHeaderTable& requestHeaderTable,
+HttpServer::HttpServer(kj::Timer& timer, const HttpHeaderTable& requestHeaderTable,
                        HttpServiceFactory serviceFactory, Settings settings)
     : HttpServer(timer, requestHeaderTable, kj::mv(serviceFactory), settings,
                  kj::newPromiseAndFulfiller<void>()) {}
 
-HttpServer::HttpServer(kj::Timer& timer, HttpHeaderTable& requestHeaderTable,
+HttpServer::HttpServer(kj::Timer& timer, const HttpHeaderTable& requestHeaderTable,
                        kj::OneOf<HttpService*, HttpServiceFactory> service,
                        Settings settings, kj::PromiseFulfillerPair<void> paf)
     : timer(timer), requestHeaderTable(requestHeaderTable), service(kj::mv(service)),

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -737,7 +737,7 @@ struct HttpClientSettings {
   // default implementation will be used.
 };
 
-kj::Own<HttpClient> newHttpClient(kj::Timer& timer, HttpHeaderTable& responseHeaderTable,
+kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
                                   kj::Network& network, kj::Maybe<kj::Network&> tlsNetwork,
                                   HttpClientSettings settings = HttpClientSettings());
 // Creates a proxy HttpClient that connects to hosts over the given network. The URL must always
@@ -753,7 +753,7 @@ kj::Own<HttpClient> newHttpClient(kj::Timer& timer, HttpHeaderTable& responseHea
 // `tlsNetwork` is required to support HTTPS destination URLs. If null, only HTTP URLs can be
 // fetched.
 
-kj::Own<HttpClient> newHttpClient(kj::Timer& timer, HttpHeaderTable& responseHeaderTable,
+kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
                                   kj::NetworkAddress& addr,
                                   HttpClientSettings settings = HttpClientSettings());
 // Creates an HttpClient that always connects to the given address no matter what URL is requested.
@@ -767,7 +767,8 @@ kj::Own<HttpClient> newHttpClient(kj::Timer& timer, HttpHeaderTable& responseHea
 //
 // `responseHeaderTable` is used when parsing HTTP responses. Requests can use any header table.
 
-kj::Own<HttpClient> newHttpClient(HttpHeaderTable& responseHeaderTable, kj::AsyncIoStream& stream,
+kj::Own<HttpClient> newHttpClient(const HttpHeaderTable& responseHeaderTable,
+                                  kj::AsyncIoStream& stream,
                                   HttpClientSettings settings = HttpClientSettings());
 // Creates an HttpClient that speaks over the given pre-established connection. The client may
 // be used as a proxy client or a host client depending on whether the peer is operating as
@@ -792,7 +793,7 @@ kj::Own<HttpService> newHttpService(HttpClient& client);
 // Adapts an HttpClient to an HttpService and vice versa.
 
 kj::Own<HttpInputStream> newHttpInputStream(
-    kj::AsyncInputStream& input, HttpHeaderTable& headerTable);
+    kj::AsyncInputStream& input, const HttpHeaderTable& headerTable);
 // Create an HttpInputStream on top of the given stream. Normally applications would not call this
 // directly, but it can be useful for implementing protocols that aren't quite HTTP but use similar
 // message delimiting.
@@ -904,13 +905,13 @@ public:
   typedef HttpServerSettings Settings;
   typedef kj::Function<kj::Own<HttpService>(kj::AsyncIoStream&)> HttpServiceFactory;
 
-  HttpServer(kj::Timer& timer, HttpHeaderTable& requestHeaderTable, HttpService& service,
+  HttpServer(kj::Timer& timer, const HttpHeaderTable& requestHeaderTable, HttpService& service,
              Settings settings = Settings());
   // Set up an HttpServer that directs incoming connections to the given service. The service
   // may be a host service or a proxy service depending on whether you are intending to implement
   // an HTTP server or an HTTP proxy.
 
-  HttpServer(kj::Timer& timer, HttpHeaderTable& requestHeaderTable,
+  HttpServer(kj::Timer& timer, const HttpHeaderTable& requestHeaderTable,
              HttpServiceFactory serviceFactory, Settings settings = Settings());
   // Like the other constructor, but allows a new HttpService object to be used for each
   // connection, based on the connection object. This is particularly useful for capturing the
@@ -947,7 +948,7 @@ private:
   class Connection;
 
   kj::Timer& timer;
-  HttpHeaderTable& requestHeaderTable;
+  const HttpHeaderTable& requestHeaderTable;
   kj::OneOf<HttpService*, HttpServiceFactory> service;
   Settings settings;
 
@@ -960,7 +961,7 @@ private:
 
   kj::TaskSet tasks;
 
-  HttpServer(kj::Timer& timer, HttpHeaderTable& requestHeaderTable,
+  HttpServer(kj::Timer& timer, const HttpHeaderTable& requestHeaderTable,
              kj::OneOf<HttpService*, HttpServiceFactory> service,
              Settings settings, kj::PromiseFulfillerPair<void> paf);
 


### PR DESCRIPTION
This allows users of the code to build the header table earlier than construction of the factory.