### PR TITLE
Make Maybe<Own<T>> compatible with ForkedPromise

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -587,6 +587,11 @@ private:
 
 template <typename T> T copyOrAddRef(T& t) { return t; }
 template <typename T> Own<T> copyOrAddRef(Own<T>& t) { return t->addRef(); }
+template <typename T> Maybe<Own<T>> copyOrAddRef(Maybe<Own<T>>& t) {
+  return t.map([](Own<T>& ptr) {
+    return ptr->addRef();
+  });
+}
 
 template <typename T>
 class ForkBranch final: public ForkBranchBase {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -383,7 +383,7 @@ template <> struct EnableIf_<true> { typedef void Type; };
 template <bool b> using EnableIf = typename EnableIf_<b>::Type;
 // Use like:
 //
-//     template <typename T, typename = EnableIf<isValid<T>()>
+//     template <typename T, typename = EnableIf<isValid<T>()>>
 //     void func(T&& t);
 
 template <typename...> struct VoidSfinae_ { using Type = void; };


### PR DESCRIPTION
Add copyOrAddRef specialization for `Maybe<Own<T>>` to make this compatible with `ForkedPromise`.
An open question is whether `addRef` should be allowed to change the returned type.

I don't think that's true for `Own<T>` so I kept it consistent, but I thought I read some documentation somewhere
where `addRef` is supposed to allow to transmute to `Own<U>` (in which case there's a bug here).