### PR TITLE
Turn create_symlink failure on Windows into a warning

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -211,7 +211,8 @@ if(NOT CAPNP_LITE)
   install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
 
   # Symlink capnpc -> capnp
-  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
+  install(CODE
+      "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\" RESULT_VARIABLE STATUS OUTPUT_VARIABLE CAPNPC_SYMLINK_ERR ERROR_VARIABLE CAPNPC_SYMLINK_ERR)\nif (STATUS AND NOT STATUS EQUAL 0)\nmessage(WARNING \"Failed to symlink capnpc -> capnp (check permissions or OS config)\")\nendif()")
 endif()  # NOT CAPNP_LITE
 
 # Tests ========================================================================


### PR DESCRIPTION
CMake versions >= 3.13 make use of Windows support for symlinks;
previously `cmake -E create_symlink` was a no-op. However, symlinks
are only available in Windows 10 > build 1607 with developer mode
enabled. Otherwise, the install step fails with:

```
EXEC : CMake error : failed to create symbolic link 'C:/bld/capnproto-build/install/bin/capnpc.exe': operation not permitted
```

This commit checks the error status of the create_symlink install
command, and reports failure as a warning but does not error out.