### PR TITLE
Expose isValidHeaderValue in HttpHeaders

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -462,13 +462,8 @@ static void requireValidHeaderName(kj::StringPtr name) {
 }
 
 static void requireValidHeaderValue(kj::StringPtr value) {
-  for (char c: value) {
-    // While the HTTP spec suggests that only printable ASCII characters are allowed in header
-    // values, reality has a different opinion. See: https://github.com/httpwg/http11bis/issues/19
-    // We follow the browsers' lead.
-    KJ_REQUIRE(c != '\0' && c != '\r' && c != '\n', "invalid header value",
-        kj::encodeCEscape(value));
-  }
+  KJ_REQUIRE(HttpHeaders::isValidHeaderValue(value), "invalid header value",
+      kj::encodeCEscape(value));
 }
 
 static const char* BUILTIN_HEADER_NAMES[] = {
@@ -565,6 +560,19 @@ kj::Maybe<HttpHeaderId> HttpHeaderTable::stringToId(kj::StringPtr name) const {
 }
 
 // =======================================================================================
+
+bool HttpHeaders::isValidHeaderValue(kj::StringPtr value) {
+  for (char c: value) {
+    // While the HTTP spec suggests that only printable ASCII characters are allowed in header
+    // values, reality has a different opinion. See: https://github.com/httpwg/http11bis/issues/19
+    // We follow the browsers' lead.
+    if (c == '\0' || c == '\r' || c == '\n') {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 HttpHeaders::HttpHeaders(const HttpHeaderTable& table)
     : table(&table),

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -249,6 +249,17 @@ class HttpHeaders {
 public:
   explicit HttpHeaders(const HttpHeaderTable& table);
 
+  static bool isValidHeaderValue(kj::StringPtr value);
+  // This returns whether the value is a valid parameter to the set call. While the HTTP spec
+  // suggests that only printable ASCII characters are allowed in header values, in practice that
+  // turns out to not be the case. We follow the browser's lead in disallowing \r and \n.
+  // https://github.com/httpwg/http11bis/issues/19
+  // Use this if you want to validate the value before supplying it to set() if you want to avoid
+  // an exception being thrown (e.g. you have custom error reporting). NOTE that set will still
+  // validate the value. If performance is a problem this API needs to be adjusted to a
+  // `validateHeaderValue` function that returns a special type that set can be confident has
+  // already passed through the validation routine.
+
   KJ_DISALLOW_COPY(HttpHeaders);
   HttpHeaders(HttpHeaders&&) = default;
   HttpHeaders& operator=(HttpHeaders&&) = default;


### PR DESCRIPTION
It's useful for the caller to be able to validate whether it's a valid
header value in case they want to handle such a situation a different
way.