### PR TITLE
Add 'acceptTimeout' option to TLS

### DIFF
--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -91,6 +91,12 @@ public:
     kj::Maybe<TlsSniCallback&> sniCallback;
     // Callback that can be used to choose a different key/certificate based on the specific
     // hostname requested by the client.
+
+    kj::Maybe<kj::Timer&> timer;
+    // The timer used for `acceptTimeout` below.
+
+    kj::Maybe<kj::Duration> acceptTimeout;
+    // Timeout applied to accepting a new TLS connection. `timer` is required if this is set.
   };
 
   TlsContext(Options options = Options());
@@ -130,6 +136,8 @@ public:
 
 private:
   void* ctx;  // actually type SSL_CTX, but we don't want to #include the OpenSSL headers here
+  kj::Maybe<kj::Timer&> timer;
+  kj::Maybe<kj::Duration> acceptTimeout;
 
   struct SniCallback;
 };

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -435,8 +435,17 @@ public:
   static const HeapDisposer instance;
 };
 
+#if _MSC_VER && _MSC_VER < 1920 && !defined(__clang__)
+template <typename T>
+__declspec(selectany) const HeapDisposer<T> HeapDisposer<T>::instance = HeapDisposer<T>();
+// On MSVC 2017 we suddenly started seeing a linker error on one specific specialization of
+// `HeapDisposer::instance` when seemingly-unrelated code was modified. Explicitly specifying
+// `__declspec(selectany)` seems to fix it. But why? Shouldn't template members have `selectany`
+// behavior by default? We don't know. It works and we're moving on.
+#else
 template <typename T>
 const HeapDisposer<T> HeapDisposer<T>::instance = HeapDisposer<T>();
+#endif
 
 }  // namespace _ (private)
 


### PR DESCRIPTION
This adds a new required constructor argument (a `Timer`) to `TlsContext`... if we want to prevent breaking existing code I could get cute and make it optional and throw an error if you try to use `acceptTimeout` without it?