### PR TITLE
Implement variadic heterogenous joinPromises

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -660,6 +660,44 @@ TEST(Async, ArrayJoinVoid) {
   promise.wait(waitScope);
 }
 
+#if __cpp_fold_expressions
+TEST(Async, TupleJoin) {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  {
+    Promise<Tuple<int, int, int>> promise = joinPromises(Promise<int>{123}, Promise<int>{456}, Promise<int>{789});
+
+    auto result = promise.wait(waitScope);
+
+    EXPECT_EQ(123, get<0>(result));
+    EXPECT_EQ(456, get<1>(result));
+    EXPECT_EQ(789, get<2>(result));
+  }
+
+  {
+    Promise<Tuple<int, int, int>> promise = joinPromises(tuple(
+        Promise<int>{123}, Promise<int>{456}, Promise<int>{789}));
+
+    auto result = promise.wait(waitScope);
+
+    EXPECT_EQ(123, get<0>(result));
+    EXPECT_EQ(456, get<1>(result));
+    EXPECT_EQ(789, get<2>(result));
+  }
+
+}
+
+TEST(Async, TupleJoinVoid) {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Promise<Tuple<void, void, void>> promise = joinPromises(READY_NOW, READY_NOW, READY_NOW);
+
+  promise.wait(waitScope);
+}
+#endif
+
 TEST(Async, Canceler) {
   EventLoop loop;
   WaitScope waitScope(loop);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -486,6 +486,21 @@ template <typename T>
 Promise<Array<T>> joinPromises(Array<Promise<T>>&& promises);
 // Join an array of promises into a promise for an array.
 
+#if __cpp_fold_expressions
+// Maybe it's possible to implement this without fold expressions in a C++11-friendly way but I
+// don't want to spend the time to figure that out. Technically this also requires
+// __cpp_generic_lambdas but fold expressions are C++17 and generic lambdas are C++14.
+
+template <typename... Ts>
+Promise<Tuple<Ts...>> joinPromises(Tuple<Promise<Ts>...>&& promises);
+// Join a tuple of promises into a promise for a tuple.
+
+template <typename T, typename U, typename... Ts>
+Promise<Tuple<T, U, Ts...>> joinPromises(Promise<T>&& first, Promise<U>&& second,
+    Promise<Ts>&&... more);
+// Join one or more (possibly heterogenous) promises into a promise for a tuple of the results.
+#endif
+
 // =======================================================================================
 // Hack for creating a lambda that holds an owned pointer.
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -604,6 +604,25 @@ inline constexpr auto max(T&& a, U&& b) -> WiderType<Decay<T>, Decay<U>> {
   return a > b ? WiderType<Decay<T>, Decay<U>>(a) : WiderType<Decay<T>, Decay<U>>(b);
 }
 
+template <typename T>
+inline constexpr auto max(std::initializer_list<T> l) -> T {
+  auto first = l.begin();
+  auto last = l.end();
+
+  KJ_IREQUIRE(first != last, "Empty list to find the maximum of");
+
+  auto largest = l.begin();
+  ++first;
+
+  for (; first != last; ++first) {
+    if (*first > *largest) {
+      largest = first;
+    }
+  }
+
+  return *largest;
+}
+
 template <typename T, size_t s>
 inline constexpr size_t size(T (&arr)[s]) { return s; }
 template <typename T>

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -998,7 +998,11 @@ public:
 #if KJ_NO_EXCEPTIONS
     logException(LogSeverity::ERROR, mv(exception));
 #else
+#if __cpp_lib_uncaught_exceptions
+    if (std::uncaught_exceptions()) {
+#else
     if (std::uncaught_exception()) {
+#endif
       // Bad time to throw an exception.  Just log instead.
       //
       // TODO(someday): We should really compare uncaughtExceptionCount() against the count at


### PR DESCRIPTION
It's pretty convenient to be able to join a heterogenous set of promises
into a single promise for the combined result (for hopefully obvious
reasons, this really only makes sense for inclusive promises).