### PR TITLE
Annotate lifetimebound

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -140,62 +140,62 @@ public:
     other.ptr = nullptr;
     other.size_ = 0;
   }
-  inline Array(T* firstElement, size_t size, const ArrayDisposer& disposer)
+  inline Array(T* firstElement KJ_LIFETIMEBOUND, size_t size, const ArrayDisposer& disposer)
       : ptr(firstElement), size_(size), disposer(&disposer) {}
 
   KJ_DISALLOW_COPY(Array);
   inline ~Array() noexcept { dispose(); }
 
-  inline operator ArrayPtr<T>() {
+  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
     return ArrayPtr<T>(ptr, size_);
   }
-  inline operator ArrayPtr<const T>() const {
+  inline operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND {
     return ArrayPtr<T>(ptr, size_);
   }
-  inline ArrayPtr<T> asPtr() {
+  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND {
     return ArrayPtr<T>(ptr, size_);
   }
-  inline ArrayPtr<const T> asPtr() const {
+  inline ArrayPtr<const T> asPtr() const KJ_LIFETIMEBOUND {
     return ArrayPtr<T>(ptr, size_);
   }
 
   inline size_t size() const { return size_; }
-  inline T& operator[](size_t index) {
+  inline T& operator[](size_t index) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(index < size_, "Out-of-bounds Array access.");
     return ptr[index];
   }
-  inline const T& operator[](size_t index) const {
+  inline const T& operator[](size_t index) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(index < size_, "Out-of-bounds Array access.");
     return ptr[index];
   }
 
-  inline const T* begin() const { return ptr; }
-  inline const T* end() const { return ptr + size_; }
-  inline const T& front() const { return *ptr; }
-  inline const T& back() const { return *(ptr + size_ - 1); }
-  inline T* begin() { return ptr; }
-  inline T* end() { return ptr + size_; }
-  inline T& front() { return *ptr; }
-  inline T& back() { return *(ptr + size_ - 1); }
+  inline const T* begin() const KJ_LIFETIMEBOUND { return ptr; }
+  inline const T* end() const KJ_LIFETIMEBOUND { return ptr + size_; }
+  inline const T& front() const KJ_LIFETIMEBOUND { return *ptr; }
+  inline const T& back() const KJ_LIFETIMEBOUND { return *(ptr + size_ - 1); }
+  inline T* begin() KJ_LIFETIMEBOUND { return ptr; }
+  inline T* end() KJ_LIFETIMEBOUND { return ptr + size_; }
+  inline T& front() KJ_LIFETIMEBOUND { return *ptr; }
+  inline T& back() KJ_LIFETIMEBOUND { return *(ptr + size_ - 1); }
 
   template <typename U>
   inline bool operator==(const U& other) const { return asPtr() == other; }
   template <typename U>
   inline bool operator!=(const U& other) const { return asPtr() != other; }
 
-  inline ArrayPtr<T> slice(size_t start, size_t end) {
+  inline ArrayPtr<T> slice(size_t start, size_t end) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().");
     return ArrayPtr<T>(ptr + start, end - start);
   }
-  inline ArrayPtr<const T> slice(size_t start, size_t end) const {
+  inline ArrayPtr<const T> slice(size_t start, size_t end) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().");
     return ArrayPtr<const T>(ptr + start, end - start);
   }
 
-  inline ArrayPtr<const byte> asBytes() const { return asPtr().asBytes(); }
-  inline ArrayPtr<PropagateConst<T, byte>> asBytes() { return asPtr().asBytes(); }
-  inline ArrayPtr<const char> asChars() const { return asPtr().asChars(); }
-  inline ArrayPtr<PropagateConst<T, char>> asChars() { return asPtr().asChars(); }
+  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asPtr().asBytes(); }
+  inline ArrayPtr<PropagateConst<T, byte>> asBytes() KJ_LIFETIMEBOUND { return asPtr().asBytes(); }
+  inline ArrayPtr<const char> asChars() const KJ_LIFETIMEBOUND { return asPtr().asChars(); }
+  inline ArrayPtr<PropagateConst<T, char>> asChars() KJ_LIFETIMEBOUND { return asPtr().asChars(); }
 
   inline Array<PropagateConst<T, byte>> releaseAsBytes() {
     // Like asBytes() but transfers ownership.
@@ -343,38 +343,38 @@ public:
   KJ_DISALLOW_COPY(ArrayBuilder);
   inline ~ArrayBuilder() noexcept(false) { dispose(); }
 
-  inline operator ArrayPtr<T>() {
+  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
     return arrayPtr(ptr, pos);
   }
-  inline operator ArrayPtr<const T>() const {
+  inline operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND {
     return arrayPtr(ptr, pos);
   }
-  inline ArrayPtr<T> asPtr() {
+  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND {
     return arrayPtr(ptr, pos);
   }
-  inline ArrayPtr<const T> asPtr() const {
+  inline ArrayPtr<const T> asPtr() const KJ_LIFETIMEBOUND {
     return arrayPtr(ptr, pos);
   }
 
   inline size_t size() const { return pos - ptr; }
   inline size_t capacity() const { return endPtr - ptr; }
-  inline T& operator[](size_t index) {
+  inline T& operator[](size_t index) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(index < implicitCast<size_t>(pos - ptr), "Out-of-bounds Array access.");
     return ptr[index];
   }
-  inline const T& operator[](size_t index) const {
+  inline const T& operator[](size_t index) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(index < implicitCast<size_t>(pos - ptr), "Out-of-bounds Array access.");
     return ptr[index];
   }
 
-  inline const T* begin() const { return ptr; }
-  inline const T* end() const { return pos; }
-  inline const T& front() const { return *ptr; }
-  inline const T& back() const { return *(pos - 1); }
-  inline T* begin() { return ptr; }
-  inline T* end() { return pos; }
-  inline T& front() { return *ptr; }
-  inline T& back() { return *(pos - 1); }
+  inline const T* begin() const KJ_LIFETIMEBOUND { return ptr; }
+  inline const T* end() const KJ_LIFETIMEBOUND { return pos; }
+  inline const T& front() const KJ_LIFETIMEBOUND { return *ptr; }
+  inline const T& back() const KJ_LIFETIMEBOUND { return *(pos - 1); }
+  inline T* begin() KJ_LIFETIMEBOUND { return ptr; }
+  inline T* end() KJ_LIFETIMEBOUND { return pos; }
+  inline T& front() KJ_LIFETIMEBOUND { return *ptr; }
+  inline T& back() KJ_LIFETIMEBOUND { return *(pos - 1); }
 
   ArrayBuilder& operator=(ArrayBuilder&& other) {
     dispose();
@@ -393,7 +393,7 @@ public:
   }
 
   template <typename... Params>
-  T& add(Params&&... params) {
+  T& add(Params&&... params) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(pos < endPtr, "Added too many elements to ArrayBuilder.");
     ctor(*pos, kj::fwd<Params>(params)...);
     return *pos++;
@@ -519,20 +519,22 @@ class FixedArray {
 
 public:
   inline constexpr size_t size() const { return fixedSize; }
-  inline constexpr T* begin() { return content; }
-  inline constexpr T* end() { return content + fixedSize; }
-  inline constexpr const T* begin() const { return content; }
-  inline constexpr const T* end() const { return content + fixedSize; }
+  inline constexpr T* begin() KJ_LIFETIMEBOUND { return content; }
+  inline constexpr T* end() KJ_LIFETIMEBOUND { return content + fixedSize; }
+  inline constexpr const T* begin() const KJ_LIFETIMEBOUND { return content; }
+  inline constexpr const T* end() const KJ_LIFETIMEBOUND { return content + fixedSize; }
 
-  inline constexpr operator ArrayPtr<T>() {
+  inline constexpr operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
     return arrayPtr(content, fixedSize);
   }
-  inline constexpr operator ArrayPtr<const T>() const {
+  inline constexpr operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND {
     return arrayPtr(content, fixedSize);
   }
 
-  inline constexpr T& operator[](size_t index) { return content[index]; }
-  inline constexpr const T& operator[](size_t index) const { return content[index]; }
+  inline constexpr T& operator[](size_t index) KJ_LIFETIMEBOUND { return content[index]; }
+  inline constexpr const T& operator[](size_t index) const KJ_LIFETIMEBOUND {
+    return content[index];
+  }
 
 private:
   T content[fixedSize];
@@ -551,20 +553,20 @@ public:
 
   inline size_t size() const { return currentSize; }
   inline void setSize(size_t s) { KJ_IREQUIRE(s <= fixedSize); currentSize = s; }
-  inline T* begin() { return content; }
-  inline T* end() { return content + currentSize; }
-  inline const T* begin() const { return content; }
-  inline const T* end() const { return content + currentSize; }
+  inline T* begin() KJ_LIFETIMEBOUND { return content; }
+  inline T* end() KJ_LIFETIMEBOUND { return content + currentSize; }
+  inline const T* begin() const KJ_LIFETIMEBOUND { return content; }
+  inline const T* end() const KJ_LIFETIMEBOUND { return content + currentSize; }
 
-  inline operator ArrayPtr<T>() {
+  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
     return arrayPtr(content, currentSize);
   }
-  inline operator ArrayPtr<const T>() const {
+  inline operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND {
     return arrayPtr(content, currentSize);
   }
 
-  inline T& operator[](size_t index) { return content[index]; }
-  inline const T& operator[](size_t index) const { return content[index]; }
+  inline T& operator[](size_t index) KJ_LIFETIMEBOUND { return content[index]; }
+  inline const T& operator[](size_t index) const KJ_LIFETIMEBOUND { return content[index]; }
 
 private:
   size_t currentSize;

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -204,6 +204,11 @@ public:
   inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asArray().asBytes(); }
   // Result does not include NUL terminator.
 
+  inline StringPtr asPtr() const KJ_LIFETIMEBOUND {
+    // Convenience operator to return a StringPtr.
+    return StringPtr{*this};
+  }
+
   inline Array<char> releaseArray() { return kj::mv(content); }
   // Disowns the backing array (which includes the NUL terminator) and returns it. The String value
   // is clobbered (as if moved away).

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -69,12 +69,13 @@ class StringPtr {
 public:
   inline StringPtr(): content("", 1) {}
   inline StringPtr(decltype(nullptr)): content("", 1) {}
-  inline StringPtr(const char* value): content(value, strlen(value) + 1) {}
-  inline StringPtr(const char* value, size_t size): content(value, size + 1) {
+  inline StringPtr(const char* value KJ_LIFETIMEBOUND): content(value, strlen(value) + 1) {}
+  inline StringPtr(const char* value KJ_LIFETIMEBOUND, size_t size): content(value, size + 1) {
     KJ_IREQUIRE(value[size] == '\0', "StringPtr must be NUL-terminated.");
   }
-  inline StringPtr(const char* begin, const char* end): StringPtr(begin, end - begin) {}
-  inline StringPtr(const String& value);
+  inline StringPtr(const char* begin KJ_LIFETIMEBOUND, const char* end KJ_LIFETIMEBOUND): StringPtr(begin, end - begin) {}
+  inline StringPtr(String&& value KJ_LIFETIMEBOUND) : StringPtr(value) {}
+  inline StringPtr(const String& value KJ_LIFETIMEBOUND);
   StringPtr& operator=(String&& value) = delete;
   inline StringPtr& operator=(decltype(nullptr)) {
     content = ArrayPtr<const char>("", 1);
@@ -82,17 +83,17 @@ public:
   }
 
 #if __cpp_char8_t
-  inline StringPtr(const char8_t* value): StringPtr(reinterpret_cast<const char*>(value)) {}
-  inline StringPtr(const char8_t* value, size_t size)
+  inline StringPtr(const char8_t* value KJ_LIFETIMEBOUND): StringPtr(reinterpret_cast<const char*>(value)) {}
+  inline StringPtr(const char8_t* value KJ_LIFETIMEBOUND, size_t size)
       : StringPtr(reinterpret_cast<const char*>(value), size) {}
-  inline StringPtr(const char8_t* begin, const char8_t* end)
+  inline StringPtr(const char8_t* begin KJ_LIFETIMEBOUND, const char8_t* end KJ_LIFETIMEBOUND)
       : StringPtr(reinterpret_cast<const char*>(begin), reinterpret_cast<const char*>(end)) {}
   // KJ strings are and always have been UTF-8, so screw this C++20 char8_t stuff.
 #endif
 
 #if KJ_COMPILER_SUPPORTS_STL_STRING_INTEROP
   template <typename T, typename = decltype(instance<T>().c_str())>
-  inline StringPtr(const T& t): StringPtr(t.c_str()) {}
+  inline StringPtr(const T& t KJ_LIFETIMEBOUND): StringPtr(t.c_str()) {}
   // Allow implicit conversion from any class that has a c_str() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for
   // those who don't want it.
@@ -195,30 +196,30 @@ public:
   inline explicit String(Array<char> buffer);
   // Does not copy.  Requires `buffer` ends with `\0`.
 
-  inline operator ArrayPtr<char>();
-  inline operator ArrayPtr<const char>() const;
-  inline ArrayPtr<char> asArray();
-  inline ArrayPtr<const char> asArray() const;
-  inline ArrayPtr<byte> asBytes() { return asArray().asBytes(); }
-  inline ArrayPtr<const byte> asBytes() const { return asArray().asBytes(); }
+  inline operator ArrayPtr<char>() KJ_LIFETIMEBOUND;
+  inline operator ArrayPtr<const char>() const KJ_LIFETIMEBOUND;
+  inline ArrayPtr<char> asArray() KJ_LIFETIMEBOUND;
+  inline ArrayPtr<const char> asArray() const KJ_LIFETIMEBOUND;
+  inline ArrayPtr<byte> asBytes() KJ_LIFETIMEBOUND { return asArray().asBytes(); }
+  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asArray().asBytes(); }
   // Result does not include NUL terminator.
 
   inline Array<char> releaseArray() { return kj::mv(content); }
   // Disowns the backing array (which includes the NUL terminator) and returns it. The String value
   // is clobbered (as if moved away).
 
-  inline const char* cStr() const;
+  inline const char* cStr() const KJ_LIFETIMEBOUND;
 
   inline size_t size() const;
   // Result does not include NUL terminator.
 
   inline char operator[](size_t index) const;
-  inline char& operator[](size_t index);
+  inline char& operator[](size_t index) KJ_LIFETIMEBOUND;
 
-  inline char* begin();
-  inline char* end();
-  inline const char* begin() const;
-  inline const char* end() const;
+  inline char* begin() KJ_LIFETIMEBOUND;
+  inline char* end() KJ_LIFETIMEBOUND;
+  inline const char* begin() const KJ_LIFETIMEBOUND;
+  inline const char* end() const KJ_LIFETIMEBOUND;
 
   inline bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
   inline bool operator!=(decltype(nullptr)) const { return content.size() > 1; }
@@ -243,8 +244,10 @@ public:
   inline bool startsWith(const StringPtr& other) const { return StringPtr(*this).startsWith(other);}
   inline bool endsWith(const StringPtr& other) const { return StringPtr(*this).endsWith(other); }
 
-  inline StringPtr slice(size_t start) const { return StringPtr(*this).slice(start); }
-  inline ArrayPtr<const char> slice(size_t start, size_t end) const {
+  inline StringPtr slice(size_t start) const KJ_LIFETIMEBOUND {
+    return StringPtr(*this).slice(start);
+  }
+  inline ArrayPtr<const char> slice(size_t start, size_t end) const KJ_LIFETIMEBOUND {
     return StringPtr(*this).slice(start, end);
   }
 
@@ -364,19 +367,29 @@ struct Stringifier {
 
   inline ArrayPtr<const char> operator*(ArrayPtr<const char> s) const { return s; }
   inline ArrayPtr<const char> operator*(ArrayPtr<char> s) const { return s; }
-  inline ArrayPtr<const char> operator*(const Array<const char>& s) const { return s; }
-  inline ArrayPtr<const char> operator*(const Array<char>& s) const { return s; }
+  inline ArrayPtr<const char> operator*(const Array<const char>& s) const KJ_LIFETIMEBOUND {
+    return s;
+  }
+  inline ArrayPtr<const char> operator*(const Array<char>& s) const KJ_LIFETIMEBOUND { return s; }
   template<size_t n>
-  inline ArrayPtr<const char> operator*(const CappedArray<char, n>& s) const { return s; }
+  inline ArrayPtr<const char> operator*(const CappedArray<char, n>& s) const KJ_LIFETIMEBOUND {
+    return s;
+  }
   template<size_t n>
-  inline ArrayPtr<const char> operator*(const FixedArray<char, n>& s) const { return s; }
-  inline ArrayPtr<const char> operator*(const char* s) const { return arrayPtr(s, strlen(s)); }
+  inline ArrayPtr<const char> operator*(const FixedArray<char, n>& s) const KJ_LIFETIMEBOUND {
+    return s;
+  }
+  inline ArrayPtr<const char> operator*(const char* s) const KJ_LIFETIMEBOUND {
+    return arrayPtr(s, strlen(s));
+  }
 #if __cpp_char8_t
-  inline ArrayPtr<const char> operator*(const char8_t* s) const {
+  inline ArrayPtr<const char> operator*(const char8_t* s) const KJ_LIFETIMEBOUND {
     return operator*(reinterpret_cast<const char*>(s));
   }
 #endif
-  inline ArrayPtr<const char> operator*(const String& s) const { return s.asArray(); }
+  inline ArrayPtr<const char> operator*(const String& s) const KJ_LIFETIMEBOUND {
+    return s.asArray();
+  }
   inline ArrayPtr<const char> operator*(const StringPtr& s) const { return s.asArray(); }
 
   inline Range<char> operator*(const Range<char>& r) const { return r; }

--- a/c++/src/kj/vector.h
+++ b/c++/src/kj/vector.h
@@ -42,25 +42,25 @@ public:
   inline explicit Vector(size_t capacity): builder(heapArrayBuilder<T>(capacity)) {}
   inline Vector(Array<T>&& array): builder(kj::mv(array)) {}
 
-  inline operator ArrayPtr<T>() { return builder; }
-  inline operator ArrayPtr<const T>() const { return builder; }
-  inline ArrayPtr<T> asPtr() { return builder.asPtr(); }
-  inline ArrayPtr<const T> asPtr() const { return builder.asPtr(); }
+  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND { return builder; }
+  inline operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND { return builder; }
+  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND { return builder.asPtr(); }
+  inline ArrayPtr<const T> asPtr() const KJ_LIFETIMEBOUND { return builder.asPtr(); }
 
   inline size_t size() const { return builder.size(); }
   inline bool empty() const { return size() == 0; }
   inline size_t capacity() const { return builder.capacity(); }
-  inline T& operator[](size_t index) { return builder[index]; }
-  inline const T& operator[](size_t index) const { return builder[index]; }
+  inline T& operator[](size_t index) KJ_LIFETIMEBOUND { return builder[index]; }
+  inline const T& operator[](size_t index) const KJ_LIFETIMEBOUND { return builder[index]; }
 
-  inline const T* begin() const { return builder.begin(); }
-  inline const T* end() const { return builder.end(); }
-  inline const T& front() const { return builder.front(); }
-  inline const T& back() const { return builder.back(); }
-  inline T* begin() { return builder.begin(); }
-  inline T* end() { return builder.end(); }
-  inline T& front() { return builder.front(); }
-  inline T& back() { return builder.back(); }
+  inline const T* begin() const KJ_LIFETIMEBOUND { return builder.begin(); }
+  inline const T* end() const KJ_LIFETIMEBOUND { return builder.end(); }
+  inline const T& front() const KJ_LIFETIMEBOUND { return builder.front(); }
+  inline const T& back() const KJ_LIFETIMEBOUND { return builder.back(); }
+  inline T* begin() KJ_LIFETIMEBOUND { return builder.begin(); }
+  inline T* end() KJ_LIFETIMEBOUND { return builder.end(); }
+  inline T& front() KJ_LIFETIMEBOUND { return builder.front(); }
+  inline T& back() KJ_LIFETIMEBOUND { return builder.back(); }
 
   inline Array<T> releaseAsArray() {
     // TODO(perf):  Avoid a copy/move by allowing Array<T> to point to incomplete space?
@@ -75,15 +75,15 @@ public:
   template <typename U>
   inline bool operator!=(const U& other) const { return asPtr() != other; }
 
-  inline ArrayPtr<T> slice(size_t start, size_t end) {
+  inline ArrayPtr<T> slice(size_t start, size_t end) KJ_LIFETIMEBOUND {
     return asPtr().slice(start, end);
   }
-  inline ArrayPtr<const T> slice(size_t start, size_t end) const {
+  inline ArrayPtr<const T> slice(size_t start, size_t end) const KJ_LIFETIMEBOUND {
     return asPtr().slice(start, end);
   }
 
   template <typename... Params>
-  inline T& add(Params&&... params) {
+  inline T& add(Params&&... params) KJ_LIFETIMEBOUND {
     if (builder.isFull()) grow();
     return builder.add(kj::fwd<Params>(params)...);
   }


### PR DESCRIPTION
Annotate `Array`/`ArrayBuilder`/`Vector`/`String` with `[[clang::lifetimebound]]` so that the compiler will warn if the lifetime of the used variable exceeds the lifetime of the underlying storage.

Unfortunately I don't think there's a way to track the lifetime bound through multiple objects (e.g. kj::Array -> kj::ArrayPtr -> slice into a new kj::ArrayPtr).