### PR TITLE
Fix async tracing through ForkedPromise.

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2319,6 +2319,10 @@ Maybe<Own<Event>> ForkHubBase::fire() {
 }
 
 void ForkHubBase::traceEvent(TraceBuilder& builder) {
+  if (inner.get() != nullptr) {
+    inner->tracePromise(builder, true);
+  }
+
   if (headBranch != nullptr) {
     // We'll trace down the first branch, I guess.
     headBranch->onReadyEvent.traceEvent(builder);


### PR DESCRIPTION
The effect of this bug is that a chunk of an async trace would be lost. For example, say you have:

    promise.then(foo).then(bar).then(baz).fork().then(qux);

Say that `foo` returns a promise, but `bar` and `baz` do not (they are simple transformations). In this case, the async trace would fail to report `bar` and `baz` -- it would trace directly from `foo` to `qux`.