### PR TITLE
Accept TLS connections in their own loop

### DIFF
--- a/c++/src/kj/async-queue-test.c++
+++ b/c++/src/kj/async-queue-test.c++
@@ -1,0 +1,147 @@
+// Copyright (c) 2021 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "async-queue.h"
+
+#include <kj/async-io.h>
+#include <kj/test.h>
+#include <kj/vector.h>
+
+namespace kj {
+namespace {
+
+struct QueueTest {
+  kj::AsyncIoContext io = setupAsyncIo();
+  ProducerConsumerQueue<size_t> queue;
+
+  QueueTest() = default;
+
+  struct Producer {
+    QueueTest& test;
+    Promise<void> promise = kj::READY_NOW;
+
+    Producer(QueueTest& test): test(test) {}
+
+    void push(size_t i) {
+      auto push = [&, i]() -> Promise<void> {
+        test.queue.push(i);
+        return kj::READY_NOW;
+      };
+      promise = promise.then(kj::mv(push));
+    }
+  };
+
+  struct Consumer {
+    QueueTest& test;
+    Promise<void> promise = kj::READY_NOW;
+
+    Consumer(QueueTest& test): test(test) {}
+
+    void pop(Vector<bool>& bits) {
+      auto pop = [&]() {
+        return test.queue.pop();
+      };
+      auto checkPop = [&](size_t j) -> Promise<void> {
+        bits[j] = true;
+        return kj::READY_NOW;
+      };
+      promise = promise.then(kj::mv(pop)).then(kj::mv(checkPop));
+    }
+  };
+};
+
+KJ_TEST("ProducerConsumerQueue with various amounts of producers and consumers") {
+  auto test = QueueTest();
+
+  size_t constexpr kItemCount = 1000;
+  for (auto producerCount: { 1, 5, 10 }) {
+    for (auto consumerCount: { 1, 5, 10 }) {
+      KJ_LOG(INFO, "Testing a new set of Producers and Consumers",  //
+             producerCount, consumerCount, kItemCount);
+      // Make a vector to track our entries.
+      auto bits = Vector<bool>(kItemCount);
+      for (size_t i = 0; i < kItemCount; ++i) {
+        bits.add(false);
+      }
+
+      // Make enough producers.
+      auto producers = Vector<QueueTest::Producer>();
+      for (size_t i = 0; i < producerCount; ++i) {
+        producers.add(test);
+      }
+
+      // Make enough consumers.
+      auto consumers = Vector<QueueTest::Consumer>();
+      for (size_t i = 0; i < consumerCount; ++i) {
+        consumers.add(test);
+      }
+
+      for (size_t i = 0; i < kItemCount; ++i) {
+        // Use a producer and a consumer for each entry.
+
+        auto& producer = producers[i % producerCount];
+        producer.push(i);
+
+        auto& consumer = consumers[i % consumerCount];
+        consumer.pop(bits);
+      }
+
+      // Confirm that all entries are produced and consumed.
+      auto promises = Vector<Promise<void>>();
+      for (auto& producer: producers) {
+        promises.add(kj::mv(producer.promise));
+      }
+      for (auto& consumer: consumers) {
+        promises.add(kj::mv(consumer.promise));
+      }
+      joinPromises(promises.releaseAsArray()).wait(test.io.waitScope);
+      for (auto i = 0; i < kItemCount; ++i) {
+        KJ_ASSERT(bits[i], i);
+      }
+    }
+  }
+}
+
+KJ_TEST("ProducerConsumerQueue with rejectAll()") {
+  auto test = QueueTest();
+
+  for (auto consumerCount: { 1, 5, 10 }) {
+    KJ_LOG(INFO, "Testing a new set of consumers with rejection", consumerCount);
+
+    // Make enough consumers.
+    auto promises = Vector<Promise<void>>();
+    for (size_t i = 0; i < consumerCount; ++i) {
+      promises.add(test.queue.pop().ignoreResult());
+    }
+
+    for (auto& promise: promises) {
+      KJ_EXPECT(!promise.poll(test.io.waitScope), "All of our consumers should be waiting");
+    }
+    test.queue.rejectAll(KJ_EXCEPTION(FAILED, "Total rejection"));
+
+    // We should have finished and swallowed the errors.
+    auto promise = joinPromises(promises.releaseAsArray());
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("Total rejection", promise.wait(test.io.waitScope));
+  }
+}
+
+}  // namespace
+}  // namespace kj

--- a/c++/src/kj/async-queue.h
+++ b/c++/src/kj/async-queue.h
@@ -1,0 +1,156 @@
+// Copyright (c) 2021 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "async.h"
+#include "common.h"
+#include "debug.h"
+#include "list.h"
+#include "memory.h"
+
+#include <list>
+
+KJ_BEGIN_HEADER
+
+namespace kj {
+
+template <typename T>
+class WaiterQueue {
+public:
+  // A WaiterQueue creates Nodes that blend newAdaptedPromise<T, Adaptor> and List<Node>.
+
+  WaiterQueue() = default;
+  KJ_DISALLOW_COPY(WaiterQueue);
+
+  Promise<T> wait() {
+    return newAdaptedPromise<T, Node>(queue);
+  }
+
+  void fulfill(T&& value) {
+    KJ_IREQUIRE(!empty());
+
+    auto& node = static_cast<Node&>(queue.front());
+    node.fulfiller.fulfill(kj::mv(value));
+    node.remove();
+  }
+
+  void reject(Exception&& exception) {
+    KJ_IREQUIRE(!empty());
+
+    auto& node = static_cast<Node&>(queue.front());
+    node.fulfiller.reject(kj::mv(exception));
+    node.remove();
+  }
+
+  bool empty() const {
+    return queue.empty();
+  }
+
+private:
+  struct BaseNode {
+    // This is a separate structure because List requires a predefined memory layout but
+    // newAdaptedPromise() only provides access to the Adaptor type in the ctor.
+
+    BaseNode(PromiseFulfiller<T>& fulfiller): fulfiller(fulfiller) {}
+
+    PromiseFulfiller<T>& fulfiller;
+    ListLink<BaseNode> link;
+  };
+
+  using Queue = List<BaseNode, &BaseNode::link>;
+
+  struct Node: public BaseNode {
+    Node(PromiseFulfiller<T>& fulfiller, Queue& queue): BaseNode(fulfiller), queue(queue) {
+      queue.add(*this);
+    }
+
+    ~Node() noexcept(false) {
+      // When the associated Promise is destructed, so is the Node thus we should leave the queue.
+      remove();
+    }
+
+    void remove() {
+      if(BaseNode::link.isLinked()){
+        queue.remove(*this);
+      }
+    }
+
+    Queue& queue;
+  };
+
+  Queue queue;
+};
+
+template <typename T>
+class ProducerConsumerQueue {
+  // ProducerConsumerQueue is an async FIFO queue.
+
+public:
+  void push(T v) {
+    // Push an existing value onto the queue.
+
+    if (!waiters.empty()) {
+      // We have at least one waiter, give the value to the oldest.
+      KJ_IASSERT(values.empty());
+
+      // Fulfill the first waiter and return without store our value.
+      waiters.fulfill(kj::mv(v));
+    } else {
+      // We don't have any waiters, store the value.
+      values.push_front(kj::mv(v));
+    }
+  }
+
+  void rejectAll(Exception e) {
+    // Reject all waiters with a given exception.
+
+    while (!waiters.empty()) {
+      auto newE = Exception(e);
+      waiters.reject(kj::mv(newE));
+    }
+  }
+
+  Promise<T> pop() {
+    // Eventually pop a value from the queue.
+    // Note that if your sinks lag your sources, the promise will always be ready.
+
+    if (!values.empty()) {
+      // We have at least one value, get the oldest.
+      KJ_IASSERT(waiters.empty());
+
+      auto value = kj::mv(values.back());
+      values.pop_back();
+      return kj::mv(value);
+    } else {
+      // We don't have any values, add ourselves to the waiting queue.
+      return waiters.wait();
+    }
+  }
+
+private:
+  std::list<T> values;
+  WaiterQueue<T> waiters;
+};
+
+}  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -26,17 +26,21 @@
 #endif
 
 #include "tls.h"
-#include <kj/test.h>
-#include <kj/async-io.h>
-#include <stdlib.h>
+
 #include <openssl/opensslv.h>
+
+#include <stdlib.h>
 
 #if _WIN32
 #include <winsock2.h>
+
 #include <kj/windows-sanity.h>
 #else
 #include <sys/socket.h>
 #endif
+
+#include <kj/async-io.h>
+#include <kj/test.h>
 
 namespace kj {
 namespace {

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -22,19 +22,20 @@
 #if KJ_HAS_OPENSSL
 
 #include "tls.h"
+
 #include "readiness-io.h"
+
 #include <openssl/bio.h>
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
-#include <openssl/evp.h>
 #include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/ssl.h>
 #include <openssl/tls1.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
 #include <kj/debug.h>
 #include <kj/vector.h>
-
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define BIO_set_init(x,v)          (x->init=v)

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -35,6 +35,7 @@
 #include <kj/debug.h>
 #include <kj/vector.h>
 
+
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define BIO_set_init(x,v)          (x->init=v)
 #define BIO_get_data(x)            (x->ptr)


### PR DESCRIPTION
This does the following:
- Adds a new general function ConnectionReceiver::run() to facilitate an async accept loop.
- Adds a queue and a TaskSet to the TlsConnectionReceiver to accept on its inner ConnectionReceiver without blocking on SSL_accept().
- Adds several new tests for the TlsConnectionReceiver.
- Converts several other TLS tests to use convenience helpers.