### PR TITLE
Allow parsing URLs without contextual validation

### DIFF
--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -45,9 +45,9 @@ const parse::CharGroup_& getEndPathPart(Url::Options::MergeFragment mergeFragmen
   static constexpr auto END_PATH_PART_REQUEST = parse::anyOfChars("/?");
 
   switch (mergeFragment) {
-    case Url::Options::MergeFragment::kAuto:  KJ_UNREACHABLE;
-    case Url::Options::MergeFragment::kNo:    return END_PATH_PART_HREF;
-    case Url::Options::MergeFragment::kYes:   return END_PATH_PART_REQUEST;
+    case Url::Options::MergeFragment::AUTO:  KJ_UNREACHABLE;
+    case Url::Options::MergeFragment::NO:    return END_PATH_PART_HREF;
+    case Url::Options::MergeFragment::YES:   return END_PATH_PART_REQUEST;
   }
 
   KJ_UNREACHABLE;
@@ -58,9 +58,9 @@ const parse::CharGroup_& getEndQueryPart(Url::Options::MergeFragment mergeFragme
   static constexpr auto END_QUERY_PART_REQUEST = parse::anyOfChars("&");
 
   switch (mergeFragment) {
-    case Url::Options::MergeFragment::kAuto:  KJ_UNREACHABLE;
-    case Url::Options::MergeFragment::kNo:    return END_QUERY_PART_HREF;
-    case Url::Options::MergeFragment::kYes:   return END_QUERY_PART_REQUEST;
+    case Url::Options::MergeFragment::AUTO:  KJ_UNREACHABLE;
+    case Url::Options::MergeFragment::NO:    return END_QUERY_PART_HREF;
+    case Url::Options::MergeFragment::YES:   return END_QUERY_PART_REQUEST;
   }
 
   KJ_UNREACHABLE;
@@ -250,7 +250,7 @@ Maybe<Url> Url::tryParseWithoutContext(StringPtr text, Options options) {
   }
 
   if (text.startsWith("#")) {
-    if (options.mergeFragment == Options::MergeFragment::kNo) {
+    if (options.mergeFragment == Options::MergeFragment::NO) {
       result.fragment = percentDecode(text.slice(1), err, options);
       text = {};
     } else {
@@ -271,23 +271,23 @@ Maybe<Url> Url::tryParseWithoutContext(StringPtr text, Options options) {
 Maybe<Url> Url::tryParse(StringPtr text, Context context, Options options) {
   switch (context) {
     case Context::REMOTE_HREF: {
-      if (options.mergeFragment == Options::MergeFragment::kAuto) {
-        options.mergeFragment = Options::MergeFragment::kNo;
+      if (options.mergeFragment == Options::MergeFragment::AUTO) {
+        options.mergeFragment = Options::MergeFragment::NO;
       }
     } break;
     case Context::HTTP_PROXY_REQUEST: {
-      if (options.mergeFragment == Options::MergeFragment::kAuto) {
-        options.mergeFragment = Options::MergeFragment::kYes;
+      if (options.mergeFragment == Options::MergeFragment::AUTO) {
+        options.mergeFragment = Options::MergeFragment::YES;
       }
     } break;
     case Context::HTTP_REQUEST: {
-      if (options.mergeFragment == Options::MergeFragment::kAuto) {
-        options.mergeFragment = Options::MergeFragment::kYes;
+      if (options.mergeFragment == Options::MergeFragment::AUTO) {
+        options.mergeFragment = Options::MergeFragment::YES;
       }
     } break;
     case Context::ARBITRARY: {
-      if (options.mergeFragment == Options::MergeFragment::kAuto) {
-        options.mergeFragment = Options::MergeFragment::kNo;
+      if (options.mergeFragment == Options::MergeFragment::AUTO) {
+        options.mergeFragment = Options::MergeFragment::NO;
       }
     } break;
   }
@@ -401,8 +401,8 @@ Maybe<Url> Url::tryParseRelative(StringPtr text) const {
   result.options = options;
   bool err = false;  // tracks percent-decoding errors
 
-  auto& END_PATH_PART = getEndPathPart(Options::MergeFragment::kNo);
-  auto& END_QUERY_PART = getEndQueryPart(Options::MergeFragment::kNo);
+  auto& END_PATH_PART = getEndPathPart(Options::MergeFragment::NO);
+  auto& END_QUERY_PART = getEndQueryPart(Options::MergeFragment::NO);
 
   // scheme
   {

--- a/c++/src/kj/compat/url.h
+++ b/c++/src/kj/compat/url.h
@@ -43,6 +43,14 @@ struct UrlOptions {
   // silently removed. In other words, setting this false causes consecutive slashes in the path or
   // consecutive ampersands in the query to be collapsed into one, whereas if true then they
   // produce empty components.
+
+  enum class MergeFragment {
+    kAuto, // Depend on the context if we merge the fragment into the previous component.
+    kNo, // Never merge the fragment into the previous component.
+    kYes // Always merge the fragment into the previous component.
+  };
+  MergeFragment mergeFragment = MergeFragment::kAuto;
+  // How the fragment component is parsed.
 };
 
 struct Url {
@@ -62,6 +70,7 @@ struct Url {
   // Username / password.
 
   String host;
+  bool hasAuthority = false;
   // Hostname, including port if specified. We choose not to parse out the port because KJ's
   // network address parsing functions already accept addresses containing port numbers, and
   // because most web standards don't actually want to separate host and port.
@@ -124,9 +133,12 @@ struct Url {
     // path, and query, but omits userInfo (which should be used to construct the Authorization
     // header) and fragment (which should not be transmitted).
 
-    HTTP_REQUEST
+    HTTP_REQUEST,
     // The path to place in the first line of a regular HTTP request. This includes only the path
     // and query. Scheme, user, host, and fragment are omitted.
+
+    ARBITRARY,
+    // An arbitrary URL that may omit any component.
 
     // TODO(someday): Add context(s) that supports things like "mailto:", "data:", "blob:". These
     //   don't have an authority section.
@@ -139,9 +151,15 @@ struct Url {
   static Maybe<Url> tryParse(StringPtr text, Context context = REMOTE_HREF, Options options = {});
   // Parse an absolute URL.
 
+  static Maybe<Url> tryParseWithoutContext(StringPtr text, Options options = {});
+  // Parse an aboslute URL without a Context object.
+
   Url parseRelative(StringPtr relative) const;
   Maybe<Url> tryParseRelative(StringPtr relative) const;
   // Parse a relative URL string with this URL as the base.
+
+  bool isValidWithContext(Context context) const;
+  // Verify that this URL obeys the rules for the given context.
 };
 
 } // namespace kj

--- a/c++/src/kj/compat/url.h
+++ b/c++/src/kj/compat/url.h
@@ -45,11 +45,11 @@ struct UrlOptions {
   // produce empty components.
 
   enum class MergeFragment {
-    kAuto, // Depend on the context if we merge the fragment into the previous component.
-    kNo, // Never merge the fragment into the previous component.
-    kYes // Always merge the fragment into the previous component.
+    AUTO, // Depend on the context if we merge the fragment into the previous component.
+    NO,   // Never merge the fragment into the previous component.
+    YES,  // Always merge the fragment into the previous component.
   };
-  MergeFragment mergeFragment = MergeFragment::kAuto;
+  MergeFragment mergeFragment = MergeFragment::AUTO;
   // How the fragment component is parsed.
 };
 


### PR DESCRIPTION
This does the following:
- Separates fragment behavior into a Url::Option member.
- Separates URL parsing from context validation.
- Adds a new Url::Context entry, ARBITRARY, that performs no validation.