### PR TITLE
Make cmake install more portable on windows

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -216,8 +216,7 @@ if(NOT CAPNP_LITE)
     install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnp${CMAKE_EXECUTABLE_SUFFIX}\" \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
   else()
     # Symlink capnpc -> capnp
-    install(CODE
-        "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\" RESULT_VARIABLE STATUS OUTPUT_VARIABLE CAPNPC_SYMLINK_ERR ERROR_VARIABLE CAPNPC_SYMLINK_ERR)\nif (STATUS AND NOT STATUS EQUAL 0)\nmessage(WARNING \"Failed to symlink capnpc -> capnp (check permissions or OS config)\")\nendif()")
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
   endif()
 endif()  # NOT CAPNP_LITE
 

--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -210,9 +210,15 @@ if(NOT CAPNP_LITE)
 
   install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
 
-  # Symlink capnpc -> capnp
-  install(CODE
-      "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\" RESULT_VARIABLE STATUS OUTPUT_VARIABLE CAPNPC_SYMLINK_ERR ERROR_VARIABLE CAPNPC_SYMLINK_ERR)\nif (STATUS AND NOT STATUS EQUAL 0)\nmessage(WARNING \"Failed to symlink capnpc -> capnp (check permissions or OS config)\")\nendif()")
+  if(WIN32)
+    # On Windows platforms symlinks are not guranteed to support. Also differnt version of CMake handle create_symlink in a different way.
+    # The most portable way in this case just copy the file.
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnp${CMAKE_EXECUTABLE_SUFFIX}\" \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
+  else()
+    # Symlink capnpc -> capnp
+    install(CODE
+        "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\" RESULT_VARIABLE STATUS OUTPUT_VARIABLE CAPNPC_SYMLINK_ERR ERROR_VARIABLE CAPNPC_SYMLINK_ERR)\nif (STATUS AND NOT STATUS EQUAL 0)\nmessage(WARNING \"Failed to symlink capnpc -> capnp (check permissions or OS config)\")\nendif()")
+  endif()
 endif()  # NOT CAPNP_LITE
 
 # Tests ========================================================================


### PR DESCRIPTION
Current implementation might produce the following CMake error:

```
CMake Error: failed to create symbolic link ...: operation not permitted
```