### PR TITLE
Implement a lazy Maybe::orDefault

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -83,7 +83,9 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(ranLazy);
 
     KJ_IF_MAYBE(v, m) {
-      const int& ref = m.orDefault([notUsed = 5]() -> const int& { return notUsed; });
+      const int& ref = m.orDefault([notUsed = 5]() -> const int& {
+        return std::cref(notUsed);
+      });
 
       EXPECT_EQ(ref, *v);
       EXPECT_EQ(&ref, v);

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -83,9 +83,7 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(ranLazy);
 
     KJ_IF_MAYBE(v, m) {
-      const int& ref = m.orDefault([notUsed = 5]() -> const int& {
-        return std::cref(notUsed);
-      });
+      const int& ref = m.orDefault([notUsed = 5]() -> const int& { return notUsed; });
 
       EXPECT_EQ(ref, *v);
       EXPECT_EQ(&ref, v);

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -83,7 +83,7 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(ranLazy);
 
     KJ_IF_MAYBE(v, m) {
-      const int& ref = m.orDefault([notUsed = 5]() -> const int& { return notUsed; });
+      const int& ref = m.orDefault([notUsed = 5]() -> int& { return notUsed; });
 
       EXPECT_EQ(ref, *v);
       EXPECT_EQ(&ref, v);

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -83,7 +83,8 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(ranLazy);
 
     KJ_IF_MAYBE(v, m) {
-      const int& ref = m.orDefault([notUsed = 5]() -> int& { return notUsed; });
+      int notUsedForRef = 5;
+      const int& ref = m.orDefault([&]() -> int& { return notUsedForRef; });
 
       EXPECT_EQ(ref, *v);
       EXPECT_EQ(&ref, v);

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1389,7 +1389,7 @@ public:
 
   template <typename F,
       typename Result = decltype(instance<bool>() ? instance<const T&>() : instance<F>()())>
-  const Result orDefault(F&& lazyDefaultValue) const & {
+  Result orDefault(F&& lazyDefaultValue) const & {
     if (ptr == nullptr) {
       return lazyDefaultValue();
     } else {
@@ -1409,7 +1409,7 @@ public:
 
   template <typename F,
       typename Result = decltype(instance<bool>() ? instance<const T&&>() : instance<F>()())>
-  const Result orDefault(F&& lazyDefaultValue) const && {
+  Result orDefault(F&& lazyDefaultValue) const && {
     if (ptr == nullptr) {
       return lazyDefaultValue();
     } else {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1377,6 +1377,46 @@ public:
     }
   }
 
+  template <typename F,
+      typename Result = decltype(instance<bool>() ? instance<T&>() : instance<F>()())>
+  Result orDefault(F&& lazyDefaultValue) & {
+    if (ptr == nullptr) {
+      return lazyDefaultValue();
+    } else {
+      return *ptr;
+    }
+  }
+
+  template <typename F,
+      typename Result = decltype(instance<bool>() ? instance<const T&>() : instance<F>()())>
+  const Result orDefault(F&& lazyDefaultValue) const & {
+    if (ptr == nullptr) {
+      return lazyDefaultValue();
+    } else {
+      return *ptr;
+    }
+  }
+
+  template <typename F,
+      typename Result = decltype(instance<bool>() ? instance<T&&>() : instance<F>()())>
+  Result orDefault(F&& lazyDefaultValue) && {
+    if (ptr == nullptr) {
+      return lazyDefaultValue();
+    } else {
+      return kj::mv(*ptr);
+    }
+  }
+
+  template <typename F,
+      typename Result = decltype(instance<bool>() ? instance<T&&>() : instance<F>()())>
+  const Result orDefault(F&& lazyDefaultValue) const && {
+    if (ptr == nullptr) {
+      return lazyDefaultValue();
+    } else {
+      return kj::mv(*ptr);
+    }
+  }
+
   template <typename Func>
   auto map(Func&& f) & -> Maybe<decltype(f(instance<T&>()))> {
     if (ptr == nullptr) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1408,7 +1408,7 @@ public:
   }
 
   template <typename F,
-      typename Result = decltype(instance<bool>() ? instance<T&&>() : instance<F>()())>
+      typename Result = decltype(instance<bool>() ? instance<const T&&>() : instance<F>()())>
   const Result orDefault(F&& lazyDefaultValue) const && {
     if (ptr == nullptr) {
       return lazyDefaultValue();


### PR DESCRIPTION
It's often times more terse/readable to use a lazy `orDefault` version
instead of writing out the KJ_IF_MAYBE logic by hand.