### PR TITLE
Add missing [[noreturn]] annotations

### DIFF
--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -175,7 +175,7 @@ private:
 
   friend class SegmentBuilder;
 
-  static void abortCheckObjectFault();
+  [[noreturn]] static void abortCheckObjectFault();
   // Called in debug mode in cases that would segfault in opt mode. (Should be impossible!)
 };
 
@@ -221,7 +221,7 @@ private:
 
   bool readOnly;
 
-  void throwNotWritable();
+  [[noreturn]] void throwNotWritable();
 
   KJ_DISALLOW_COPY(SegmentBuilder);
 };

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -735,7 +735,7 @@ TEST(AsyncUnixTest, Wake) {
 }
 
 int exitCodeForSignal = 0;
-void exitSignalHandler(int) {
+[[noreturn]] void exitSignalHandler(int) {
   _exit(exitCodeForSignal);
 }
 

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -454,7 +454,7 @@ private:
   Impl* impl;
 #endif
 
-  void run();
+  [[noreturn]] void run();
 
   bool isReset() { return main == nullptr; }
 };
@@ -1382,7 +1382,7 @@ struct FiberStack::StartRoutine {
     reinterpret_cast<FiberStack*>(ptr)->run();
   }
 #else
-  static void run(int arg1, int arg2) {
+  [[noreturn]] static void run(int arg1, int arg2) {
     // This is the static C-style function we pass to makeContext().
 
     // POSIX says the arguments are ints, not pointers. So we split our pointer in half in order to

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -753,7 +753,7 @@ struct ThrowOverflow {
   // Functor which throws an exception complaining about integer overflow. Usually this is used
   // with the interfaces in units.h, but is defined here because Cap'n Proto wants to avoid
   // including units.h when not using CAPNP_DEBUG_TYPES.
-  void operator()() const;
+  [[noreturn]] void operator()() const;
 };
 
 #if __GNUC__ || __clang__ || _MSC_VER

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -43,7 +43,7 @@ private:
   z_stream ctx = {};
   byte buffer[4096];
 
-  void fail(int result);
+  [[noreturn]] void fail(int result);
 };
 
 }  // namespace _ (private)

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -426,7 +426,7 @@ namespace {
 
 #if !KJ_NO_EXCEPTIONS
 
-void terminateHandler() {
+[[noreturn]] void terminateHandler() {
   void* traceSpace[32];
 
   // ignoreCount = 3 to ignore std::terminate entry.
@@ -566,7 +566,7 @@ void printStackTraceOnCrash() {
 #else
 namespace {
 
-void crashHandler(int signo, siginfo_t* info, void* context) {
+[[noreturn]] void crashHandler(int signo, siginfo_t* info, void* context) {
   void* traceSpace[32];
 
 #if KJ_USE_WIN32_DBGHELP


### PR DESCRIPTION
Recommended when building with -Wmissing-noreturn. Unfortunately the
warning isn't quite as helpful as one might like. Ideally it would only
warn about functions with external linkage - I would expect that the
optimizer should be responsible for figuring out the "noreturn"-ness of
functions with internal linkage... Still, maybe not a bad idea for us to annotate
these functions correctly to allow for turning on the warning downstream.