### PR TITLE
Annotate all fallthroughs.

### DIFF
--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -904,7 +904,7 @@ private:
               state = COMMENT;
               break;
             }
-            // fallthrough
+            KJ_FALLTHROUGH;
           case NORMAL:
             switch (c) {
               case '#': state = COMMENT; break;

--- a/c++/src/capnp/compiler/compiler.c++
+++ b/c++/src/capnp/compiler/compiler.c++
@@ -520,7 +520,7 @@ kj::Maybe<Compiler::Node::Content&> Compiler::Node::getContent(Content::State mi
       }
 
       content.advanceState(Content::EXPANDED);
-    } // fallthrough
+    } KJ_FALLTHROUGH;
 
     case Content::EXPANDED: {
       if (minimumState <= Content::EXPANDED) break;
@@ -583,7 +583,7 @@ kj::Maybe<Compiler::Node::Content&> Compiler::Node::getContent(Content::State mi
       }));
 
       content.advanceState(Content::BOOTSTRAP);
-    } // fallthrough
+    } KJ_FALLTHROUGH;
 
     case Content::BOOTSTRAP: {
       if (minimumState <= Content::BOOTSTRAP) break;
@@ -604,7 +604,7 @@ kj::Maybe<Compiler::Node::Content&> Compiler::Node::getContent(Content::State mi
       content.sourceInfo = kj::mv(nodeSet.sourceInfo);
 
       content.advanceState(Content::FINISHED);
-    } // fallthrough
+    } KJ_FALLTHROUGH;
 
     case Content::FINISHED:
       break;

--- a/c++/src/capnp/compiler/generics.c++
+++ b/c++/src/capnp/compiler/generics.c++
@@ -168,7 +168,7 @@ bool BrandedDecl::compileAsType(
         addError(errorReporter,
             "As of Cap'n Proto 0.4, 'Object' has been renamed to 'AnyPointer'.  Sorry for the "
             "inconvenience, and thanks for being an early adopter.  :)");
-        // fallthrough
+        KJ_FALLTHROUGH;
       case Declaration::BUILTIN_ANY_POINTER:
         target.initAnyPointer().initUnconstrained().setAnyKind();
         return true;

--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -1893,7 +1893,7 @@ kj::Maybe<Orphan<DynamicValue>> ValueTranslator::compileValue(Expression::Reader
         return kj::mv(result);
       }
 
-    } // fallthrough -- value is positive, so we can just go on to the uint case below.
+    } KJ_FALLTHROUGH;  // value is positive, so we can just go on to the uint case below.
 
     case DynamicValue::UINT: {
       uint64_t maxValue = 0;

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -341,6 +341,12 @@ KJ_NORETURN(void unreachable());
 #define KJ_KNOWN_UNREACHABLE(code) do {code;} while(false)
 #endif
 
+#if KJ_HAS_CPP_ATTRIBUTE(fallthrough)
+#define KJ_FALLTHROUGH [[fallthrough]]
+#else
+#define KJ_FALLTHROUGH
+#endif
+
 // #define KJ_STACK_ARRAY(type, name, size, minStack, maxStack)
 //
 // Allocate an array, preferably on the stack, unless it is too big.  On GCC this will use

--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -733,6 +733,7 @@ int base64_encode_block(const char* plaintext_in, int length_in,
 
   switch (state_in->step) {
     while (1) {
+      KJ_FALLTHROUGH;
   case step_A:
       if (plainchar == plaintextend) {
         state_in->result = result;
@@ -743,7 +744,7 @@ int base64_encode_block(const char* plaintext_in, int length_in,
       result = (fragment & 0x0fc) >> 2;
       *codechar++ = base64_encode_value(result);
       result = (fragment & 0x003) << 4;
-      // fallthrough
+      KJ_FALLTHROUGH;
   case step_B:
       if (plainchar == plaintextend) {
         state_in->result = result;
@@ -754,7 +755,7 @@ int base64_encode_block(const char* plaintext_in, int length_in,
       result |= (fragment & 0x0f0) >> 4;
       *codechar++ = base64_encode_value(result);
       result = (fragment & 0x00f) << 2;
-      // fallthrough
+      KJ_FALLTHROUGH;
   case step_C:
       if (plainchar == plaintextend) {
         state_in->result = result;
@@ -912,6 +913,7 @@ int base64_decode_block(const char* code_in, const int length_in,
   {
     while (1)
     {
+      KJ_FALLTHROUGH;
   case step_a:
       do {
         if (codechar == code_in+length_in) {
@@ -924,7 +926,7 @@ int base64_decode_block(const char* code_in, const int length_in,
         ERROR_IF(fragment < -1);
       } while (fragment < 0);
       *plainchar    = (fragment & 0x03f) << 2;
-      // fallthrough
+      KJ_FALLTHROUGH;
   case step_b:
       do {
         if (codechar == code_in+length_in) {
@@ -942,7 +944,7 @@ int base64_decode_block(const char* code_in, const int length_in,
       } while (fragment < 0);
       *plainchar++ |= (fragment & 0x030) >> 4;
       *plainchar    = (fragment & 0x00f) << 4;
-      // fallthrough
+      KJ_FALLTHROUGH;
   case step_c:
       do {
         if (codechar == code_in+length_in) {
@@ -962,7 +964,7 @@ int base64_decode_block(const char* code_in, const int length_in,
       ERROR_IF(state_in->nPaddingBytesSeen > 0);
       *plainchar++ |= (fragment & 0x03c) >> 2;
       *plainchar    = (fragment & 0x003) << 6;
-      // fallthrough
+      KJ_FALLTHROUGH;
   case step_d:
       do {
         if (codechar == code_in+length_in) {

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -185,7 +185,7 @@ private:
           Sleep(10);
           goto retry;
         }
-        // fallthrough
+        KJ_FALLTHROUGH;
       default:
         KJ_FAIL_WIN32("RemoveDirectory", error) { break; }
     }

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -779,7 +779,7 @@ public:
         if (!exists(path)) {
           return nullptr;
         }
-        // fallthrough
+        KJ_FALLTHROUGH;
       default:
         KJ_FAIL_SYSCALL("openat(fd, path, O_DIRECTORY)", error, path) { return nullptr; }
     }
@@ -914,7 +914,7 @@ public:
           mode = mode - WriteMode::CREATE_PARENT;
           return createNamedTemporary(finalName, mode, kj::mv(tryCreate));
         }
-        // fallthrough
+        KJ_FALLTHROUGH;
       default:
         KJ_FAIL_SYSCALL("create(path)", error, path) { break; }
         return nullptr;
@@ -957,7 +957,7 @@ public:
             // Retry, but make sure we don't try to create the parent again.
             return tryReplaceNode(path, mode - WriteMode::CREATE_PARENT, kj::mv(tryCreate));
           }
-          // fallthrough
+          KJ_FALLTHROUGH;
         default:
           KJ_FAIL_SYSCALL("create(path)", error, path) { return false; }
       } else {

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -197,7 +197,7 @@ static void rmrfChildren(ArrayPtr<const wchar_t> path) {
             Sleep(10);
             goto retry;
           }
-          // fallthrough
+          KJ_FALLTHROUGH;
         default:
           KJ_FAIL_WIN32("RemoveDirectory", error, dbgStr(child)) { break; }
       }
@@ -813,7 +813,7 @@ public:
           mode = mode - WriteMode::CREATE_PARENT;
           return createNamedTemporary(finalName, mode, kj::mv(tryCreate));
         }
-        // fallthrough
+        KJ_FALLTHROUGH;
       default:
         KJ_FAIL_WIN32("create(path)", error, path) { break; }
         return nullptr;
@@ -864,7 +864,7 @@ public:
             // Retry, but make sure we don't try to create the parent again.
             return tryReplaceNode(path, mode - WriteMode::CREATE_PARENT, kj::mv(tryCreate));
           }
-          // fallthrough
+          KJ_FALLTHROUGH;
         default:
           KJ_FAIL_WIN32("create(path)", error, path) { return false; }
       } else {

--- a/c++/src/kj/hash.c++
+++ b/c++/src/kj/hash.c++
@@ -47,10 +47,10 @@ uint HashCoder::operator*(ArrayPtr<const byte> s) const {
   switch (len) {
   case 3:
     h ^= data[2] << 16;
-    // fallthrough
+    KJ_FALLTHROUGH;
   case 2:
     h ^= data[1] << 8;
-    // fallthrough
+    KJ_FALLTHROUGH;
   case 1:
     h ^= data[0];
     h *= m;

--- a/super-test.sh
+++ b/super-test.sh
@@ -351,6 +351,12 @@ done
 export CXXFLAGS="-O2 -DDEBUG -Wall -Wextra -Werror -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -DCAPNP_EXPENSIVE_TESTS=1 ${CPP_FEATURES}"
 export LIBS="$EXTRA_LIBS"
 
+if [ "${CXX:-}" != "g++-5" ]; then
+  # This warning flag is missing on g++-5 but available on all other GCC/Clang versions we target
+  # in CI.
+  export CXXFLAGS="$CXXFLAGS -Wimplicit-fallthrough"
+fi
+
 STAGING=$PWD/tmp-staging
 
 rm -rf "$STAGING"


### PR DESCRIPTION
This allows the code to compile with -Wimplicit-fallthrough on both GCC and Clang. Note that Clang's version of the warning doesn't seem to accept comments the way GCC's does (or I couldn't figure out how to make a comment that it accepted), so I am using the explicit annotation everywhere instead. Technically this annotation wasn't recognized until C++17, but GCC seems to accept it with C++14. I'm hoping the others do to (we'll see what CI says), otherwise I'll need a KJ_FALLTHROUGH macro I guess.