### PR TITLE
Clarify that kj's async Timer only updates when the event loop waits

### DIFF
--- a/c++/src/kj/timer.h
+++ b/c++/src/kj/timer.h
@@ -41,6 +41,13 @@ class Timer: public MonotonicClock {
   // guaranteed to be synchronized with the `MonotonicClock` returned by
   // `systemPreciseMonotonicClock()` (or, more precisely, is updated to match that clock whenever
   // the loop waits).
+  //
+  // Note that the value returned by `Timer::now()` only changes each time the
+  // event loop waits for I/O from the system. While the event loop is actively
+  // running, the time stays constant. This is intended to make behavior more
+  // deterministic and reproducible. However, if you need up-to-the-cycle
+  // accurate time, then `Timer::now()` is not appropriate. Instead, use
+  // `systemPreciseMonotonicClock()` directly in this case.
 
 public:
   virtual TimePoint now() const = 0;


### PR DESCRIPTION
Th original comment was misleading to me. I understood it to mean "Timer counts
on its own, but may get slightly out of sync until the start of the event loop,"
especially because of the "guaranteed to be synchronized" bit. The actual
meaning is "At any given point, Timer is frozen in time, and is only updated at
the start of the event loop."

cc @a-robinson