### PR TITLE
Make TSAN happy about variable we double-check on destruction

### DIFF
--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -210,7 +210,10 @@ Mutex::AcquiredMetadata Mutex::lockedInfo() const {
 Mutex::Mutex(): futex(0) {}
 Mutex::~Mutex() {
   // This will crash anyway, might as well crash with a nice error message.
-  KJ_ASSERT(futex == 0, "Mutex destroyed while locked.") { break; }
+  // Atomic load to make TSAN happy.
+  KJ_ASSERT(__atomic_load_n(&futex, __ATOMIC_RELAXED) == 0, "Mutex destroyed while locked.") {
+    break;
+  }
 }
 
 bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLocationArg location) {

--- a/c++/src/kj/refcount.c++
+++ b/c++/src/kj/refcount.c++
@@ -48,7 +48,12 @@ void Refcounted::disposeImpl(void* pointer) const {
 // Atomic (thread-safe) refcounting
 
 AtomicRefcounted::~AtomicRefcounted() noexcept(false) {
+#if defined(__clang__) || !defined(_MSC_VER)
+  KJ_ASSERT(__atomic_load_n(&refcount, __ATOMIC_RELAXED) == 0,
+      "Refcounted object deleted with non-zero refcount.");
+#else
   KJ_ASSERT(refcount == 0, "Refcounted object deleted with non-zero refcount.");
+#endif
 }
 
 void AtomicRefcounted::disposeImpl(void* pointer) const {


### PR DESCRIPTION
Not actually a bug but TSAN is unhappy that this value is read
non-atomically (even though the non-atomic read here is safe since we're
destroying the object anyway).