### PR TITLE
Disallow copying of B-Tree table indexes and fix their move operations

### DIFF
--- a/c++/src/kj/table-test.c++
+++ b/c++/src/kj/table-test.c++
@@ -810,6 +810,35 @@ KJ_TEST("simple tree table") {
     KJ_EXPECT(*iter++ == "waldo");
     KJ_EXPECT(iter == table.end());
   }
+
+  // Verify that move constructor/assignment work.
+  Table<StringPtr, TreeIndex<StringCompare>> other(kj::mv(table));
+  KJ_EXPECT(other.size() == 5);
+  KJ_EXPECT(table.size() == 0);
+  KJ_EXPECT(table.begin() == table.end());
+  {
+    auto iter = other.begin();
+    KJ_EXPECT(*iter++ == "garply");
+    KJ_EXPECT(*iter++ == "grault");
+    KJ_EXPECT(*iter++ == "qux");
+    KJ_EXPECT(*iter++ == "corge");
+    KJ_EXPECT(*iter++ == "waldo");
+    KJ_EXPECT(iter == other.end());
+  }
+
+  table = kj::mv(other);
+  KJ_EXPECT(other.size() == 0);
+  KJ_EXPECT(table.size() == 5);
+  {
+    auto iter = table.begin();
+    KJ_EXPECT(*iter++ == "garply");
+    KJ_EXPECT(*iter++ == "grault");
+    KJ_EXPECT(*iter++ == "qux");
+    KJ_EXPECT(*iter++ == "corge");
+    KJ_EXPECT(*iter++ == "waldo");
+    KJ_EXPECT(iter == table.end());
+  }
+  KJ_EXPECT(other.begin() == other.end());
 }
 
 class UintCompare {

--- a/c++/src/kj/table.c++
+++ b/c++/src/kj/table.c++
@@ -207,10 +207,41 @@ BTreeImpl::BTreeImpl()
       freelistSize(0),
       beginLeaf(0),
       endLeaf(0) {}
+
 BTreeImpl::~BTreeImpl() noexcept(false) {
   if (tree != &EMPTY_NODE) {
     aligned_free(tree);
   }
+}
+
+BTreeImpl::BTreeImpl(BTreeImpl&& other)
+  : BTreeImpl() {
+  *this = kj::mv(other);
+}
+
+BTreeImpl& BTreeImpl::operator=(BTreeImpl&& other) {
+  KJ_DASSERT(&other != this);
+
+  if (tree != &EMPTY_NODE) {
+    aligned_free(tree);
+  }
+  tree = other.tree;
+  treeCapacity = other.treeCapacity;
+  height = other.height;
+  freelistHead = other.freelistHead;
+  freelistSize = other.freelistSize;
+  beginLeaf = other.beginLeaf;
+  endLeaf = other.endLeaf;
+
+  other.tree = const_cast<NodeUnion*>(&EMPTY_NODE);
+  other.treeCapacity = 1;
+  other.height = 0;
+  other.freelistHead = 1;
+  other.freelistSize = 0;
+  other.beginLeaf = 0;
+  other.endLeaf = 0;
+
+  return *this;
 }
 
 const BTreeImpl::NodeUnion BTreeImpl::EMPTY_NODE = {{{0, {0}}}};

--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -1076,6 +1076,10 @@ public:
   BTreeImpl();
   ~BTreeImpl() noexcept(false);
 
+  KJ_DISALLOW_COPY(BTreeImpl);
+  BTreeImpl(BTreeImpl&& other);
+  BTreeImpl& operator=(BTreeImpl&& other);
+
   void logInconsistency() const;
 
   void reserve(size_t size);


### PR DESCRIPTION
Previously, copying of B-Tree table indexes was incorrectly allowed (and
broken) and moving them was also similarly broken.

Specifically, there were two different sources of bad behavior:
* If you copied or moved a B-Tree index, its underlying `tree` memory
  would be freed multiple times.
* And if you assigned one B-Tree index over top of another, the target
  of the assignment would fail to free its underlying `tree` memory.

I found this when debugging a recently-added memory leak involving a
Table with a TreeIndex stored within an `ExternalMutexGuarded`. The
destructor of ExternalMutexGuarded<T> attempts to clear out its
underlying T object while under the protection of the mutex by assigning
a default-constructed T to it. This triggered the bug where we BTreeImpl
failed to free its memory when assigned to.

@kentonv @vlovich 