### PR TITLE
Explicitly specify rule of five for QueueTest/TlsReceiverTest

### DIFF
--- a/c++/src/kj/async-queue-test.c++
+++ b/c++/src/kj/async-queue-test.c++
@@ -33,6 +33,10 @@ struct QueueTest {
   ProducerConsumerQueue<size_t> queue;
 
   QueueTest() = default;
+  QueueTest(QueueTest&&) = delete;
+  QueueTest(const QueueTest&) = delete;
+  QueueTest& operator=(QueueTest&&) = delete;
+  QueueTest& operator=(const QueueTest&) = delete;
 
   struct Producer {
     QueueTest& test;
@@ -69,7 +73,7 @@ struct QueueTest {
 };
 
 KJ_TEST("ProducerConsumerQueue with various amounts of producers and consumers") {
-  auto test = QueueTest();
+  QueueTest test;
 
   size_t constexpr kItemCount = 1000;
   for (auto producerCount: { 1, 5, 10 }) {
@@ -121,7 +125,7 @@ KJ_TEST("ProducerConsumerQueue with various amounts of producers and consumers")
 }
 
 KJ_TEST("ProducerConsumerQueue with rejectAll()") {
-  auto test = QueueTest();
+  QueueTest test;
 
   for (auto consumerCount: { 1, 5, 10 }) {
     KJ_LOG(INFO, "Testing a new set of consumers with rejection", consumerCount);

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -914,6 +914,11 @@ public:
     receiver = tlsServer.wrapPort(kj::mv(baseReceiverPtr));
   }
 
+  TlsReceiverTest(TlsReceiverTest&&) = delete;
+  TlsReceiverTest(const TlsReceiverTest&) = delete;
+  TlsReceiverTest& operator=(TlsReceiverTest&&) = delete;
+  TlsReceiverTest& operator=(const TlsReceiverTest&) = delete;
+
   Own<ConnectionReceiver> receiver;
   MockConnectionReceiver* baseReceiver;
 };


### PR DESCRIPTION
It seems I was leaning on elision when I wrote this test and that matters for some compile configurations.