### PR TITLE
Print reader contention location

### DIFF
--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -179,6 +179,10 @@ private:
   //   waiting for a read lock, otherwise it is the count of threads that currently hold a read
   //   lock.
 
+#ifdef KJ_CONTENTION_WARNING_THRESHOLD
+  bool printContendedReader = false;
+#endif
+
   static constexpr uint EXCLUSIVE_HELD = 1u << 31;
   static constexpr uint EXCLUSIVE_REQUESTED = 1u << 30;
   static constexpr uint SHARED_COUNT_MASK = EXCLUSIVE_REQUESTED - 1;


### PR DESCRIPTION
This should provide an additional breadcrumb to debug the contended mutex case.

In the future we might want to hide this behind a dedicated separate macro to avoid
the bloat of the `kj::Mutex`.