### PR TITLE
Lock contention tests

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang-9]
-        features: ["-DKJ_TRACK_LOCK_BLOCKING=1 -DKJ_SAVE_ACQUIRED_LOCK_INFO=1"]
+        features: ["-DKJ_TRACK_LOCK_BLOCKING=1 -DKJ_SAVE_ACQUIRED_LOCK_INFO=1 -DKJ_CONTENTION_WARNING_THRESHOLD=200"]
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -549,6 +549,11 @@ void Mutex::induceSpuriousWakeupForTest() {
   }
 }
 
+uint Mutex::numReadersWaitingForTest() const {
+  assertLockedByCaller(EXCLUSIVE);
+  return futex & SHARED_COUNT_MASK;
+}
+
 void Once::runOnce(Initializer& init, LockSourceLocationArg location) {
 startOver:
   uint state = UNINITIALIZED;

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -428,7 +428,7 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
   }
 }
 
-void Mutex::assertLockedByCaller(Exclusivity exclusivity) {
+void Mutex::assertLockedByCaller(Exclusivity exclusivity) const {
   switch (exclusivity) {
     case EXCLUSIVE:
       KJ_ASSERT(futex & EXCLUSIVE_HELD,
@@ -689,7 +689,7 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
   }
 }
 
-void Mutex::assertLockedByCaller(Exclusivity exclusivity) {
+void Mutex::assertLockedByCaller(Exclusivity exclusivity) const {
   // We could use TryAcquireSRWLock*() here like we do with the pthread version. However, as of
   // this writing, my version of Wine (1.6.2) doesn't implement these functions and will abort if
   // they are called. Since we were only going to use them as a hacky way to check if the lock is
@@ -902,7 +902,7 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
   }
 }
 
-void Mutex::assertLockedByCaller(Exclusivity exclusivity) {
+void Mutex::assertLockedByCaller(Exclusivity exclusivity) const {
   switch (exclusivity) {
     case EXCLUSIVE:
       // A read lock should fail if the mutex is already held for writing.

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -161,6 +161,13 @@ public:
   // are waiting for a wait() condition. Assuming correct implementation, all those threads
   // should immediately go back to sleep.
 
+#if KJ_USE_FUTEX
+  uint numReadersWaitingForTest() const;
+  // The number of reader locks that are currently blocked on this lock (must be called while
+  // holding the writer lock). This is really only a utility method for mutex-test.c++ so it can
+  // validate certain invariants.
+#endif
+
 #if KJ_SAVE_ACQUIRED_LOCK_INFO
   using AcquiredMetadata = kj::OneOf<HoldingExclusively, HoldingShared>;
   KJ_DISABLE_TSAN AcquiredMetadata lockedInfo() const;

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -139,7 +139,7 @@ public:
   bool lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLocationArg location);
   void unlock(Exclusivity exclusivity, Waiter* waiterToSkip = nullptr);
 
-  void assertLockedByCaller(Exclusivity exclusivity);
+  void assertLockedByCaller(Exclusivity exclusivity) const;
   // In debug mode, assert that the mutex is locked by the calling thread, or if that is
   // non-trivial, assert that the mutex is locked (which should be good enough to catch problems
   // in unit tests).  In non-debug builds, do nothing.


### PR DESCRIPTION
#1284 might have accidentally broken the lock contention code if not caught in code review. Add a unit test to protect accidental breakage in the future.