### PR TITLE
Fix UBSAN errors.

### DIFF
--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -912,7 +912,9 @@ private:
             "InMemoryFile cannot resize the file backing store while memory mappings exist.");
 
         auto newBytes = heapArray<byte>(kj::max(capacity, bytes.size() * 2));
-        memcpy(newBytes.begin(), bytes.begin(), size);
+        if (size > 0) {  // placate ubsan; bytes.begin() might be null
+          memcpy(newBytes.begin(), bytes.begin(), size);
+        }
         memset(newBytes.begin() + size, 0, newBytes.size() - size);
         bytes = kj::mv(newBytes);
       }

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -187,7 +187,11 @@ static CappedArray<char, sizeof(T) * 3 + 2> stringifyImpl(T i) {
   // We don't use sprintf() because it's not async-signal-safe (for strPreallocated()).
   CappedArray<char, sizeof(T) * 3 + 2> result;
   bool negative = i < 0;
-  Unsigned u = negative ? -i : i;
+  // Note that if `i` is the most-negative value, negating it produces the same bit value. But
+  // since it's a signed integer, this is considered an overflow. We therefore must make it
+  // unsigned first, then negate it, to avoid ubsan complaining.
+  Unsigned u = i;
+  if (negative) u = -u;
   uint8_t reverse[sizeof(T) * 3 + 1];
   uint8_t* p = reverse;
   if (u == 0) {


### PR DESCRIPTION
Motivated by: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33710

Clusterfuzz considers any UBSAN violation to be a possible security flaw. In practice, none of the actual errors are likely to be exploitable.

This commit fixes all errors reported by `capnp-test` with UBSAN enabled.