### PR TITLE
Fix stack overflow potential destroying TaskSet

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -25,6 +25,19 @@
 #include "mutex.h"
 #include "thread.h"
 
+// TODO(later): Refactor this more cleanly so that the KJ library itself defines this.
+#if !__BIONIC__
+#define KJ_FIBERS_AVAILABLE 1
+#else
+#define KJ_FIBERS_AVAILABLE 0
+#endif
+
+#if !KJ_FIBERS_AVAILABLE
+// For bionic & OpenBSD, enables the regression test for kj::TaskSet::~TaskSet potentially causing a
+// stack overflow.
+#include <pthread.h>
+#endif
+
 namespace kj {
 namespace {
 
@@ -733,6 +746,45 @@ TEST(Async, TaskSet) {
   EXPECT_EQ(1u, errorHandler.exceptionCount);
 }
 
+TEST(Async, LargeTaskSetDestruction) {
+  static constexpr size_t stackSize = 200 * 1024;
+
+  static auto testBody = [] {
+
+    ErrorHandlerImpl errorHandler;
+    TaskSet tasks(errorHandler);
+
+    for (int i = 0; i < stackSize / sizeof(void*); i++) {
+      tasks.add(kj::NEVER_DONE);
+    }
+  };
+
+#if KJ_FIBERS_AVAILABLE
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  startFiber(stackSize,
+      [](WaitScope&) mutable {
+    testBody();
+  }).wait(waitScope);
+
+#else
+  pthread_attr_t attr;
+  KJ_REQUIRE(0 == pthread_attr_init(&attr));
+  KJ_DEFER(KJ_REQUIRE(0 == pthread_attr_destroy(&attr)));
+
+  KJ_REQUIRE(0 == pthread_attr_setstacksize(&attr, stackSize));
+  pthread_t thread;
+  KJ_REQUIRE(0 == pthread_create(&thread, &attr, [](void*) -> void* {
+    EventLoop loop;
+    WaitScope waitScope(loop);
+    testBody();
+    return nullptr;
+  }, nullptr));
+  KJ_REQUIRE(0 == pthread_join(thread, nullptr));
+#endif
+}
+
 TEST(Async, TaskSet) {
   EventLoop loop;
   WaitScope waitScope(loop);
@@ -946,7 +998,7 @@ KJ_TEST("exclusiveJoin both events complete simultaneously") {
   KJ_EXPECT(!joined.poll(waitScope));
 }
 
-#if !__BIONIC__ && !KJ_NO_EXCEPTIONS
+#if KJ_FIBERS_AVAILABLE && !KJ_NO_EXCEPTIONS
 KJ_TEST("start a fiber") {
   EventLoop loop;
   WaitScope waitScope(loop);


### PR DESCRIPTION
If the size of the linked list is really large (e.g. 20000000), it's easy to generate a stack overflow
because the compiler will unwind the object graph through the stack. Switch this to unwind with
a fixed size loop to avoid that problem. Obviously a large list like this can take time to unwind
anyway, so it may be worthwhile to consider adding limits to how large a task set that is directly
under untrusted control is allowed to get.

I don't have a Windows machine so I haven't verified that the stack test without the fix fails on its
own there but presumably this simple test uses roughly the same amount of stack on all platforms.