### PR TITLE
Fix promise chain stack overflow

### DIFF
--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -831,8 +831,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
           }
         }
 
-        SocketAddress addr;
-        memset(&addr, 0, sizeof(addr));  // mollify valgrind
+        SocketAddress addr{};
         if (params.host == "*") {
           // Set up a wildcard SocketAddress.  Only use the port number returned by getaddrinfo().
           addr.wildcard = true;

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -87,7 +87,14 @@
 #include <intrin.h>
 #endif
 
-#if KJ_HAS_COMPILER_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#if _MSC_VER && !__clang__
+#define KJ_MIGHT_HAVE_LSAN 0
+#else
+#define KJ_MIGHT_HAVE_LSAN 1
+#endif
+
+#if KJ_MIGHT_HAVE_LSAN && (KJ_HAS_COMPILER_FEATURE(address_sanitizer) || \
+                           defined(__SANITIZE_ADDRESS__))
 #include <sanitizer/lsan_interface.h>
 #else
 static void __lsan_ignore_object(const void* p) {}

--- a/c++/src/kj/test-helpers.c++
+++ b/c++/src/kj/test-helpers.c++
@@ -50,7 +50,7 @@ bool hasSubstring(StringPtr haystack, StringPtr needle) {
 #if !defined(_WIN32)
     return memmem(haystack.begin(), haystack.size(), needle.begin(), needle.size()) != nullptr;
 #elif defined(__cpp_lib_boyer_moore_searcher)
-    std::boyer_moore_horspool_searcher searcher{needle.begin(), needle.size()};
+    std::boyer_moore_horspool_searcher searcher{needle.begin(), needle.end()};
     return std::search(haystack.begin(), haystack.end(), searcher) != haystack.end();
 #else
     // TODO(perf): This is not the best algorithm for substring matching. strstr can't be used


### PR DESCRIPTION
This closes the ability for tail call optimization failures (on purpose or accidental) to generate
a stack overflow on destruction. KJ can now be built with a `KJ_CHAIN_PROMISE_DEPTH_WARNING_THRESHOLD`
to generate a warning whenever the promise chain is too long (similar to `KJ_CONTENTION_WARNING_THRESHOLD`).

@kentonv this wasn't actually that much work & I think this makes things a bit easier to debug. While Sentry does have contextual
information, it requires quite a bit of knowledge about the application using KJ (& sometimes both the application & KJ) to
convert it to a reasonable guess. I know your analysis was straightforward for you, but I have trouble following it & I suspect
other new people will struggle to perform the same analysis you did. However, now, if the warning threshold is set, we'll get a
precise stack trace of the issue & can even set this fairly aggressively within Workers since I suspect anything above a
relatively small number like is going to be an issue we want to examine on our end.