### PR TITLE
Fix large taskset test when building with KJ_NO_EXCEPTIONS

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -26,15 +26,15 @@
 #include "thread.h"
 
 // TODO(later): Refactor this more cleanly so that the KJ library itself defines this.
-#if !__BIONIC__
+#if !__BIONIC__ && !KJ_NO_EXCEPTIONS
 #define KJ_FIBERS_AVAILABLE 1
 #else
 #define KJ_FIBERS_AVAILABLE 0
 #endif
 
 #if !KJ_FIBERS_AVAILABLE
-// For bionic & OpenBSD, enables the regression test for kj::TaskSet::~TaskSet potentially causing a
-// stack overflow.
+// For bionic, OpenBSD, and no-exception builds, enables the regression test for
+// kj::TaskSet::~TaskSet potentially causing a stack overflow.
 #include <pthread.h>
 #endif
 


### PR DESCRIPTION
Looks like `-fno-exceptions` builds have been failing in `Async/LargeTaskSetDestruction` since b6e26ae was merged, because FiberStack's constructor fails when exceptions are turned off.