### PR TITLE
Fix some compiler warnings

### DIFF
--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -315,7 +315,7 @@ kj::Promise<void> writeMessagesImpl(
 
   size_t tableValsWritten = 0;
   size_t piecesWritten = 0;
-  for (int i = 0; i < messages.size(); ++i) {
+  for (auto i : kj::indices(messages)) {
     const size_t tableValsToWrite = tableSizeForSegments(messages[i].size());
     const size_t piecesToWrite = messages[i].size() + 1;
     fillWriteArraysWithMessage(
@@ -360,7 +360,7 @@ kj::Promise<void> writeMessages(
 kj::Promise<void> writeMessages(
     kj::AsyncOutputStream& output, kj::ArrayPtr<MessageBuilder*> builders) {
   auto messages = kj::heapArray<kj::ArrayPtr<const kj::ArrayPtr<const word>>>(builders.size());
-  for (int i = 0; i < builders.size(); ++i) {
+  for (auto i : kj::indices(builders)) {
     messages[i] = builders[i]->getSegmentsForOutput();
   }
   return writeMessages(output, messages);
@@ -368,7 +368,7 @@ kj::Promise<void> writeMessages(
 
 kj::Promise<void> MessageStream::writeMessages(kj::ArrayPtr<MessageBuilder*> builders) {
   auto messages = kj::heapArray<kj::ArrayPtr<const kj::ArrayPtr<const word>>>(builders.size());
-  for (int i = 0; i < builders.size(); ++i) {
+  for (auto i : kj::indices(builders)) {
     messages[i] = builders[i]->getSegmentsForOutput();
   }
   return writeMessages(messages);

--- a/c++/src/kj/async-queue-test.c++
+++ b/c++/src/kj/async-queue-test.c++
@@ -82,23 +82,23 @@ KJ_TEST("ProducerConsumerQueue with various amounts of producers and consumers")
              producerCount, consumerCount, kItemCount);
       // Make a vector to track our entries.
       auto bits = Vector<bool>(kItemCount);
-      for (size_t i = 0; i < kItemCount; ++i) {
+      for (auto i KJ_UNUSED : kj::zeroTo(kItemCount)) {
         bits.add(false);
       }
 
       // Make enough producers.
       auto producers = Vector<QueueTest::Producer>();
-      for (size_t i = 0; i < producerCount; ++i) {
+      for (auto i KJ_UNUSED : kj::zeroTo(producerCount)) {
         producers.add(test);
       }
 
       // Make enough consumers.
       auto consumers = Vector<QueueTest::Consumer>();
-      for (size_t i = 0; i < consumerCount; ++i) {
+      for (auto i KJ_UNUSED : kj::zeroTo(consumerCount)) {
         consumers.add(test);
       }
 
-      for (size_t i = 0; i < kItemCount; ++i) {
+      for (auto i : kj::zeroTo(kItemCount)) {
         // Use a producer and a consumer for each entry.
 
         auto& producer = producers[i % producerCount];
@@ -117,7 +117,7 @@ KJ_TEST("ProducerConsumerQueue with various amounts of producers and consumers")
         promises.add(kj::mv(consumer.promise));
       }
       joinPromises(promises.releaseAsArray()).wait(test.io.waitScope);
-      for (auto i = 0; i < kItemCount; ++i) {
+      for (auto i : kj::zeroTo(kItemCount)) {
         KJ_ASSERT(bits[i], i);
       }
     }
@@ -132,7 +132,7 @@ KJ_TEST("ProducerConsumerQueue with rejectAll()") {
 
     // Make enough consumers.
     auto promises = Vector<Promise<void>>();
-    for (size_t i = 0; i < consumerCount; ++i) {
+    for (auto i KJ_UNUSED : kj::zeroTo(consumerCount)) {
       promises.add(test.queue.pop().ignoreResult());
     }
 


### PR DESCRIPTION
These were of the form `warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]`.
This shouldn't affect the behavior in practice, but the fix was easy and it makes the build quieter.