### PR TITLE
Don't add remote exception prefix if already present for exceptions coming in over RPC

### DIFF
--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -1305,6 +1305,23 @@ KJ_TEST("method throws exception") {
   KJ_EXPECT(exception.getRemoteTrace() == nullptr);
 }
 
+KJ_TEST("method throws exception won't redundantly add remote exception prefix") {
+  TestContext context;
+
+  auto client = context.connect(test::TestSturdyRefObjectId::Tag::TEST_MORE_STUFF)
+      .castAs<test::TestMoreStuff>();
+
+  kj::Maybe<kj::Exception> maybeException;
+  client.throwRemoteExceptionRequest().send().ignoreResult()
+      .catch_([&](kj::Exception&& e) {
+    maybeException = kj::mv(e);
+  }).wait(context.waitScope);
+
+  auto exception = KJ_ASSERT_NONNULL(maybeException);
+  KJ_EXPECT(exception.getDescription() == "remote exception: test exception");
+  KJ_EXPECT(exception.getRemoteTrace() == nullptr);
+}
+
 KJ_TEST("method throws exception with trace encoder") {
   TestContext context;
 

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -3112,7 +3112,7 @@ public:
       // disassemble it.
       if (!connections.empty()) {
         kj::Vector<kj::Own<RpcConnectionState>> deleteMe(connections.size());
-        kj::Exception shutdownException = KJ_EXCEPTION(FAILED, "RpcSystem was destroyed.");
+        kj::Exception shutdownException = KJ_EXCEPTION(DISCONNECTED, "RpcSystem was destroyed.");
         for (auto& entry: connections) {
           entry.second->disconnect(kj::cp(shutdownException));
           deleteMe.add(kj::mv(entry.second));

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -112,8 +112,16 @@ Orphan<List<rpc::PromisedAnswer::Op>> fromPipelineOps(
 }
 
 kj::Exception toException(const rpc::Exception::Reader& exception) {
+  auto reason = [&]() {
+    if (exception.getReason().startsWith("remote exception: ")) {
+      return kj::str(exception.getReason());
+    } else {
+      return kj::str("remote exception: ", exception.getReason());
+    }
+  }();
+
   kj::Exception result(static_cast<kj::Exception::Type>(exception.getType()),
-      "(remote)", 0, kj::str("remote exception: ", exception.getReason()));
+      "(remote)", 0, kj::mv(reason));
   if (exception.hasTrace()) {
     result.setRemoteTrace(kj::str(exception.getTrace()));
   }

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -1190,6 +1190,10 @@ kj::Promise<void> TestMoreStuffImpl::throwException(ThrowExceptionContext contex
   return KJ_EXCEPTION(FAILED, "test exception");
 }
 
+kj::Promise<void> TestMoreStuffImpl::throwRemoteException(ThrowRemoteExceptionContext context) {
+  return KJ_EXCEPTION(FAILED, "remote exception: test exception");
+}
+
 #endif  // !CAPNP_LITE
 
 }  // namespace _ (private)

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -280,6 +280,8 @@ public:
 
   kj::Promise<void> throwException(ThrowExceptionContext context) override;
 
+  kj::Promise<void> throwRemoteException(ThrowRemoteExceptionContext context) override;
+
 private:
   int& callCount;
   int& handleCount;

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -884,6 +884,7 @@ interface TestMoreStuff extends(TestCallOrder) {
   # the second. Also creates a socketpair, writes "baz" to one end, and returns the other end.
 
   throwException @14 ();
+  throwRemoteException @15 ();
 }
 
 interface TestMembrane {


### PR DESCRIPTION
Also, change type of `RpcSystem was destroyed` exception to `DISCONNECTED` to reduce INFO log spam