### PR TITLE
Add address to connect() error message

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1286,7 +1286,8 @@ public:
           // Fine.
           break;
         } else if (error != EINTR) {
-          KJ_FAIL_SYSCALL("connect()", error) { break; }
+          auto address = SocketAddress(addr, addrlen).toString();
+          KJ_FAIL_SYSCALL("connect()", error, address) { break; }
           return Own<AsyncIoStream>();
         }
       } else {


### PR DESCRIPTION
To make the "connect()" error message a bit more useful, add the address that was being attempted.

/cc @kentonv @vlovich 

Signed-off-by: James M Snell <jasnell@gmail.com>