### PR TITLE
Fix capnp/capnpc --version when built using CMake

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -187,8 +187,9 @@ if(NOT CAPNP_LITE)
   set_target_properties(capnp_tool PROPERTIES CAPNP_INCLUDE_DIRECTORY
     $<JOIN:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>,$<INSTALL_INTERFACE:${CMAKE_INSTALL_BINDIR}/..>>
   )
-  set_target_properties(capnp_tool PROPERTIES
-    COMPILE_DEFINITIONS CAPNP_INCLUDE_DIR=\"${CMAKE_INSTALL_FULL_INCLUDEDIR}\"
+  target_compile_definitions(capnp_tool PRIVATE
+    "CAPNP_INCLUDE_DIR=\"${CMAKE_INSTALL_FULL_INCLUDEDIR}\""
+    "VERSION=\"${VERSION}\""
   )
 
   add_executable(capnpc_cpp


### PR DESCRIPTION
Currently, running `capnp[c] --version` on Arch Linux (both the current 0.8.0 and my self-built 0.9.0 package) prints "Cap'n Proto version (unknown)" because `VERSION` is a CMake variable but not a C++ definition. This adds `VERSION` as a C++ definition, fixing the resulting binaries. This also switches `CAPNP_INCLUDE_DIR` to a `target_compile_definitions` call for simplicity.

## Old

The existing CMakeLists.txt is strange though; the following *overwrites* the list of definitions:

```cpp
  set_target_properties(capnp_tool PROPERTIES
    COMPILE_DEFINITIONS CAPNP_INCLUDE_DIR=\"${CMAKE_INSTALL_FULL_INCLUDEDIR}\"
  )
```

I tried adding variations of `;VERSION="${VERSION}"` to set two definitions, but it was rejected since CMake thought it was multiple arguments to set_target_properties. I decided to append onto your existing string with a separate `target_compile_definitions` command, since it was easier to get working.

Do you want to replace `set_target_properties(... COMPILE_DEFINITIONS)` with `target_compile_definitions` entirely?