### PR TITLE
Fix tee stack overflow

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -75,6 +75,10 @@ void AsyncInputStream::registerAncillaryMessageHandler(
  KJ_UNIMPLEMENTED("registerAncillaryMsgHandler is not implemented by this AsyncInputStream");
 }
 
+Maybe<Own<AsyncInputStream>> AsyncInputStream::tryTee(uint64_t) {
+  return nullptr;
+}
+
 namespace {
 
 class AsyncPump {

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -91,6 +91,15 @@ public:
   // The provided callback will be called whenever any are encountered. The messages passed to
   // the function do not live beyond when function returns.
   // Only supported on Unix (the default impl throws UNIMPLEMENTED). Most apps will not use this.
+
+  virtual Maybe<Own<AsyncInputStream>> tryTee(uint64_t limit = kj::maxValue);
+  // Primarily intended as an optimization for the `tee` call. Returns an input stream whose state
+  // is independent from this one but which will return the exact same set of bytes read going
+  // forward. limit is a total limit on the amount of memory, in bytes, which a tee implementation
+  // may use to buffer stream data. An implementation must throw an exception if a read operation
+  // would cause the limit to be exceeded. If tryTee() can see that the new limit is impossible to
+  // satisfy, it should return nullptr so that the pessimized path is taken in newTee. This is
+  // likely to arise if tryTee() is called twice with different limits on the same stream.
 };
 
 class AsyncOutputStream {


### PR DESCRIPTION
The behavior of the `limit` with `tryTee` was unclear. I just assumed that if the new limit is smaller, then we fail the optimization & force the regular `newTee` path, which seems reasonable since the limit applies to the overall tee, not any individual branch.

It's also important to note that I think the way we use the limit may be incorrect, or at least need to feed back into V8's external memory usage calculation. The reason is that if have 200 branches & set a limit of 5 MB on the tee, each branch would be allowed to have a 5 MB buffer...