### PR TITLE
Add CallContextHook::from().

### DIFF
--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -407,6 +407,7 @@ private:
 
   friend class Capability::Server;
   friend struct DynamicCapability;
+  friend class CallContextHook;
 };
 
 template <typename Params>
@@ -431,6 +432,7 @@ private:
 
   friend class Capability::Server;
   friend struct DynamicCapability;
+  friend class CallContextHook;
 };
 
 class Capability::Server {
@@ -774,6 +776,11 @@ public:
   // promise fulfiller for onTailCall() with the returned pipeline.
 
   virtual kj::Own<CallContextHook> addRef() = 0;
+
+  template <typename Params, typename Results>
+  static CallContextHook& from(CallContext<Params, Results>& context) { return *context.hook; }
+  template <typename Params>
+  static CallContextHook& from(StreamingCallContext<Params>& context) { return *context.hook; }
 };
 
 kj::Own<ClientHook> newLocalPromiseClient(kj::Promise<kj::Own<ClientHook>>&& promise);


### PR DESCRIPTION
Most other hook types already have similar `from()` methods, but this one was missing.