### PR TITLE
Fix tls-test.c++ when linked against BoringSSL in FIPS mode

### DIFF
--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -728,7 +728,7 @@ KJ_TEST("TLS client certificate verification") {
                        // KJ_EXPECT_THROW_MESSAGE() runs in a forked child process.
     KJ_EXPECT_THROW_MESSAGE(
         SSL_MESSAGE("alert",  // "alert handshake failure" or "alert certificate required"
-                    "CERTIFICATE_REQUIRED"),
+                    "ALERT"), // "ALERT_HANDSHAKE_FAILURE" or "ALERT_CERTIFICATE_REQUIRED"
         clientPromise.wait(test.io.waitScope));
 #endif
   }


### PR DESCRIPTION
Just a difference in error message, maybe because BoringSSL FIPS is simply so old.