### PR TITLE
Add support for OpenBSD

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -421,10 +421,15 @@ capnpc_c___SOURCES = src/capnp/compiler/capnpc-c++.c++
 # Also attempt to run ldconfig, because otherwise users get confused.  If
 # it fails (e.g. because the platform doesn't have it, or because the
 # user doesn't have root privileges), don't worry about it.
+#
+# We need to specify the path for OpenBSD.
 install-exec-hook:
 	ln -sf capnp $(DESTDIR)$(bindir)/capnpc
-	ldconfig < /dev/null > /dev/null 2>&1 || true
-
+	if [ `uname` == 'OpenBSD' ]; then \
+	        (ldconfig /usr/local/lib /usr/lib /usr/X11R6/lib > /dev/null 2>&1 || true); \
+	else \
+		ldconfig < /dev/null > /dev/null 2>&1 || true; \
+	fi
 uninstall-hook:
 	rm -f $(DESTDIR)$(bindir)/capnpc
 

--- a/c++/src/capnp/compiler/capnp-test.sh
+++ b/c++/src/capnp/compiler/capnp-test.sh
@@ -77,7 +77,7 @@ $CAPNP convert json:binary $SCHEMA TestAllTypes < $TESTDATA/pretty.json | cmp $T
 $CAPNP convert json:binary $SCHEMA TestAllTypes < $TESTDATA/short.json | cmp $TESTDATA/binary - || fail short json to binary
 
 $CAPNP convert json:binary $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated.json | cmp $TESTDATA/annotated-json.binary - || fail annotated json to binary
-$CAPNP convert binary:json $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated-json.binary | cmp $TESTDATA/annotated.json - || fail annotated json to binary
+$CAPNP convert binary:json $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated-json.binary | cmp $TESTDATA/annotated.json - || fail annotated binary to json
 
 [ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" BrandedAlias)" = '(foo = (text = "abc"), uv = void)' ]  || fail branded alias
 [ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" BrandedAlias.Inner)" = '(foo = (text = "abc"))' ]  || fail branded alias

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1480,7 +1480,9 @@ kj::Own<PeerIdentity> SocketAddress::getIdentity(kj::LowLevelAsyncIoProvider& ll
       // seen vague references on the internet saying that a PID of 0 and a UID of uid_t(-1) are used
       // as invalid values.
 
-#if defined(SO_PEERCRED)
+// OpenBSD defines SO_PEERCRED but uses a different interface for it
+// hence we're falling back to LOCAL_PEERCRED
+#if defined(SO_PEERCRED) && !__OpenBSD__
       struct ucred creds;
       uint length = sizeof(creds);
       stream.getsockopt(SOL_SOCKET, SO_PEERCRED, &creds, &length);
@@ -1492,7 +1494,7 @@ kj::Own<PeerIdentity> SocketAddress::getIdentity(kj::LowLevelAsyncIoProvider& ll
       }
 
 #elif defined(LOCAL_PEERCRED)
-      // MacOS / FreeBSD
+      // MacOS / FreeBSD / OpenBSD
       struct xucred creds;
       uint length = sizeof(creds);
       stream.getsockopt(SOL_LOCAL, LOCAL_PEERCRED, &creds, &length);

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -53,8 +53,12 @@
 #include <windows.h>  // for Sleep(0) and fibers
 #include "windows-sanity.h"
 #else
+
+#if KJ_USE_FIBERS
 #include <ucontext.h>
 #include <setjmp.h>    // for fibers
+#endif
+
 #include <sys/mman.h>  // mmap(), for allocating new stacks
 #include <unistd.h>    // sysconf()
 #include <errno.h>


### PR DESCRIPTION
It's been on my to-do list for quite some time now, finally got a chance to do it. This PR aims to:

  - fix test for systems with bsd cmp
    - a single dash is required for bsd style cmp to accept input from stdin
  - Allow disable fibers with KJ_USE_FIBERS
    - as discussed in https://github.com/capnproto/capnproto/issues/1208 and https://github.com/capnproto/capnproto/issues/1167
  - Use appropriate ldconfig command for OpenBSD 

Tested on OpenBSD 7.0-beta/AMD64.

output of `make check`: https://github.com/ZhanYF/static/blob/main/checkLog
  - 1 of 3 tests failed, but I guess that's due to not building fibers?


any comment?  I have to admit I'm not familiar with capnproto/fibers/c++ in general, so please feel free to tweak it :)