### PR TITLE
Fix copy-pasto resulting in uninitialized use of `kind`.

### DIFF
--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -2395,7 +2395,7 @@ Orphan<List<schema::Annotation>> NodeTranslator::compileAnnotationApplications(
             }
           }
         }
-      } else if (*kind != Declaration::ANNOTATION) {
+      } else {
         errorReporter.addErrorOn(name, kj::str(
             "'", expressionString(name), "' is not an annotation."));
       }

--- a/c++/src/capnp/testdata/errors.capnp.nobuild
+++ b/c++/src/capnp/testdata/errors.capnp.nobuild
@@ -142,6 +142,7 @@ enum DupEnumerants {
 const recursive: UInt32 = .recursive;
 
 struct Generic(T, U) {
+  foo @0 :UInt32 $T;
 }
 
 struct UseGeneric {

--- a/c++/src/capnp/testdata/errors.txt
+++ b/c++/src/capnp/testdata/errors.txt
@@ -51,13 +51,14 @@ file:136:3-10: error: 'dupName' previously defined here.
 file:139:15-16: error: Duplicate ordinal number.
 file:138:15-16: error: Ordinal @2 originally used here.
 file:142:7-16: error: Declaration recursively depends on itself.
-file:148:14-27: error: Not enough generic parameters.
-file:149:15-47: error: Too many generic parameters.
-file:150:18-49: error: Double-application of generic parameters.
-file:151:38-43: error: Sorry, only pointer types can be used as generic parameters.
-file:154:30-44: error: Embeds can only be used when Text, Data, or a struct is expected.
-file:155:37-51: error: Couldn't read file for embed: no-such-file
-file:161:23-27: error: Only pointer parameters can declare their default as 'null'.
-file:162:10-16: error: 'stream' can only appear after '->', not before.
-file:162:10-16: error: A method declaration uses streaming, but '/capnp/stream.capnp' is not found in the import path. This is a standard file that should always be installed with the Cap'n Proto compiler.
-file:157:20-45: error: Import failed: nosuchfile-unused.capnp
+file:145:19-20: error: 'T' is not an annotation.
+file:149:14-27: error: Not enough generic parameters.
+file:150:15-47: error: Too many generic parameters.
+file:151:18-49: error: Double-application of generic parameters.
+file:152:38-43: error: Sorry, only pointer types can be used as generic parameters.
+file:155:30-44: error: Embeds can only be used when Text, Data, or a struct is expected.
+file:156:37-51: error: Couldn't read file for embed: no-such-file
+file:162:23-27: error: Only pointer parameters can declare their default as 'null'.
+file:163:10-16: error: 'stream' can only appear after '->', not before.
+file:163:10-16: error: A method declaration uses streaming, but '/capnp/stream.capnp' is not found in the import path. This is a standard file that should always be installed with the Cap'n Proto compiler.
+file:158:20-45: error: Import failed: nosuchfile-unused.capnp


### PR DESCRIPTION
In practice this would only result in incorrect behavior if the uninitialized value turned out to be equal to a certain non-zero constant. Hence, in practice, incorrect behavior was unlikely and maybe impossible. I wasn't able to trigger it in tests.

This is one part of #1311.