### PR TITLE
Fix build regression introduced in d3b0dc209 - the SOL_LOCAL is not defined on FreeBSD 11.x and below.

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -55,6 +55,11 @@
 #include <sys/ucred.h>
 #endif
 
+#if !defined(SOL_LOCAL) && (__FreeBSD__ || __DragonflyBSD__)
+// On DragonFly or FreeBSD < 12.2 you're supposed to use 0 for SOL_LOCAL.
+#define SOL_LOCAL 0
+#endif
+
 namespace kj {
 
 namespace {


### PR DESCRIPTION
On FreeBSD versions <= 11 the magic value of "0" would be used instead.