### PR TITLE
Fix WebSocket over http capnp to notice peer disconnect

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -149,7 +149,7 @@ public:
     if (shorteningFulfiller->isWaiting()) {
       // We want to make sure the fulfiller is not rejected with a bogus "PromiseFulfiller
       // destroyed" error, so fulfill it with never-done.
-      shorteningFulfiller->fulfill(kj::NEVER_DONE);
+      shorteningFulfiller->fulfill(KJ_EXCEPTION(DISCONNECTED));
     }
   }
 


### PR DESCRIPTION
@kentonv any thoughts about why the `#if 0` chunk of the test is broken? I confirmed in a debugger that the promise is rejected with DISCONNECTED, but the client's whenAborted never is. This does fix the issue I observed though so maybe the test itself is just invalid?