### PR TITLE
Add Cirrus CI configuration to test capnproto on a few actively maintained FreeBSD versions and fix few issues

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,34 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+freebsd_task:
+  matrix:
+    - name: FreeBSD 13.0 (GCC 10 from packages)
+      # RunCatchingExceptionsOtherException fails on 13.0 with system Clang
+      # 11.0 and ports Clang 10/11 as well, so GCC 10 is used instead.
+      freebsd_instance:
+        image_family: freebsd-13-0
+      preinstall_script:
+        # Stock clang11 fails some exception unit tests
+        pkg install -y gcc10
+      env:
+        CC: gcc10
+        CXX: g++10
+    - name: FreeBSD 12.2 (System Clang 10)
+      freebsd_instance:
+        image_family: freebsd-12-2
+    - name: FreeBSD 11.4 (System Clang 10)
+      freebsd_instance:
+        image_family: freebsd-11-4
+  install_script:
+    pkg install -y automake autoconf libtool
+  compiler_version_script:
+    ${CXX:-"c++"} --version
+  autoreconf_script:
+    - cd c++ && autoreconf -i
+  configure_script:
+    - cd c++ && ./configure
+  build_script:
+    - make -C c++
+  test_script:
+    - make -C c++ check

--- a/c++/src/capnp/compiler/capnp-test.sh
+++ b/c++/src/capnp/compiler/capnp-test.sh
@@ -76,8 +76,8 @@ $CAPNP convert binary:json --short $SCHEMA TestAllTypes < $TESTDATA/binary | cmp
 $CAPNP convert json:binary $SCHEMA TestAllTypes < $TESTDATA/pretty.json | cmp $TESTDATA/binary - || fail json to binary
 $CAPNP convert json:binary $SCHEMA TestAllTypes < $TESTDATA/short.json | cmp $TESTDATA/binary - || fail short json to binary
 
-$CAPNP convert json:binary $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated.json | cmp $TESTDATA/annotated-json.binary || fail annotated json to binary
-$CAPNP convert binary:json $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated-json.binary | cmp $TESTDATA/annotated.json || fail annotated json to binary
+$CAPNP convert json:binary $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated.json | cmp $TESTDATA/annotated-json.binary - || fail annotated json to binary
+$CAPNP convert binary:json $JSON_SCHEMA TestJsonAnnotations -I"$SRCDIR" < $TESTDATA/annotated-json.binary | cmp $TESTDATA/annotated.json - || fail annotated json to binary
 
 [ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" BrandedAlias)" = '(foo = (text = "abc"), uv = void)' ]  || fail branded alias
 [ "$(echo '(foo = (text = "abc"))' | $CAPNP convert text:text "$SRCDIR/capnp/test.capnp" BrandedAlias.Inner)" = '(foo = (text = "abc"))' ]  || fail branded alias

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -299,11 +299,11 @@ TEST(AsyncIo, AncillaryMessageHandlerNoMsg) {
 }
 #endif
 
-// We only support ancillary messages on Unix.
-// MacOS only supports SO_TIMESTAMP on datagram sockets, so this test won't work.
-// Android fails this test for unknown reasons and I don't care because it's an extremely obscure
-// feature anyway.
-#if !_WIN32 && !__CYGWIN__  && !__APPLE__ && !__ANDROID__
+// This test uses SO_TIMESTAMP on a SOCK_STREAM, which is only supported by Linux. Ideally we'd
+// rewrite the test to use some other message type that is widely supported on streams. But for
+// now we just limit the test to Linux. Also, it doesn't work on Android for some reason, and it
+// isn't worth investigating, so we skip it there.
+#if __linux__ && !__ANDROID__
 TEST(AsyncIo, AncillaryMessageHandler) {
   auto ioContext = setupAsyncIo();
   auto& network = ioContext.provider->getNetwork();

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1146,6 +1146,9 @@ public:
               ownFd.get(), IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(one))) {
           case EOPNOTSUPP:
           case ENOPROTOOPT: // (returned for AF_UNIX in cygwin)
+#if __FreeBSD__
+          case EINVAL: // (returned for AF_UNIX in FreeBSD)
+#endif
             break;
           default:
             KJ_FAIL_SYSCALL("setsocketopt(IPPROTO_TCP, TCP_NODELAY)", error);

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -25,16 +25,7 @@
 #include "mutex.h"
 #include "thread.h"
 
-// TODO(later): Refactor this more cleanly so that the KJ library itself defines this.
-#if !__BIONIC__ && !KJ_NO_EXCEPTIONS
-#define KJ_FIBERS_AVAILABLE 1
-#else
-#define KJ_FIBERS_AVAILABLE 0
-#endif
-
-#if !KJ_FIBERS_AVAILABLE
-// For bionic, OpenBSD, and no-exception builds, enables the regression test for
-// kj::TaskSet::~TaskSet potentially causing a stack overflow.
+#if !KJ_USE_FIBERS
 #include <pthread.h>
 #endif
 
@@ -759,7 +750,7 @@ TEST(Async, LargeTaskSetDestruction) {
     }
   };
 
-#if KJ_FIBERS_AVAILABLE
+#if KJ_USE_FIBERS
   EventLoop loop;
   WaitScope waitScope(loop);
 
@@ -998,7 +989,7 @@ KJ_TEST("exclusiveJoin both events complete simultaneously") {
   KJ_EXPECT(!joined.poll(waitScope));
 }
 
-#if KJ_FIBERS_AVAILABLE && !KJ_NO_EXCEPTIONS
+#if KJ_USE_FIBERS
 KJ_TEST("start a fiber") {
   EventLoop loop;
   WaitScope waitScope(loop);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -27,6 +27,19 @@
 
 KJ_BEGIN_HEADER
 
+#ifndef KJ_USE_FIBERS
+  #if __BIONIC__ || __FreeBSD__ || __OpenBSD__ || KJ_NO_EXCEPTIONS
+    // These platforms don't support fibers.
+    #define KJ_USE_FIBERS 0
+  #else
+    #define KJ_USE_FIBERS 1
+  #endif
+#else
+  #if KJ_NO_EXCEPTIONS && KJ_USE_FIBERS
+    #error "Fibers cannot be enabled when exceptions are disabled."
+  #endif
+#endif
+
 namespace kj {
 
 class EventLoop;

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -1176,8 +1176,10 @@ public:
         if (S_ISDIR(stats.st_mode)) {
           return mkdirat(fd, candidatePath.cStr(), 0700);
         } else {
-#if __APPLE__
-          // No mknodat() on OSX, gotta open() a file, ugh.
+#if __APPLE__ || __FreeBSD__
+          // - No mknodat() on OSX, gotta open() a file, ugh.
+          // - On a modern FreeBSD, mknodat() is reserved strictly for device nodes,
+          //   you cannot create a regular file using it (EINVAL).
           int newFd = openat(fd, candidatePath.cStr(),
                              O_RDWR | O_CREAT | O_EXCL | MAYBE_O_CLOEXEC, 0700);
           if (newFd >= 0) close(newFd);

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -282,7 +282,8 @@ KJ_TEST("float stringification and parsing is not locale-dependent") {
   KJ_EXPECT("1.5"_kj.parseAs<double>() == 1.5);
 
   if (setlocale(LC_NUMERIC, "es_ES") == nullptr &&
-      setlocale(LC_NUMERIC, "es_ES.utf8") == nullptr) {
+      setlocale(LC_NUMERIC, "es_ES.utf8") == nullptr &&
+      setlocale(LC_NUMERIC, "es_ES.UTF-8") == nullptr) {
     // Some systems may not have the desired locale available.
     KJ_LOG(WARNING, "Couldn't set locale to es_ES. Skipping this test.");
   } else {


### PR DESCRIPTION
This should run automatically on PRs and commits and will ensure no regressions are made over time (might need project maintainers to make few clicks to enable).

Few issues preventing unit test suite from completing have been identified and fixed.