### PR TITLE
Add new Exception::Type::CANCELED type

### DIFF
--- a/c++/src/capnp/rpc.capnp
+++ b/c++/src/capnp/rpc.capnp
@@ -1194,6 +1194,9 @@ struct Exception {
     # The server doesn't implement the requested method. If there is some other method that the
     # client could call (perhaps an older and/or slower interface), it should try that instead.
     # Otherwise, this should be treated like `failed`.
+
+    canceled @4;
+    # The operation was canceled.
   }
 
   obsoleteIsCallersFault @1 :Bool;

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -719,7 +719,8 @@ StringPtr KJ_STRINGIFY(Exception::Type type) {
     "failed",
     "overloaded",
     "disconnected",
-    "unimplemented"
+    "unimplemented",
+    "canceled"
   };
 
   return TYPE_STRINGS[static_cast<uint>(type)];

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -59,9 +59,12 @@ public:
     // The call required communication over a connection that has been lost. The callee will need
     // to re-establish connections and try again.
 
-    UNIMPLEMENTED = 3
+    UNIMPLEMENTED = 3,
     // The requested method is not implemented. The caller may wish to revert to a fallback
     // approach based on other methods.
+
+    CANCELED = 4
+    // The operation was canceled.
 
     // IF YOU ADD A NEW VALUE:
     // - Update the stringifier.


### PR DESCRIPTION
For use when indicating that an operation was explicitly canceled.