### PR TITLE
Make kj time types safe to serialize in signal handler

### DIFF
--- a/c++/src/kj/time.h
+++ b/c++/src/kj/time.h
@@ -56,9 +56,9 @@ using TimePoint = Absolute<Duration, _::TimeLabel>;
 using Date = Absolute<Duration, _::DateLabel>;
 // A point in real-world time, measured relative to the Unix epoch (Jan 1, 1970 00:00:00 UTC).
 
-kj::String KJ_STRINGIFY(TimePoint);
-kj::String KJ_STRINGIFY(Date);
-kj::String KJ_STRINGIFY(Duration);
+CappedArray<char, sizeof(int64_t) * 3 + 2 + 4> KJ_STRINGIFY(TimePoint);
+CappedArray<char, sizeof(int64_t) * 3 + 2 + 4> KJ_STRINGIFY(Date);
+CappedArray<char, sizeof(int64_t) * 3 + 2 + 4> KJ_STRINGIFY(Duration);
 
 constexpr Date UNIX_EPOCH = origin<Date>();
 // The `Date` representing Jan 1, 1970 00:00:00 UTC.
@@ -110,7 +110,6 @@ const MonotonicClock& systemPreciseMonotonicClock();
 // The "coarse" version has precision around 1-10ms, while the "precise" version has precision
 // better than 1us. The "precise" version may be slightly slower, though on modern hardware and
 // a reasonable operating system the difference is usually negligible.
-
 }  // namespace kj
 
 KJ_END_HEADER


### PR DESCRIPTION
strPreallocated can now accept kj::Duration/kj::TimePoint/kj::Date and
serialize things safely to not need any memory allocation. This is
pretty convenient and these types were accidentally used in Workers.

My primary motivation here was to fix the signal safety issue more robustly
and the bike-shedding in #1330 is dragging on far longer than I anticipated so
pulling in a targeted fix that should hopefully not be objectionable.