### PR TITLE
Add examples of using `filesystem.h` to the KJ tour and docs.

### DIFF
--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -57,10 +57,11 @@ public:
   //
   //     auto fs = kj::newDiskFilesystem();
   //     auto file = fs->getCurrent().openFile(kj::Path::parse("mydata"));
-  //     kj::Array<const kj::byte> fileBuffer = file->mmap(0, file->stat().size).releaseAsChars()
+  //     kj::Array<const kj::byte> fileBuffer = file->mmap(0, file->stat().size);
   //     kj::ArrayPtr<const capnp::word> messageBuffer(
-  //       reinterpret_cast<const capnp::word *>(fileBuffer.begin()), fileBuffer.size() / sizeof(capnp::word));
-  //     capnp::FlatArrayMessageReader capnpReader { messageBuffer };
+  //       reinterpret_cast<const capnp::word *>(fileBuffer.begin()),
+  //       fileBuffer.size() / sizeof(capnp::word));
+  //     capnp::FlatArrayMessageReader capnpReader(messageBuffer);
 
   kj::ArrayPtr<const word> getSegment(uint id) override;
 

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -53,7 +53,14 @@ class FlatArrayMessageReader: public MessageReader {
 
 public:
   FlatArrayMessageReader(kj::ArrayPtr<const word> array, ReaderOptions options = ReaderOptions());
-  // The array must remain valid until the MessageReader is destroyed.
+  // The array must remain valid until the MessageReader is destroyed. Example:
+  //
+  //     auto fs = kj::newDiskFilesystem();
+  //     auto file = fs->getCurrent().openFile(kj::Path::parse("mydata"));
+  //     kj::Array<const kj::byte> fileBuffer = file->mmap(0, file->stat().size).releaseAsChars()
+  //     kj::ArrayPtr<const capnp::word> messageBuffer(
+  //       reinterpret_cast<const capnp::word *>(fileBuffer.begin()), fileBuffer.size() / sizeof(capnp::word));
+  //     capnp::FlatArrayMessageReader capnpReader { messageBuffer };
 
   kj::ArrayPtr<const word> getSegment(uint id) override;
 
@@ -169,7 +176,11 @@ void writeMessage(kj::OutputStream& output, kj::ArrayPtr<const kj::ArrayPtr<cons
 // Specializations for reading from / writing to file descriptors.
 
 class StreamFdMessageReader: private kj::FdInputStream, public InputStreamMessageReader {
-  // A MessageReader that reads from a stream-based file descriptor.
+  // A MessageReader that reads from a stream-based file descriptor. Example:
+  //
+  //     auto fs = kj::newDiskFilesystem();
+  //     auto file = fs->getCurrent().openFile(kj::Path::parse("mydata"));
+  //     capnp::StreamFdMessageReader capnpReader { KJ_ASSERT_NONNULL(file->getFd()) };
 
 public:
   StreamFdMessageReader(int fd, ReaderOptions options = ReaderOptions(),

--- a/kjdoc/tour.md
+++ b/kjdoc/tour.md
@@ -1022,19 +1022,20 @@ KJ provides an advanced, cross-platform filesystem API in `kj/filesystem.h`. Fea
 * Sparse files ("hole punching"), copy-on-write file cloning (`FICLONE`, `FICLONERANGE`), `sendfile()`-based copying, `renameat2()` atomic replacements, and more will automatically be used when available.
 
 ```c++
-// NOTE: in most cases, you should construct the `Filesystem` at the entry point of your program,
-// then pass it in as a parameter wherever it's used. This allows test implementations or user-space
-// filesystems.
+// NOTE: in most cases, you should construct the `Filesystem` at the entry
+// point of your program, then pass it in as a parameter wherever it's used.
+// This allows dependency injection of alternative filesystem implementations
+// for testing or other interesting use cases.
 kj::Own<kj::Filesystem> fs = kj::newDiskFilesystem();
-kj::Own<const kj::ReadableFile>> file = fs->getCurrent().openFile(kj::Path::parse("README.md"));
+kj::Own<const kj::ReadableFile>> file =
+    fs->getCurrent().openFile(kj::Path::parse("README.md"));
 kj::String text = file->readAllText();
 ```
 
-For large files, consider using mmap when you want to read the full contents of a file, which uses
-on demand paging as contents are accessed rather than buffering the contents into memory first.
+For large files, consider using mmap when you want to read the full contents of a file, which uses on demand paging as contents are accessed rather than buffering the contents into memory first.
 
 ```c++
-kj::Array<const char> fileBuffer = file->mmap(0, file->stat().size).releaseAsChars();
+kj::Array<const kj::byte> fileBuffer = file->mmap(0, file->stat().size);
 ```
 
 See the API reference (header file) for details.

--- a/kjdoc/tour.md
+++ b/kjdoc/tour.md
@@ -1021,7 +1021,24 @@ KJ provides an advanced, cross-platform filesystem API in `kj/filesystem.h`. Fea
 * Symlinks, hard links, listing directories, recursive delete, recursive create parents, recursive copy directory, memory mapping, and unnamed temporary files are all exposed and easy to use.
 * Sparse files ("hole punching"), copy-on-write file cloning (`FICLONE`, `FICLONERANGE`), `sendfile()`-based copying, `renameat2()` atomic replacements, and more will automatically be used when available.
 
+```c++
+// NOTE: in most cases, you should construct the `Filesystem` at the entry point of your program,
+// then pass it in as a parameter wherever it's used. This allows test implementations or user-space
+// filesystems.
+kj::Own<kj::Filesystem> fs = kj::newDiskFilesystem();
+kj::Own<const kj::ReadableFile>> file = fs->getCurrent().openFile(kj::Path::parse("README.md"));
+kj::String text = file->readAllText();
+```
+
+For large files, consider using mmap when you want to read the full contents of a file, which uses
+on demand paging as contents are accessed rather than buffering the contents into memory first.
+
+```c++
+kj::Array<const char> fileBuffer = file->mmap(0, file->stat().size).releaseAsChars();
+```
+
 See the API reference (header file) for details.
+See `parseFromDirectory` in `capnp/schema-parser.h` for more examples.
 
 ### Clocks and time
 


### PR DESCRIPTION
I had trouble with this while working on improvements to Ekam; it seems useful to document.

cc @vlovich - is this the sort of documentation you were thinking of? I certainly would have found it useful.
I also noticed that `capnp/schema-parser.h` has lots of useful examples around `parseFromDirectory` - maybe it makes sense to link to those from the kj docs? Or move parts of them to kj? I only found them by searching for `newDiskFilesystem`.