### PR TITLE
Fix build on MSVC with conformant preprocessor enabled

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -294,7 +294,10 @@ KJ_NORETURN(void unreachable());
 }  // namespace _ (private)
 
 #ifdef KJ_DEBUG
-#if _MSC_VER && !defined(__clang__)
+#if _MSC_VER && !defined(__clang__) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
+#define KJ_MSVC_TRADITIONAL_CPP 1
+#endif
+#if KJ_MSVC_TRADITIONAL_CPP
 #define KJ_IREQUIRE(condition, ...) \
     if (KJ_LIKELY(condition)); else ::kj::_::inlineRequireFailure( \
         __FILE__, __LINE__, #condition, "" #__VA_ARGS__, __VA_ARGS__)


### PR DESCRIPTION
MSVC's conformant preprocessor (`/Zc:preprocessor`) adds support for the `##__VA_ARGS__` extension and the `__VA_OPT__(,)` C++20 feature.

(OUTDATED) Technically `_MSVC_TRADITIONAL` is a [reserved identifier](https://stackoverflow.com/q/228783) and we shouldn't be defining it, though I don't think it's a problem in practice. If you don't like this, whether because it defines a reserved identifier, or because defining the identifier in a library header will affect users which check for the macro, there are alternative (but less clear IMO) approaches I listed in #1307.

Fixes #1307.