### PR TITLE
Fix building test-helpers.c++ hasSubstring() on Windows C++17

### DIFF
--- a/c++/src/kj/test-helpers.c++
+++ b/c++/src/kj/test-helpers.c++
@@ -34,8 +34,6 @@
 #include <process.h>
 #endif
 
-#include <functional>
-
 namespace kj {
 namespace _ {  // private
 
@@ -49,9 +47,6 @@ bool hasSubstring(StringPtr haystack, StringPtr needle) {
 
 #if !defined(_WIN32)
     return memmem(haystack.begin(), haystack.size(), needle.begin(), needle.size()) != nullptr;
-#elif defined(__cpp_lib_boyer_moore_searcher)
-    std::boyer_moore_horspool_searcher searcher{needle.begin(), needle.size()};
-    return std::search(haystack.begin(), haystack.end(), searcher) != haystack.end();
 #else
     // TODO(perf): This is not the best algorithm for substring matching. strstr can't be used
     //   because this is supposed to be safe to call on strings with embedded nulls.


### PR DESCRIPTION
When I vendored capnproto into a C++20 project, test-helpers.c++ failed to build on Windows Clang for two reasons:

- std::boyer_moore_horspool_searcher() takes begin and end, not begin and size.
- std::search() requires #include <algorithm>.

This makes me think that the boyer_moore_horspool_searcher codepath was never tested to work. I did not test to ensure that `hasSubstring()` functions correctly, only that it compiles. There may be undiscovered logical bugs even after this PR is merged, so you should test it further yourself.

----

The build doesn't fail on Linux because it takes the memmem codepath. Non-vendored standalone capnproto builds don't fail on Windows, because standalone capnproto configures both Clang and MSVC in C++14 mode, causing them to take the TODO(perf) path.

----

Also why is ["test-helpers.c++" included in `kj_sources_lite`](https://github.com/capnproto/capnproto/blob/73b35402140c5afb54a0fe89bd6658d0dc22aea9/c%2B%2B/src/kj/CMakeLists.txt#L20)? I don't need it, since it's never used in library-only builds of kj and capnproto. Could it be moved to `kj_sources_heavy`, or only included if `BUILD_TESTING=ON`?