### PR TITLE
Incoming flow control for RPC

### DIFF
--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -85,6 +85,7 @@ public:
   RpcSystemBase(RpcSystemBase&& other) noexcept;
   ~RpcSystemBase() noexcept(false);
 
+  void setFlowController(RpcFlowController& flowController);
   void setTraceEncoder(kj::Function<kj::String(const kj::Exception&)> func);
 
   kj::Promise<void> run();

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1312,6 +1312,10 @@ const Executor& getCurrentThreadExecutor() {
   return currentEventLoop().getExecutor();
 }
 
+const EventLoop::Stats getCurrentThreadLoopStats() {
+  return currentEventLoop().stats;
+}
+
 // =======================================================================================
 // Fiber implementation.
 
@@ -1995,6 +1999,7 @@ void Event::armDepthFirst() {
              "Executor to queue events cross-thread.");
 
   if (prev == nullptr) {
+    ++loop.stats.count;
     next = *loop.depthFirstInsertPoint;
     prev = loop.depthFirstInsertPoint;
     *prev = this;
@@ -2021,6 +2026,7 @@ void Event::armBreadthFirst() {
              "Executor to queue events cross-thread.");
 
   if (prev == nullptr) {
+    ++loop.stats.count;
     next = *loop.breadthFirstInsertPoint;
     prev = loop.breadthFirstInsertPoint;
     *prev = this;
@@ -2044,6 +2050,7 @@ void Event::armLast() {
              "Executor to queue events cross-thread.");
 
   if (prev == nullptr) {
+    ++loop.stats.count;
     next = *loop.breadthFirstInsertPoint;
     prev = loop.breadthFirstInsertPoint;
     *prev = this;
@@ -2068,6 +2075,7 @@ bool Event::isNext() {
 
 void Event::disarm() {
   if (prev != nullptr) {
+    --loop.stats.count;
     if (threadLocalEventLoop != &loop && threadLocalEventLoop != nullptr) {
       KJ_LOG(FATAL, "Promise destroyed from a different thread than it was created in.");
       // There's no way out of this place without UB, so abort now.

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1052,6 +1052,11 @@ public:
   // Note that this is only needed for cross-thread scheduling. To schedule code to run later in
   // the current thread, use `kj::evalLater()`, which will be more efficient.
 
+  struct Stats {
+    int count = 0;
+  };
+  // Statistics about the event loop, accessible by kj::getCurrentThreadLoopStats();
+
 private:
   kj::Maybe<EventPort&> port;
   // If null, this thread doesn't receive I/O events from the OS. It can potentially receive
@@ -1067,6 +1072,8 @@ private:
   _::Event** tail = &head;
   _::Event** depthFirstInsertPoint = &head;
   _::Event** breadthFirstInsertPoint = &head;
+
+  Stats stats;
 
   kj::Maybe<Own<Executor>> executor;
   // Allocated the first time getExecutor() is requested, making cross-thread request possible.
@@ -1095,7 +1102,10 @@ private:
   friend class _::FiberBase;
   friend class _::FiberStack;
   friend ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space);
+  friend const Stats getCurrentThreadLoopStats();
 };
+
+const EventLoop::Stats getCurrentThreadLoopStats();
 
 class WaitScope {
   // Represents a scope in which asynchronous programming can occur.  A `WaitScope` should usually


### PR DESCRIPTION
This PR expands the utility of the RpcFlowController interface for use on incoming messages as well, and replaces the existing flow limit controller in RpcSystem with the ability to set an arbitrary RpcFlowController.