### PR TITLE
Move BUILD_TESTING to root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
 cmake_minimum_required(VERSION 3.4)
 project("Cap'n Proto Root" CXX)
+include(CTest)
+
 add_subdirectory(c++)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -4,6 +4,7 @@ set(VERSION 0.10-dev)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+include(CTest)
 include(CheckIncludeFileCXX)
 include(GNUInstallDirs)
 if(MSVC)
@@ -25,7 +26,6 @@ set(INSTALL_TARGETS_DEFAULT_ARGS
 
 # Options ======================================================================
 
-option(BUILD_TESTING "Build unit tests and enable CTest 'check' target." ON)
 option(EXTERNAL_CAPNP "Use the system capnp binary, or the one specified in $CAPNP, instead of using the compiled one." OFF)
 option(CAPNP_LITE "Compile Cap'n Proto in 'lite mode', in which all reflection APIs (schema.h, dynamic.h, etc.) are not included. Produces a smaller library at the cost of features. All programs built against the library must be compiled with -DCAPNP_LITE. Requires EXTERNAL_CAPNP." OFF)
 


### PR DESCRIPTION
This fixes #1323 since enable_testing has to be in the top-level
CMakeLists.txt file before any add_subdirectory call.

https://stackoverflow.com/questions/30250494/ctest-not-detecting-tests