### PR TITLE
refcount from zero instead of one

### DIFF
--- a/c++/src/kj/refcount.c++
+++ b/c++/src/kj/refcount.c++
@@ -39,7 +39,10 @@ Refcounted::~Refcounted() noexcept(false) {
 }
 
 void Refcounted::disposeImpl(void* pointer) const {
-  if (--refcount == 0) {
+  if (refcount) {
+    --refcount;
+  }
+  else {
     delete this;
   }
 }


### PR DESCRIPTION
 - avoids a write on construction
 - avoids a write to stale memory on destruction
 - isShared() compares to zero