### PR TITLE
Fix an irrelevant bug in BTreeIndex.

### DIFF
--- a/c++/src/kj/table.c++
+++ b/c++/src/kj/table.c++
@@ -730,7 +730,7 @@ void BTreeImpl::merge(Leaf& dst, uint dstPos, uint pivot, Leaf& src) {
   KJ_DASSERT(dst.isHalfFull());
 
   constexpr size_t mid = Leaf::NROWS/2;
-  dst.rows[mid] = pivot;
+  KJ_DASSERT(dst.rows[mid-1] == pivot);
   acopy(dst.rows + mid, src.rows, mid);
 
   dst.next = src.next;


### PR DESCRIPTION
The deleted line was wrong, but has no effect because the line immediately after would overwrite the same memory position.

Instead I replaced it with an assert showing that the previous slot already contains the pivot value.