### PR TITLE
Fix async-io-win32 for vs2019 & C++20

### DIFF
--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -808,7 +808,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
   auto thread = heap<Thread>(kj::mvCapture(params, [outFd,portHint](LookupParams&& params) {
     KJ_DEFER(closesocket(outFd));
 
-    struct addrinfo* list;
+    addrinfo* list;
     int status = getaddrinfo(
         params.host == "*" ? nullptr : params.host.cStr(),
         params.service == nullptr ? nullptr : params.service.cStr(),
@@ -816,7 +816,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
     if (status == 0) {
       KJ_DEFER(freeaddrinfo(list));
 
-      struct addrinfo* cur = list;
+      addrinfo* cur = list;
       while (cur != nullptr) {
         if (params.service == nullptr) {
           switch (cur->ai_addr->sa_family) {


### PR DESCRIPTION
When compiling this file under C++20 MSVC gives an error about the addrinfo types being different:

```
1>async-io-win32.c++
1>...\c++\src\kj\async-io-win32.c++(819,28): error C2440: 'initializing': cannot convert from 'addrinfo *' to 'kj::`anonymous-namespace'::SocketAddress::lookupHost::<lambda_1>::()::addrinfo *'
1>...\c++\src\kj\async-io-win32.c++(819,28): message : Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
1>...\c++\src\kj\async-io-win32.c++(874,1): error C2027: use of undefined type 'kj::`anonymous-namespace'::SocketAddress::lookupHost::<lambda_1>::()::addrinfo'
1>...\c++\src\kj\async-io-win32.c++(874): message : see declaration of 'kj::`anonymous-namespace'::SocketAddress::lookupHost::<lambda_1>::()::addrinfo'
1>...\c++\src\kj\async-io-win32.c++(854,11): error C2660: 'memcpy': function does not take 1 arguments
```

Since these types are included I just removed the forward `struct` and it works fine.

C++17 works as expected without this change. If it matters I'm using Visual Studio 2019 (16.11.2).