### PR TITLE
RFC/WIP: Attempt to define a CAPNP_EMBEDDED compilation option.

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -28,6 +28,11 @@ set(INSTALL_TARGETS_DEFAULT_ARGS
 
 option(EXTERNAL_CAPNP "Use the system capnp binary, or the one specified in $CAPNP, instead of using the compiled one." OFF)
 option(CAPNP_LITE "Compile Cap'n Proto in 'lite mode', in which all reflection APIs (schema.h, dynamic.h, etc.) are not included. Produces a smaller library at the cost of features. All programs built against the library must be compiled with -DCAPNP_LITE. Requires EXTERNAL_CAPNP." OFF)
+option(CAPNP_EMBEDDED "Builds capnp library for bare metal embedded systems.  Library will not be thread or interrupt safe." OFF)
+
+if(CAPNP_EMBEDDED)
+  add_definitions(-DKJ_NO_FD -DKJ_NO_POSIX -DKJ_NO_EXCEPTIONS -DKJ_NO_THREADS)
+endif()
 
 # Check for invalid combinations of build options
 if(CAPNP_LITE AND BUILD_TESTING AND NOT EXTERNAL_CAPNP)
@@ -92,7 +97,7 @@ else()
     message(SEND_ERROR "Cap'n Proto requires compiler-specific extensions (e.g., -std=gnu++14). Please leave CMAKE_CXX_EXTENSIONS undefined or ON.")
   endif()
 
-  if (NOT ANDROID)
+  if (NOT ANDROID AND NOT CAPNP_EMBEDDED)
     add_compile_options(-pthread)
   endif()
 endif()
@@ -140,7 +145,7 @@ install(FILES
 #install CapnProtoMacros for CapnProtoConfig.cmake build directory consumers
 configure_file(cmake/CapnProtoMacros.cmake cmake/CapnProtoMacros.cmake COPYONLY)
 
-if(NOT MSVC)  # Don't install pkg-config files when building with MSVC
+if(NOT MSVC AND NOT CAPNP_EMBEDDED)  # Don't install pkg-config files when building with MSVC
   # Variables for pkg-config files
   set(prefix "${CMAKE_INSTALL_PREFIX}")
   set(exec_prefix "") # not needed since we use absolute paths in libdir and includedir

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -102,7 +102,7 @@ private:
   KJ_DISALLOW_COPY(ReadLimiter);
 
   KJ_ALWAYS_INLINE(void setLimit(uint64_t newLimit)) {
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(KJ_NO_THREADS)
     __atomic_store_n(&limit, newLimit, __ATOMIC_RELAXED);
 #else
     limit = newLimit;
@@ -110,7 +110,7 @@ private:
   }
 
   KJ_ALWAYS_INLINE(uint64_t readLimit() const) {
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(KJ_NO_THREADS)
     return __atomic_load_n(&limit, __ATOMIC_RELAXED);
 #else
     return limit;

--- a/c++/src/capnp/serialize-packed.c++
+++ b/c++/src/capnp/serialize-packed.c++
@@ -439,6 +439,8 @@ PackedMessageReader::PackedMessageReader(
 
 PackedMessageReader::~PackedMessageReader() noexcept(false) {}
 
+#ifndef KJ_NO_FD
+
 PackedFdMessageReader::PackedFdMessageReader(
     int fd, ReaderOptions options, kj::ArrayPtr<word> scratchSpace)
     : FdInputStream(fd),
@@ -454,6 +456,8 @@ PackedFdMessageReader::PackedFdMessageReader(
                           options, scratchSpace) {}
 
 PackedFdMessageReader::~PackedFdMessageReader() noexcept(false) {}
+
+#endif
 
 void writePackedMessage(kj::BufferedOutputStream& output,
                         kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) {
@@ -472,10 +476,14 @@ void writePackedMessage(kj::OutputStream& output,
   }
 }
 
+#ifndef KJ_NO_FD
+
 void writePackedMessageToFd(int fd, kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) {
   kj::FdOutputStream output(fd);
   writePackedMessage(output, segments);
 }
+
+#endif
 
 size_t computeUnpackedSizeInWords(kj::ArrayPtr<const byte> packedBytes) {
   const byte* ptr = packedBytes.begin();

--- a/c++/src/capnp/serialize-packed.h
+++ b/c++/src/capnp/serialize-packed.h
@@ -70,6 +70,8 @@ public:
   ~PackedMessageReader() noexcept(false);
 };
 
+#ifndef KJ_NO_FD
+
 class PackedFdMessageReader: private kj::FdInputStream, private kj::BufferedInputStreamWrapper,
                              public PackedMessageReader {
 public:
@@ -88,6 +90,8 @@ public:
   ~PackedFdMessageReader() noexcept(false);
 };
 
+#endif
+
 void writePackedMessage(kj::BufferedOutputStream& output, MessageBuilder& builder);
 void writePackedMessage(kj::BufferedOutputStream& output,
                         kj::ArrayPtr<const kj::ArrayPtr<const word>> segments);
@@ -100,9 +104,13 @@ void writePackedMessage(kj::OutputStream& output,
 // in succession, consider wrapping your output in a buffered stream in order to reduce system
 // call overhead.
 
+#ifndef KJ_NO_FD
+
 void writePackedMessageToFd(int fd, MessageBuilder& builder);
 void writePackedMessageToFd(int fd, kj::ArrayPtr<const kj::ArrayPtr<const word>> segments);
 // Write a single packed message to the file descriptor.
+
+#endif
 
 size_t computeUnpackedSizeInWords(kj::ArrayPtr<const byte> packedBytes);
 // Computes the number of words to which the given packed bytes will unpack. Not intended for use
@@ -119,9 +127,13 @@ inline void writePackedMessage(kj::OutputStream& output, MessageBuilder& builder
   writePackedMessage(output, builder.getSegmentsForOutput());
 }
 
+#ifndef KJ_NO_FD
+
 inline void writePackedMessageToFd(int fd, MessageBuilder& builder) {
   writePackedMessageToFd(fd, builder.getSegmentsForOutput());
 }
+
+#endif
 
 }  // namespace capnp
 

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -302,6 +302,8 @@ void writeMessage(kj::OutputStream& output, kj::ArrayPtr<const kj::ArrayPtr<cons
 
 // =======================================================================================
 
+#ifndef KJ_NO_FD
+
 StreamFdMessageReader::~StreamFdMessageReader() noexcept(false) {}
 
 void writeMessageToFd(int fd, kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) {
@@ -323,5 +325,7 @@ void readMessageCopyFromFd(int fd, MessageBuilder& target,
   kj::FdInputStream stream(fd);
   readMessageCopy(stream, target, options, scratchSpace);
 }
+
+#endif
 
 }  // namespace capnp

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -165,6 +165,8 @@ void writeMessage(kj::OutputStream& output, MessageBuilder& builder);
 void writeMessage(kj::OutputStream& output, kj::ArrayPtr<const kj::ArrayPtr<const word>> segments);
 // Write the segment array to the given output stream.
 
+#ifndef KJ_NO_FD
+
 // =======================================================================================
 // Specializations for reading from / writing to file descriptors.
 
@@ -210,6 +212,8 @@ void writeMessageToFd(int fd, kj::ArrayPtr<const kj::ArrayPtr<const word>> segme
 // you catch this exception at the call site.  If throwing an exception is not acceptable, you
 // can implement your own OutputStream with arbitrary error handling and then use writeMessage().
 
+#endif
+
 // =======================================================================================
 // inline stuff
 
@@ -225,9 +229,11 @@ inline void writeMessage(kj::OutputStream& output, MessageBuilder& builder) {
   writeMessage(output, builder.getSegmentsForOutput());
 }
 
+#ifndef KJ_NO_FD
 inline void writeMessageToFd(int fd, MessageBuilder& builder) {
   writeMessageToFd(fd, builder.getSegmentsForOutput());
 }
+#endif
 
 }  // namespace capnp
 

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -14,13 +14,19 @@ set(kj_sources_lite
   source-location.c++
   hash.c++
   table.c++
-  thread.c++
-  main.c++
   arena.c++
   test-helpers.c++
   units.c++
   encoding.c++
 )
+
+if(NOT CAPNP_EMBEDDED)
+  list(APPEND kj_sources_lite
+      thread.c++
+      main.c++
+      )
+endif()
+
 set(kj_sources_heavy
   refcount.c++
   string-tree.c++
@@ -105,14 +111,17 @@ set(kj-test_headers
 set(kj-test-compat_headers
   compat/gtest.h
 )
-add_library(kj-test ${kj-test_sources})
-add_library(CapnProto::kj-test ALIAS kj-test)
-target_link_libraries(kj-test PUBLIC kj)
-# Ensure the library has a version set to match autotools build
-set_target_properties(kj-test PROPERTIES VERSION ${VERSION})
-install(TARGETS kj-test ${INSTALL_TARGETS_DEFAULT_ARGS})
-install(FILES ${kj-test_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
-install(FILES ${kj-test-compat_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
+
+if(BUILD_TESTING)
+  add_library(kj-test ${kj-test_sources})
+  add_library(CapnProto::kj-test ALIAS kj-test)
+  target_link_libraries(kj-test PUBLIC kj)
+  # Ensure the library has a version set to match autotools build
+  set_target_properties(kj-test PROPERTIES VERSION ${VERSION})
+  install(TARGETS kj-test ${INSTALL_TARGETS_DEFAULT_ARGS})
+  install(FILES ${kj-test_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj")
+  install(FILES ${kj-test-compat_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
+endif()
 
 set(kj-async_sources
   async.c++

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -29,7 +29,9 @@
 
 #include "io.h"
 #include "debug.h"
+#ifndef KJ_NO_POSIX
 #include "miniposix.h"
+#endif
 #include <algorithm>
 #include <errno.h>
 #include "vector.h"
@@ -37,7 +39,7 @@
 #if _WIN32
 #include <windows.h>
 #include "windows-sanity.h"
-#else
+#elif !defined(KJ_NO_POSIX)
 #include <sys/uio.h>
 #endif
 
@@ -324,6 +326,8 @@ void VectorOutputStream::grow(size_t minSize) {
 
 // =======================================================================================
 
+#ifndef KJ_NO_FD
+
 AutoCloseFd::~AutoCloseFd() noexcept(false) {
   if (fd >= 0) {
     // Don't use SYSCALL() here because close() should not be repeated on EINTR.
@@ -420,6 +424,8 @@ void FdOutputStream::write(ArrayPtr<const ArrayPtr<const byte>> pieces) {
   }
 #endif
 }
+
+#endif
 
 // =======================================================================================
 

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -247,6 +247,8 @@ private:
   void grow(size_t minSize);
 };
 
+#ifndef KJ_NO_FD
+
 // =======================================================================================
 // File descriptor I/O
 
@@ -341,6 +343,7 @@ private:
   int fd;
   AutoCloseFd autoclose;
 };
+#endif
 
 // =======================================================================================
 // Win32 Handle I/O

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -151,7 +151,7 @@ bool Mutex::checkPredicate(Waiter& waiter) {
   return result;
 }
 
-#if !_WIN32 && !__CYGWIN__
+#if !_WIN32 && !__CYGWIN__ && !defined(KJ_NO_THREADS)
 namespace {
 
 TimePoint toTimePoint(struct timespec ts) {
@@ -849,6 +849,15 @@ bool Once::isInitialized() noexcept {
 void Once::reset() {
   InitOnceInitialize(&coercedInitOnce);
 }
+
+#elif defined(KJ_NO_THREADS)
+
+Mutex::Mutex() {}
+Mutex::~Mutex() {}
+bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, NoopSourceLocation) {
+  return true;
+}
+void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {}
 
 #else
 // =======================================================================================

--- a/c++/src/kj/threadlocal.h
+++ b/c++/src/kj/threadlocal.h
@@ -47,7 +47,11 @@ KJ_BEGIN_HEADER
 
 namespace kj {
 
-#if __GNUC__
+#ifdef KJ_NO_THREADS
+
+#define KJ_THREADLOCAL_PTR(type) static type*
+
+#elif __GNUC__
 
 #define KJ_THREADLOCAL_PTR(type) static __thread type*
 // GCC's __thread is lighter-weight than thread_local and is good enough for our purposes.


### PR DESCRIPTION
This PR is a request for comment on the `CAPNP_EMBEDDED` option and how it is wound into the library.  The idea is to cut out portions of the kj and capnp library that won't exist in a bare metal embedded system.  This is suitable for:
 - Targets that support C++14/17 but lacks exceptions, RTTI, etc.
 - Cannot assume existence of POSIX support.
    - No file descriptors.
    - No file system.
    - No mmap.
 - Threading is not in use.
   - Library will **not** be safe to use in interrupt context as well as main context.