### PR TITLE
Work around old OpenSSL versions not being able to verify Let's Encrypt certificate chains.

### DIFF
--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -151,6 +151,14 @@ public:
       throwOpensslError();
     }
 
+    // As of OpenSSL 1.1.0, X509_V_FLAG_TRUSTED_FIRST is on by default. Turning it on for older
+    // versions -- as well as certain OpenSSL-compatible libraries -- fixes the problem described
+    // here: https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816
+    //
+    // Otherwise, certificates issued by Let's Encrypt won't work as of September 30, 2021:
+    // https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
+    X509_VERIFY_PARAM_set_flags(verify, X509_V_FLAG_TRUSTED_FIRST);
+
     return sslCall([this]() { return SSL_connect(ssl); }).then([this](size_t) {
       X509* cert = SSL_get_peer_certificate(ssl);
       KJ_REQUIRE(cert != nullptr, "TLS peer provided no certificate");


### PR DESCRIPTION
As of September 30, 2021, old versions of OpenSSL (1.0.x) could no longer verify Let's Encrypt certificate chains by default, due to the problems described here:

https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816

It turns out the problem can be solved by setting a flag. That flag actually became the default in 1.1.0.

Of course, no one should be using OpenSSL 1.0.x anymore, but the various OpenSSL forks fixed this problem at different times, and the FIPS-certified version of BoringSSL is known to have this problem as well, thus requiring the work-around.