### PR TITLE
Replace boolean `destroyed` with magic integer `live` in `Event`.

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -206,7 +206,9 @@ private:
   Event* next;
   Event** prev;
   bool firing = false;
-  bool destroyed = false;
+
+  static constexpr uint MAGIC_LIVE_VALUE = 0x1e366381u;
+  uint live = MAGIC_LIVE_VALUE;
   SourceLocation location;
 };
 


### PR DESCRIPTION
This integer is set to an unlikely constant on construction, and set to zero in the destructor. It is then used to detect an event that is armed after destruction.

The previous boolean approach works sometimes but seems unreliable, probably because the successor occupier of the memory often tends to zero out the byte where the boolean is supposed to be.