### PR TITLE
Fix tryTee() optimization when limits are used.

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -2336,7 +2336,7 @@ private:
 }  // namespace
 
 Tee newTee(Own<AsyncInputStream> input, uint64_t limit) {
-  KJ_IF_MAYBE(t, input->tryTee()) {
+  KJ_IF_MAYBE(t, input->tryTee(limit)) {
     return { { mv(input), mv(*t) }};
   }
 


### PR DESCRIPTION
The effect of this bug is that the optimization wouldn't kick in when using limits since the optimization is only allowed when the limits match.