### PR TITLE
Log exceptions when serving HTTP errors by default

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -5528,7 +5528,7 @@ kj::Promise<void> HttpServerErrorHandler::handleApplicationError(
   }
 
   KJ_IF_MAYBE(r, response) {
-    KJ_LOG(INFO, "Internal error serving HTTP response", exception);
+    KJ_LOG(INFO, "threw exception while serving HTTP response", exception);
 
     HttpHeaderTable headerTable {};
     HttpHeaders headers(headerTable);

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -5528,6 +5528,8 @@ kj::Promise<void> HttpServerErrorHandler::handleApplicationError(
   }
 
   KJ_IF_MAYBE(r, response) {
+    KJ_LOG(INFO, "Internal error serving HTTP response", exception);
+
     HttpHeaderTable headerTable {};
     HttpHeaders headers(headerTable);
     headers.set(HttpHeaderId::CONTENT_TYPE, "text/plain");


### PR DESCRIPTION
Previously, KJ would return a 5XX error to the client, but wouldn't actually log the error anywhere,
making it difficult to tell what went wrong.