### PR TITLE
Lie about the true size of the fiber stack on M1 Macs

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1374,10 +1374,10 @@ struct FiberStack::Impl {
     // page only. This appears to work as no particular bounds checks or
     // anything are set up based on what we say here.
     context->uc_stack.ss_size = pageSize - sizeof(Impl);
-    context->uc_stack.ss_sp = reinterpret_cast<byte*>(stack) + stackSize - min(pageSize, stackSize);
+    context->uc_stack.ss_sp = reinterpret_cast<char*>(stack) + stackSize - min(pageSize, stackSize);
 #else
-    context->uc_stack.ss_size = stackSize;
-    context->uc_stack.ss_sp = stack;
+    context->uc_stack.ss_size = stackSize - sizeof(Impl);
+    context->uc_stack.ss_sp = reinterpret_cast<char*>(stack);
 #endif
     context->uc_stack.ss_flags = 0;
     // We don't use uc_link since our fiber start routine runs forever in a loop to allow for

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1373,7 +1373,7 @@ struct FiberStack::Impl {
     // we allocate the full size, but tell the ucontext the stack is the last
     // page only. This appears to work as no particular bounds checks or
     // anything are set up based on what we say here.
-    context->uc_stack.ss_size = pageSize - sizeof(Impl);
+    context->uc_stack.ss_size = min(pageSize, stackSize) - sizeof(Impl);
     context->uc_stack.ss_sp = reinterpret_cast<char*>(stack) + stackSize - min(pageSize, stackSize);
 #else
     context->uc_stack.ss_size = stackSize - sizeof(Impl);


### PR DESCRIPTION
`makecontext` on the new M1 macs calls `bzero` on the entire stack configured in the `ucontext_t`. Because we set up a guard page, this was faulting. Instead, only pass the usable stack, leaving the guard page below the configured stack start.

Fixes #1386