### PR TITLE
Introduce ConnectionReceiver implementation that aggregates from multiple underlying receivers.

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1357,29 +1357,31 @@ public:
   }
 
   Own<ConnectionReceiver> listen() override {
-    if (addrs.size() > 1) {
-      KJ_LOG(WARNING, "Bind address resolved to multiple addresses.  Only the first address will "
-          "be used.  If this is incorrect, specify the address numerically.  This may be fixed "
-          "in the future.", addrs[0].toString());
+    auto makeReceiver = [&](SocketAddress& addr) {
+      int fd = addr.socket(SOCK_STREAM);
+
+      {
+        KJ_ON_SCOPE_FAILURE(close(fd));
+
+        // We always enable SO_REUSEADDR because having to take your server down for five minutes
+        // before it can restart really sucks.
+        int optval = 1;
+        KJ_SYSCALL(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)));
+
+        addr.bind(fd);
+
+        // TODO(someday):  Let queue size be specified explicitly in string addresses.
+        KJ_SYSCALL(::listen(fd, SOMAXCONN));
+      }
+
+      return lowLevel.wrapListenSocketFd(fd, filter, NEW_FD_FLAGS);
+    };
+
+    if (addrs.size() == 1) {
+      return makeReceiver(addrs[0]);
+    } else {
+      return newAggregateConnectionReceiver(KJ_MAP(addr, addrs) { return makeReceiver(addr); });
     }
-
-    int fd = addrs[0].socket(SOCK_STREAM);
-
-    {
-      KJ_ON_SCOPE_FAILURE(close(fd));
-
-      // We always enable SO_REUSEADDR because having to take your server down for five minutes
-      // before it can restart really sucks.
-      int optval = 1;
-      KJ_SYSCALL(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)));
-
-      addrs[0].bind(fd);
-
-      // TODO(someday):  Let queue size be specified explicitly in string addresses.
-      KJ_SYSCALL(::listen(fd, SOMAXCONN));
-    }
-
-    return lowLevel.wrapListenSocketFd(fd, filter, NEW_FD_FLAGS);
   }
 
   Own<DatagramPort> bindDatagramPort() override {

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -2764,6 +2764,121 @@ String CapabilityStreamNetworkAddress::toString() {
 
 // =======================================================================================
 
+namespace {
+
+class AggregateConnectionReceiver final: public ConnectionReceiver {
+public:
+  AggregateConnectionReceiver(Array<Own<ConnectionReceiver>> receiversParam)
+      : receivers(kj::mv(receiversParam)),
+        acceptTasks(kj::heapArray<Maybe<Promise<void>>>(receivers.size())) {}
+
+  Promise<Own<AsyncIoStream>> accept() override {
+    return acceptAuthenticated().then([](AuthenticatedStream&& authenticated) {
+      return kj::mv(authenticated.stream);
+    });
+  }
+
+  Promise<AuthenticatedStream> acceptAuthenticated() override {
+    if (backlog.empty()) {
+      auto result = kj::newAdaptedPromise<AuthenticatedStream, Waiter>(*this);
+      ensureAllAccepting();
+      return result;
+    } else {
+      auto result = kj::mv(backlog.front());
+      backlog.pop_front();
+      return result;
+    }
+  }
+
+  uint getPort() override {
+    return receivers[0]->getPort();
+  }
+  void getsockopt(int level, int option, void* value, uint* length) override {
+    return receivers[0]->getsockopt(level, option, value, length);
+  }
+  void setsockopt(int level, int option, const void* value, uint length) override {
+    // Apply to all.
+    for (auto& r: receivers) {
+      r->setsockopt(level, option, value, length);
+    }
+  }
+  void getsockname(struct sockaddr* addr, uint* length) override {
+    return receivers[0]->getsockname(addr, length);
+  }
+
+private:
+  Array<Own<ConnectionReceiver>> receivers;
+  Array<Maybe<Promise<void>>> acceptTasks;
+
+  struct Waiter {
+    Waiter(PromiseFulfiller<AuthenticatedStream>& fulfiller,
+           AggregateConnectionReceiver& parent)
+        : fulfiller(fulfiller), parent(parent) {
+      parent.waiters.add(*this);
+    }
+    ~Waiter() noexcept(false) {
+      if (link.isLinked()) {
+        parent.waiters.remove(*this);
+      }
+    }
+
+    PromiseFulfiller<AuthenticatedStream>& fulfiller;
+    AggregateConnectionReceiver& parent;
+    ListLink<Waiter> link;
+  };
+
+  List<Waiter, &Waiter::link> waiters;
+  std::deque<Promise<AuthenticatedStream>> backlog;
+  // At least one of `waiters` or `backlog` is always empty.
+
+  void ensureAllAccepting() {
+    for (auto i: kj::indices(receivers)) {
+      if (acceptTasks[i] == nullptr) {
+        acceptTasks[i] = acceptLoop(i);
+      }
+    }
+  }
+
+  Promise<void> acceptLoop(size_t index) {
+    return kj::evalNow([&]() { return receivers[index]->acceptAuthenticated(); })
+            .then([this](AuthenticatedStream&& as) {
+      if (waiters.empty()) {
+        backlog.push_back(kj::mv(as));
+      } else {
+        auto& waiter = waiters.front();
+        waiter.fulfiller.fulfill(kj::mv(as));
+        waiters.remove(waiter);
+      }
+    }, [this](Exception&& e) {
+      if (waiters.empty()) {
+        backlog.push_back(kj::mv(e));
+      } else {
+        auto& waiter = waiters.front();
+        waiter.fulfiller.reject(kj::mv(e));
+        waiters.remove(waiter);
+      }
+    }).then([this, index]() -> Promise<void> {
+      if (waiters.empty()) {
+        // Don't keep accepting if there's no one waiting.
+        // HACK: We can't cancel ourselves, so detach the task so we can null out the slot.
+        KJ_ASSERT_NONNULL(acceptTasks[index]).detach([](auto&&) {});
+        acceptTasks[index] = nullptr;
+        return READY_NOW;
+      } else {
+        return acceptLoop(index);
+      }
+    });
+  }
+};
+
+}  // namespace
+
+Own<ConnectionReceiver> newAggregateConnectionReceiver(Array<Own<ConnectionReceiver>> receivers) {
+  return kj::heap<AggregateConnectionReceiver>(kj::mv(receivers));
+}
+
+// =======================================================================================
+
 namespace _ {  // private
 
 #if !_WIN32

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -439,6 +439,10 @@ public:
   // Same as the methods of AsyncIoStream.
 };
 
+Own<ConnectionReceiver> newAggregateConnectionReceiver(Array<Own<ConnectionReceiver>> receivers);
+// Create a ConnectionReceiver that listens on several other ConnectionReceivers and returns
+// sockets from any of them.
+
 // =======================================================================================
 // Datagram I/O
 


### PR DESCRIPTION
Use this to implement binding to a hostname that resolves to multiple addresses. This is common for `localhost`, which may return both ipv4 and ipv6 addresses.

(I didn't actually create this class for this purpose, but it was super-easy to use it to resolve this very old TODO...)