### PR TITLE
Optimize fd-to-fd pumps on Linux using splice().

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -228,6 +228,149 @@ public:
     return promise.attach(kj::mv(fds), kj::mv(streams));
   }
 
+#if __linux__
+  Maybe<Promise<uint64_t>> tryPumpFrom(
+      AsyncInputStream& inputParam, uint64_t amount = kj::maxValue) override {
+    AsyncStreamFd& input = KJ_UNWRAP_OR_RETURN(
+        kj::dynamicDowncastIfAvailable<AsyncStreamFd>(inputParam), nullptr);
+
+    // The input is another AsyncStreamFd, so perhaps we can do an optimized pump with splice().
+
+    // Before we resort to a bunch of syscalls, let's try to see if the pump is small and able to
+    // be fully satisfied immediately. This optimizes for the case of small streams, e.g. a short
+    // HTTP body.
+
+    byte buffer[4096];
+    size_t pos = 0;
+    size_t initialAmount = kj::min(sizeof(buffer), amount);
+
+    bool eof = false;
+
+    // Read into the buffer until it's full or there are no bytes available. Note that we'd expect
+    // one call to read() will pull as much data out of the socket as possible (up to our buffer
+    // size), so you might think the loop is unnecessary. The reason we want to do a second read(),
+    // though, is to find out if we're at EOF or merely waiting for more data. In the EOF case,
+    // we can end the pump early without splicing.
+    while (pos < initialAmount) {
+      ssize_t n;
+      KJ_NONBLOCKING_SYSCALL(n = ::read(input.fd, buffer + pos, initialAmount - pos));
+      if (n <= 0) {
+        eof = n == 0;
+        break;
+      }
+      pos += n;
+    }
+
+    // Write the bytes that we just read back out to the output.
+    {
+      ssize_t n;
+      KJ_NONBLOCKING_SYSCALL(n = ::write(fd, buffer, pos));
+      if (n < 0) n = 0;  // treat EAGAIN as "zero bytes written"
+      if (size_t(n) < pos) {
+        // Oh crap, the output buffer is full. This should be rare. But, now we're going to have
+        // to copy the remaining bytes into the heap to do an async write.
+        auto leftover = kj::heapArray<byte>(buffer + n, pos - n);
+        auto promise = write(leftover.begin(), leftover.size());
+        promise = promise.attach(kj::mv(leftover));
+        if (eof || pos == amount) {
+          return promise.then([pos]() { return pos; });
+        } else {
+          return promise.then([&input, this, pos, amount]() {
+            return splicePumpFrom(input, pos, amount);
+          });
+        }
+      }
+    }
+
+    if (eof || pos == amount) {
+      // We finished the pump in one go, so don't splice.
+      return Promise<uint64_t>(uint64_t(pos));
+    } else {
+      // Use splice for the rest of the pump.
+      return splicePumpFrom(input, pos, amount);
+    }
+  }
+
+private:
+  static constexpr size_t MAX_SPLICE_BUFFER = 65536;
+
+  Promise<uint64_t> splicePumpFrom(AsyncStreamFd& input, uint64_t readSoFar, uint64_t limit) {
+    // splice() requires that either its input or its output is a pipe. But chances are neither
+    // `input.fd` nor `this->fd` is a pipe -- in most use cases they are sockets. In order to take
+    // advantage of splice(), then, we need to allocate a pipe to act as the middleman, so we can
+    // splice() from the input to the pipe, and then from the pipe to the output.
+    //
+    // You might wonder why this pipe middleman is required. Why can't splice() go directly from
+    // a socket to a socket? Linus Torvalds attempts to explain here:
+    //     https://yarchive.net/comp/linux/splice.html
+    //
+    // The short version is that the pipe itself is equivalent to an in-memory buffer. In a naive
+    // pump implementation, we allocate a buffer, read() into it and write() out. With splice(),
+    // we allocate a kernelspace buffer by allocating a pipe, then we splice() into the pipe and
+    // splice() back out.
+
+    int pipeFds[2];
+    KJ_SYSCALL(pipe2(pipeFds, O_NONBLOCK | O_CLOEXEC));
+
+    AutoCloseFd pipeIn(pipeFds[0]), pipeOut(pipeFds[1]);
+
+    KJ_SYSCALL(fcntl(pipeIn, F_SETPIPE_SZ, int(MAX_SPLICE_BUFFER)));
+
+    return splicePumpLoop(input, pipeFds[0], pipeFds[1], readSoFar, limit, 0)
+        .attach(kj::mv(pipeIn), kj::mv(pipeOut));
+  }
+
+  Promise<uint64_t> splicePumpLoop(AsyncStreamFd& input, int pipeIn, int pipeOut,
+                                   uint64_t readSoFar, uint64_t limit, size_t bufferedAmount) {
+    for (;;) {
+      while (bufferedAmount > 0) {
+        // First flush out whatever is in the pipe buffer.
+        ssize_t n;
+        KJ_NONBLOCKING_SYSCALL(n = splice(pipeIn, nullptr, fd, nullptr,
+            MAX_SPLICE_BUFFER, SPLICE_F_MOVE | SPLICE_F_NONBLOCK));
+        if (n > 0) {
+          KJ_ASSERT(n <= bufferedAmount, "splice pipe larger than bufferedAmount?");
+          bufferedAmount -= n;
+        } else {
+          KJ_ASSERT(n < 0, "splice pipe empty before bufferedAmount reached?", bufferedAmount);
+          return observer.whenBecomesWritable()
+              .then([this, &input, pipeIn, pipeOut, readSoFar, limit, bufferedAmount]() {
+            return splicePumpLoop(input, pipeIn, pipeOut, readSoFar, limit, bufferedAmount);
+          });
+        }
+      }
+
+      // Now the pipe buffer is empty, so we can try to read some more.
+      {
+        if (readSoFar >= limit) {
+          // Hit the limit, we're done.
+          KJ_ASSERT(readSoFar == limit);
+          return readSoFar;
+        }
+
+        ssize_t n;
+        KJ_NONBLOCKING_SYSCALL(n = splice(input.fd, nullptr, pipeOut, nullptr,
+            kj::min(limit - readSoFar, MAX_SPLICE_BUFFER), SPLICE_F_MOVE | SPLICE_F_NONBLOCK));
+        if (n == 0) {
+          // EOF.
+          return readSoFar;
+        } else if (n < 0) {
+          // No data available, wait.
+          return input.observer.whenBecomesReadable()
+              .then([this, &input, pipeIn, pipeOut, readSoFar, limit]() {
+            return splicePumpLoop(input, pipeIn, pipeOut, readSoFar, limit, 0);
+          });
+        }
+
+        readSoFar += n;
+        bufferedAmount = n;
+      }
+    }
+  }
+
+public:
+#endif  // __linux__
+
   Promise<void> whenWriteDisconnected() override {
     KJ_IF_MAYBE(p, writeDisconnectedPromise) {
       return p->addBranch();


### PR DESCRIPTION
Rough tests show this reduces the CPU usage of pumping a large stream by more than half (!).

(I also tried simply increasing the buffer size used by the existing pump implementation, but that didn't seem to affect performance much.)