### PR TITLE
Fix corruption in Tables with a TreeIndex after clear()

### DIFF
--- a/c++/src/kj/table-test.c++
+++ b/c++/src/kj/table-test.c++
@@ -972,6 +972,27 @@ KJ_TEST("TreeIndex fuzz test") {
   }
 }
 
+KJ_TEST("TreeIndex clear() leaves tree in valid state") {
+  // A test which ensures that calling clear() does not break the internal state of a TreeIndex.
+  // It used to be the case that clearing a non-empty tree would leave it thinking that it had room
+  // for one more node than it really did, causing it to write and read beyond the end of its
+  // internal array of nodes.
+  Table<uint, TreeIndex<UintCompare>> table;
+
+  // Insert at least one value to allocate an initial set of tree nodes.
+  table.upsert(1, [](auto&&, auto&&) {});
+  KJ_EXPECT(table.find(1) != nullptr);
+  table.clear();
+
+  // Insert enough values to force writes/reads beyond the end of the tree's internal node array.
+  for (uint i = 0; i < 29; ++i) {
+    table.upsert(i, [](auto&&, auto&&) {});
+  }
+  for (uint i = 0; i < 29; ++i) {
+    KJ_EXPECT(table.find(i) != nullptr);
+  }
+}
+
 KJ_TEST("benchmark: kj::Table<uint, TreeIndex>") {
   constexpr uint SOME_PRIME = BIG_PRIME;
   constexpr uint STEP[] = {1, 2, 4, 7, 43, 127};

--- a/c++/src/kj/table.c++
+++ b/c++/src/kj/table.c++
@@ -335,7 +335,7 @@ void BTreeImpl::clear() {
     azero(tree, treeCapacity);
     height = 0;
     freelistHead = 1;
-    freelistSize = treeCapacity;
+    freelistSize = treeCapacity - 1;  // subtract one to account for the root node
     beginLeaf = 0;
     endLeaf = 0;
   }


### PR DESCRIPTION
This causes the BTreeImpl to think it has room for one more node than it
really does, leading to reading/writing beyond the end of its allocated
memory.

For example, in the test case this commit adds, at the time of
failure GDB shows the tree having an allocated capacity of 4 nodes but a
tree that contains the 1 root Parent node and 4 Leaf nodes.

The Parent contains:
```
keys = {{i = 7}, {i = 14}, {i = 21}, {i = 0}, {i = 0}, {i = 0}, {i = 0}}
```

The Leaf nodes contain, respectively:
```
rows = {{i = 1}, {i = 2}, {i = 3}, {i = 4}, {i = 5}, {i = 6}, {i = 7}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}}
rows = {{i = 8}, {i = 9}, {i = 10}, {i = 11}, {i = 12}, {i = 13}, {i = 14}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}}
rows = {{i = 15}, {i = 16}, {i = 17}, {i = 18}, {i = 19}, {i = 20}, {i = 21}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}, {i = 0}}
rows = {{i = 22}, {i = 23}, {i = 24}, {i = 25}, {i = 26}, {i = 27}, {i = 28}, {i = 21845}, {i = 6}, {i = 0}, {i = 1441926008}, {i = 21845}, {i = 6}, {i = 0}}}
```

The last leaf is the one that's beyond the end of the allocated
capacity, as is probably obvious from the garbage at its end.