### PR TITLE
Fix bug where HttpServer listen loop would terminate early.

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -5402,7 +5402,7 @@ kj::Promise<void> HttpServer::listenLoop(kj::ConnectionReceiver& port) {
       return kj::READY_NOW;
     }
 
-    tasks.add(listenHttp(kj::mv(connection)));
+    tasks.add(kj::evalNow([&]() { return listenHttp(kj::mv(connection)); }));
     return listenLoop(port);
   });
 }


### PR DESCRIPTION
If a newly-accepted connection was immediately broken such that the very first read failed without even blocking then the loop itself would terminate early due to failing to the exception being thrown synchronously.

Fixes #1219.