### PR TITLE
Build fails with -O0 on Ubuntu 20.04

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -804,6 +804,10 @@ private:
   }
 };
 
+#if __linux__
+constexpr size_t AsyncStreamFd::MAX_SPLICE_LEN;
+#endif  // __linux__
+
 // =======================================================================================
 
 class SocketAddress {


### PR DESCRIPTION
I don't really understand why it passed the current CI, but with the latest PR in capnproto, both the tests and samples fail to build for me. It works from commit 8009588ff84cbdf233f6d23d1d507462b050b427.

The error I get is:

```
[ 44%] Linking CXX executable kj-heavy-tests
/usr/bin/ld: libkj-async.a(async-io-unix.c++.o): in function `kj::(anonymous namespace)::AsyncStreamFd::splicePumpLoop(kj::(anonymous namespace)::AsyncStreamFd&, int, int, unsigned long, unsigned long, unsigned long)::{lambda()#3}::operator()() const':
async-io-unix.c++:(.text+0x1f1d): undefined reference to `kj::(anonymous namespace)::AsyncStreamFd::MAX_SPLICE_LEN'
collect2: error: ld returned 1 exit status
```

I don't think that it is necessary to add this github workflow, because capnproto already should cover that in the CI. I just thought it would be easier to report like this (and I don't understand why the current CI did not catch this). As can be seen, all I do is configuring and building capnproto and the samples.

EDIT: actually I realize that the CI is using the Makefile, so maybe it would make sense to add this workflow to check that it builds with CMake, right?