### PR TITLE
Add support for musl

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -10,6 +10,15 @@ on:
     - 'release-*'
 
 jobs:
+  Linux-musl:
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: apk add autoconf automake build-base cmake libtool libucontext-dev linux-headers openssl-dev
+      - name: super-test
+        run: ./super-test.sh quick
   Linux:
     runs-on: ubuntu-latest
     strategy:

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.6)
 project("Cap'n Proto" CXX)
 set(VERSION 0.10-dev)
 
@@ -62,6 +62,50 @@ elseif (WITH_OPENSSL STREQUAL "AUTO")
   endif()
 elseif (WITH_OPENSSL)
   find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
+endif()
+
+set(WITH_FIBERS "AUTO" CACHE STRING
+  "Whether or not to build libkj-async with fibers")
+# define list of values GUI will offer for the variable
+set_property(CACHE WITH_FIBERS PROPERTY STRINGS AUTO ON OFF)
+
+# CapnProtoConfig.cmake.in needs this variable.
+set(_WITH_LIBUCONTEXT OFF)
+
+if (WITH_FIBERS OR WITH_FIBERS STREQUAL "AUTO")
+  set(_capnp_fibers_found OFF)
+  if (WIN32 OR CYGWIN)
+    set(_capnp_fibers_found ON)
+  else()
+    # Fibers need makecontext, setcontext, getcontext, swapcontext that may be in libc,
+    # or in libucontext (e.g. for musl).
+    # We assume that makecontext implies that the others are present.
+    include(CheckLibraryExists)
+    check_library_exists(c makecontext "" HAVE_UCONTEXT_LIBC)
+    if (HAVE_UCONTEXT_LIBC)
+      set(_capnp_fibers_found ON)
+    else()
+      # Try with libucontext
+      find_package(PkgConfig)
+      if (PKG_CONFIG_FOUND)
+        pkg_check_modules(libucontext IMPORTED_TARGET libucontext)
+        if (libucontext_FOUND)
+          set(_WITH_LIBUCONTEXT ON)
+          set(_capnp_fibers_found ON)
+        endif()
+      else()
+        set(_capnp_fibers_found OFF)
+      endif()
+    endif()
+  endif()
+
+  if (_capnp_fibers_found)
+    set(WITH_FIBERS ON)
+  elseif(WITH_FIBERS STREQUAL "AUTO")
+    set(WITH_FIBERS OFF)
+  else()
+    message(FATAL_ERROR "Missing 'makecontext', 'getcontext', 'setcontext' or 'swapcontext' symbol in libc and no libucontext found: KJ won't be able to build with fibers. Disable fibers (-DWITH_FIBERS=OFF).")
+  endif()
 endif()
 
 if(MSVC)

--- a/c++/cmake/CapnProtoConfig.cmake.in
+++ b/c++/cmake/CapnProtoConfig.cmake.in
@@ -62,6 +62,38 @@ if (@WITH_OPENSSL@)  # WITH_OPENSSL
   endif()
 endif()
 
+if (@_WITH_LIBUCONTEXT@) # _WITH_LIBUCONTEXT
+  set(forwarded_config_flags)
+  if(CapnProto_FIND_QUIETLY)
+    list(APPEND forwarded_config_flags QUIET)
+  endif()
+  if(CapnProto_FIND_REQUIRED)
+    list(APPEND forwarded_config_flags REQUIRED)
+  endif()
+  # If the consuming project called find_package(CapnProto) with the QUIET or REQUIRED flags, forward
+  # them to calls to find_package(PkgConfig) and pkg_check_modules(). Note that find_dependency()
+  # would do this for us in the former case, but there is no such forwarding wrapper for
+  # pkg_check_modules().
+
+  find_package(PkgConfig ${forwarded_config_flags})
+  if(NOT ${PkgConfig_FOUND})
+    # If we're here, the REQUIRED flag must not have been passed, else we would have had a fatal
+    # error. Nevertheless, a diagnostic for this case is probably nice.
+    if(NOT CapnProto_FIND_QUIETLY)
+      message(WARNING "pkg-config cannot be found")
+    endif()
+    set(CapnProto_FOUND OFF)
+    return()
+  endif()
+
+  if (CMAKE_VERSION VERSION_LESS 3.6)
+    # CMake >= 3.6 required due to the use of IMPORTED_TARGET
+    message(SEND_ERROR "libucontext support requires CMake >= 3.6.")
+  endif()
+
+  pkg_check_modules(libucontext IMPORTED_TARGET ${forwarded_config_flags} libucontext)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/CapnProtoTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/CapnProtoMacros.cmake")
 

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -32,6 +32,11 @@ AC_ARG_WITH([openssl],
     [build libkj-tls by linking against openssl @<:@default=check@:>@])],
   [],[with_openssl=check])
 
+AC_ARG_WITH([fibers],
+  [AS_HELP_STRING([--with-fibers],
+    [build libkj-async with fibers @<:@default=check@:>@])],
+  [],[with_fibers=check])
+
 AC_ARG_ENABLE([reflection], [
   AS_HELP_STRING([--disable-reflection], [
     compile Cap'n Proto in "lite mode", in which all reflection APIs (schema.h, dynamic.h, etc.)
@@ -195,8 +200,46 @@ AS_IF([test "$with_openssl" != no], [
 ])
 AM_CONDITIONAL([BUILD_KJ_TLS], [test "$with_openssl" != no])
 
-# CapnProtoConfig.cmake.in needs this variable.
-AC_SUBST(WITH_OPENSSL, $with_openssl)
+# Fibers need the symbols getcontext, setcontext, swapcontext and makecontext.
+# We assume that makecontext implies the rest.
+AS_IF([test "$with_fibers" != no], [
+  libc_supports_fibers=yes
+  AC_SEARCH_LIBS([makecontext], [], [], [
+    libc_supports_fibers=no
+  ])
+
+  AS_IF([test "$libc_supports_fibers" = yes], [
+      with_fibers=yes
+    ], [
+    # If getcontext does not exist in libc, try with libucontext
+    ucontext_supports_fibers=yes
+    AC_CHECK_LIB(ucontext, [makecontext], [], [
+      ucontext_supports_fibers=no
+    ])
+    AS_IF([test "$ucontext_supports_fibers" = yes], [
+      ASYNC_LIBS="$ASYNC_LIBS -lucontext"
+      with_fibers=yes
+    ], [
+      AS_IF([test "$with_fibers" = yes], [
+        AC_MSG_ERROR([Missing symbols required for fibers (makecontext, setcontext, ...). Disable fibers (--without-fibers) or install libucontext])
+      ], [
+        AC_MSG_WARN([could not find required symbols (makecontext, setcontext, ...) -- won't build with fibers])
+        with_fibers=no
+      ])
+    ])
+  ])
+])
+AS_IF([test "$with_fibers" = yes], [
+  CXXFLAGS="$CXXFLAGS -DKJ_USE_FIBERS"
+], [
+  CXXFLAGS="$CXXFLAGS -DKJ_USE_FIBERS=0"
+])
+
+# CapnProtoConfig.cmake.in needs these variables,
+# we force them to NO because we don't need the CMake dependency for them,
+# the dependencies are provided by the .pc files.
+AC_SUBST(WITH_OPENSSL, NO)
+AC_SUBST(_WITH_LIBUCONTEXT, NO)
 
 AM_CONDITIONAL([HAS_FUZZING_ENGINE], [test "x$LIB_FUZZING_ENGINE" != "x"])
 

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -137,6 +137,15 @@ if(NOT CAPNP_LITE)
   add_library(kj-async ${kj-async_sources})
   add_library(CapnProto::kj-async ALIAS kj-async)
   target_link_libraries(kj-async PUBLIC kj)
+  if(WITH_FIBERS)
+    target_compile_definitions(kj-async PUBLIC KJ_USE_FIBERS)
+    if(_WITH_LIBUCONTEXT)
+      target_link_libraries(kj-async PUBLIC PkgConfig::libucontext)
+    endif()
+  else()
+    target_compile_definitions(kj-async PUBLIC KJ_USE_FIBERS=0)
+  endif()
+
   if(UNIX)
     # external clients of this library need to link to pthreads
     target_compile_options(kj-async INTERFACE "-pthread")
@@ -182,7 +191,7 @@ if(NOT CAPNP_LITE)
   add_library(kj-tls ${kj-tls_sources})
   add_library(CapnProto::kj-tls ALIAS kj-tls)
   target_link_libraries(kj-tls PUBLIC kj-async)
-  if (WITH_OPENSSL)
+  if(WITH_OPENSSL)
     target_compile_definitions(kj-tls PRIVATE KJ_HAS_OPENSSL)
     target_link_libraries(kj-tls PRIVATE OpenSSL::SSL OpenSSL::Crypto)
   endif()
@@ -270,7 +279,7 @@ if(BUILD_TESTING)
       compat/tls-test.c++
     )
     target_link_libraries(kj-heavy-tests kj-http kj-gzip kj-tls kj-async kj-test kj)
-    if (WITH_OPENSSL)
+    if(WITH_OPENSSL)
       set_property(
         SOURCE compat/tls-test.c++
         APPEND PROPERTY COMPILE_DEFINITIONS KJ_HAS_OPENSSL

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -373,9 +373,17 @@ bool systemSupportsAddress(StringPtr addr, StringPtr service = nullptr) {
   // Can getaddrinfo() parse this addresses? This is only true if the address family (e.g., ipv6)
   // is configured on at least one interface. (The loopback interface usually has both ipv4 and
   // ipv6 configured, but not always.)
+  struct addrinfo hints;
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = 0;
+  hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG;
+  hints.ai_protocol = 0;
+  hints.ai_canonname = nullptr;
+  hints.ai_addr = nullptr;
+  hints.ai_next = nullptr;
   struct addrinfo* list;
   int status = getaddrinfo(
-      addr.cStr(), service == nullptr ? nullptr : service.cStr(), nullptr, &list);
+      addr.cStr(), service == nullptr ? nullptr : service.cStr(), &hints, &list);
   if (status == 0) {
     freeaddrinfo(list);
     return true;

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1208,11 +1208,19 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
   auto thread = heap<Thread>(kj::mvCapture(params, [outFd,portHint](LookupParams&& params) {
     FdOutputStream output((AutoCloseFd(outFd)));
 
+    struct addrinfo hints;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = 0;
+    hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG;
+    hints.ai_protocol = 0;
+    hints.ai_canonname = nullptr;
+    hints.ai_addr = nullptr;
+    hints.ai_next = nullptr;
     struct addrinfo* list;
     int status = getaddrinfo(
         params.host == "*" ? nullptr : params.host.cStr(),
         params.service == nullptr ? nullptr : params.service.cStr(),
-        nullptr, &list);
+        &hints, &list);
     if (status == 0) {
       KJ_DEFER(freeaddrinfo(list));
 


### PR DESCRIPTION
Add support for musl systems both for cmake and makefile (related to #1167).

* For makefile, it searches for the `getcontext` symbol in `libucontext`, and adds `-lucontext` if it is found.
* For cmake, it searches for `libucontext` using `pkg-config`, and links it if found.

Note: this PR makes the assumption that a system that has `libucontext` needs it for the `getcontext`, `makecontext` and `setcontext` symbols.

The CI fails for two tests, I believe because docker on the github workflow does not support ipv6 (see https://github.com/actions/virtual-environments/issues/668):

```
2022-01-15T01:25:57.4242371Z kj/async-io-unix.c++:865: failed: ::bind(sockfd, &addr.generic, addrlen): Address not available; toString() = [::1]:0
2022-01-15T01:25:57.4242816Z [ FAIL ] capnp/ez-rpc-test.c++:32: legacy test: EzRpc/Basic (354 μs)
2022-01-15T01:25:57.4249502Z kj/async-io-unix.c++:865: failed: ::bind(sockfd, &addr.generic, addrlen): Address not available; toString() = [::1]:0
2022-01-15T01:25:57.4250008Z [ FAIL ] capnp/ez-rpc-test.c++:49: legacy test: EzRpc/DeprecatedNames (650 μs)
```

One alternative would be to not add the alpine build to the CI (which is a bit sad), another would be to add some kind of `--no-ipv6` flag to `super-test.sh`, but I'm not sure how much work that requires.

Resolves #1167.