### PR TITLE
Disable the coroutine immediately-ready optimization before the first suspension

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1911,6 +1911,8 @@ private:
   OnReadyEvent onReadyEvent;
   bool waiting = true;
 
+  bool hasSuspendedAtLeastOnce = false;
+
   Maybe<PromiseNode&> promiseNodeForTrace;
   // Whenever this coroutine is suspended waiting on another promise, we keep a reference to that
   // promise so tracePromise()/traceEvent() can trace into it.


### PR DESCRIPTION
This behavior was erroneous, and broke the guarantee that calling code could observe its own subsequent synchronous code run before newly-enqueued asynchronous code.