### PR TITLE
Assert that HttpHeaders instances know about indexed ids

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -528,7 +528,9 @@ struct HttpHeaderTable::IdsByNameMap {
 };
 
 HttpHeaderTable::Builder::Builder()
-    : table(kj::heap<HttpHeaderTable>()) {}
+    : table(kj::heap<HttpHeaderTable>()) {
+  table->buildStatus = BuildStatus::BUILDING;
+}
 
 HttpHeaderId HttpHeaderTable::Builder::add(kj::StringPtr name) {
   requireValidHeaderName(name);
@@ -576,7 +578,11 @@ bool HttpHeaders::isValidHeaderValue(kj::StringPtr value) {
 
 HttpHeaders::HttpHeaders(const HttpHeaderTable& table)
     : table(&table),
-      indexedHeaders(kj::heapArray<kj::StringPtr>(table.idCount())) {}
+      indexedHeaders(kj::heapArray<kj::StringPtr>(table.idCount())) {
+  KJ_ASSERT(
+      table.isReady(), "HttpHeaders object was constructed from "
+      "HttpHeaderTable that wasn't fully built yet at the time of construction");
+}
 
 void HttpHeaders::clear() {
   for (auto& header: indexedHeaders) {


### PR DESCRIPTION
The HttpHeaderTable::Builder class allows you to reference its future table before it is fully built. But that HttpHeaderTable must be used to make HttpHeaders instances only after HttpHeaderTable::Builder::build() is invoked under peril of index out of bounds error in debug mode or segfault in release mode. These errors can be somewhat mysterious since they usually occur on a different stack from where the HttpHeaders instance was made. This commit adds an assertion that makes this situation more evident and logs useful diagnostic info about which header id was added after the construction. Hopefully, it should downgrade a segfault to failed Promise or thrown Exception for most users.