### PR TITLE
Check if SYS_renameat2 defined before using it

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -1090,7 +1090,7 @@ public:
       }
     }
 
-#if __linux__ && defined(RENAME_EXCHANGE)
+#if __linux__ && defined(RENAME_EXCHANGE) && defined(SYS_renameat2)
     // Try to use Linux's renameat2() to atomically check preconditions and apply.
 
     if (has(mode, WriteMode::MODIFY)) {


### PR DESCRIPTION
This PR adds a check for `SYS_renameat2` which is needed on older Linux; specifically [manylinux2014](https://www.python.org/dev/peps/pep-0599/) which is essentially CentOS 7.

Here is a test on a Linux system with Docker for reproducibility:

```console
# Reproduce as of 2022-01-22: docker run --rm "dockcross/manylinux2014-x86:latest" > ./dockcross
$ docker run --rm "dockcross/manylinux2014-x86@sha256:8adf47eceeeeab1d1a14c43e425de1c75004cf0f7bca5705d21164335d5cc97d" > ./dockcross
WARNING: The requested image's platform (linux/386) does not match the detected host platform (linux/amd64) and no specific platform was requested

$ bash dockcross ./super-test.sh cmake
...
[ 13%] Building CXX object src/kj/CMakeFiles/kj.dir/parse/char.c++.o
cd /work/c++/cmake-build/src/kj && /opt/rh/devtoolset-10/root/usr/bin/g++   -D KJ_HAS_ZLIB=1 -Wall -Wextra -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -pthread -MD -MT src/kj/CMakeFiles/kj.dir/parse/char.c++.o -MF CMakeFiles/kj.dir/parse/char.c++.o.d -o CMakeFiles/kj.dir/parse/char.c++.o -c /work/c++/src/kj/parse/char.c++
In file included from /work/c++/src/kj/filesystem-disk-unix.c++:29:
/work/c++/src/kj/filesystem-disk-unix.c++: In lambda function:
/work/c++/src/kj/filesystem-disk-unix.c++:1103:40: error: ‘SYS_renameat2’ was not declared in this scope; did you mean ‘SYS_renameat’?
 1103 |       KJ_SYSCALL_HANDLE_ERRORS(syscall(SYS_renameat2,
      |                                        ^~~~~~~~~~~~~
/work/c++/src/kj/filesystem-disk-unix.c++: In lambda function:
/work/c++/src/kj/filesystem-disk-unix.c++:1135:40: error: ‘SYS_renameat2’ was not declared in this scope; did you mean ‘SYS_renameat’?
 1135 |       KJ_SYSCALL_HANDLE_ERRORS(syscall(SYS_renameat2,
      |                                        ^~~~~~~~~~~~~
```

Also, using `bash dockcross ./super-test.sh` as done in this PR to test out older Linux distros should be simple to add to your Release tests.

Thanks