### PR TITLE
Add dockcross/manylinux2014 to tests

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -51,6 +51,24 @@ jobs:
         run: |
             # librt is used for timer_create in the unit tests for lock tracking (mutex-test.c++).
             ./super-test.sh quick ${{ matrix.compiler }} cpp-features "${{matrix.features}}" extra-libs "-lrt"
+  ManyLinux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cross-compiler: manylinux2014-x64
+          - cross-compiler: manylinux2014-x86
+            docker-run-args: --platform linux/386
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dockcross
+        run: |
+            docker run ${{ matrix.docker-run-args }} --rm dockcross/${{ matrix.cross-compiler }} > ./dockcross
+            chmod +x ./dockcross
+      - name: super-test
+        run: |
+            ./dockcross ./super-test.sh quick g++
   MacOS:
     runs-on: macos-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@
 
 # editor artefacts
 *~
+
+# cross-compiling / glibc testing
+/dockcross


### PR DESCRIPTION
**This PR should not be merged yet! ** It contains a GitHub Actions commit that will be removed when complete.

This PR adds a `dockcross manylinux2014` test target for GitHub Actions. Using `dockcross` gives a modern compiler (GCC 10.2 right now) while `manylinux2014` gives an old glibc ABI from 2014.

Some tweaks included in this PR:
* Put in flags to disable 32-bit testing (dockcross only includes either 64-bit and 32-bit, not both) and disable valgrind testing (dockcross does not provide this).

Maintenance cost: Every 4 years or so the "manylinux2014" will need to be bumped (ex. manylinux2018). `dockcross/manylinux2014-*` is implicitly `dockcross/manylinux2014-*:latest` which will always use a modern GCC compiler. For reproducibility we may want the Docker image pinned to a specific version but then the image version needs to be bumped occasionally.

---

Testing: I tested at https://github.com/jonahbeckford/capnproto/actions . Some things to notice:

1. The ["ManyLinux (manylinux2014-x86, --platform linux/386)" *Quick* Test](https://github.com/jonahbeckford/capnproto/runs/4930324685?check_suite_focus=true) fails due to the same error (`error: could not convert ... from ‘kj::PromiseForResult<kj::{anonymous}::AsyncStreamFd::tryPumpFrom(kj::AsyncInputStream&, uint64_t)::<lambda()>, void>’ {aka ‘kj::Promise<unsigned int>’} to ‘kj::Maybe<kj::Promise<long long unsigned int> >’`) as the pre-existing ["Linux (g++-7)" *Full* Test](https://github.com/jonahbeckford/capnproto/runs/4930324277?check_suite_focus=true). Those same tests are failing in the [capnproto repository](https://github.com/capnproto/capnproto/actions/runs/1742620367) so this PR will need to wait until the underlying unrelated problem is fixed.
2. The ["ManyLinux (manylinux2014-x64)" *Full* Test](https://github.com/jonahbeckford/capnproto/runs/4930324724?check_suite_focus=true) fails during the "Testing with -fno-rtti and -fno-exceptions" section. I have no clue why. I could remove the Full Test but I thought it was better to let someone else see the problem.