### PR TITLE
Fix computeCurrentPath test with generic Unix test

### DIFF
--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -966,7 +966,7 @@ KJ_TEST("DiskFilesystem::computeCurrentPath") {
     "some_path_longer_than_256_bytes"
   }), WriteMode::CREATE | WriteMode::CREATE_PARENT);
 
-  auto origDir = open(".", O_RDONLY | O_DIRECTORY);
+  auto origDir = open(".", O_RDONLY);
   KJ_SYSCALL(fchdir(KJ_ASSERT_NONNULL(subdir->getFd())));
   KJ_DEFER(KJ_SYSCALL(fchdir(origDir)));
 


### PR DESCRIPTION
Test fails in ekam since it also runs as a generic Unix test, which doesn't have O_DIRECTORY. This should fix the test in the short-term.