### PR TITLE
OpenSSL 3.0

### DIFF
--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -369,9 +369,8 @@ private:
     switch (cmd) {
       case BIO_CTRL_FLUSH:
         return 1;
-      case BIO_CTRL_INFO:
       case BIO_CTRL_EOF:
-        // Queries for info and EOF
+        // Queries for EOF
         return 0;
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L && \
         !defined(OPENSSL_IS_BORINGSSL) && \

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -370,7 +370,10 @@ private:
       case BIO_CTRL_FLUSH:
         return 1;
       case BIO_CTRL_EOF:
-        // Queries for EOF
+        // Queries for EOF. OpenSSL sometimes polls this BIO_CTRL after
+        // attempting a read, but we don't have a good way to check for
+        // an EOF explicitly so we "lie" and say we have not reached EOF.
+        // OpenSSL can still use the read return value to indicate EOF.
         return 0;
 #ifdef BIO_CTRL_GET_KTLS_SEND
       case BIO_CTRL_GET_KTLS_SEND:

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -372,9 +372,7 @@ private:
       case BIO_CTRL_EOF:
         // Queries for EOF
         return 0;
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && \
-        !defined(OPENSSL_IS_BORINGSSL) && \
-        !defined(OPENSSL_NO_KTLS)
+#ifdef BIO_CTRL_GET_KTLS_SEND
       case BIO_CTRL_GET_KTLS_SEND:
       case BIO_CTRL_GET_KTLS_RECV:
         // Queries to determine if our BIO supports KTLS

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -369,6 +369,18 @@ private:
     switch (cmd) {
       case BIO_CTRL_FLUSH:
         return 1;
+      case BIO_CTRL_INFO:
+      case BIO_CTRL_EOF:
+        // Queries for info and EOF
+        return 0;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && \
+        !defined(OPENSSL_IS_BORINGSSL) && \
+        !defined(OPENSSL_NO_KTLS)
+      case BIO_CTRL_GET_KTLS_SEND:
+      case BIO_CTRL_GET_KTLS_RECV:
+        // Queries to determine if our BIO supports KTLS
+        return 0;
+#endif
       case BIO_CTRL_PUSH:
       case BIO_CTRL_POP:
         // Informational?


### PR DESCRIPTION
Debian is preparing to transition to OpenSSL 3.0 and we ran into two issues with this in capnproto:

1. Failing tests attributable to openssl error messages changing slightly
2. Lots of "unimplemented bioctrl" warnings, mostly associated with kTLS
