### PR TITLE
More detailed OpenSSL errors

### DIFF
--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -1123,6 +1123,19 @@ KJ_TEST("TLS receiver does not stall on hung client") {
   KJ_EXPECT(!extraAcceptPromise.poll(test.io.waitScope));
 }
 
+void throwBadContext() {
+  TlsContext::Options options;
+  options.cipherList = "bogus,broken,wrong";
+
+  TlsContext ctx(kj::mv(options));
+}
+
+KJ_TEST("OpenSSL error formatting") {
+  KJ_EXPECT_THROW_MESSAGE("ssl_lib.c", throwBadContext());
+  KJ_EXPECT_THROW_MESSAGE("SSL_CTX_set_cipher_list", throwBadContext());
+  KJ_EXPECT_THROW_MESSAGE("no cipher match", throwBadContext());
+}
+
 #ifdef KJ_EXTERNAL_TESTS
 KJ_TEST("TLS to capnproto.org") {
   kj::AsyncIoContext io = setupAsyncIo();


### PR DESCRIPTION
While working on the OpenSSL 3.0 test failures that led to #1434 I ran into a test failure that was a bit harder to debug because there wasn't a lot of detail in the OpenSSL error reported by capnproto:

```
[ TEST ] kj/compat/tls-test.c++:710: TLS client certificate verification
kj/compat/tls.c++:66: failed: OpenSSL error; message = error:16000069:STORE routines::unregistered scheme
error:80000002:system library::No such file or directory
stack: ffff8323ba33 ffff832465ab ffff832468b3 ffff83197d27 ffff83197bff aaaabff624d3 aaaabff62663 aaaabff6bb17 ffff8312e1fb
[ FAIL ] kj/compat/tls-test.c++:710: TLS client certificate verification (30588 μs)
```

Here the `system library` is reporting a missing file/directory, but which one?

It turns out the details are hidden away in the `data` associated with the error. The same error with additional detail from `ERR_get_error_all` (the OpenSSL 3.x function that supersedes `ERR_get_error_line_data`) from an earlier incarnation of this change:

```
kj/compat/tls.c++:72: failed: OpenSSL error; message = src/kj/compat/tls.c++:329
error:16000069:STORE routines::unregistered scheme, filename=../crypto/store/store_register.c, lineno=237, func=ossl_store_get0_loader_int, data=scheme=file, flags=3
error:80000002:system library::No such file or directory, filename=../providers/implementations/storemgmt/file_store.c, lineno=269, func=file_open, data=calling stat(/usr/lib/ssl/certs), flags=3
stack: ffffbe174d3b ffffbe17fbef ffffbe17fef3 ffffbe0d0d27 ffffbe0d0bff aaaae0780553 aaaae07806e3 aaaae0789c97 ffffbe0671fb
```

We can clearly see OpenSSL was looking for `/usr/lib/ssl/certs` but it didn't exist. With this info in the build logs it was trivial to fix the broken test.

To make this kind of issue clearer/easier to debug going forward this PR outputs the additional error detail (filename, lineno, data) as part of `throwOpensslError`.

Note that it's tricky to force an error with `data` set so the test here is a little incomplete, but the implementation follows [examples found in the OpenSSL code base](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1m/crypto/err/err_prn.c#L36-L42).