### PR TITLE
Add `SchemaParser::getAllLoaded()` to get all parsed schemas.

### DIFF
--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -313,6 +313,10 @@ SchemaLoader& SchemaParser::getLoader() {
   return impl->compiler.getLoader();
 }
 
+const SchemaLoader& SchemaParser::getLoader() const {
+  return impl->compiler.getLoader();
+}
+
 kj::Maybe<ParsedSchema> ParsedSchema::findNested(kj::StringPtr name) const {
   // TODO(someday): lookup() doesn't handle generics correctly. Use the ModuleScope/CompiledType
   //   interface instead. We can also add an applybrand() method to ParsedSchema using those

--- a/c++/src/capnp/schema-parser.h
+++ b/c++/src/capnp/schema-parser.h
@@ -141,6 +141,11 @@ public:
     getLoader().loadCompiledTypeAndDependencies<T>();
   }
 
+  kj::Array<Schema> getAllLoaded() const {
+    // Gets an array of all schema nodes that have been parsed so far.
+    return getLoader().getAllLoaded();
+  }
+
 private:
   struct Impl;
   struct DiskFileCompat;
@@ -149,6 +154,7 @@ private:
   mutable bool hadErrors = false;
 
   ModuleImpl& getModuleImpl(kj::Own<SchemaFile>&& file) const;
+  const SchemaLoader& getLoader() const;
   SchemaLoader& getLoader();
 
   friend class ParsedSchema;


### PR DESCRIPTION
This allows you to write a tool that parses a bunch of schemas and then dumps the whole set of compiled schemas.