### PR TITLE
Allow changing an exception's description

### DIFF
--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -80,6 +80,8 @@ public:
   StringPtr getDescription() const { return description; }
   ArrayPtr<void* const> getStackTrace() const { return arrayPtr(trace, traceCount); }
 
+  void setDescription(kj::String&& desc) { description = kj::mv(desc); }
+
   StringPtr getRemoteTrace() const { return remoteTrace; }
   void setRemoteTrace(kj::String&& value) { remoteTrace = kj::mv(value); }
   // Additional stack trace data originating from a remote server. If present, then


### PR DESCRIPTION
There are a few spots in the workers runtime where we want to modify an
exception's description in a trivial way (e.g. adding a prefix to it)
before passing it along. In order to do so, we currently have to do
something like:

```
kj::Exception(e.getType(), e.getFile(), e.getLine(), str("prefix", e.getDesc());
```

This concerns me for a couple reasons:

1. We lose any additional information in the original exception
   (context, trace, remote trace)
2. More importantly, if the `file` StringPtr points to a String owned by
   the original exception, its ownFile will be destructed when the old
   exception is lost, leading to a use after free if the new exception's
   file is ever read.

I suppose point 2 isn't actually a concern in practice if the only place
an Exception's file names ever come from are the __FILE__ macro's string
literals, but I don't know for sure if that's something we can rely on.

It seems easy and safe enough to allow this so that we could instead:

e.setDescription(str("prefix", e.getDesc());