### PR TITLE
Make threads move-constructible and move-assignable

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -241,6 +241,7 @@ if(BUILD_TESTING)
     io-test.c++
     mutex-test.c++
     time-test.c++
+    thread-test.c++
     threadlocal-test.c++
     test-test.c++
     std/iostream-test.c++

--- a/c++/src/kj/thread.h
+++ b/c++/src/kj/thread.h
@@ -93,25 +93,25 @@ inline Thread::Thread(Thread&& other) noexcept
 
 inline Thread& Thread::operator=(Thread&& other) noexcept {
   {
-    ThreadState* tempState = state;
+    ThreadState* temp = state;
     state = other.state;
-    other.state = tempState;
+    other.state = temp;
   }
   {
 #if _WIN32
-    void* tempThreadHandle = threadHandle;
+    void* temp = threadHandle;
     threadHandle = other.threadHandle;
-    other.threadHandle = tempThreadHandle;
+    other.threadHandle = temp;
 #else
-    unsigned long long tempThreadId = threadId;
+    unsigned long long temp = threadId;
     threadId = other.threadId;
-    other.threadId = tempThreadId;
+    other.threadId = temp;
 #endif
   }
   {
-    bool tempDetached = detached;
+    bool temp = detached;
     detached = other.detached;
-    other.detached = tempDetached;
+    other.detached = temp;
   }
 
   return *this;


### PR DESCRIPTION
`std::thread`s are movable and `kj::Thread`s are internally very simple so there's no reason for them not to be as well.

This restores `thread-test.c++` in the list of test files, but I suppose there's a good reason it wasn't there in the first place so this can be removed.

For the implementation of `Thread& Thread::operator=(Thread&&)`, in the absence of a `std::swap` equivalent, I manually typed the swaps, which is verbose.