### PR TITLE
Replace angle bracket includes with quotes

### DIFF
--- a/c++/samples/addressbook.c++
+++ b/c++/samples/addressbook.c++
@@ -37,8 +37,8 @@
 // TODO(test):  Needs cleanup.
 
 #include "addressbook.capnp.h"
-#include <capnp/message.h>
-#include <capnp/serialize-packed.h>
+#include "capnp/message.h"
+#include "capnp/serialize-packed.h"
 #include <iostream>
 
 using addressbook::Person;
@@ -116,11 +116,11 @@ void printAddressBook(int fd) {
 #if !CAPNP_LITE
 
 #include "addressbook.capnp.h"
-#include <capnp/message.h>
-#include <capnp/serialize-packed.h>
+#include "capnp/message.h"
+#include "capnp/serialize-packed.h"
 #include <iostream>
-#include <capnp/schema.h>
-#include <capnp/dynamic.h>
+#include "capnp/schema.h"
+#include "capnp/dynamic.h"
 
 using ::capnp::DynamicValue;
 using ::capnp::DynamicStruct;

--- a/c++/samples/calculator-client.c++
+++ b/c++/samples/calculator-client.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "calculator.capnp.h"
-#include <capnp/ez-rpc.h>
-#include <kj/debug.h>
+#include "capnp/ez-rpc.h"
+#include "kj/debug.h"
 #include <math.h>
 #include <iostream>
 

--- a/c++/samples/calculator-server.c++
+++ b/c++/samples/calculator-server.c++
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 
 #include "calculator.capnp.h"
-#include <kj/debug.h>
-#include <capnp/ez-rpc.h>
-#include <capnp/message.h>
+#include "kj/debug.h"
+#include "capnp/ez-rpc.h"
+#include "capnp/message.h"
 #include <iostream>
 
 typedef unsigned int uint;

--- a/c++/src/benchmark/capnproto-common.h
+++ b/c++/src/benchmark/capnproto-common.h
@@ -26,11 +26,11 @@
 #endif
 
 #include "common.h"
-#include <capnp/serialize.h>
-#include <capnp/serialize-packed.h>
-#include <kj/debug.h>
+#include "capnp/serialize.h"
+#include "capnp/serialize-packed.h"
+#include "kj/debug.h"
 #if HAVE_SNAPPY
-#include <capnp/serialize-snappy.h>
+#include "capnp/serialize-snappy.h"
 #endif  // HAVE_SNAPPY
 #include <thread>
 

--- a/c++/src/capnp/afl-testcase.c++
+++ b/c++/src/capnp/afl-testcase.c++
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 
 #include "test-util.h"
-#include <kj/main.h>
+#include "kj/main.h"
 #include "serialize.h"
-#include <capnp/test.capnp.h>
+#include "capnp/test.capnp.h"
 #include <unistd.h>
 
 namespace capnp {

--- a/c++/src/capnp/any-test.c++
+++ b/c++/src/capnp/any-test.c++
@@ -21,7 +21,7 @@
 
 #include "any.h"
 #include "message.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include "test-util.h"
 
 namespace capnp {

--- a/c++/src/capnp/any.c++
+++ b/c++/src/capnp/any.c++
@@ -21,7 +21,7 @@
 
 #include "any.h"
 
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 #if !CAPNP_LITE
 #include "capability.h"

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -25,8 +25,8 @@
 #include "pointer-helpers.h"
 #include "orphan.h"
 #include "list.h"
-#include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
-#include <kj/hash.h>
+#include "kj/windows-sanity.h"  // work-around macro conflict with `VOID`
+#include "kj/hash.h"
 
 CAPNP_BEGIN_HEADER
 
@@ -116,15 +116,15 @@ struct AnyPointer {
 
     template <typename T>
     inline ReaderFor<T> getAs(StructSchema schema) const;
-    // Only valid for T = DynamicStruct.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicStruct.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline ReaderFor<T> getAs(ListSchema schema) const;
-    // Only valid for T = DynamicList.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicList.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline ReaderFor<T> getAs(InterfaceSchema schema) const;
-    // Only valid for T = DynamicCapability.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicCapability.  Requires `#include "capnp/dynamic.h"`.
 
 #if !CAPNP_LITE
     kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) const;
@@ -177,15 +177,15 @@ struct AnyPointer {
 
     template <typename T>
     inline BuilderFor<T> getAs(StructSchema schema);
-    // Only valid for T = DynamicStruct.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicStruct.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline BuilderFor<T> getAs(ListSchema schema);
-    // Only valid for T = DynamicList.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicList.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline BuilderFor<T> getAs(InterfaceSchema schema);
-    // Only valid for T = DynamicCapability.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicCapability.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline BuilderFor<T> initAs();
@@ -197,11 +197,11 @@ struct AnyPointer {
 
     template <typename T>
     inline BuilderFor<T> initAs(StructSchema schema);
-    // Only valid for T = DynamicStruct.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicStruct.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline BuilderFor<T> initAs(ListSchema schema, uint elementCount);
-    // Only valid for T = DynamicList.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicList.  Requires `#include "capnp/dynamic.h"`.
 
     inline AnyList::Builder initAsAnyList(ElementSize elementSize, uint elementCount);
     // Note: Does not accept INLINE_COMPOSITE for elementSize.
@@ -214,7 +214,7 @@ struct AnyPointer {
     template <typename T>
     inline void setAs(ReaderFor<T> value);
     // Valid for ReaderType = T::Reader for T = any generated struct type, List<U>, Text, Data,
-    // DynamicStruct, or DynamicList (the dynamic types require `#include <capnp/dynamic.h>`).
+    // DynamicStruct, or DynamicList (the dynamic types require `#include "capnp/dynamic.h"`).
 
     template <typename T>
     inline void setAs(std::initializer_list<ReaderFor<ListElementType<T>>> list);
@@ -231,7 +231,7 @@ struct AnyPointer {
     template <typename T>
     inline void adopt(Orphan<T>&& orphan);
     // Valid for T = any generated struct type, List<U>, Text, Data, DynamicList, DynamicStruct,
-    // or DynamicValue (the dynamic types require `#include <capnp/dynamic.h>`).
+    // or DynamicValue (the dynamic types require `#include "capnp/dynamic.h"`).
 
     template <typename T>
     inline Orphan<T> disownAs();
@@ -239,15 +239,15 @@ struct AnyPointer {
 
     template <typename T>
     inline Orphan<T> disownAs(StructSchema schema);
-    // Only valid for T = DynamicStruct.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicStruct.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline Orphan<T> disownAs(ListSchema schema);
-    // Only valid for T = DynamicList.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicList.  Requires `#include "capnp/dynamic.h"`.
 
     template <typename T>
     inline Orphan<T> disownAs(InterfaceSchema schema);
-    // Only valid for T = DynamicCapability.  Requires `#include <capnp/dynamic.h>`.
+    // Only valid for T = DynamicCapability.  Requires `#include "capnp/dynamic.h"`.
 
     inline Orphan<AnyPointer> disown();
     // Disown without a type.

--- a/c++/src/capnp/arena.c++
+++ b/c++/src/capnp/arena.c++
@@ -22,8 +22,8 @@
 #define CAPNP_PRIVATE
 #include "arena.h"
 #include "message.h"
-#include <kj/debug.h>
-#include <kj/refcount.h>
+#include "kj/debug.h"
+#include "kj/refcount.h"
 #include <vector>
 #include <string.h>
 #include <stdio.h>

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -25,15 +25,15 @@
 #error "This header is only meant to be included by Cap'n Proto's own source code."
 #endif
 
-#include <kj/common.h>
-#include <kj/mutex.h>
-#include <kj/exception.h>
-#include <kj/vector.h>
-#include <kj/units.h>
+#include "kj/common.h"
+#include "kj/mutex.h"
+#include "kj/exception.h"
+#include "kj/vector.h"
+#include "kj/units.h"
 #include "common.h"
 #include "message.h"
 #include "layout.h"
-#include <kj/map.h>
+#include "kj/map.h"
 
 #if !CAPNP_LITE
 #include "capability.h"

--- a/c++/src/capnp/blob-test.c++
+++ b/c++/src/capnp/blob-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "blob.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <iostream>
 #include <string>
 #include "test-util.h"

--- a/c++/src/capnp/blob.h
+++ b/c++/src/capnp/blob.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <kj/common.h>
-#include <kj/string.h>
+#include "kj/common.h"
+#include "kj/string.h"
 #include "common.h"
 #include <string.h>
 

--- a/c++/src/capnp/c++.capnp.h
+++ b/c++/src/capnp/c++.capnp.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 
 #if CAPNP_VERSION != 10000
 #error "Version mismatch between generated code and library headers.  You must use the same version of the Cap'n Proto compiler and library."

--- a/c++/src/capnp/canonicalize-test.c++
+++ b/c++/src/capnp/canonicalize-test.c++
@@ -21,8 +21,8 @@
 
 #include "message.h"
 #include "any.h"
-#include <kj/debug.h>
-#include <kj/test.h>
+#include "kj/debug.h"
+#include "kj/test.h"
 #include "test-util.h"
 
 namespace capnp {

--- a/c++/src/capnp/capability-test.c++
+++ b/c++/src/capnp/capability-test.c++
@@ -25,7 +25,7 @@
 #error "schema.capnp should not depend on capability.h, because it contains no interfaces."
 #endif
 
-#include <capnp/test.capnp.h>
+#include "capnp/test.capnp.h"
 
 #ifndef CAPNP_CAPABILITY_H_INCLUDED
 #error "test.capnp did not include capability.h."
@@ -33,8 +33,8 @@
 
 #include "capability.h"
 #include "test-util.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
 
 namespace capnp {
 namespace _ {

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -24,9 +24,9 @@
 #include "capability.h"
 #include "message.h"
 #include "arena.h"
-#include <kj/refcount.h>
-#include <kj/debug.h>
-#include <kj/vector.h>
+#include "kj/refcount.h"
+#include "kj/debug.h"
+#include "kj/vector.h"
 #include <map>
 #include "generated-header-support.h"
 

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -25,8 +25,8 @@
 #error "RPC APIs, including this header, are not available in lite mode."
 #endif
 
-#include <kj/async.h>
-#include <kj/vector.h>
+#include "kj/async.h"
+#include "kj/vector.h"
 #include "raw-schema.h"
 #include "any.h"
 #include "pointer-helpers.h"
@@ -216,7 +216,7 @@ public:
 
   template <typename T>
   typename T::Client castAs(InterfaceSchema schema);
-  // Dynamic version.  `T` must be `DynamicCapability`, and you must `#include <capnp/dynamic.h>`.
+  // Dynamic version.  `T` must be `DynamicCapability`, and you must `#include "capnp/dynamic.h"`.
 
   kj::Promise<void> whenResolved();
   // If the capability is actually only a promise, the returned promise resolves once the

--- a/c++/src/capnp/common-test.c++
+++ b/c++/src/capnp/common-test.c++
@@ -20,10 +20,10 @@
 // THE SOFTWARE.
 
 #include "common.h"
-#include <kj/compat/gtest.h>
-#include <kj/string.h>
-#include <kj/debug.h>
-#include <capnp/test.capnp.h>
+#include "kj/compat/gtest.h"
+#include "kj/string.h"
+#include "kj/debug.h"
+#include "capnp/test.capnp.h"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -26,12 +26,12 @@
 #pragma once
 
 #include <inttypes.h>
-#include <kj/string.h>
-#include <kj/memory.h>
-#include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+#include "kj/string.h"
+#include "kj/memory.h"
+#include "kj/windows-sanity.h"  // work-around macro conflict with `VOID`
 
 #if CAPNP_DEBUG_TYPES
-#include <kj/units.h>
+#include "kj/units.h"
 #endif
 
 #if !defined(CAPNP_HEADER_WARNINGS) || !CAPNP_HEADER_WARNINGS

--- a/c++/src/capnp/compat/byte-stream-test.c++
+++ b/c++/src/capnp/compat/byte-stream-test.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "byte-stream.h"
-#include <kj/test.h>
-#include <capnp/rpc-twoparty.h>
+#include "kj/test.h"
+#include "capnp/rpc-twoparty.h"
 #include <stdlib.h>
 
 namespace capnp {

--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "byte-stream.h"
-#include <kj/one-of.h>
-#include <kj/debug.h>
+#include "kj/one-of.h"
+#include "kj/debug.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/byte-stream.h
+++ b/c++/src/capnp/compat/byte-stream.h
@@ -22,8 +22,8 @@
 #pragma once
 // Bridges from KJ streams to Cap'n Proto ByteStream RPC protocol.
 
-#include <capnp/compat/byte-stream.capnp.h>
-#include <kj/async-io.h>
+#include "capnp/compat/byte-stream.capnp.h"
+#include "kj/async-io.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "http-over-capnp.h"
-#include <kj/test.h>
+#include "kj/test.h"
 
 namespace capnp {
 namespace {

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "http-over-capnp.h"
-#include <kj/debug.h>
-#include <capnp/schema.h>
+#include "kj/debug.h"
+#include "capnp/schema.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/http-over-capnp.h
+++ b/c++/src/capnp/compat/http-over-capnp.h
@@ -22,9 +22,9 @@
 #pragma once
 // Bridges from KJ HTTP to Cap'n Proto HTTP-over-RPC.
 
-#include <capnp/compat/http-over-capnp.capnp.h>
-#include <kj/compat/http.h>
-#include <kj/map.h>
+#include "capnp/compat/http-over-capnp.capnp.h"
+#include "kj/compat/http.h"
+#include "kj/map.h"
 #include "byte-stream.h"
 
 namespace capnp {

--- a/c++/src/capnp/compat/json-rpc-test.c++
+++ b/c++/src/capnp/compat/json-rpc-test.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "json-rpc.h"
-#include <kj/test.h>
-#include <capnp/test-util.h>
+#include "kj/test.h"
+#include "capnp/test-util.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/compat/json-rpc.c++
+++ b/c++/src/capnp/compat/json-rpc.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "json-rpc.h"
-#include <kj/compat/http.h>
-#include <capnp/compat/json-rpc.capnp.h>
+#include "kj/compat/http.h"
+#include "capnp/compat/json-rpc.capnp.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/json-rpc.h
+++ b/c++/src/capnp/compat/json-rpc.h
@@ -22,9 +22,9 @@
 #pragma once
 
 #include "json.h"
-#include <kj/async-io.h>
-#include <capnp/capability.h>
-#include <kj/map.h>
+#include "kj/async-io.h"
+#include "capnp/capability.h"
+#include "kj/map.h"
 
 namespace kj { class HttpInputStream; }
 

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -20,12 +20,12 @@
 // THE SOFTWARE.
 
 #include "json.h"
-#include <capnp/test-util.h>
-#include <capnp/compat/json.capnp.h>
-#include <capnp/compat/json-test.capnp.h>
-#include <kj/debug.h>
-#include <kj/string.h>
-#include <kj/test.h>
+#include "capnp/test-util.h"
+#include "capnp/compat/json.capnp.h"
+#include "capnp/compat/json-test.capnp.h"
+#include "kj/debug.h"
+#include "kj/string.h"
+#include "kj/test.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -20,13 +20,13 @@
 // THE SOFTWARE.
 
 #include "json.h"
-#include <capnp/orphan.h>
-#include <kj/debug.h>
-#include <kj/function.h>
-#include <kj/vector.h>
-#include <kj/one-of.h>
-#include <kj/encoding.h>
-#include <kj/map.h>
+#include "capnp/orphan.h"
+#include "kj/debug.h"
+#include "kj/function.h"
+#include "kj/vector.h"
+#include "kj/one-of.h"
+#include "kj/encoding.h"
+#include "kj/map.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/json.capnp.h
+++ b/c++/src/capnp/compat/json.capnp.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 #if !CAPNP_LITE
-#include <capnp/capability.h>
+#include "capnp/capability.h"
 #endif  // !CAPNP_LITE
 
 #if CAPNP_VERSION != 10000

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include <capnp/schema.h>
-#include <capnp/dynamic.h>
-#include <capnp/compat/json.capnp.h>
+#include "capnp/schema.h"
+#include "capnp/dynamic.h"
+#include "capnp/compat/json.capnp.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/websocket-rpc-test.c++
+++ b/c++/src/capnp/compat/websocket-rpc-test.c++
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 
 #include "websocket-rpc.h"
-#include <kj/test.h>
+#include "kj/test.h"
 
-#include <capnp/test.capnp.h>
+#include "capnp/test.capnp.h"
 
 KJ_TEST("WebSocketMessageStream") {
   kj::EventLoop loop;

--- a/c++/src/capnp/compat/websocket-rpc.c++
+++ b/c++/src/capnp/compat/websocket-rpc.c++
@@ -19,9 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <capnp/compat/websocket-rpc.h>
-#include <kj/io.h>
-#include <capnp/serialize.h>
+#include "capnp/compat/websocket-rpc.h"
+#include "kj/io.h"
+#include "capnp/serialize.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/websocket-rpc.h
+++ b/c++/src/capnp/compat/websocket-rpc.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <kj/compat/http.h>
-#include <capnp/serialize-async.h>
+#include "kj/compat/http.h"
+#include "capnp/serialize-async.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -24,7 +24,7 @@
 #endif
 
 #if _WIN32
-#include <kj/win32-api-version.h>
+#include "kj/win32-api-version.h"
 #endif
 
 #include "lexer.h"
@@ -32,30 +32,30 @@
 #include "compiler.h"
 #include "module-loader.h"
 #include "node-translator.h"
-#include <capnp/pretty-print.h>
-#include <capnp/schema.capnp.h>
-#include <kj/vector.h>
-#include <kj/io.h>
-#include <kj/miniposix.h>
-#include <kj/debug.h>
+#include "capnp/pretty-print.h"
+#include "capnp/schema.capnp.h"
+#include "kj/vector.h"
+#include "kj/io.h"
+#include "kj/miniposix.h"
+#include "kj/debug.h"
 #include "../message.h"
 #include <iostream>
-#include <kj/main.h>
-#include <kj/parse/char.h>
+#include "kj/main.h"
+#include "kj/parse/char.h"
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <capnp/serialize.h>
-#include <capnp/serialize-packed.h>
-#include <capnp/serialize-text.h>
-#include <capnp/compat/json.h>
+#include "capnp/serialize.h"
+#include "capnp/serialize-packed.h"
+#include "capnp/serialize-text.h"
+#include "capnp/compat/json.h"
 #include <errno.h>
 #include <stdlib.h>
-#include <kj/map.h>
+#include "kj/map.h"
 
 #if _WIN32
 #include <process.h>
 #include <windows.h>
-#include <kj/windows-sanity.h>
+#include "kj/windows-sanity.h"
 #undef CONST
 #else
 #include <sys/wait.h>

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -22,30 +22,30 @@
 // This program is a code generator plugin for `capnp compile` which generates C++ code.
 
 #if _WIN32
-#include <kj/win32-api-version.h>
+#include "kj/win32-api-version.h"
 #endif
 
-#include <capnp/schema.capnp.h>
+#include "capnp/schema.capnp.h"
 #include "../serialize.h"
-#include <kj/debug.h>
-#include <kj/io.h>
-#include <kj/string-tree.h>
-#include <kj/tuple.h>
-#include <kj/vector.h>
-#include <kj/filesystem.h>
+#include "kj/debug.h"
+#include "kj/io.h"
+#include "kj/string-tree.h"
+#include "kj/tuple.h"
+#include "kj/vector.h"
+#include "kj/filesystem.h"
 #include "../schema-loader.h"
 #include "../dynamic.h"
 #include <unordered_map>
 #include <unordered_set>
 #include <map>
 #include <set>
-#include <kj/main.h>
+#include "kj/main.h"
 #include <algorithm>
-#include <capnp/stream.capnp.h>
+#include "capnp/stream.capnp.h"
 
 #if _WIN32
 #include <windows.h>
-#include <kj/windows-sanity.h>
+#include "kj/windows-sanity.h"
 #undef CONST
 #else
 #include <sys/time.h>
@@ -549,7 +549,7 @@ private:
             case schema::Type::AnyPointer::Unconstrained::LIST:
               return CppTypeName::makePrimitive(" ::capnp::AnyList");
             case schema::Type::AnyPointer::Unconstrained::CAPABILITY: {
-              hasInterfaces = true;  // Probably need to #include <capnp/capability.h>.
+              hasInterfaces = true;  // Probably need to #include "capnp/capability.h".
               auto result = CppTypeName::makePrimitive(" ::capnp::Capability");
               result.setHasInterfaces();
               return result;
@@ -3034,11 +3034,11 @@ private:
           "\n"
           "#pragma once\n"
           "\n"
-          "#include <capnp/generated-header-support.h>\n"
-          "#include <kj/windows-sanity.h>\n",  // work-around macro conflict with VOID
+          "#include \"capnp/generated-header-support.h\"\n"
+          "#include \"kj/windows-sanity.h\"\n",  // work-around macro conflict with VOID
           hasInterfaces ? kj::strTree(
             "#if !CAPNP_LITE\n"
-            "#include <capnp/capability.h>\n"
+            "#include \"capnp/capability.h\"\n"
             "#endif  // !CAPNP_LITE\n"
           ) : kj::strTree(),
           "\n"

--- a/c++/src/capnp/compiler/capnpc-capnp.c++
+++ b/c++/src/capnp/compiler/capnpc-capnp.c++
@@ -26,20 +26,20 @@
 #define _GNU_SOURCE
 #endif
 
-#include <capnp/schema.capnp.h>
+#include "capnp/schema.capnp.h"
 #include "../serialize.h"
-#include <kj/debug.h>
-#include <kj/io.h>
-#include <kj/string-tree.h>
-#include <kj/vector.h>
+#include "kj/debug.h"
+#include "kj/io.h"
+#include "kj/string-tree.h"
+#include "kj/vector.h"
 #include "../schema-loader.h"
 #include "../dynamic.h"
-#include <kj/miniposix.h>
+#include "kj/miniposix.h"
 #include <unordered_map>
-#include <kj/main.h>
+#include "kj/main.h"
 #include <algorithm>
 #include <map>
-#include <capnp/stream.capnp.h>
+#include "capnp/stream.capnp.h"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/c++/src/capnp/compiler/compiler.c++
+++ b/c++/src/capnp/compiler/compiler.c++
@@ -21,11 +21,11 @@
 
 #include "compiler.h"
 #include "parser.h"      // only for generateChildId()
-#include <kj/mutex.h>
-#include <kj/arena.h>
-#include <kj/vector.h>
-#include <kj/debug.h>
-#include <capnp/message.h>
+#include "kj/mutex.h"
+#include "kj/arena.h"
+#include "kj/vector.h"
+#include "kj/debug.h"
+#include "capnp/message.h"
 #include <map>
 #include <set>
 #include <unordered_map>

--- a/c++/src/capnp/compiler/compiler.h
+++ b/c++/src/capnp/compiler/compiler.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/schema.capnp.h>
-#include <capnp/schema-loader.h>
+#include "capnp/compiler/grammar.capnp.h"
+#include "capnp/schema.capnp.h"
+#include "capnp/schema-loader.h"
 #include "error-reporter.h"
 #include "generics.h"
 

--- a/c++/src/capnp/compiler/error-reporter.c++
+++ b/c++/src/capnp/compiler/error-reporter.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "error-reporter.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/error-reporter.h
+++ b/c++/src/capnp/compiler/error-reporter.h
@@ -22,10 +22,10 @@
 #pragma once
 
 #include "../common.h"
-#include <kj/string.h>
-#include <kj/exception.h>
-#include <kj/vector.h>
-#include <kj/filesystem.h>
+#include "kj/string.h"
+#include "kj/exception.h"
+#include "kj/vector.h"
+#include "kj/filesystem.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/compiler/evolution-test.c++
+++ b/c++/src/capnp/compiler/evolution-test.c++
@@ -30,18 +30,18 @@
 #define _GNU_SOURCE
 #endif
 
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/schema-loader.h>
-#include <capnp/message.h>
-#include <capnp/pretty-print.h>
+#include "capnp/compiler/grammar.capnp.h"
+#include "capnp/schema-loader.h"
+#include "capnp/message.h"
+#include "capnp/pretty-print.h"
 #include "compiler.h"
-#include <kj/function.h>
-#include <kj/debug.h>
+#include "kj/function.h"
+#include "kj/debug.h"
 #include <stdlib.h>
 #include <time.h>
-#include <kj/main.h>
-#include <kj/io.h>
-#include <kj/miniposix.h>
+#include "kj/main.h"
+#include "kj/io.h"
+#include "kj/miniposix.h"
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/generics.h
+++ b/c++/src/capnp/compiler/generics.h
@@ -21,12 +21,12 @@
 
 #pragma once
 
-#include <capnp/orphan.h>
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/schema.capnp.h>
-#include <capnp/dynamic.h>
-#include <kj/vector.h>
-#include <kj/one-of.h>
+#include "capnp/orphan.h"
+#include "capnp/compiler/grammar.capnp.h"
+#include "capnp/schema.capnp.h"
+#include "capnp/dynamic.h"
+#include "kj/vector.h"
+#include "kj/one-of.h"
 #include "error-reporter.h"
 #include "resolver.h"
 

--- a/c++/src/capnp/compiler/grammar.capnp.h
+++ b/c++/src/capnp/compiler/grammar.capnp.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 
 #if CAPNP_VERSION != 10000
 #error "Version mismatch between generated code and library headers.  You must use the same version of the Cap'n Proto compiler and library."

--- a/c++/src/capnp/compiler/lexer-test.c++
+++ b/c++/src/capnp/compiler/lexer-test.c++
@@ -21,7 +21,7 @@
 
 #include "lexer.h"
 #include "../message.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/lexer.c++
+++ b/c++/src/capnp/compiler/lexer.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "lexer.h"
-#include <kj/parse/char.h>
-#include <kj/debug.h>
+#include "kj/parse/char.h"
+#include "kj/debug.h"
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/lexer.capnp.h
+++ b/c++/src/capnp/compiler/lexer.capnp.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 
 #if CAPNP_VERSION != 10000
 #error "Version mismatch between generated code and library headers.  You must use the same version of the Cap'n Proto compiler and library."

--- a/c++/src/capnp/compiler/lexer.h
+++ b/c++/src/capnp/compiler/lexer.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include <capnp/compiler/lexer.capnp.h>
-#include <kj/parse/common.h>
-#include <kj/arena.h>
+#include "capnp/compiler/lexer.capnp.h"
+#include "kj/parse/common.h"
+#include "kj/arena.h"
 #include "error-reporter.h"
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -22,11 +22,11 @@
 #include "module-loader.h"
 #include "lexer.h"
 #include "parser.h"
-#include <kj/vector.h>
-#include <kj/mutex.h>
-#include <kj/debug.h>
-#include <kj/io.h>
-#include <capnp/message.h>
+#include "kj/vector.h"
+#include "kj/mutex.h"
+#include "kj/debug.h"
+#include "kj/io.h"
+#include "capnp/message.h"
 #include <unordered_map>
 
 namespace capnp {

--- a/c++/src/capnp/compiler/module-loader.h
+++ b/c++/src/capnp/compiler/module-loader.h
@@ -23,10 +23,10 @@
 
 #include "compiler.h"
 #include "error-reporter.h"
-#include <kj/memory.h>
-#include <kj/array.h>
-#include <kj/string.h>
-#include <kj/filesystem.h>
+#include "kj/memory.h"
+#include "kj/array.h"
+#include "kj/string.h"
+#include "kj/filesystem.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -21,14 +21,14 @@
 
 #include "node-translator.h"
 #include "parser.h"      // only for generateGroupId() and expressionString()
-#include <capnp/serialize.h>
-#include <kj/debug.h>
-#include <kj/arena.h>
-#include <kj/encoding.h>
+#include "capnp/serialize.h"
+#include "kj/debug.h"
+#include "kj/arena.h"
+#include "kj/encoding.h"
 #include <set>
 #include <map>
 #include <stdlib.h>
-#include <capnp/stream.capnp.h>
+#include "capnp/stream.capnp.h"
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/node-translator.h
+++ b/c++/src/capnp/compiler/node-translator.h
@@ -21,12 +21,12 @@
 
 #pragma once
 
-#include <capnp/orphan.h>
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/schema.capnp.h>
-#include <capnp/dynamic.h>
-#include <kj/vector.h>
-#include <kj/one-of.h>
+#include "capnp/orphan.h"
+#include "capnp/compiler/grammar.capnp.h"
+#include "capnp/schema.capnp.h"
+#include "capnp/dynamic.h"
+#include "kj/vector.h"
+#include "kj/one-of.h"
 #include "error-reporter.h"
 #include "resolver.h"
 #include "generics.h"

--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -20,14 +20,14 @@
 // THE SOFTWARE.
 
 #if _WIN32
-#include <kj/win32-api-version.h>
+#include "kj/win32-api-version.h"
 #endif
 
 #include "parser.h"
 #include "type-id.h"
-#include <capnp/dynamic.h>
-#include <kj/debug.h>
-#include <kj/encoding.h>
+#include "capnp/dynamic.h"
+#include "kj/debug.h"
+#include "kj/encoding.h"
 #if !_MSC_VER
 #include <unistd.h>
 #endif
@@ -39,7 +39,7 @@
 #include <windows.h>
 #include <wincrypt.h>
 #undef CONST
-#include <kj/windows-sanity.h>
+#include "kj/windows-sanity.h"
 #endif
 
 namespace capnp {

--- a/c++/src/capnp/compiler/parser.h
+++ b/c++/src/capnp/compiler/parser.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/compiler/lexer.capnp.h>
-#include <kj/parse/common.h>
-#include <kj/arena.h>
+#include "capnp/compiler/grammar.capnp.h"
+#include "capnp/compiler/lexer.capnp.h"
+#include "kj/parse/common.h"
+#include "kj/arena.h"
 #include "error-reporter.h"
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/capnp/compiler/resolver.h
+++ b/c++/src/capnp/compiler/resolver.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/schema.capnp.h>
-#include <capnp/schema.h>
-#include <kj/one-of.h>
+#include "capnp/compiler/grammar.capnp.h"
+#include "capnp/schema.capnp.h"
+#include "capnp/schema.h"
+#include "kj/one-of.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/compiler/type-id-test.c++
+++ b/c++/src/capnp/compiler/type-id-test.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "type-id.h"
-#include <capnp/schema.capnp.h>
-#include <kj/test.h>
+#include "capnp/schema.capnp.h"
+#include "kj/test.h"
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/type-id.c++
+++ b/c++/src/capnp/compiler/type-id.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "type-id.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 #include <string.h>
 
 namespace capnp {

--- a/c++/src/capnp/compiler/type-id.h
+++ b/c++/src/capnp/compiler/type-id.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include <kj/string.h>
-#include <kj/array.h>
-#include <capnp/common.h>
+#include "kj/string.h"
+#include "kj/array.h"
+#include "capnp/common.h"
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/dynamic-capability.c++
+++ b/c++/src/capnp/dynamic-capability.c++
@@ -22,7 +22,7 @@
 // This file contains the parts of dynamic.h that live in capnp-rpc.so.
 
 #include "dynamic.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/dynamic-test.c++
+++ b/c++/src/capnp/dynamic-test.c++
@@ -21,8 +21,8 @@
 
 #include "dynamic.h"
 #include "message.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
 #include "test-util.h"
 
 namespace capnp {

--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "dynamic.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -37,7 +37,7 @@
 #include "message.h"
 #include "any.h"
 #include "capability.h"
-#include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+#include "kj/windows-sanity.h"  // work-around macro conflict with `VOID`
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/encoding-test.c++
+++ b/c++/src/capnp/encoding-test.c++
@@ -19,11 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <capnp/test-import.capnp.h>
-#include <capnp/test-import2.capnp.h>
+#include "capnp/test-import.capnp.h"
+#include "capnp/test-import2.capnp.h"
 #include "message.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
 #include "test-util.h"
 #include "schema-lite.h"
 #include "serialize-packed.h"

--- a/c++/src/capnp/endian-reverse-test.c++
+++ b/c++/src/capnp/endian-reverse-test.c++
@@ -27,7 +27,7 @@
 // the bswap-based code.
 #define CAPNP_REVERSE_ENDIAN 1
 #include "endian.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/endian-test.c++
+++ b/c++/src/capnp/endian-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "endian.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/ez-rpc-test.c++
+++ b/c++/src/capnp/ez-rpc-test.c++
@@ -23,7 +23,7 @@
 
 #include "ez-rpc.h"
 #include "test-util.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace capnp {
 namespace _ {

--- a/c++/src/capnp/ez-rpc.c++
+++ b/c++/src/capnp/ez-rpc.c++
@@ -21,10 +21,10 @@
 
 #include "ez-rpc.h"
 #include "rpc-twoparty.h"
-#include <capnp/rpc.capnp.h>
-#include <kj/async-io.h>
-#include <kj/debug.h>
-#include <kj/threadlocal.h>
+#include "capnp/rpc.capnp.h"
+#include "kj/async-io.h"
+#include "kj/debug.h"
+#include "kj/threadlocal.h"
 #include <map>
 
 namespace capnp {

--- a/c++/src/capnp/fuzz-test.c++
+++ b/c++/src/capnp/fuzz-test.c++
@@ -23,13 +23,13 @@
 #define _GNU_SOURCE
 #endif
 
-#include <capnp/test-import.capnp.h>
-#include <capnp/test-import2.capnp.h>
+#include "capnp/test-import.capnp.h"
+#include "capnp/test-import2.capnp.h"
 #include "message.h"
 #include "serialize.h"
-#include <kj/test.h>
+#include "kj/test.h"
 #include <stdlib.h>
-#include <kj/miniposix.h>
+#include "kj/miniposix.h"
 #include "test-util.h"
 
 namespace capnp {

--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -29,9 +29,9 @@
 #include "orphan.h"
 #include "pointer-helpers.h"
 #include "any.h"
-#include <kj/string.h>
-#include <kj/string-tree.h>
-#include <kj/hash.h>
+#include "kj/string.h"
+#include "kj/string-tree.h"
+#include "kj/hash.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/layout-test.c++
+++ b/c++/src/capnp/layout-test.c++
@@ -23,7 +23,7 @@
 #include "layout.h"
 #include "message.h"
 #include "arena.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 #if CAPNP_DEBUG_TYPES
 namespace kj {

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -21,7 +21,7 @@
 
 #define CAPNP_PRIVATE
 #include "layout.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 #include "arena.h"
 #include <string.h>
 #include <stdlib.h>

--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -28,12 +28,12 @@
 
 #pragma once
 
-#include <kj/common.h>
-#include <kj/memory.h>
+#include "kj/common.h"
+#include "kj/memory.h"
 #include "common.h"
 #include "blob.h"
 #include "endian.h"
-#include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+#include "kj/windows-sanity.h"  // work-around macro conflict with `VOID`
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/llvm-fuzzer-testcase.c++
+++ b/c++/src/capnp/llvm-fuzzer-testcase.c++
@@ -1,7 +1,7 @@
 #include "test-util.h"
-#include <kj/main.h>
+#include "kj/main.h"
 #include "serialize.h"
-#include <capnp/test.capnp.h>
+#include "capnp/test.capnp.h"
 #include <unistd.h>
 
 /* This is the entry point of a fuzz target to be used with libFuzzer

--- a/c++/src/capnp/membrane-test.c++
+++ b/c++/src/capnp/membrane-test.c++
@@ -20,10 +20,10 @@
 // THE SOFTWARE.
 
 #include "membrane.h"
-#include <kj/test.h>
+#include "kj/test.h"
 #include "test-util.h"
-#include <kj/function.h>
-#include <kj/async-io.h>
+#include "kj/function.h"
+#include "kj/async-io.h"
 #include "rpc-twoparty.h"
 
 namespace capnp {

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "membrane.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/message-test.c++
+++ b/c++/src/capnp/message-test.c++
@@ -21,10 +21,10 @@
 
 #include "message.h"
 #include "test-util.h"
-#include <kj/array.h>
-#include <kj/vector.h>
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
+#include "kj/array.h"
+#include "kj/vector.h"
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/message.c++
+++ b/c++/src/capnp/message.c++
@@ -21,7 +21,7 @@
 
 #define CAPNP_PRIVATE
 #include "message.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 #include "arena.h"
 #include "orphan.h"
 #include <stdlib.h>

--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -21,11 +21,11 @@
 
 #pragma once
 
-#include <kj/common.h>
-#include <kj/memory.h>
-#include <kj/mutex.h>
-#include <kj/debug.h>
-#include <kj/vector.h>
+#include "kj/common.h"
+#include "kj/memory.h"
+#include "kj/mutex.h"
+#include "kj/debug.h"
+#include "kj/vector.h"
 #include "common.h"
 #include "layout.h"
 #include "any.h"
@@ -115,7 +115,7 @@ public:
   template <typename RootType, typename SchemaType>
   typename RootType::Reader getRoot(SchemaType schema);
   // Dynamically interpret the root struct of the message using the given schema (a StructSchema).
-  // RootType in this case must be DynamicStruct, and you must #include <capnp/dynamic.h> to
+  // RootType in this case must be DynamicStruct, and you must #include "capnp/dynamic.h" to
   // use this.
 
   bool isCanonical();
@@ -216,13 +216,13 @@ public:
   template <typename RootType, typename SchemaType>
   typename RootType::Builder getRoot(SchemaType schema);
   // Dynamically interpret the root struct of the message using the given schema (a StructSchema).
-  // RootType in this case must be DynamicStruct, and you must #include <capnp/dynamic.h> to
+  // RootType in this case must be DynamicStruct, and you must #include "capnp/dynamic.h" to
   // use this.
 
   template <typename RootType, typename SchemaType>
   typename RootType::Builder initRoot(SchemaType schema);
   // Dynamically init the root struct of the message using the given schema (a StructSchema).
-  // RootType in this case must be DynamicStruct, and you must #include <capnp/dynamic.h> to
+  // RootType in this case must be DynamicStruct, and you must #include "capnp/dynamic.h" to
   // use this.
 
   template <typename T>

--- a/c++/src/capnp/orphan-test.c++
+++ b/c++/src/capnp/orphan-test.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "message.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
 #include "test-util.h"
 
 namespace capnp {

--- a/c++/src/capnp/orphan.h
+++ b/c++/src/capnp/orphan.h
@@ -126,10 +126,10 @@ public:
 
   Orphan<DynamicStruct> newOrphan(StructSchema schema) const;
   // Dynamically create an orphan struct with the given schema.  You must
-  // #include <capnp/dynamic.h> to use this.
+  // #include "capnp/dynamic.h" to use this.
 
   Orphan<DynamicList> newOrphan(ListSchema schema, uint size) const;
-  // Dynamically create an orphan list with the given schema.  You must #include <capnp/dynamic.h>
+  // Dynamically create an orphan list with the given schema.  You must #include "capnp/dynamic.h"
   // to use this.
 
   template <typename Reader>

--- a/c++/src/capnp/persistent.capnp.h
+++ b/c++/src/capnp/persistent.capnp.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 #if !CAPNP_LITE
-#include <capnp/capability.h>
+#include "capnp/capability.h"
 #endif  // !CAPNP_LITE
 
 #if CAPNP_VERSION != 10000

--- a/c++/src/capnp/pretty-print.h
+++ b/c++/src/capnp/pretty-print.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "dynamic.h"
-#include <kj/string-tree.h>
+#include "kj/string-tree.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/reconnect-test.c++
+++ b/c++/src/capnp/reconnect-test.c++
@@ -21,9 +21,9 @@
 
 #include "reconnect.h"
 #include "test-util.h"
-#include <kj/debug.h>
-#include <kj/test.h>
-#include <kj/async-io.h>
+#include "kj/debug.h"
+#include "kj/test.h"
+#include "kj/async-io.h"
 #include "rpc-twoparty.h"
 
 namespace capnp {

--- a/c++/src/capnp/reconnect.h
+++ b/c++/src/capnp/reconnect.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "capability.h"
-#include <kj/function.h>
+#include "kj/function.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -25,10 +25,10 @@
 #include "test-util.h"
 #include "schema.h"
 #include "serialize.h"
-#include <kj/debug.h>
-#include <kj/string-tree.h>
-#include <kj/compat/gtest.h>
-#include <capnp/rpc.capnp.h>
+#include "kj/debug.h"
+#include "kj/string-tree.h"
+#include "kj/compat/gtest.h"
+#include "capnp/rpc.capnp.h"
 #include <map>
 #include <queue>
 

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -27,21 +27,21 @@
 
 // Includes just for need SOL_SOCKET and SO_SNDBUF
 #if _WIN32
-#include <kj/win32-api-version.h>
+#include "kj/win32-api-version.h"
 #endif
 
 #include "rpc-twoparty.h"
 #include "test-util.h"
-#include <capnp/rpc.capnp.h>
-#include <kj/debug.h>
-#include <kj/thread.h>
-#include <kj/compat/gtest.h>
-#include <kj/miniposix.h>
+#include "capnp/rpc.capnp.h"
+#include "kj/debug.h"
+#include "kj/thread.h"
+#include "kj/compat/gtest.h"
+#include "kj/miniposix.h"
 
 #if _WIN32
 #include <winsock2.h>
 #include <mswsock.h>
-#include <kj/windows-sanity.h>
+#include "kj/windows-sanity.h"
 #else
 #include <sys/socket.h>
 #endif

--- a/c++/src/capnp/rpc-twoparty.c++
+++ b/c++/src/capnp/rpc-twoparty.c++
@@ -21,8 +21,8 @@
 
 #include "rpc-twoparty.h"
 #include "serialize-async.h"
-#include <kj/debug.h>
-#include <kj/io.h>
+#include "kj/debug.h"
+#include "kj/io.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/rpc-twoparty.capnp.h
+++ b/c++/src/capnp/rpc-twoparty.capnp.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 
 #if CAPNP_VERSION != 10000
 #error "Version mismatch between generated code and library headers.  You must use the same version of the Cap'n Proto compiler and library."

--- a/c++/src/capnp/rpc-twoparty.h
+++ b/c++/src/capnp/rpc-twoparty.h
@@ -23,10 +23,10 @@
 
 #include "rpc.h"
 #include "message.h"
-#include <kj/async-io.h>
-#include <capnp/serialize-async.h>
-#include <capnp/rpc-twoparty.capnp.h>
-#include <kj/one-of.h>
+#include "kj/async-io.h"
+#include "capnp/serialize-async.h"
+#include "capnp/rpc-twoparty.capnp.h"
+#include "kj/one-of.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -21,18 +21,18 @@
 
 #include "rpc.h"
 #include "message.h"
-#include <kj/debug.h>
-#include <kj/vector.h>
-#include <kj/async.h>
-#include <kj/one-of.h>
-#include <kj/function.h>
+#include "kj/debug.h"
+#include "kj/vector.h"
+#include "kj/async.h"
+#include "kj/one-of.h"
+#include "kj/function.h"
 #include <functional>  // std::greater
 #include <unordered_map>
 #include <map>
 #include <queue>
-#include <capnp/rpc.capnp.h>
-#include <kj/io.h>
-#include <kj/map.h>
+#include "capnp/rpc.capnp.h"
+#include "kj/io.h"
+#include "kj/map.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/rpc.capnp.h
+++ b/c++/src/capnp/rpc.capnp.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 
 #if CAPNP_VERSION != 10000
 #error "Version mismatch between generated code and library headers.  You must use the same version of the Cap'n Proto compiler and library."

--- a/c++/src/capnp/schema-lite.h
+++ b/c++/src/capnp/schema-lite.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <capnp/schema.capnp.h>
+#include "capnp/schema.capnp.h"
 #include "message.h"
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/capnp/schema-loader-test.c++
+++ b/c++/src/capnp/schema-loader-test.c++
@@ -22,9 +22,9 @@
 #define CAPNP_TESTING_CAPNP 1
 
 #include "schema-loader.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include "test-util.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -23,13 +23,13 @@
 #include "schema-loader.h"
 #include "message.h"
 #include "arena.h"
-#include <kj/debug.h>
-#include <kj/exception.h>
-#include <kj/arena.h>
-#include <kj/vector.h>
+#include "kj/debug.h"
+#include "kj/exception.h"
+#include "kj/arena.h"
+#include "kj/vector.h"
 #include <algorithm>
-#include <kj/map.h>
-#include <capnp/stream.capnp.h>
+#include "kj/map.h"
+#include "capnp/stream.capnp.h"
 
 #if _MSC_VER && !defined(__clang__)
 #include <atomic>

--- a/c++/src/capnp/schema-loader.h
+++ b/c++/src/capnp/schema-loader.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include "schema.h"
-#include <kj/memory.h>
-#include <kj/mutex.h>
+#include "kj/memory.h"
+#include "kj/mutex.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/schema-parser-test.c++
+++ b/c++/src/capnp/schema-parser-test.c++
@@ -22,9 +22,9 @@
 #define CAPNP_TESTING_CAPNP 1
 
 #include "schema-parser.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include "test-util.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 #include <map>
 
 namespace capnp {

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -21,16 +21,16 @@
 
 #include "schema-parser.h"
 #include "message.h"
-#include <capnp/compiler/compiler.h>
-#include <capnp/compiler/lexer.capnp.h>
-#include <capnp/compiler/lexer.h>
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/compiler/parser.h>
+#include "capnp/compiler/compiler.h"
+#include "capnp/compiler/lexer.capnp.h"
+#include "capnp/compiler/lexer.h"
+#include "capnp/compiler/grammar.capnp.h"
+#include "capnp/compiler/parser.h"
 #include <unordered_map>
-#include <kj/mutex.h>
-#include <kj/vector.h>
-#include <kj/debug.h>
-#include <kj/io.h>
+#include "kj/mutex.h"
+#include "kj/vector.h"
+#include "kj/debug.h"
+#include "kj/io.h"
 #include <map>
 
 namespace capnp {

--- a/c++/src/capnp/schema-parser.h
+++ b/c++/src/capnp/schema-parser.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include "schema-loader.h"
-#include <kj/string.h>
-#include <kj/filesystem.h>
+#include "kj/string.h"
+#include "kj/filesystem.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/schema-test.c++
+++ b/c++/src/capnp/schema-test.c++
@@ -22,7 +22,7 @@
 #define CAPNP_TESTING_CAPNP 1
 
 #include "schema.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include "test-util.h"
 
 // TODO(cleanup): Auto-generate stringification functions for union discriminants.

--- a/c++/src/capnp/schema.c++
+++ b/c++/src/capnp/schema.c++
@@ -21,8 +21,8 @@
 
 #include "schema.h"
 #include "message.h"
-#include <kj/debug.h>
-#include <capnp/stream.capnp.h>
+#include "kj/debug.h"
+#include "capnp/stream.capnp.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/schema.capnp.h
+++ b/c++/src/capnp/schema.capnp.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 
 #if CAPNP_VERSION != 10000
 #error "Version mismatch between generated code and library headers.  You must use the same version of the Cap'n Proto compiler and library."

--- a/c++/src/capnp/schema.h
+++ b/c++/src/capnp/schema.h
@@ -36,9 +36,9 @@
 // Please don't file a bug report telling us to change our enum naming style. You are at least
 // seven years too late.
 
-#include <capnp/schema.capnp.h>
-#include <kj/hash.h>
-#include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
+#include "capnp/schema.capnp.h"
+#include "kj/hash.h"
+#include "kj/windows-sanity.h"  // work-around macro conflict with `VOID`
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/serialize-async-test.c++
+++ b/c++/src/capnp/serialize-async-test.c++
@@ -24,21 +24,21 @@
 #endif
 
 #if _WIN32
-#include <kj/win32-api-version.h>
+#include "kj/win32-api-version.h"
 #endif
 
 #include "serialize-async.h"
 #include "serialize.h"
-#include <kj/debug.h>
-#include <kj/thread.h>
+#include "kj/debug.h"
+#include "kj/thread.h"
 #include <stdlib.h>
-#include <kj/miniposix.h>
+#include "kj/miniposix.h"
 #include "test-util.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 #if _WIN32
 #include <winsock2.h>
-#include <kj/windows-sanity.h>
+#include "kj/windows-sanity.h"
 namespace kj {
   namespace _ {
     int win32Socketpair(SOCKET socks[2]);

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -21,18 +21,18 @@
 
 // Includes just for need SOL_SOCKET and SO_SNDBUF
 #if _WIN32
-#include <kj/win32-api-version.h>
+#include "kj/win32-api-version.h"
 
 #include <winsock2.h>
 #include <mswsock.h>
-#include <kj/windows-sanity.h>
+#include "kj/windows-sanity.h"
 #else
 #include <sys/socket.h>
 #endif
 
 #include "serialize-async.h"
-#include <kj/debug.h>
-#include <kj/io.h>
+#include "kj/debug.h"
+#include "kj/io.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/serialize-async.h
+++ b/c++/src/capnp/serialize-async.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <kj/async-io.h>
+#include "kj/async-io.h"
 #include "message.h"
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/capnp/serialize-packed-test.c++
+++ b/c++/src/capnp/serialize-packed-test.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "serialize-packed.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
 #include <string>
 #include <stdlib.h>
 #include "test-util.h"

--- a/c++/src/capnp/serialize-packed.c++
+++ b/c++/src/capnp/serialize-packed.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "serialize-packed.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 #include "layout.h"
 #include <vector>
 

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -24,9 +24,9 @@
 #endif
 
 #include "serialize.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
-#include <kj/miniposix.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
+#include "kj/miniposix.h"
 #include <string>
 #include <stdlib.h>
 #include <fcntl.h>

--- a/c++/src/capnp/serialize-text-test.c++
+++ b/c++/src/capnp/serialize-text-test.c++
@@ -20,13 +20,13 @@
 // THE SOFTWARE.
 
 #include "serialize-text.h"
-#include <kj/compat/gtest.h>
-#include <kj/string.h>
-#include <capnp/pretty-print.h>
-#include <capnp/message.h>
+#include "kj/compat/gtest.h"
+#include "kj/string.h"
+#include "capnp/pretty-print.h"
+#include "capnp/message.h"
 #include "test-util.h"
 
-#include <capnp/test.capnp.h>
+#include "capnp/test.capnp.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/serialize-text.c++
+++ b/c++/src/capnp/serialize-text.c++
@@ -21,7 +21,7 @@
 
 #include "serialize-text.h"
 
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 #include "pretty-print.h"
 #include "compiler/lexer.capnp.h"

--- a/c++/src/capnp/serialize-text.h
+++ b/c++/src/capnp/serialize-text.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <kj/string.h>
+#include "kj/string.h"
 #include "dynamic.h"
 #include "orphan.h"
 #include "schema.h"

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -21,7 +21,7 @@
 
 #include "serialize.h"
 #include "layout.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 #include <exception>
 #ifdef _WIN32
 #include <io.h>

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -41,7 +41,7 @@
 #pragma once
 
 #include "message.h"
-#include <kj/io.h>
+#include "kj/io.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/stream.capnp.h
+++ b/c++/src/capnp/stream.capnp.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <capnp/generated-header-support.h>
-#include <kj/windows-sanity.h>
+#include "capnp/generated-header-support.h"
+#include "kj/windows-sanity.h"
 
 #if CAPNP_VERSION != 10000
 #error "Version mismatch between generated code and library headers.  You must use the same version of the Cap'n Proto compiler and library."

--- a/c++/src/capnp/stringify-test.c++
+++ b/c++/src/capnp/stringify-test.c++
@@ -22,8 +22,8 @@
 #include "message.h"
 #include "dynamic.h"
 #include "pretty-print.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
 #include "test-util.h"
 
 namespace capnp {

--- a/c++/src/capnp/stringify.c++
+++ b/c++/src/capnp/stringify.c++
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 
 #include "dynamic.h"
-#include <kj/debug.h>
-#include <kj/vector.h>
-#include <kj/encoding.h>
+#include "kj/debug.h"
+#include "kj/vector.h"
+#include "kj/encoding.h"
 
 namespace capnp {
 

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -24,10 +24,10 @@
 #endif
 
 #include "test-util.h"
-#include <kj/debug.h>
-#include <kj/compat/gtest.h>
-#include <kj/io.h>
-#include <kj/miniposix.h>
+#include "kj/debug.h"
+#include "kj/compat/gtest.h"
+#include "kj/io.h"
+#include "kj/miniposix.h"
 
 namespace capnp {
 namespace _ {  // private

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -21,14 +21,14 @@
 
 #pragma once
 
-#include <capnp/test.capnp.h>
+#include "capnp/test.capnp.h"
 #include <iostream>
 #include "blob.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 #if !CAPNP_LITE
 #include "dynamic.h"
-#include <kj/io.h>
+#include "kj/io.h"
 #endif  // !CAPNP_LITE
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/kj/arena-test.c++
+++ b/c++/src/kj/arena-test.c++
@@ -21,7 +21,7 @@
 
 #include "arena.h"
 #include "debug.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <stdint.h>
 
 namespace kj {

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -23,7 +23,7 @@
 #include "debug.h"
 #include <string>
 #include <list>
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -19,11 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <kj/async.h>
-#include <kj/array.h>
-#include <kj/compat/http.h>
-#include <kj/debug.h>
-#include <kj/test.h>
+#include "kj/async.h"
+#include "kj/array.h"
+#include "kj/compat/http.h"
+#include "kj/debug.h"
+#include "kj/test.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -31,8 +31,8 @@
 #include "debug.h"
 #include "io.h"
 #include "miniposix.h"
-#include <kj/compat/gtest.h>
-#include <kj/time.h>
+#include "kj/compat/gtest.h"
+#include "kj/time.h"
 #include <sys/types.h>
 #if _WIN32
 #include <ws2tcpip.h>

--- a/c++/src/kj/async-queue-test.c++
+++ b/c++/src/kj/async-queue-test.c++
@@ -21,9 +21,9 @@
 
 #include "async-queue.h"
 
-#include <kj/async-io.h>
-#include <kj/test.h>
-#include <kj/vector.h>
+#include "kj/async-io.h"
+#include "kj/test.h"
+#include "kj/vector.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -21,7 +21,7 @@
 
 #include "async.h"
 #include "debug.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include "mutex.h"
 #include "thread.h"
 

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -31,7 +31,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <netinet/in.h>
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <pthread.h>
 #include <algorithm>
 #include <sys/wait.h>

--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -27,7 +27,7 @@
 #include "debug.h"
 #include "thread.h"
 #include "mutex.h"
-#include <kj/test.h>
+#include "kj/test.h"
 
 #if _WIN32
 #include <windows.h>

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -22,7 +22,7 @@
 #include "common.h"
 #include "test.h"
 #include <inttypes.h>
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/compat/gtest.h
+++ b/c++/src/kj/compat/gtest.h
@@ -30,7 +30,7 @@
 //   in the constructor, teardown in the destructor.
 
 #include "../test.h"
-#include <kj/windows-sanity.h>  // work-around macro conflict with `ERROR`
+#include "kj/windows-sanity.h"  // work-around macro conflict with `ERROR`
 
 namespace kj {
 

--- a/c++/src/kj/compat/gzip-test.c++
+++ b/c++/src/kj/compat/gzip-test.c++
@@ -22,8 +22,8 @@
 #if KJ_HAS_ZLIB
 
 #include "gzip.h"
-#include <kj/test.h>
-#include <kj/debug.h>
+#include "kj/test.h"
+#include "kj/debug.h"
 #include <stdlib.h>
 
 namespace kj {

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -22,7 +22,7 @@
 #if KJ_HAS_ZLIB
 
 #include "gzip.h"
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 namespace kj {
 

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <kj/io.h>
-#include <kj/async-io.h>
+#include "kj/io.h"
+#include "kj/async-io.h"
 #include <zlib.h>
 
 namespace kj {

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -22,9 +22,9 @@
 #define KJ_TESTING_KJ 1
 
 #include "http.h"
-#include <kj/debug.h>
-#include <kj/test.h>
-#include <kj/encoding.h>
+#include "kj/debug.h"
+#include "kj/test.h"
+#include "kj/encoding.h"
 #include <map>
 
 #if KJ_HTTP_TEST_USE_OS_PIPE

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -21,11 +21,11 @@
 
 #include "http.h"
 #include "url.h"
-#include <kj/debug.h>
-#include <kj/parse/char.h>
+#include "kj/debug.h"
+#include "kj/parse/char.h"
 #include <unordered_map>
 #include <stdlib.h>
-#include <kj/encoding.h>
+#include "kj/encoding.h"
 #include <deque>
 #include <queue>
 #include <map>

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -34,11 +34,11 @@
 //   values to them.
 // - Methods are identified by an enum.
 
-#include <kj/string.h>
-#include <kj/vector.h>
-#include <kj/memory.h>
-#include <kj/one-of.h>
-#include <kj/async-io.h>
+#include "kj/string.h"
+#include "kj/vector.h"
+#include "kj/memory.h"
+#include "kj/one-of.h"
+#include "kj/async-io.h"
 
 namespace kj {
 

--- a/c++/src/kj/compat/readiness-io-test.c++
+++ b/c++/src/kj/compat/readiness-io-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "readiness-io.h"
-#include <kj/test.h>
+#include "kj/test.h"
 #include <stdlib.h>
 
 namespace kj {

--- a/c++/src/kj/compat/readiness-io.h
+++ b/c++/src/kj/compat/readiness-io.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <kj/async-io.h>
+#include "kj/async-io.h"
 
 namespace kj {
 

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -22,7 +22,7 @@
 #if KJ_HAS_OPENSSL
 
 #if _WIN32
-#include <kj/win32-api-version.h>
+#include "kj/win32-api-version.h"
 #endif
 
 #include "tls.h"
@@ -34,13 +34,13 @@
 #if _WIN32
 #include <winsock2.h>
 
-#include <kj/windows-sanity.h>
+#include "kj/windows-sanity.h"
 #else
 #include <sys/socket.h>
 #endif
 
-#include <kj/async-io.h>
-#include <kj/test.h>
+#include "kj/async-io.h"
+#include "kj/test.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -34,9 +34,9 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
-#include <kj/async-queue.h>
-#include <kj/debug.h>
-#include <kj/vector.h>
+#include "kj/async-queue.h"
+#include "kj/debug.h"
+#include "kj/vector.h"
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define BIO_set_init(x,v)          (x->init=v)

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -28,7 +28,7 @@
 // ciphers and settings are used by default. Certificates validation is performed automatically
 // and cannot be bypassed.
 
-#include <kj/async-io.h>
+#include "kj/async-io.h"
 
 namespace kj {
 

--- a/c++/src/kj/compat/url-test.c++
+++ b/c++/src/kj/compat/url-test.c++
@@ -20,8 +20,8 @@
 // THE SOFTWARE.
 
 #include "url.h"
-#include <kj/debug.h>
-#include <kj/test.h>
+#include "kj/debug.h"
+#include "kj/test.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 
 #include "url.h"
-#include <kj/encoding.h>
-#include <kj/parse/char.h>
-#include <kj/debug.h>
+#include "kj/encoding.h"
+#include "kj/parse/char.h"
+#include "kj/debug.h"
 #include <stdlib.h>
 
 namespace kj {

--- a/c++/src/kj/compat/url.h
+++ b/c++/src/kj/compat/url.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <kj/string.h>
-#include <kj/vector.h>
+#include "kj/string.h"
+#include "kj/vector.h"
 #include <inttypes.h>
 
 namespace kj {

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -25,7 +25,7 @@
 
 #include "debug.h"
 #include "exception.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <string>
 #include <stdio.h>
 #include <signal.h>

--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "encoding.h"
-#include <kj/test.h>
+#include "kj/test.h"
 #include <stdint.h>
 
 namespace kj {

--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -21,7 +21,7 @@
 
 #include "exception.h"
 #include "debug.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <stdexcept>
 #include <stdint.h>
 

--- a/c++/src/kj/filesystem-disk-old-kernel-test.c++
+++ b/c++/src/kj/filesystem-disk-old-kernel-test.c++
@@ -41,7 +41,7 @@
 #include <sys/ptrace.h>
 #include <linux/seccomp.h>
 #include <linux/filter.h>
-#include <kj/debug.h>
+#include "kj/debug.h"
 
 #ifdef SECCOMP_SET_MODE_FILTER
 
@@ -128,6 +128,6 @@ SetupSeccompForFilesystemTest setupSeccompForFilesystemTest;
 //   test on the host platform then it needs to be a test on all other targets, too. So add a dummy
 //   test here.
 // TODO(cleanup): Make Ekam cross-compiling better.
-#include <kj/test.h>
+#include "kj/test.h"
 KJ_TEST("old kernel test -- not supported on this architecture") {}
 #endif

--- a/c++/src/kj/function-test.c++
+++ b/c++/src/kj/function-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "function.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/io-test.c++
+++ b/c++/src/kj/io-test.c++
@@ -26,7 +26,7 @@
 #include "io.h"
 #include "debug.h"
 #include "miniposix.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/list-test.c++
+++ b/c++/src/kj/list-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "list.h"
-#include <kj/test.h>
+#include "kj/test.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/map-test.c++
+++ b/c++/src/kj/map-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "map.h"
-#include <kj/test.h>
+#include "kj/test.h"
 
 namespace kj {
 namespace _ {

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "memory.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include "debug.h"
 
 namespace kj {

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -31,7 +31,7 @@
 #include "mutex.h"
 #include "debug.h"
 #include "thread.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <stdlib.h>
 
 #if _WIN32

--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -21,7 +21,7 @@
 
 #include "one-of.h"
 #include "string.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 

--- a/c++/src/kj/parse/char-test.c++
+++ b/c++/src/kj/parse/char-test.c++
@@ -21,7 +21,7 @@
 
 #include "char.h"
 #include "../string.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace parse {

--- a/c++/src/kj/parse/common-test.c++
+++ b/c++/src/kj/parse/common-test.c++
@@ -21,7 +21,7 @@
 
 #include "common.h"
 #include "../string.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace parse {

--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "refcount.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 

--- a/c++/src/kj/std/iostream-test.c++
+++ b/c++/src/kj/std/iostream-test.c++
@@ -21,7 +21,7 @@
 
 #include "iostream.h"
 #include <sstream>
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace std {

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "string.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <string>
 #include "vector.h"
 #include <locale.h>

--- a/c++/src/kj/string-tree-test.c++
+++ b/c++/src/kj/string-tree-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "string-tree.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace _ {  // private

--- a/c++/src/kj/table-test.c++
+++ b/c++/src/kj/table-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "table.h"
-#include <kj/test.h>
+#include "kj/test.h"
 #include <set>
 #include <unordered_set>
 #include "hash.h"

--- a/c++/src/kj/threadlocal-test.c++
+++ b/c++/src/kj/threadlocal-test.c++
@@ -22,7 +22,7 @@
 #include "threadlocal.h"
 #include "debug.h"
 #include "thread.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 namespace {

--- a/c++/src/kj/time-test.c++
+++ b/c++/src/kj/time-test.c++
@@ -25,7 +25,7 @@
 
 #include "time.h"
 #include "debug.h"
-#include <kj/test.h>
+#include "kj/test.h"
 #include <time.h>
 
 #if _WIN32

--- a/c++/src/kj/tuple-test.c++
+++ b/c++/src/kj/tuple-test.c++
@@ -22,7 +22,7 @@
 #include "tuple.h"
 #include "memory.h"
 #include "string.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 
 namespace kj {
 

--- a/c++/src/kj/units-test.c++
+++ b/c++/src/kj/units-test.c++
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "units.h"
-#include <kj/compat/gtest.h>
+#include "kj/compat/gtest.h"
 #include <iostream>
 
 namespace kj {

--- a/doc/cxx.md
+++ b/doc/cxx.md
@@ -49,8 +49,8 @@ You might write code like:
 
 {% highlight c++ %}
 #include "addressbook.capnp.h"
-#include <capnp/message.h>
-#include <capnp/serialize-packed.h>
+#include "capnp/message.h"
+#include "capnp/serialize-packed.h"
 #include <iostream>
 
 void writeAddressBook(int fd) {
@@ -478,11 +478,11 @@ of the dynamic API:
 
 {% highlight c++ %}
 #include "addressbook.capnp.h"
-#include <capnp/message.h>
-#include <capnp/serialize-packed.h>
+#include "capnp/message.h"
+#include "capnp/serialize-packed.h"
 #include <iostream>
-#include <capnp/schema.h>
-#include <capnp/dynamic.h>
+#include "capnp/schema.h"
+#include "capnp/dynamic.h"
 
 using ::capnp::DynamicValue;
 using ::capnp::DynamicStruct;

--- a/doc/cxxrpc.md
+++ b/doc/cxxrpc.md
@@ -356,7 +356,7 @@ show you how to use EZ RPC to get started.
 A client should typically look like this:
 
 {% highlight c++ %}
-#include <capnp/ez-rpc.h>
+#include "capnp/ez-rpc.h"
 #include "my-interface.capnp.h"
 #include <iostream>
 
@@ -401,7 +401,7 @@ For a more complete example, see the
 A server might look something like this:
 
 {% highlight c++ %}
-#include <capnp/ez-rpc.h>
+#include "capnp/ez-rpc.h"
 #include "my-interface-impl.h"
 #include <iostream>
 

--- a/style-guide.md
+++ b/style-guide.md
@@ -571,7 +571,7 @@ Headers:
     #pragma once
     // Documentation for file.
 
-    #include <kj/common.h>
+    #include "kj/common.h"
 
     namespace myproject {
 
@@ -593,7 +593,7 @@ Source code:
     // Licensed under the Whatever License blah blah no warranties.
 
     #include "this-module.h"
-    #include <other-module.h>
+    #include "other-module.h"
 
     namespace myproject {
 
@@ -609,7 +609,7 @@ Test:
     // Licensed under the Whatever License blah blah no warranties.
 
     #include "this-module.h"
-    #include <other-module.h>
+    #include "other-module.h"
 
     namespace myproject {
     namespace {


### PR DESCRIPTION
Bazel treats angle bracket includes as system headers, and therefore
does not include them in the search path.

https://docs.bazel.build/versions/main/bazel-and-cpp.html#include-paths

https://stackoverflow.com/questions/21593/what-is-the-difference-between-include-filename-and-include-filename

Changing the angle bracket includes to quoted includes removes the need
for explicit -isystem (or -I) copts.

Commands used:

```
sd '#include <capnp(.*)>' '#include "capnp$1"' $(fd -t f)
sd '#include <kj(.*)>' '#include "kj$1"' $(fd -t f)
```