### PR TITLE
Update outdated references to Sandstorm.

### DIFF
--- a/doc/_includes/footer.html
+++ b/doc/_includes/footer.html
@@ -23,8 +23,7 @@
     <!-- FOOTER  -->
     <div id="footer_wrap" class="outer">
       <footer class="inner">
-        <p class="copyright">Cap'n Proto is a project of <a href="https://sandstorm.io">Sandstorm.io</a></p>
-        <p>Maintained by <a href="https://github.com/kentonv">kentonv</a> ∙ Design by <a href="http://www.starfruit-cafe.net/blog">sailorhg</a>
+        <p>Maintained by <a href="https://github.com/kentonv">kentonv</a> and friends ∙ Design by <a href="https://twitter.com/sailorhg">sailorhg</a>
         <p><a href="https://twitter.com/capnproto">Follow Cap'n Proto on Twitter</a></p>
       </footer>
     </div>

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -197,15 +197,26 @@ Cap'n Proto may be layered on top of an existing encrypted transport, such as TL
 
 ### How do I report security bugs?
 
-Please email [security@sandstorm.io](mailto:security@sandstorm.io).
+Please email [kenton@cloudflare.com](mailto:kenton@cloudflare.com).
 
 ## Sandstorm
 
 ### How does Cap'n Proto relate to Sandstorm.io?
 
-[Sandstorm.io](https://sandstorm.io) is an Open Source project and startup founded by Kenton, the author of Cap'n Proto. Cap'n Proto is owned and developed by Sandstorm the company and heavily used in Sandstorm the project.
+[Sandstorm.io](https://sandstorm.io) is an Open Source project and startup founded by Kenton, the author of Cap'n Proto. Cap'n Proto was developed by Sandstorm the company and heavily used in Sandstorm the project. Sandstorm ceased most operations in 2017 and formally dissolved as a company in 2022, but the open source project continues to be developed by the community.
 
 ### How does Sandstorm use Cap'n Proto?
 
 See [this Sandstorm blog post](https://blog.sandstorm.io/news/2014-12-15-capnproto-0.5.html).
 
+## Cloudflare
+
+### How does Cap'n Proto relate to Cloudflare?
+
+[Cloudflare Workers](https://workers.dev) is a next-generation cloud application platform. Kenton, the author of Cap'n Proto, is the lead engineer on the Workers project. Workers heavily uses Cap'n Proto in its implementation, and the Cloudflare Workers team are now the primarily developers and maintainers of Cap'n Proto's primary C++ implementation.
+
+### How does Cloudflare use Cap'n Proto?
+
+The Cloudflare Workers runtime is built on Cap'n Proto and it's associated C++ toolkit library, KJ. Cap'n Proto is used for a variety of things, such as communication between sandbox processes and their supervisors, as well between machines and datacenters, especially in the implementation of [Durable Objects](https://blog.cloudflare.com/introducing-workers-durable-objects/).
+
+Cloudflare has also [long used Cap'n Proto in its logging pipeline](http://www.thedotpost.com/2015/06/john-graham-cumming-i-got-10-trillion-problems-but-logging-aint-one) and [developed the Lua implementation of Cap'n Proto](https://blog.cloudflare.com/introducing-lua-capnproto-better-serialization-in-lua/) -- both of these actually predate Kenton joining the company.

--- a/doc/index.md
+++ b/doc/index.md
@@ -51,7 +51,7 @@ Cap'n Proto generates classes with accessor methods that you use to traverse the
 
 Thus, Cap'n Proto checks the structural integrity of the message just like any other serialization protocol would. And, just like any other protocol, it is up to the app to check the validity of the content.
 
-Cap'n Proto was built to be used in [Sandstorm.io](https://sandstorm.io), where security is a major concern. As of this writing, Cap'n Proto has not undergone a security review, therefore we suggest caution when handling messages from untrusted sources. That said, our response to security issues was once described by security guru Ben Laurie as ["the most awesome response I've ever had."](https://twitter.com/BenLaurie/status/575079375307153409) (Please report all security issues to [security@sandstorm.io](mailto:security@sandstorm.io).)
+Cap'n Proto was built to be used in [Sandstorm.io](https://sandstorm.io), and is now heavily used in [Cloudflare Workers](https://workers.dev), two environments where security is a major concern. Cap'n Proto has undergone fuzzing and expert security review. Our response to security issues was once described by security guru Ben Laurie as ["the most awesome response I've ever had."](https://twitter.com/BenLaurie/status/575079375307153409) (Please report all security issues to [kenton@cloudflare.com](mailto:kenton@cloudflare.com).)
 
 **_Are there other advantages?_**
 
@@ -90,7 +90,7 @@ version 2, which is the version that Google released open source. Cap'n Proto is
 years of experience working on Protobufs, listening to user feedback, and thinking about how
 things could be done better.
 
-Note that I no longer work for Google. Cap'n Proto is not, and never has been, affiliated with Google; in fact, it is a property of [Sandstorm.io](https://sandstorm.io), of which I am co-founder.
+Note that I no longer work for Google. Cap'n Proto is not, and never has been, affiliated with Google.
 
 **_OK, how do I get started?_**
 


### PR DESCRIPTION
Sandstorm-the-company no longer exists, and these references have been inaccurate for many years.

Some places describe Cap'n Proto as being owned by Sandstorm. What this was meant to describe is that Sandstorm was primarily responsible for development at the time, and held copyright of the code it developed. All code is copyright by whoever wrote it, or their respective employer. There are no registered trademarks. Kenton owns the domain, which was registered long before Sandstorm existed.