### PR TITLE
Move `countLines()` inside if pragma

### DIFF
--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -378,6 +378,7 @@ KJ_TEST("co_await only sees coroutine destruction exceptions if promise was not 
       awaitPromise(kj::mv(rejectedThrowyDtorPromise)).wait(waitScope));
 }
 
+#if (!_MSC_VER || defined(__clang__)) && !__aarch64__
 uint countLines(StringPtr s) {
   uint lines = 0;
   for (char c: s) {
@@ -386,7 +387,6 @@ uint countLines(StringPtr s) {
   return lines;
 }
 
-#if (!_MSC_VER || defined(__clang__)) && !__aarch64__
 // TODO(msvc): This test relies on GetFunctorStartAddress, which is not supported on MSVC currently,
 //   so skip the test.
 // TODO(someday): Test is flakey on arm64, depending on how it's compiled. I haven't had a chance to


### PR DESCRIPTION
This function was recognized as unused for MSVC and arm builds.