### PR TITLE
CI: alpine needs bash to run the tests

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: apk add autoconf automake build-base cmake libtool libucontext-dev linux-headers openssl-dev
+        run: apk add autoconf automake bash build-base cmake libtool libucontext-dev linux-headers openssl-dev
       - name: super-test
         run: ./super-test.sh quick
   Linux:


### PR DESCRIPTION
The musl build fails in https://github.com/capnproto/capnproto/pull/1460 because alpine doesn't have bash by default. I don't know why it was working before, but this fixes it.