### PR TITLE
Fix linux-musl build

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: apk add autoconf automake build-base cmake libtool libucontext-dev linux-headers openssl-dev
+        run: apk add autoconf automake build-base cmake libtool libucontext-dev linux-headers openssl-dev bash
       - name: super-test
         run: ./super-test.sh quick
   Linux:


### PR DESCRIPTION
Apparently `bash` is no longer installed by default?