### PR TITLE
Optimize ArrayPtr::operator== for integral types

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -811,6 +811,10 @@ KJ_TEST("ArrayPtr operator ==") {
              ArrayPtr<const char* const>({"foo", "baz"})));
   KJ_EXPECT((ArrayPtr<const StringPtr>({"foo", "bar"}) !=
              ArrayPtr<const char* const>({"foo"})));
+
+  // operator== should not use memcmp for double elements.
+  double d[1] = { nan() };
+  KJ_EXPECT(ArrayPtr<double>(d, 1) != ArrayPtr<double>(d, 1));
 }
 
 KJ_TEST("kj::range()") {

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -74,19 +74,6 @@ class Bounded;
 template <uint value>
 class BoundedConst;
 
-template <typename T> constexpr bool isIntegral() { return false; }
-template <> constexpr bool isIntegral<char>() { return true; }
-template <> constexpr bool isIntegral<signed char>() { return true; }
-template <> constexpr bool isIntegral<short>() { return true; }
-template <> constexpr bool isIntegral<int>() { return true; }
-template <> constexpr bool isIntegral<long>() { return true; }
-template <> constexpr bool isIntegral<long long>() { return true; }
-template <> constexpr bool isIntegral<unsigned char>() { return true; }
-template <> constexpr bool isIntegral<unsigned short>() { return true; }
-template <> constexpr bool isIntegral<unsigned int>() { return true; }
-template <> constexpr bool isIntegral<unsigned long>() { return true; }
-template <> constexpr bool isIntegral<unsigned long long>() { return true; }
-
 template <typename T>
 struct IsIntegralOrBounded_ { static constexpr bool value = isIntegral<T>(); };
 template <uint64_t m, typename T>


### PR DESCRIPTION
Make `ArrayPtr<T>::operator==` much faster when `T` is an integral type, including `const char`, which is used by `StringPtr`.