### PR TITLE
Introduce a debugging aid to detect when KJ I/O objects are held in the wrong places.

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -134,7 +134,7 @@ private:
   void** limit;
 };
 
-class Event {
+class Event: private AsyncObject {
   // An event waiting to be executed.  Not for direct use by applications -- promises use this
   // internally.
 
@@ -212,7 +212,7 @@ private:
   SourceLocation location;
 };
 
-class PromiseNode {
+class PromiseNode: private AsyncObject {
   // A Promise<T> contains a chain of PromiseNodes tracking the pending transformations.
   //
   // To reduce generated code bloat, PromiseNode is not a template.  Instead, it makes very hacky

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -48,7 +48,7 @@ class AncillaryMessage;
 // =======================================================================================
 // Streaming I/O
 
-class AsyncInputStream {
+class AsyncInputStream: private AsyncObject {
   // Asynchronous equivalent of InputStream (from io.h).
 
 public:
@@ -102,7 +102,7 @@ public:
   // likely to arise if tryTee() is called twice with different limits on the same stream.
 };
 
-class AsyncOutputStream {
+class AsyncOutputStream: private AsyncObject {
   // Asynchronous equivalent of OutputStream (from io.h).
 
 public:
@@ -428,7 +428,7 @@ public:
 // =======================================================================================
 // Accepting connections
 
-class ConnectionReceiver {
+class ConnectionReceiver: private AsyncObject {
   // Represents a server socket listening on a port.
 
 public:
@@ -563,7 +563,7 @@ public:
 // =======================================================================================
 // Networks
 
-class NetworkAddress {
+class NetworkAddress: private AsyncObject {
   // Represents a remote address to which the application can connect.
 
 public:

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -187,7 +187,7 @@ private:
   Maybe<Own<ChildSet>> childSet;
 };
 
-class UnixEventPort::FdObserver {
+class UnixEventPort::FdObserver: private AsyncObject {
   // Object which watches a file descriptor to determine when it is readable or writable.
   //
   // For listen sockets, "readable" means that there is a connection to accept(). For everything

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -969,14 +969,17 @@ KJ_THREADLOCAL_PTR(ExceptionCallback) threadLocalCallback = nullptr;
 
 }  // namespace
 
-ExceptionCallback::ExceptionCallback(): next(getExceptionCallback()) {
-  char stackVar;
+void requireOnStack(void* ptr, kj::StringPtr description) {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-  ptrdiff_t offset = reinterpret_cast<char*>(this) - &stackVar;
-  KJ_ASSERT(offset < 65536 && offset > -65536,
-            "ExceptionCallback must be allocated on the stack.");
+  char stackVar;
+  ptrdiff_t offset = reinterpret_cast<char*>(ptr) - &stackVar;
+  KJ_REQUIRE(offset < 65536 && offset > -65536,
+            kj::str(description));
 #endif
+}
 
+ExceptionCallback::ExceptionCallback(): next(getExceptionCallback()) {
+  requireOnStack(this, "ExceptionCallback must be allocated on the stack.");
   threadLocalCallback = this;
 }
 

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -442,6 +442,10 @@ kj::ArrayPtr<void* const> computeRelativeTrace(
 //
 // This is useful for debugging, when reporting several related traces at once.
 
+void requireOnStack(void* ptr, kj::StringPtr description);
+// Throw an exception if `ptr` does not appear to point to something near the top of the stack.
+// Used as a safety check for types that must be stack-allocated, like ExceptionCallback.
+
 }  // namespace kj
 
 KJ_END_HEADER


### PR DESCRIPTION
KJ I/O objects cannot cross threads. This implies that objects which can cross threads must never own KJ I/O objects, execpt perhaps through specific mechanisms designed to allow it. This commit introduces some utilities that can be used to detect when KJ I/O objects are held in the wrong places.