### PR TITLE
Support `permessage-deflate` WebSocket Extension

### DIFF
--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -534,6 +534,16 @@ public:
   virtual void generate(kj::ArrayPtr<byte> buffer) = 0;
 };
 
+struct CompressionParameters {
+  // These are the parameters for `Sec-WebSocket-Extensions` permessage-deflate extension.
+  // Since we cannot distinguish the client/server in `upgradeToWebSocket`, we use the prefixes
+  // `inbound` and `outbound` instead.
+  bool outbound_no_context_takeover = false;
+  bool inbound_no_context_takeover = false;
+  kj::Maybe<size_t> outbound_max_window_bits = nullptr;
+  kj::Maybe<size_t> inbound_max_window_bits = nullptr;
+};
+
 class WebSocket {
   // Interface representincg an open WebSocket session.
   //


### PR DESCRIPTION
## WIP
**Edit**
The first 3 commits were essentially:
1. build the extension header for the request (drop everything but `permessage-deflate` offers)
2. parse the offers as the server + build a response
3. parse the servers response as the client

I wasn't sure how I wanted to move the code since a lot of it could be shared, so rather than doing fixups I made a 4th commit for refactoring everything. This was... not a great idea... since now commits 1-3 are pretty outdated.

I'm considering: 
- leaving it as is (first 3 commits are helpful indications of where each step of negotiation takes place), or
- closing the PR and opening a new one with a single squashed commit. 

@kentonv do you have a preference either way?

---

Since the first chunk of this feature involves parsing the `Sec-WebSocket-Extensions` header, I figured it might be better to get eyes on it before moving past extension negotiation. Once we're happy with how negotiation is handled, I'll move on to compression.

As of now, we can:
- Drop all `Sec-WebSocket-Extensions` aside from `permessage-deflate` before sending the request to the server.
- Parse `permessage-deflate` offers as the server, populate a struct `CompressionParameters`, then build a response with agreed parameters.
- Parse `permessage-deflate` in a response (as a client), comparing the clients offer with what the server agreed to support, then populate `CompressionParameters`.
- Handle invalid offers/agreements, i.e. decline offers as the server/fail connections as the client.

Would be nice to add some tests for the string parsing code, though we indirectly test this by testing `Sec-WebSocket-Extensions` negotiation.