### PR TITLE
Add missing header to makefiles.

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -177,6 +177,7 @@ includekj_HEADERS =                                            \
   src/kj/async-queue.h                                         \
   src/kj/main.h                                                \
   src/kj/test.h                                                \
+  src/kj/win32-api-version.h                                   \
   src/kj/windows-sanity.h
 
 includekjparse_HEADERS =                                       \

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -64,6 +64,7 @@ set(kj_headers
   filesystem.h
   time.h
   main.h
+  win32-api-version.h
   windows-sanity.h
 )
 set(kj-parse_headers


### PR DESCRIPTION
The 0.10.0 release package doesn't actually build on Windows because this header isn't in the package. :(