### PR TITLE
Add header guards to all headers that were missing them.

### DIFF
--- a/c++/src/capnp/compat/byte-stream.h
+++ b/c++/src/capnp/compat/byte-stream.h
@@ -25,6 +25,8 @@
 #include <capnp/compat/byte-stream.capnp.h>
 #include <kj/async-io.h>
 
+CAPNP_BEGIN_HEADER
+
 namespace capnp {
 
 class ByteStreamFactory {
@@ -45,3 +47,5 @@ private:
 };
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compat/http-over-capnp.h
+++ b/c++/src/capnp/compat/http-over-capnp.h
@@ -27,6 +27,8 @@
 #include <kj/map.h>
 #include "byte-stream.h"
 
+CAPNP_BEGIN_HEADER
+
 namespace capnp {
 
 class HttpOverCapnpFactory {
@@ -82,3 +84,5 @@ private:
 };
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compat/json-rpc.h
+++ b/c++/src/capnp/compat/json-rpc.h
@@ -26,6 +26,8 @@
 #include <capnp/capability.h>
 #include <kj/map.h>
 
+CAPNP_BEGIN_HEADER
+
 namespace kj { class HttpInputStream; }
 
 namespace capnp {
@@ -110,3 +112,5 @@ private:
 };
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -25,6 +25,8 @@
 #include <capnp/dynamic.h>
 #include <capnp/compat/json.capnp.h>
 
+CAPNP_BEGIN_HEADER
+
 namespace capnp {
 
 typedef json::Value JsonValue;
@@ -523,3 +525,5 @@ void JsonCodec::handleByAnnotation() {
 }
 
 } // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compat/std-iterator.h
+++ b/c++/src/capnp/compat/std-iterator.h
@@ -29,6 +29,8 @@
 #include "../list.h"
 #include <iterator>
 
+CAPNP_BEGIN_HEADER
+
 namespace std {
 
 template <typename Container, typename Element>
@@ -37,3 +39,4 @@ struct iterator_traits<capnp::_::IndexingIterator<Container, Element>>
 
 }  // namespace std
 
+CAPNP_END_HEADER

--- a/c++/src/capnp/compat/websocket-rpc.h
+++ b/c++/src/capnp/compat/websocket-rpc.h
@@ -24,6 +24,8 @@
 #include <kj/compat/http.h>
 #include <capnp/serialize-async.h>
 
+CAPNP_BEGIN_HEADER
+
 namespace capnp {
 
 class WebSocketMessageStream final : public MessageStream {
@@ -51,3 +53,5 @@ private:
 };
 
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/compiler/type-id.h
+++ b/c++/src/capnp/compiler/type-id.h
@@ -25,6 +25,8 @@
 #include <kj/array.h>
 #include <capnp/common.h>
 
+CAPNP_BEGIN_HEADER
+
 namespace capnp {
 namespace compiler {
 
@@ -40,3 +42,5 @@ uint64_t generateMethodParamsId(uint64_t parentId, uint16_t methodOrdinal, bool 
 
 }  // namespace compiler
 }  // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -49,6 +49,8 @@
 
 #include "capability.h"
 
+CAPNP_BEGIN_HEADER
+
 namespace capnp {
 
 class MembranePolicy {
@@ -275,3 +277,5 @@ Orphan<typename kj::Decay<Reader>::Reads> copyOutOfMembrane(
 }
 
 } // namespace capnp
+
+CAPNP_END_HEADER

--- a/c++/src/kj/async-io-internal.h
+++ b/c++/src/kj/async-io-internal.h
@@ -26,6 +26,8 @@
 #include "async-io.h"
 #include <stdint.h>
 
+KJ_BEGIN_HEADER
+
 struct sockaddr;
 struct sockaddr_un;
 
@@ -86,3 +88,5 @@ private:
 
 }  // namespace _ (private)
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/async-win32.h
+++ b/c++/src/kj/async-win32.h
@@ -38,6 +38,8 @@
 #include <windows.h>
 #include "windows-sanity.h"
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 class Win32EventPort: public EventPort {
@@ -227,3 +229,5 @@ private:
 };
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/compat/gtest.h
+++ b/c++/src/kj/compat/gtest.h
@@ -32,6 +32,8 @@
 #include "../test.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `ERROR`
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 namespace _ {  // private
@@ -118,3 +120,5 @@ private:
 #define TEST(x, y) KJ_TEST("legacy test: " #x "/" #y)
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -25,6 +25,8 @@
 #include <kj/async-io.h>
 #include <zlib.h>
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 namespace _ {  // private
@@ -140,3 +142,5 @@ private:
 };
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -40,6 +40,8 @@
 #include <kj/one-of.h>
 #include <kj/async-io.h>
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 #define KJ_HTTP_FOR_EACH_METHOD(MACRO) \
@@ -1154,3 +1156,5 @@ inline void HttpHeaders::forEach(Func1&& func1, Func2&& func2) const {
 }
 
 }  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/compat/readiness-io.h
+++ b/c++/src/kj/compat/readiness-io.h
@@ -23,6 +23,8 @@
 
 #include <kj/async-io.h>
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 class ReadyInputStreamWrapper {
@@ -122,3 +124,5 @@ private:
 };
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -30,6 +30,8 @@
 
 #include <kj/async-io.h>
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 class TlsPrivateKey;
@@ -296,3 +298,5 @@ public:  // (not really public, only TlsConnection can call this)
 };
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/compat/url.h
+++ b/c++/src/kj/compat/url.h
@@ -25,6 +25,8 @@
 #include <kj/vector.h>
 #include <inttypes.h>
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 struct UrlOptions {
@@ -145,3 +147,5 @@ struct Url {
 };
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/filesystem.h
+++ b/c++/src/kj/filesystem.h
@@ -28,6 +28,8 @@
 #include "function.h"
 #include "hash.h"
 
+KJ_BEGIN_HEADER
+
 namespace kj {
 
 template <typename T>
@@ -1110,3 +1112,5 @@ void Directory::Replacer<T>::commit() {
 }
 
 } // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/source-location.h
+++ b/c++/src/kj/source-location.h
@@ -23,6 +23,8 @@
 
 #include "string.h"
 
+KJ_BEGIN_HEADER
+
 // GCC does not implement __builtin_COLUMN() as that's non-standard but MSVC & clang do.
 // MSVC does as of version https://github.com/microsoft/STL/issues/54) but there's currently not any
 // pressing need for this for MSVC & writing the write compiler version check is annoying.
@@ -105,3 +107,5 @@ KJ_UNUSED static kj::String KJ_STRINGIFY(const NoopSourceLocation& l) {
   return kj::String();
 }
 }  // namespace kj
+
+KJ_END_HEADER


### PR DESCRIPTION
These guards ensure that if a dependent project enables stricter compiler warnings than we do, they won't see warnings in our headers.

Most of the headers already had these guards but it seems that many new headers introduced over the years forgot to include them.

Fixes #1470