### PR TITLE
Add Android to CI

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -64,11 +64,41 @@ jobs:
       - uses: actions/checkout@v2
       - name: install dockcross
         run: |
-            docker run ${{ matrix.docker-run-args }} --rm dockcross/${{ matrix.cross-compiler }} > ./dockcross
-            chmod +x ./dockcross
+            docker run ${{ matrix.docker-run-args }} --rm dockcross/${{ matrix.cross-compiler }} > ./dockcross-${{ matrix.cross-compiler }}
+            chmod +x ./dockcross-${{ matrix.cross-compiler }}
       - name: super-test
         run: |
-            ./dockcross ./super-test.sh quick g++
+            ./dockcross-${{ matrix.cross-compiler }} ./super-test.sh quick g++
+  Android:
+    name: Android (${{ matrix.cross-compiler }})
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - cross-compiler: android-arm
+            arch: arm
+          - cross-compiler: android-arm64
+            arch: aarch64
+          - cross-compiler: android-x86
+            arch: x86
+          - cross-compiler: android-x86_64
+            arch: x86_64
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dockcross
+        run: |
+            docker run --rm dockcross/${{ matrix.cross-compiler }} > ./dockcross-${{ matrix.cross-compiler }}
+            chmod +x ./dockcross-${{ matrix.cross-compiler }}
+      - name: cmake build
+        run: |
+            ./dockcross-${{ matrix.cross-compiler }} cmake -DBUILD_TESTING=OFF -Bbuild -S.
+            ./dockcross-${{ matrix.cross-compiler }} cmake --build build
+      - name: automake build
+        run: |
+            cd c++
+            ../dockcross-${{ matrix.cross-compiler }} autoreconf -i
+            ../dockcross-${{ matrix.cross-compiler }} ./configure --host ${{ matrix.arch }} --disable-tests
+            ../dockcross-${{ matrix.cross-compiler }} make
   MacOS:
     runs-on: macos-latest
     strategy:

--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -448,6 +448,8 @@ endif LITE_MODE
 
 # Tests ==============================================================
 
+if BUILD_TESTING
+
 test_capnpc_inputs =                                           \
   src/capnp/test.capnp                                         \
   src/capnp/test-import.capnp                                  \
@@ -614,3 +616,5 @@ TESTS = capnp-test
 else !LITE_MODE
 TESTS = capnp-test capnp-evolution-test src/capnp/compiler/capnp-test.sh
 endif !LITE_MODE
+
+endif BUILD_TESTING

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -61,6 +61,10 @@ AC_ARG_ENABLE([reflection], [
     esac
   ], [lite_mode=no])
 
+AC_ARG_ENABLE([tests],
+  [AS_HELP_STRING([--disable-tests], [build without tests])],
+  [build_testing=no], [build_testing=yes])
+
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX
@@ -104,6 +108,8 @@ AS_IF([test "$external_capnp" != "no"], [
 AM_CONDITIONAL([USE_EXTERNAL_CAPNP], [test "$external_capnp" != "no"])
 
 AM_CONDITIONAL([LITE_MODE], [test "$lite_mode" = "yes"])
+
+AM_CONDITIONAL([BUILD_TESTING], [test "$build_testing" = "yes"])
 
 AS_IF([test "$lite_mode" = "yes"], [
   CXXFLAGS="-DCAPNP_LITE $CXXFLAGS"


### PR DESCRIPTION
Is there any interest in that? I was trying it for myself and figured I could share it here, just in case. Feel free to close if it is superfluous :+1:.

Two things:
1. It doesn't run the tests, because the tests need to run `capnp` to generate code (e.g. tests.capnp.c++, I believe), and I would have to jump through hoops to get the `capnp` binary in the dockcross image (and anyway I would need an emulator to run them). So those CI tests just verify that capnproto _builds_ on Android.
2. I added a `--disable-tests` options to the configure script for that reason. `-DBUILD_TESTING` was already there in CMake.

I also have experience with cross-compiling for iOS using CMake, so let me know if there is interest in that, I could open a PR to show how I do it. Though I don't think I would know how to do it with Autoconf/Automake :thinking:.