### PR TITLE
Add kj::VectorOutputStream::clear()

### DIFF
--- a/c++/src/kj/io-test.c++
+++ b/c++/src/kj/io-test.c++
@@ -111,6 +111,11 @@ KJ_TEST("VectorOutputStream") {
 
   KJ_ASSERT(output.getWriteBuffer().size() == 24);
   KJ_ASSERT(output.getWriteBuffer().begin() == output.getArray().begin() + 40);
+
+  output.clear();
+  KJ_ASSERT(output.getWriteBuffer().begin() == output.getArray().begin());
+  KJ_ASSERT(output.getWriteBuffer().size() == 64);
+  KJ_ASSERT(output.getArray().size() == 0);
 }
 
 class MockInputStream: public InputStream {

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -236,6 +236,8 @@ public:
     return arrayPtr(vector.begin(), fillPos);
   }
 
+  void clear() { fillPos = vector.begin(); }
+
   // implements BufferedInputStream ----------------------------------
   ArrayPtr<byte> getWriteBuffer() override;
   void write(const void* buffer, size_t size) override;


### PR DESCRIPTION
My use case is that I want to repeatedly `capnp::writePackedMessage` so I'd like to use and reuse a `kj::VectorOutputStream` for that. If you have a better solution I'll take it but this seemed reasonable.