### PR TITLE
using absolute includes across library boundary

### DIFF
--- a/c++/src/capnp/compiler/error-reporter.h
+++ b/c++/src/capnp/compiler/error-reporter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "../common.h"
+#include <capnp/common.h>
 #include <kj/string.h>
 #include <kj/exception.h>
 #include <kj/vector.h>

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -33,7 +33,7 @@
 
 KJ_BEGIN_HEADER
 
-#include "list.h"
+#include <kj/list.h>
 
 namespace kj {
 namespace _ {  // private

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -22,9 +22,9 @@
 #pragma once
 
 #include "async.h"
-#include "function.h"
-#include "thread.h"
-#include "timer.h"
+#include <kj/function.h>
+#include <kj/thread.h>
+#include <kj/timer.h>
 
 KJ_BEGIN_HEADER
 

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include "exception.h"
-#include "tuple.h"
-#include "source-location.h"
+#include <kj/exception.h>
+#include <kj/tuple.h>
+#include <kj/source-location.h>
 
 // Detect whether or not we should enable kj::Promise<T> coroutine integration.
 //

--- a/c++/src/kj/async-queue.h
+++ b/c++/src/kj/async-queue.h
@@ -22,10 +22,10 @@
 #pragma once
 
 #include "async.h"
-#include "common.h"
-#include "debug.h"
-#include "list.h"
-#include "memory.h"
+#include <kj/common.h>
+#include <kj/debug.h>
+#include <kj/list.h>
+#include <kj/memory.h>
 
 #include <list>
 

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include "async-prelude.h"
-#include "exception.h"
-#include "refcount.h"
+#include <kj/exception.h>
+#include <kj/refcount.h>
 
 KJ_BEGIN_HEADER
 

--- a/c++/src/kj/timer.h
+++ b/c++/src/kj/timer.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "time.h"
+#include <kj/time.h>
 #include "async.h"
 
 KJ_BEGIN_HEADER


### PR DESCRIPTION
bazel doesn't support relative includes across library boundaries, thus makes it impossible to defined componentized build.