### PR TITLE
Don't use deprecated std::iterator

### DIFF
--- a/c++/src/capnp/compat/std-iterator.h
+++ b/c++/src/capnp/compat/std-iterator.h
@@ -34,8 +34,13 @@ CAPNP_BEGIN_HEADER
 namespace std {
 
 template <typename Container, typename Element>
-struct iterator_traits<capnp::_::IndexingIterator<Container, Element>>
-      : public std::iterator<std::random_access_iterator_tag, Element, int> {};
+struct iterator_traits<capnp::_::IndexingIterator<Container, Element>> {
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = Element;
+  using difference_type	= int;
+  using pointer = Element*;
+  using reference = Element&;
+};
 
 }  // namespace std
 


### PR DESCRIPTION
Instead, define type aliases directly.