### PR TITLE
Allow unused parameter in KJ_STRINGIFY

### DIFF
--- a/c++/src/kj/source-location.h
+++ b/c++/src/kj/source-location.h
@@ -103,7 +103,7 @@ class NoopSourceLocation {
   // isn't accidentally used in the wrong compilation context.
 };
 
-KJ_UNUSED static kj::String KJ_STRINGIFY(const NoopSourceLocation& l) {
+KJ_UNUSED static kj::String KJ_STRINGIFY(KJ_UNUSED const NoopSourceLocation& l) {
   return kj::String();
 }
 }  // namespace kj


### PR DESCRIPTION
The parameter `l` is not actually used anywhere in KJ_STRINGIFY function. This change allows the `l` parameter to be unused.

Original compilation error message:
```
source-location.h:104:68: error: unused parameter ‘l’ [-Werror=unused-parameter]
 KJ_UNUSED static kj::String KJ_STRINGIFY(const NoopSourceLocation& l) { 
 ```