### PR TITLE
Schema loader for

### DIFF
--- a/c++/src/capnp/schema-loader-test.c++
+++ b/c++/src/capnp/schema-loader-test.c++
@@ -400,6 +400,19 @@ TEST(SchemaLoader, LoadStreaming) {
   KJ_EXPECT(results.getShortDisplayName() == "StreamResult", results.getShortDisplayName());
 }
 
+TEST(SchemaLoader, SchemaFor) {
+  SchemaLoader loader;
+  
+  using TargetCls = test::TestLists;
+  
+  Schema nativeSchema = Schema::from<TargetCls>();
+  Schema loaderFromProto = loader.load(nativeSchema.getProto());
+  Schema loaderFromSchemaFor = loader.getSchemaFor<TargetCls>();
+  
+  EXPECT_FALSE(nativeSchema == loaderFromProto);
+  EXPECT_TRUE(loaderFromSchemaFor == loaderFromProto);
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp

--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -103,6 +103,8 @@ public:
       const _::RawSchema* schema, schema::Brand::Reader proto,
       kj::Maybe<kj::ArrayPtr<const _::RawBrandedSchema::Scope>> clientBrand);
 
+  const _::RawBrandedSchema* cloneNative(const _::RawBrandedSchema* loadNative);
+
   struct TryGetResult {
     _::RawSchema* schema;
     kj::Maybe<const LazyLoadCallback&> callback;
@@ -1506,6 +1508,11 @@ const _::RawBrandedSchema* SchemaLoader::Impl::makeBranded(
   return makeBranded(schema, copyDeduped(dstScopes));
 }
 
+const _::RawBrandedSchema* SchemaLoader::Impl::cloneNative(const _::RawBrandedSchema* native) {
+  return makeBranded(loadNative(native->generic), kj::ArrayPtr<const _::RawBrandedSchema::Scope>(
+      native->scopes, native->scopeCount));
+}
+
 const _::RawBrandedSchema* SchemaLoader::Impl::makeBranded(
     const _::RawSchema* schema, kj::ArrayPtr<const _::RawBrandedSchema::Scope> bindings) {
   if (bindings.size() == 0) {
@@ -2088,6 +2095,10 @@ kj::Array<Schema> SchemaLoader::getAllLoaded() const {
 
 void SchemaLoader::loadNative(const _::RawSchema* nativeSchema) {
   impl.lockExclusive()->get()->loadNative(nativeSchema);
+}
+
+const _::RawBrandedSchema* SchemaLoader::loadNative(const _::RawBrandedSchema* nativeSchema) {
+  return impl.lockExclusive()->get()->cloneNative(nativeSchema);
 }
 
 }  // namespace capnp

--- a/c++/src/capnp/schema-loader.h
+++ b/c++/src/capnp/schema-loader.h
@@ -163,7 +163,7 @@ private:
   kj::MutexGuarded<kj::Own<Impl>> impl;
 
   void loadNative(const _::RawSchema* nativeSchema);
-  const _::RawBrandedSchema* loadNative(const const _::RawBrandedSchema* native);
+  const _::RawBrandedSchema* loadNative(const _::RawBrandedSchema* native);
 };
 
 template <typename T>

--- a/c++/src/capnp/schema-loader.h
+++ b/c++/src/capnp/schema-loader.h
@@ -143,6 +143,11 @@ public:
   // If you want to be able to cast a DynamicValue built from this SchemaLoader to the compiled-in
   // type using as<T>(), you must call this method before constructing the DynamicValue.  Otherwise,
   // as<T>() will throw an exception complaining about type mismatch.
+  
+  template<typename T>
+  Schema getSchemaFor();
+  // Load the schema for the given compiled-in type (as in loadCompiledTypeAndDependencies) and
+  // return this loader's schema for the given type.
 
   kj::Array<Schema> getAllLoaded() const;
   // Get a complete list of all loaded schema nodes.  It is particularly useful to call this after
@@ -158,11 +163,17 @@ private:
   kj::MutexGuarded<kj::Own<Impl>> impl;
 
   void loadNative(const _::RawSchema* nativeSchema);
+  const _::RawBrandedSchema* loadNative(const const _::RawBrandedSchema* native);
 };
 
 template <typename T>
 inline void SchemaLoader::loadCompiledTypeAndDependencies() {
   loadNative(&_::rawSchema<T>());
+}
+
+template<typename T>
+inline Schema SchemaLoader::getSchemaFor() {
+  return Schema(loadNative(&_::rawBrandedSchema<T>()));
 }
 
 }  // namespace capnp


### PR DESCRIPTION
Currently, when using the dynamic API via SchemaLoader, it is possible to convert dynamic objects obtained with a SchemaLoader to C++ objects (as long as the conversion is registered via loadCompiledTypeAndDependencies). However, the opposite direction, passing a dynamic object obtained from a statically-typed C++ object into structs / capabilities from the SchemaLoader, is currently not available.

This is because the SchemaLoader maintains its own copy of the schema, and therefore the C++ object's schema will compare unequal to the types requested by other dynamic structs and/or capabilities.

This pull requests adds a new method, SchemaLoader::getSchemaFor<StructOrCapability>, which constructs a capnp::Schema object equivalent to the static schema in the loader. This is achieved simply by combining SchemaLoader::Impl::loadNative and SchemaLoader::Impl::makeBranded (which is done in a new method added to SchemaLoader:: Impl).

A small test is also added. I tested compilation and the test itself (it is part of capnp-tests the way I wrote it, right?) locally on MSVC 19, CLANG 15 (WSL) and GCC 9 (WSL).