### PR TITLE
Overloaded kj::WaitScope::poll to accept a max turn count argument

### DIFF
--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1164,8 +1164,10 @@ public:
   inline ~WaitScope() { if (fiber == nullptr) loop.leaveScope(); }
   KJ_DISALLOW_COPY(WaitScope);
 
-  void poll();
-  // Pumps the event queue and polls for I/O until there's nothing left to do (without blocking).
+  uint poll(uint maxTurnCount = maxValue);
+  // Pumps the event queue and polls for I/O until there's nothing left to do (without blocking) or
+  // the maximum turn count has been reached. Returns the number of events popped off the event
+  // queue.
   //
   // Not supported in fibers.
 


### PR DESCRIPTION
It might be useful to consumers to be able to poll for a bounded number of
events in order to yield control of the thread over to other time-sensitive
processing that is unable to run on another thread.

Added a test case to assert that events are only processed up to the max turn
count.