### PR TITLE
Added method to list brand binding scopes

### DIFF
--- a/c++/src/capnp/schema.c++
+++ b/c++/src/capnp/schema.c++
@@ -265,6 +265,18 @@ Schema::BrandArgumentList Schema::getBrandArgumentsAtScope(uint64_t scopeId) con
   return BrandArgumentList(scopeId, raw->isUnbound());
 }
 
+kj::Array<uint64_t> Schema::listBrandArgumentScopes() const {
+  KJ_REQUIRE(getProto().getIsGeneric(), "Not a generic type.", getProto().getDisplayName());
+  
+  auto result = kj::heapArray<uint64_t>(raw->scopeCount);
+  for(auto iScope : kj::indices(result)) {
+	result[iScope] = raw->scopes[iScope].typeId;
+  }
+  
+  return result;
+}
+	
+
 StructSchema Schema::asStruct() const {
   KJ_REQUIRE(getProto().isStruct(), "Tried to use non-struct schema as a struct.",
              getProto().getDisplayName()) {

--- a/c++/src/capnp/schema.c++
+++ b/c++/src/capnp/schema.c++
@@ -265,8 +265,9 @@ Schema::BrandArgumentList Schema::getBrandArgumentsAtScope(uint64_t scopeId) con
   return BrandArgumentList(scopeId, raw->isUnbound());
 }
 
-kj::Array<uint64_t> Schema::listBrandArgumentScopes() const {
-  KJ_REQUIRE(getProto().getIsGeneric(), "Not a generic type.", getProto().getDisplayName());
+kj::Array<uint64_t> Schema::getGenericScopeIds() const {
+  if (!getProto().getIsGeneric())
+    return nullptr;
   
   auto result = kj::heapArray<uint64_t>(raw->scopeCount);
   for (auto iScope: kj::indices(result)) {

--- a/c++/src/capnp/schema.c++
+++ b/c++/src/capnp/schema.c++
@@ -269,8 +269,8 @@ kj::Array<uint64_t> Schema::listBrandArgumentScopes() const {
   KJ_REQUIRE(getProto().getIsGeneric(), "Not a generic type.", getProto().getDisplayName());
   
   auto result = kj::heapArray<uint64_t>(raw->scopeCount);
-  for(auto iScope : kj::indices(result)) {
-	result[iScope] = raw->scopes[iScope].typeId;
+  for (auto iScope: kj::indices(result)) {
+    result[iScope] = raw->scopes[iScope].typeId;
   }
   
   return result;

--- a/c++/src/capnp/schema.h
+++ b/c++/src/capnp/schema.h
@@ -125,6 +125,8 @@ public:
   class BrandArgumentList;
   BrandArgumentList getBrandArgumentsAtScope(uint64_t scopeId) const;
   // Gets the values bound to the brand parameters at the given scope.
+  
+  kj::Array<uint64_t> listBrandArgumentScopes() const;
 
   StructSchema asStruct() const;
   EnumSchema asEnum() const;

--- a/c++/src/capnp/schema.h
+++ b/c++/src/capnp/schema.h
@@ -126,7 +126,9 @@ public:
   BrandArgumentList getBrandArgumentsAtScope(uint64_t scopeId) const;
   // Gets the values bound to the brand parameters at the given scope.
   
-  kj::Array<uint64_t> listBrandArgumentScopes() const;
+  kj::Array<uint64_t> getGenericScopeIds() const;
+  // Returns the type IDs of all parent scopes that have generic parameters, to which this type is
+  // subject.
 
   StructSchema asStruct() const;
   EnumSchema asEnum() const;


### PR DESCRIPTION
As mentioned in #1490, in order to accurately reconstruct brand bindings in a way that will lead to identically comparing schemas, I need to be able to get an exact list of binding scopes. This PR adds a new method to the schema class that lists all the brand binding scopes of the underlying RawBrandedSchema. This should hopefully be both simpler to review and a lower-risk addition, as it only reads information instead of mutating the schema loader's state.