### PR TITLE
[bazel] upstream compilation fixes

### DIFF
--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -24,9 +24,30 @@ cc_library(
 )
 
 cc_capnp_library(
-    name = "http-over-capnp",
-    srcs = ["http-over-capnp.capnp", "byte-stream.capnp"],
+    name = "http-over-capnp_capnp",
+    srcs = [
+        "byte-stream.capnp",
+        "http-over-capnp.capnp",
+    ],
     include_prefix = "capnp/compat",
     src_prefix = "src",
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "http-over-capnp",
+    srcs = [
+        "byte-stream.c++",
+        "http-over-capnp.c++",
+    ],
+    hdrs = [
+        "byte-stream.h",
+        "http-over-capnp.h",
+    ],
+    include_prefix = "capnp/compat",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":http-over-capnp_capnp",
+        "//src/kj/compat:kj-http",
+    ],
 )

--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "capability.h"
+#include <capnp/capability.h>
 #include "persistent.capnp.h"
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/capnp/rpc-twoparty.h
+++ b/c++/src/capnp/rpc-twoparty.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "rpc.h"
-#include "message.h"
+#include <capnp/message.h>
 #include <kj/async-io.h>
 #include <capnp/serialize-async.h>
 #include <capnp/rpc-twoparty.capnp.h>

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "capability.h"
+#include <capnp/capability.h>
 #include "rpc-prelude.h"
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -27,8 +27,8 @@
 
 #include "async.h"
 #include "timer.h"
-#include "vector.h"
-#include "io.h"
+#include <kj/vector.h>
+#include <kj/io.h>
 #include <signal.h>
 
 KJ_BEGIN_HEADER

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -10,7 +10,7 @@ cc_library(
         "readiness-io.h",
         "tls.h",
     ],
-    include_prefix = "kj",
+    include_prefix = "kj/compat",
     target_compatible_with = select({
         "//src/kj:use_openssl": [],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -32,7 +32,7 @@ cc_library(
         "http.h",
         "url.h",
     ],
-    include_prefix = "kj",
+    include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = ["//src/kj:kj-async"],
 )
@@ -41,7 +41,7 @@ cc_library(
     name = "kj-gzip",
     srcs = ["gzip.c++"],
     hdrs = ["gzip.h"],
-    include_prefix = "kj",
+    include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = [
         "//src/kj:kj-async",


### PR DESCRIPTION
These are mainly using absolute imports across the component boundary and making
bazel definitions more precise.