### PR TITLE
Revert "Implement $Cxx.omitSchemas annotation"

### DIFF
--- a/c++/src/capnp/c++.capnp
+++ b/c++/src/capnp/c++.capnp
@@ -24,13 +24,3 @@ $namespace("capnp::annotations");
 
 annotation namespace(file): Text;
 annotation name(field, enumerant, struct, enum, interface, method, param, group, union): Text;
-
-annotation omitSchemas(file): Void;
-# Requests that the generated code does not embed the types' schemas.
-# This means you will not be able to use <capnp/schema.h> or <capnp/dynamic.h> APIs with this type.
-# By extension, that means you will not be able to stringify messages nor use the JSON codec.
-# However, the generated code will be somewhat smaller and will not include easily-extractable
-# type information, which may be important in some use cases.
-#
-# All files that import your file will also be required to set this option if they are used to
-# generate C++ code.

--- a/c++/src/capnp/c++.capnp.c++
+++ b/c++/src/capnp/c++.capnp.c++
@@ -64,35 +64,5 @@ const ::capnp::_::RawSchema s_f264a779fef191ce = {
   0, 0, nullptr, nullptr, nullptr, { &s_f264a779fef191ce, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<21> b_e17e871ab8a5deab = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
-    171, 222, 165, 184,  26, 135, 126, 225,
-     16,   0,   0,   0,   5,   0,   1,   0,
-    129,  78,  48, 184, 123, 125, 248, 189,
-      0,   0,   0,   0,   0,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     21,   0,   0,   0, 226,   0,   0,   0,
-     33,   0,   0,   0,   7,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     28,   0,   0,   0,   3,   0,   1,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     99,  97, 112, 110, 112,  47,  99,  43,
-     43,  46,  99,  97, 112, 110, 112,  58,
-    111, 109, 105, 116,  83,  99, 104, 101,
-    109,  97, 115,   0,   0,   0,   0,   0,
-      0,   0,   0,   0,   1,   0,   1,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0, }
-};
-::capnp::word const* const bp_e17e871ab8a5deab = b_e17e871ab8a5deab.words;
-#if !CAPNP_LITE
-const ::capnp::_::RawSchema s_e17e871ab8a5deab = {
-  0xe17e871ab8a5deab, b_e17e871ab8a5deab.words, 21, nullptr, nullptr,
-  0, 0, nullptr, nullptr, nullptr, { &s_e17e871ab8a5deab, nullptr, nullptr, 0, 0, nullptr }
-};
-#endif  // !CAPNP_LITE
 }  // namespace schemas
 }  // namespace capnp

--- a/c++/src/capnp/c++.capnp.h
+++ b/c++/src/capnp/c++.capnp.h
@@ -18,7 +18,6 @@ namespace schemas {
 
 CAPNP_DECLARE_SCHEMA(b9c6f99ebf805f2c);
 CAPNP_DECLARE_SCHEMA(f264a779fef191ce);
-CAPNP_DECLARE_SCHEMA(e17e871ab8a5deab);
 
 }  // namespace schemas
 }  // namespace capnp

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -64,7 +64,6 @@ namespace {
 
 static constexpr uint64_t NAMESPACE_ANNOTATION_ID = 0xb9c6f99ebf805f2cull;
 static constexpr uint64_t NAME_ANNOTATION_ID = 0xf264a779fef191ceull;
-static constexpr uint64_t OMIT_SCHEMAS_ANNOTATION_ID = 0xe17e871ab8a5deabull;
 
 bool hasDiscriminantValue(const schema::Field::Reader& reader) {
   return reader.getDiscriminantValue() != schema::Field::NO_DISCRIMINANT;
@@ -2986,14 +2985,6 @@ private:
 
     kj::Vector<kj::ArrayPtr<const char>> namespaceParts;
     kj::String namespacePrefix;
-    bool omitSchemas = false;
-
-    for (auto annotation : node.getAnnotations()) {
-      if (annotation.getId() == OMIT_SCHEMAS_ANNOTATION_ID) {
-        omitSchemas = true;
-        break;
-      }
-    }
 
     for (auto annotation: node.getAnnotations()) {
       if (annotation.getId() == NAMESPACE_ANNOTATION_ID) {
@@ -3094,8 +3085,7 @@ private:
           "\n"
           "namespace capnp {\n"
           "namespace schemas {\n",
-          omitSchemas ? kj::Array<kj::StringTree>() : KJ_MAP(n, nodeTexts) { return kj::mv(n.capnpSchemaDefs); },
-          omitSchemas ? "// Schemas omitted due to $Cxx.omitSchemas\n" : "",
+          KJ_MAP(n, nodeTexts) { return kj::mv(n.capnpSchemaDefs); },
           "}  // namespace schemas\n"
           "}  // namespace capnp\n",
           sourceDefs.size() == 0 ? kj::strTree() : kj::strTree(

--- a/c++/src/capnp/test-import2.capnp
+++ b/c++/src/capnp/test-import2.capnp
@@ -21,36 +21,12 @@
 
 @0xc64a3bf0338a124a;
 
-using Cxx = import "/capnp/c++.capnp";
 using Import1 = import "/capnp/schema.capnp";
 using Import2 = import "test-import.capnp";
 using Import3 = import "test.capnp";
-
-$Cxx.omitSchemas;
 
 struct TestImport2 {
   foo @0 :Import3.TestAllTypes;
   bar @1 :Import1.Node;
   baz @2 :Import2.TestImport;
-}
-
-interface TestImport2Interface {
-  testInterfaceMethod @0 () -> (result :Bool);
-}
-
-interface TestImport2ExtendingInterface extends(TestImport2Interface) {
-  testInterfaceMethodTwo @0 () -> (result :Bool);
-}
-
-enum TestImport2Enum {
-  zero @0;
-  one @1;
-  two @2;
-  three @3;
-  four @4;
-}
-
-struct TestImport2Structure {
-  enumValue @0 :TestImport2Enum;
-  anInterface @1 :TestImport2ExtendingInterface;
 }


### PR DESCRIPTION
Reverts capnproto/capnproto#1502

This didn't actually remove the schema declarations, only the definitions. As a result the code fails to link under certain conditions (unclear what conditions, seems to affect cmake and bazel but not automake).