### PR TITLE
Introduce the ability to share the same signalfd among many threads.

### DIFF
--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -962,6 +962,58 @@ KJ_TEST("UnixEventPort can receive multiple queued instances of an RT signal") {
 }
 #endif
 
+template <typename... Params>
+void doThreadSpecificSignalsTest(Params&&... params) {
+  Vector<Own<Thread>> threads;
+  std::atomic<uint> readyCount = 0;
+  std::atomic<uint> doneCount = 0;
+  for (auto i KJ_UNUSED: kj::zeroTo(16)) {
+    threads.add(kj::heap<Thread>([&]() noexcept {
+      UnixEventPort port(params...);
+      EventLoop loop(port);
+      WaitScope waitScope(loop);
+
+      readyCount.fetch_add(1, std::memory_order_relaxed);
+      port.onSignal(SIGIO).wait(waitScope);
+      doneCount.fetch_add(1, std::memory_order_relaxed);
+    }));
+  }
+
+  ([&]() noexcept {
+    do {
+      usleep(1000);
+    } while (readyCount.load(std::memory_order_relaxed) < 16);
+
+    KJ_ASSERT(doneCount.load(std::memory_order_relaxed) == 0);
+
+    uint count = 0;
+    for (uint i: {5, 14, 4, 6, 7, 11, 1, 3, 8, 0, 12, 9, 10, 15, 2, 13}) {
+      threads[i]->sendSignal(SIGIO);
+      threads[i] = nullptr;  // wait for that one thread to exit
+      usleep(1000);
+      KJ_ASSERT(doneCount.load(std::memory_order_relaxed) == ++count);
+    }
+  })();
+}
+
+KJ_TEST("UnixEventPort thread-specific signals") {
+  // Verify a signal directed to a thread is only received on the intended thread. Amazingly, this
+  // works even though all threads use the same signalfd.
+
+  captureSignals();
+
+  doThreadSpecificSignalsTest();
+
+  {
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGIO);
+    sigaddset(&sigset, SIGURG);
+    UnixEventPort::SharedSignalFd sharedSignalFd(sigset);
+    doThreadSpecificSignalsTest(sharedSignalFd);
+  }
+}
+
 }  // namespace
 }  // namespace kj
 

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -68,7 +68,34 @@ class UnixEventPort: public EventPort {
   //   until after daemonization to create a UnixEventPort.
 
 public:
-  UnixEventPort();
+#if KJ_USE_EPOLL
+  class SharedSignalFd {
+    // HACK: On Linux, if you have many threads waiting on the same signals, you may want them to
+    // use the same underlying signalfd. This turns out to work due to the bizarre behavior of
+    // signalfd, in which it always returns signals for the calling thread, rather than whatever
+    // thread created it. Taking advantage of this allows you to expend fewer FDs on signalfd,
+    // and may help avoid surprisingly-expensive creation cost of signalfds.
+    //
+    // To use this, create the object once and pass it to the constructors of many event ports.
+    //
+    // WARNING: This class will probably go away soon as we switch away from signalfd.
+  public:
+    SharedSignalFd(const sigset_t& sigset);
+    // The sigset must include all signals that you will wait on using `onSignal()`. Note that
+    // this has the side effect that the thread will accept any signal in this set regardless of
+    // whether `onSignal()` has been called. If a signal in the set arrives but no one has waited
+    // for it using `onSignal()`, it will be discarded and an error will be logged. Note that
+    // if RT signals are in the set, and multiple signals are delivered at once, you may only
+    // receive notification of the first one.
+
+  private:
+    kj::AutoCloseFd fd;
+
+    friend class UnixEventPort;
+  };
+#endif
+
+  UnixEventPort(kj::Maybe<SharedSignalFd&> sharedSignalFd = nullptr);
   ~UnixEventPort() noexcept(false);
 
   class FdObserver;
@@ -160,7 +187,8 @@ private:
 
 #if KJ_USE_EPOLL
   AutoCloseFd epollFd;
-  AutoCloseFd signalFd;
+  int signalFd;
+  AutoCloseFd ownSignalFd;
   AutoCloseFd eventFd;   // Used for cross-thread wakeups.
 
   sigset_t signalFdSigset;
@@ -319,6 +347,12 @@ private:
 
   friend class UnixEventPort;
 };
+
+#if KJ_USE_EPOLL
+class AsyncIoContext;
+AsyncIoContext setupAsyncIo(UnixEventPort::SharedSignalFd& sharedSignalFd);
+// Alternate version of setupAsyncIo() that accepts a shared signal Fd.
+#endif
 
 }  // namespace kj
 

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -93,9 +93,12 @@ public:
 
     friend class UnixEventPort;
   };
-#endif
 
   UnixEventPort(kj::Maybe<SharedSignalFd&> sharedSignalFd = nullptr);
+#else
+  UnixEventPort();
+#endif
+
   ~UnixEventPort() noexcept(false);
 
   class FdObserver;
@@ -349,7 +352,7 @@ private:
 };
 
 #if KJ_USE_EPOLL
-class AsyncIoContext;
+struct AsyncIoContext;
 AsyncIoContext setupAsyncIo(UnixEventPort::SharedSignalFd& sharedSignalFd);
 // Alternate version of setupAsyncIo() that accepts a shared signal Fd.
 #endif


### PR DESCRIPTION
It turns out that creating a signalfd is weirdly expensive. But, due to their unintuitive behavior of always checking the signals of the calling thread, not the creating thread, we can actually share just one among many threads, as long as those threads are waiting on the same signals.

We should probably stop using signalfd altogether, maybe falling back to the old longjmp() trick we use on other platforms, but that's a bigger change than I want to make right now.