### PR TITLE
Implement buffered async message reading 

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -79,6 +79,124 @@ Maybe<Own<AsyncInputStream>> AsyncInputStream::tryTee(uint64_t) {
   return nullptr;
 }
 
+AsyncBufferedInputStream::~AsyncBufferedInputStream() noexcept(false) {}
+
+ArrayPtr<const byte> AsyncBufferedInputStream::getReadBuffer() {
+  auto result = tryGetReadBuffer();
+  KJ_REQUIRE(result.size() > 0, "Premature EOF");
+  return result;
+}
+
+AsyncBufferedInputStreamWrapper::AsyncBufferedInputStreamWrapper(AsyncInputStream& inner,
+    ArrayPtr<byte> buffer) : inner(inner),
+    ownedBuffer(buffer == nullptr ? heapArray<byte>(8192) : nullptr),
+    buffer(buffer == nullptr ? ownedBuffer : buffer) {}
+
+AsyncBufferedInputStreamWrapper::AsyncBufferedInputStreamWrapper(
+    AsyncBufferedInputStreamWrapper&& other)
+    : inner(other.inner), ownedBuffer(kj::mv(other.ownedBuffer)),
+      buffer(other.buffer), bufferAvailable(other.bufferAvailable) {}
+
+AsyncBufferedInputStreamWrapper::~AsyncBufferedInputStreamWrapper() noexcept(false) {}
+
+ArrayPtr<const byte> AsyncBufferedInputStreamWrapper::tryGetReadBuffer() {
+  return bufferAvailable;
+}
+
+Promise<size_t> AsyncBufferedInputStreamWrapper::tryRead(void* dst, size_t minBytes, size_t maxBytes) {
+  if (minBytes <= bufferAvailable.size()) {
+    // Serve from current buffer.
+    size_t n = std::min(bufferAvailable.size(), maxBytes);
+    memcpy(dst, bufferAvailable.begin(), n);
+    bufferAvailable = bufferAvailable.slice(n, bufferAvailable.size());
+    return n;
+  } else {
+    // Copy current available into destination.
+    memcpy(dst, bufferAvailable.begin(), bufferAvailable.size());
+    size_t fromFirstBuffer = bufferAvailable.size();
+
+    dst = reinterpret_cast<byte*>(dst) + fromFirstBuffer;
+    minBytes -= fromFirstBuffer;
+    maxBytes -= fromFirstBuffer;
+
+    if (maxBytes <= buffer.size()) {
+      // Read the next buffer-full.
+      return inner.read(buffer.begin(), minBytes, buffer.size()).then(
+          [this, dst, maxBytes, fromFirstBuffer](size_t n) {
+        size_t fromSecondBuffer = std::min(n, maxBytes);
+        memcpy(dst, buffer.begin(), fromSecondBuffer);
+        bufferAvailable = buffer.slice(fromSecondBuffer, n);
+        return fromFirstBuffer + fromSecondBuffer;
+      });
+    } else {
+      // Forward large read to the underlying stream.
+      bufferAvailable = nullptr;
+      return inner.read(dst, minBytes, maxBytes).then(
+          [fromFirstBuffer](size_t n) {
+        return fromFirstBuffer + n;
+      });
+    }
+  }
+}
+
+void AsyncBufferedInputStreamWrapper::registerAncillaryMessageHandler(
+  Function<void(ArrayPtr<AncillaryMessage>)> fn) {
+  inner.registerAncillaryMessageHandler(kj::mv(fn));
+}
+
+
+AsyncBufferedIoStreamWrapper::AsyncBufferedIoStreamWrapper(AsyncIoStream& inner,
+    ArrayPtr<byte> buffer) : inner(inner), input(inner, buffer) {}
+AsyncBufferedIoStreamWrapper::AsyncBufferedIoStreamWrapper(AsyncBufferedIoStreamWrapper&& other)
+    : inner(other.inner), input(kj::mv(other.input)) {}
+
+Promise<size_t> AsyncBufferedIoStreamWrapper::tryRead(
+    void* buffer, size_t minBytes, size_t maxBytes) {
+  return input.tryRead(buffer, minBytes, maxBytes);
+}
+
+void AsyncBufferedIoStreamWrapper::registerAncillaryMessageHandler(
+  Function<void(ArrayPtr<AncillaryMessage>)> fn) {
+  inner.registerAncillaryMessageHandler(kj::mv(fn));
+}
+
+
+Promise<void> AsyncBufferedIoStreamWrapper::write(const void* buffer, size_t size) {
+  return inner.write(buffer, size);
+}
+Promise<void> AsyncBufferedIoStreamWrapper::write(ArrayPtr<const ArrayPtr<const byte>> pieces) {
+  return inner.write(pieces);
+}
+Maybe<Promise<uint64_t>> AsyncBufferedIoStreamWrapper::tryPumpFrom(AsyncInputStream& input, uint64_t amount) {
+  return inner.tryPumpFrom(input, amount);
+}
+Promise<void> AsyncBufferedIoStreamWrapper::whenWriteDisconnected() {
+  return inner.whenWriteDisconnected();
+}
+
+// Implements AsyncIoStream
+void AsyncBufferedIoStreamWrapper::shutdownWrite() {
+  inner.shutdownWrite();
+}
+void AsyncBufferedIoStreamWrapper::abortRead() {
+  inner.abortRead();
+}
+void AsyncBufferedIoStreamWrapper::getsockopt(int level, int option, void* value, uint* length) {
+  inner.getsockopt(level, option, value, length);
+}
+void AsyncBufferedIoStreamWrapper::setsockopt(int level, int option, const void* value, uint length) {
+  inner.setsockopt(level, option, value, length);
+}
+void AsyncBufferedIoStreamWrapper::getsockname(struct sockaddr* addr, uint* length) {
+  inner.getsockname(addr, length);
+}
+void AsyncBufferedIoStreamWrapper::getpeername(struct sockaddr* addr, uint* length) {
+  inner.getpeername(addr, length);
+}
+kj::Maybe<int> AsyncBufferedIoStreamWrapper::getFd() const {
+  return inner.getFd();
+}
+
 namespace {
 
 class AsyncPump {

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -136,6 +136,60 @@ public:
   // multiple times without canceling the previous promises.
 };
 
+class AsyncBufferedInputStream {
+  // Does not inherit from InputStream so this can act as a mixin to allow implementing
+  // AsyncBufferedIoStreamWrapper and AsyncBufferedCapabilityStreamWrapper
+
+public:
+  virtual ~AsyncBufferedInputStream() noexcept(false);
+
+  ArrayPtr<const byte> getReadBuffer();
+  // TODO(now): No skip for AsyncInputStream -- I guess we could implement an async form?
+  // Get a direct pointer into the read buffer, which contains the next bytes in the input.  If the
+  // caller consumes any bytes, it should then call skip() to indicate this.  This always returns a
+  // non-empty buffer or throws an exception.  Implemented in terms of tryGetReadBuffer().
+
+  virtual ArrayPtr<const byte> tryGetReadBuffer() = 0;
+  // Like getReadBuffer() but may return an empty buffer on EOF.
+};
+
+class AsyncBufferedInputStreamWrapper: public AsyncBufferedInputStream, public AsyncInputStream {
+  // Implements AsyncBufferedInputStream in terms of AsyncInputStream
+  //
+  // Note that the underlying stream's position is unpredictable once the wrapper is destroyed,
+  // unless the entire stream was consumed.  To read a predictable number of bytes in a buffered
+  // way without going over, you'd need this wrapper to wrap some other wrapper which itself
+  // implements an artificial EOF at the desired point.  Such a stream should be trivial to write
+  // but is not provided by the library at this time.
+
+public:
+  explicit AsyncBufferedInputStreamWrapper(AsyncInputStream& inner, ArrayPtr<byte> buffer = nullptr);
+  // Creates a buffered stream wrapping the given non-buffered stream.  No guarantee is made about
+  // the position of the inner stream after a buffered wrapper has been created unless the entire
+  // input is read.
+  //
+  // If the second parameter is non-null, the stream uses the given buffer instead of allocating
+  // its own.  This may improve performance if the buffer can be reused.
+
+  AsyncBufferedInputStreamWrapper(AsyncBufferedInputStreamWrapper&& other);
+  KJ_DISALLOW_COPY(AsyncBufferedInputStreamWrapper);
+
+  ~AsyncBufferedInputStreamWrapper() noexcept(false);
+
+  // implements AsyncBufferedInputStream ----------------------------------
+  ArrayPtr<const byte> tryGetReadBuffer() override;
+
+  // Implements AsyncInputStream
+  Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+  void registerAncillaryMessageHandler(Function<void(ArrayPtr<AncillaryMessage>)> fn) override;
+
+private:
+  AsyncInputStream& inner;
+  Array<byte> ownedBuffer;
+  ArrayPtr<byte> buffer;
+  ArrayPtr<byte> bufferAvailable;
+};
+
 class AsyncIoStream: public AsyncInputStream, public AsyncOutputStream {
   // A combination input and output stream.
 
@@ -166,6 +220,37 @@ public:
   virtual kj::Maybe<int> getFd() const { return nullptr; }
   // Get the underlying Unix file descriptor, if any. Returns nullptr if this object actually
   // isn't wrapping a file descriptor.
+};
+
+class AsyncBufferedIoStreamWrapper: public AsyncIoStream {
+  // An AsyncIoStream where the input stream is an AsyncBufferedInputStream
+public:
+  explicit AsyncBufferedIoStreamWrapper(AsyncIoStream& inner, ArrayPtr<byte> buffer = nullptr);
+  AsyncBufferedIoStreamWrapper(AsyncBufferedIoStreamWrapper&& other);
+  KJ_DISALLOW_COPY(AsyncBufferedIoStreamWrapper);
+
+  // Implements AsyncInputStream
+  Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+  void registerAncillaryMessageHandler(Function<void(ArrayPtr<AncillaryMessage>)> fn) override;
+
+  // Implements AsyncOutputStream
+  Promise<void> write(const void* buffer, size_t size) override;
+  Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
+  Maybe<Promise<uint64_t>> tryPumpFrom(
+      AsyncInputStream& input, uint64_t amount = kj::maxValue) override;
+  Promise<void> whenWriteDisconnected() override;
+
+  // Implements AsyncIoStream
+  void shutdownWrite() override;
+  void abortRead() override;
+  void getsockopt(int level, int option, void* value, uint* length) override;
+  void setsockopt(int level, int option, const void* value, uint length) override;
+  void getsockname(struct sockaddr* addr, uint* length) override;
+  void getpeername(struct sockaddr* addr, uint* length) override;
+  kj::Maybe<int> getFd() const override;
+private:
+  AsyncIoStream& inner;
+  AsyncBufferedInputStreamWrapper input;
 };
 
 Promise<uint64_t> unoptimizedPumpTo(


### PR DESCRIPTION
Capnp's async message reading was particularly syscall heavy, as it read the first segment, segment tables, and each segment in separate calls. This PR introduces buffered readers, that read a batch of messages at once which significantly reduces the number of syscalls required to read messages.