### PR TITLE
Buffer writes using `evalLast` in TwoPartyVatNetwork

### DIFF
--- a/c++/src/capnp/rpc-twoparty.h
+++ b/c++/src/capnp/rpc-twoparty.h
@@ -79,6 +79,7 @@ public:
   // clock is used for calculating the oldest queued message age, which is a useful metric for
   // detecting queue overload
 
+  ~TwoPartyVatNetwork() noexcept(false);
   KJ_DISALLOW_COPY(TwoPartyVatNetwork);
 
   kj::Promise<void> onDisconnect() { return disconnectPromise.addBranch(); }
@@ -90,7 +91,7 @@ public:
   // Get the number of bytes worth of outgoing messages that are currently queued in memory waiting
   // to be sent on this connection. This may be useful for backpressure.
 
-  size_t getCurrentQueueCount() { return currentQueueCount; }
+  size_t getCurrentQueueCount() { return queuedMessages.size(); }
   // Get the count of outgoing messages that are currently queued in memory waiting
   // to be sent on this connection. This may be useful for backpressure.
 
@@ -135,8 +136,8 @@ private:
 
   kj::ForkedPromise<void> disconnectPromise = nullptr;
 
+  kj::Vector<kj::Own<OutgoingMessageImpl>> queuedMessages;
   size_t currentQueueSize = 0;
-  size_t currentQueueCount = 0;
   const kj::MonotonicClock& clock;
   kj::TimePoint currentOutgoingMessageSendTime;
 

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -381,7 +381,7 @@ kj::Promise<void> MessageStream::writeMessages(kj::ArrayPtr<MessageAndFds> messa
 
       return writeMessage(messages[0].fds, messages[0].segments);
     } else {
-      kj::Vector<kj::ArrayPtr<const kj::ArrayPtr<const word>>> bareMessages;
+      kj::Vector<kj::ArrayPtr<const kj::ArrayPtr<const word>>> bareMessages(messages.size());
       for(auto i : kj::zeroTo(messages.size())) {
         if (messages[i].fds.size() > 0) {
           break;

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -366,6 +366,45 @@ kj::Promise<void> writeMessages(
   return writeMessages(output, messages);
 }
 
+kj::Promise<void> MessageStream::writeMessages(kj::ArrayPtr<MessageAndFds> messages) {
+  if (messages.size() == 0) return kj::READY_NOW;
+  kj::ArrayPtr<MessageAndFds> remainingMessages;
+
+  auto writeProm = [&]() {
+    if (messages[0].fds.size() > 0) {
+      // We have a message with FDs attached. We need to write any bare messages we've accumulated,
+      // if any, then write the message with FDs, then continue on with any remaining messages.
+
+      if (messages.size() > 1) {
+        remainingMessages = messages.slice(1, messages.size());
+      }
+
+      return writeMessage(messages[0].fds, messages[0].segments);
+    } else {
+      kj::Vector<kj::ArrayPtr<const kj::ArrayPtr<const word>>> bareMessages;
+      for(auto i : kj::zeroTo(messages.size())) {
+        if (messages[i].fds.size() > 0) {
+          break;
+        }
+        bareMessages.add(messages[i].segments);
+      }
+
+      if (messages.size() > bareMessages.size()) {
+        remainingMessages = messages.slice(bareMessages.size(), messages.size());
+      }
+      return writeMessages(bareMessages.asPtr()).attach(kj::mv(bareMessages));
+    }
+  }();
+
+  if (remainingMessages.size() > 0) {
+    return writeProm.then([this, remainingMessages]() mutable {
+      return writeMessages(remainingMessages);
+    });
+  } else {
+    return writeProm;
+  }
+}
+
 kj::Promise<void> MessageStream::writeMessages(kj::ArrayPtr<MessageBuilder*> builders) {
   auto messages = kj::heapArray<kj::ArrayPtr<const kj::ArrayPtr<const word>>>(builders.size());
   for (auto i : kj::indices(builders)) {

--- a/c++/src/capnp/serialize-async.h
+++ b/c++/src/capnp/serialize-async.h
@@ -33,6 +33,11 @@ struct MessageReaderAndFds {
   kj::ArrayPtr<kj::AutoCloseFd> fds;
 };
 
+struct MessageAndFds {
+  kj::ArrayPtr<const kj::ArrayPtr<const word>> segments;
+  kj::ArrayPtr<const int> fds;
+};
+
 class MessageStream {
   // Interface over which messages can be sent and received; virtualizes
   // the functionality above.
@@ -76,6 +81,9 @@ public:
       KJ_WARN_UNUSED_RESULT;
   // Equivalent to the above with fds = nullptr.
 
+  kj::Promise<void> writeMessages(
+      kj::ArrayPtr<MessageAndFds> messages)
+    KJ_WARN_UNUSED_RESULT;
   virtual kj::Promise<void> writeMessages(
       kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages)
     KJ_WARN_UNUSED_RESULT = 0;


### PR DESCRIPTION
I'm not sure if we want this to be a default, or configurable behavior -- If your event loop was backed up enough for this to cause problems, I think that you'd be hurting from queueing writes regardless. And even if so, you could run into stack overflow if you queue enough messages, which this PR should also stop from happening.

First commit is same as (https://github.com/capnproto/capnproto/pull/1509) but I can't set the merge target to a branch in my own repo for a PR in this one.