### PR TITLE
[bazel] using correct warning settings

### DIFF
--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -1,4 +1,9 @@
 build --cxxopt='-std=c++14' --host_cxxopt='-std=c++14' --force_pic --verbose_failures
+build --cxxopt='-Wall' --host_cxxopt='-Wall'
+build --cxxopt='-Wextra' --host_cxxopt='-Wextra'
+build --cxxopt='-Wno-strict-aliasing' --host_cxxopt='-Wno-strict-aliasing'
+build --cxxopt='-Wno-sign-compare' --host_cxxopt='-Wno-sign-compare'
+build --cxxopt='-Wno-unused-parameter' --host_cxxopt='-Wno-unused-parameter'
 
 # build with ssl and zlib by default
 build --//src/kj:openssl=True --//src/kj:zlib=True


### PR DESCRIPTION
It seems we need to mess with toolchains, which I'd rather not do, if we want to set these up in a more sophisticated way.