### PR TITLE
Use stringifyStackTraceAddresses in kj_test

### DIFF
--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -172,7 +172,7 @@ public:
 
     if (severity == LogSeverity::ERROR || severity == LogSeverity::FATAL) {
       sawError = true;
-      context.error(kj::str(text, "\nstack: ", strArray(trace, " "), stringifyStackTrace(trace)));
+      context.error(kj::str(text, "\nstack: ", stringifyStackTraceAddresses(trace), stringifyStackTrace(trace)));
     } else {
       context.warning(text);
     }


### PR DESCRIPTION
  Fixes stack format when KJ_HAS_LIBDL is defined