### PR TITLE
implement buffered forms of `AsyncIoMessageStream`/`AsyncCapabilityMessageStream`

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -169,6 +169,7 @@ includekj_HEADERS =                                            \
   src/kj/async-prelude.h                                       \
   src/kj/async.h                                               \
   src/kj/async-inl.h                                           \
+  src/kj/buffering.h                                           \
   src/kj/time.h                                                \
   src/kj/timer.h                                               \
   src/kj/async-unix.h                                          \
@@ -284,7 +285,7 @@ libkj_la_SOURCES=                                              \
   src/kj/thread.c++                                            \
   src/kj/time.c++                                              \
   src/kj/filesystem.c++                                        \
-  src/kj/filesystem-disk-unix.c++                                   \
+  src/kj/filesystem-disk-unix.c++                              \
   src/kj/filesystem-disk-win32.c++                             \
   src/kj/test-helpers.c++                                      \
   src/kj/main.c++                                              \
@@ -304,6 +305,7 @@ libkj_async_la_SOURCES=                                        \
   src/kj/async-io.c++                                          \
   src/kj/async-io-unix.c++                                     \
   src/kj/async-io-win32.c++                                    \
+  src/kj/buffering.c++                                         \
   src/kj/timer.c++
 
 if BUILD_KJ_GZIP

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -163,6 +163,13 @@ size_t computeSerializedSizeInWords(kj::ArrayPtr<const kj::ArrayPtr<const word>>
   return totalSize;
 }
 
+size_t computeHeaderSizeInWordsFromPrefix(word firstWord) {
+  const auto* table = reinterpret_cast<const _::WireValue<uint32_t>*>(&firstWord);
+
+  uint segmentCount = table[0].get() + 1;
+  return segmentCount / 2u + 1u;
+}
+
 // =======================================================================================
 
 InputStreamMessageReader::InputStreamMessageReader(

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -105,6 +105,9 @@ size_t computeSerializedSizeInWords(MessageBuilder& builder);
 size_t computeSerializedSizeInWords(kj::ArrayPtr<const kj::ArrayPtr<const word>> segments);
 // Version of computeSerializedSizeInWords that takes a raw segment array.
 
+size_t computeHeaderSizeInWordsFromPrefix(word firstWord);
+// Given the first word of a serialized message, determine the total size of the message header,
+
 size_t expectedSizeInWordsFromPrefix(kj::ArrayPtr<const word> messagePrefix);
 // Given a prefix of a serialized message, try to determine the expected total size of the message,
 // in words. The returned size is based on the information known so far; it may be an underestimate

--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -85,6 +85,7 @@ cc_library(
         "async-io-win32.c++",
         "async-unix.c++",
         "async-win32.c++",
+        "buffering.c++",
         "timer.c++",
     ],
     hdrs = [
@@ -95,6 +96,7 @@ cc_library(
         "async-queue.h",
         "async-unix.h",
         "async-win32.h",
+        "buffering.h",
         "timer.h",
     ],
     include_prefix = "kj",

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -122,6 +122,7 @@ set(kj-async_sources
   async-io-win32.c++
   async-io.c++
   async-io-unix.c++
+  buffering.c++
   timer.c++
 )
 set(kj-async_headers
@@ -132,6 +133,7 @@ set(kj-async_headers
   async-win32.h
   async-io.h
   async-queue.h
+  buffering.h
   timer.h
 )
 if(NOT CAPNP_LITE)

--- a/c++/src/kj/buffering.c++
+++ b/c++/src/kj/buffering.c++
@@ -1,0 +1,248 @@
+#include "buffering.h"
+#include <kj/debug.h>
+
+namespace kj {
+
+namespace _ {
+
+static inline uint lg(uint value) {
+  // Compute floor(log2(value)).
+  //
+  // Undefined for value = 0.
+#if _MSC_VER && !defined(__clang__)
+  unsigned long i;
+  auto found = _BitScanReverse(&i, value);
+  KJ_DASSERT(found);  // !found means value = 0
+  return i;
+#else
+  return sizeof(uint) * 8 - 1 - __builtin_clz(value);
+#endif
+}
+
+FdRangeInputBufferBase::FdRangeInputBufferBase(FdRangeInputBufferOptions options)
+    : options(options),
+      allBytes(heapArray<byte>(options.size)), fds(heapArray<AutoCloseFd>(options.maxFds)) {}
+
+ArrayPtr<byte> FdRangeInputBufferBase::getByteRange() {
+  KJ_SWITCH_ONEOF(state) {
+    KJ_CASE_ONEOF(_, Empty) {
+      return ArrayPtr<byte>(allBytes.begin(), size_t(0));
+    }
+    KJ_CASE_ONEOF(range, FdRange) {
+      return range.bytes;
+    }
+    KJ_CASE_ONEOF(ranges, TwoFdRange) {
+      return ranges.bytes;
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+void FdRangeInputBufferBase::setByteRange(ArrayPtr<byte> bytes) {
+  KJ_SWITCH_ONEOF(state) {
+    KJ_CASE_ONEOF(_, Empty) {
+      KJ_FAIL_ASSERT("buffer is empty");
+    }
+    KJ_CASE_ONEOF(range, FdRange) {
+      range.bytes = bytes;
+    }
+    KJ_CASE_ONEOF(ranges, TwoFdRange) {
+      ranges.bytes = bytes;
+    }
+  }
+}
+
+bool FdRangeInputBufferBase::overflowed() { return allBytes.size() > options.size; }
+
+FdRangeInputBufferBase::ReadParams FdRangeInputBufferBase::prepareForRead(size_t min) {
+  auto nextPowerOf2 = [](size_t n) {
+    // Round up to the next power of 2.
+    size_t result = 1u << (_::lg(n) + 1);
+    KJ_DASSERT(result > n);
+    KJ_DASSERT(result <= n * 2);
+    return result;
+  };
+
+  auto bytes = getByteRange();
+
+  auto spaceNeeded = bytes.size() + min;
+
+  if (spaceNeeded > allBytes.size()) {
+    // We need an overflow buffer. Allocate one (sized to the next power of 2 after spaceNeeded),
+    // copy our buffer into it, and empty the state of our old parent buffer.
+
+    auto overflow = heapArray<byte>(nextPowerOf2(spaceNeeded));
+    memcpy(overflow.begin(), bytes.begin(), bytes.size());
+    bytes = ArrayPtr<byte>(overflow.begin(), bytes.size());
+    setByteRange(bytes);
+
+    allBytes = mv(overflow);
+  } else if (bytes.begin() != allBytes.begin()) {
+    // Move range to front of buffer before reading
+    memmove(allBytes.begin(), bytes.begin(), bytes.size());
+    bytes = ArrayPtr<byte>(allBytes.begin(), bytes.size());
+    setByteRange(bytes);
+  }
+
+  size_t max = min;
+  if (allBytes.size() == options.size) {
+    // Optimization: allow reading up to the end of the parent buffer
+    // when it is not an overflow buffer.
+    max = allBytes.size() - bytes.size();
+  }
+
+  return ReadParams{ bytes.end(), max };
+}
+
+void FdRangeInputBufferBase::handleReadResult(size_t byteCount, Array<AutoCloseFd> fds) {
+  KJ_SWITCH_ONEOF(state) {
+    KJ_CASE_ONEOF(_, FdRangeInputBufferBase::Empty) {
+      state = FdRangeInputBufferBase::FdRange {
+          ArrayPtr<byte>(allBytes.begin(), byteCount), mv(fds) };
+    }
+    KJ_CASE_ONEOF(range, FdRangeInputBufferBase::FdRange) {
+      KJ_DASSERT(range.bytes.begin() = allBytes.begin());
+      if (range.fds.size()) {
+        // The current range already has some FDs.
+        // We need to handle this by treating the extra bytes as part of a new FD range.
+        auto two = FdRangeInputBufferBase::FdRange {
+            ArrayPtr<byte>(range.bytes.end(), byteCount), mv(fds) };
+
+        state = FdRangeInputBufferBase::TwoFdRange {
+          ArrayPtr<byte>(range.bytes.begin(), range.bytes.size() + byteCount),
+          mv(range.fds),
+          mv(fds),
+          range.bytes.size()
+        };
+      } else {
+        // We can treat this read as an extension of the existing FD range.
+        state = FdRangeInputBufferBase::FdRange {
+            ArrayPtr<byte>(range.bytes.begin(), range.bytes.size() + byteCount),
+            mv(fds) };
+      }
+    }
+    KJ_CASE_ONEOF(ranges, FdRangeInputBufferBase::TwoFdRange) {
+      KJ_DASSERT(ranges.bytes.begin() = allBytes.begin());
+      KJ_REQUIRE(ranges.twoFds.size() == 0, "Cannot buffer more than two FD ranges at once.");
+
+      ranges.bytes = ArrayPtr<byte>(ranges.bytes.begin(), ranges.bytes.size() + byteCount);
+      ranges.twoFds = mv(fds);
+    }
+  }
+}
+
+Own<RetainableRange> FdRangeInputBufferBase::split(size_t splitAt) {
+  auto bytes = getByteRange();
+  auto newSize = bytes.size() - splitAt;
+
+  Own<RetainableRange> result;
+  if (overflowed()) {
+    // This is an overflow buffer, so when we call `split` it's expected that we split out
+    // the entire contents of the buffer, and the buffer has a single FD range in it.
+
+    KJ_REQUIRE(newSize == 0,
+        "Attempted to split() an overflow buffer such that leftover bytes would be left inside.");
+    result = refcounted<RetainableRange>(Badge<FdRangeInputBufferBase>(),
+        mv(allBytes), ArrayPtr<byte>(bytes.begin(), splitAt), nullptr);
+    allBytes = heapArray<byte>(options.size);
+  } else {
+    result = refcounted<RetainableRange>(Badge<FdRangeInputBufferBase>(),
+        *this, ArrayPtr<byte>(bytes.begin(), splitAt), nullptr);
+  }
+
+  auto newFront = bytes.begin() + splitAt;
+  bytes = ArrayPtr<byte>(newFront, newSize);
+
+  KJ_SWITCH_ONEOF(state) {
+    KJ_CASE_ONEOF(_, FdRangeInputBufferBase::Empty) {
+      KJ_FAIL_ASSERT("Cannot call split() on empty range");
+    }
+    KJ_CASE_ONEOF(range, FdRangeInputBufferBase::FdRange) {
+      if (newSize == 0) {
+        result->fds = mv(range.fds);
+        state = FdRangeInputBufferBase::Empty{};
+      } else {
+        range.bytes = bytes;
+      }
+    }
+    KJ_CASE_ONEOF(ranges, FdRangeInputBufferBase::TwoFdRange) {
+      if (newSize == 0) {
+        KJ_REQUIRE(ranges.twoFds.size() == 0, "split() cannot include FDs from two ranges",
+              ranges.bytes.size(), ranges.lengthOfFirstRange, ranges.oneFds.size(), ranges.twoFds.size());
+
+        result->fds = mv(ranges.oneFds);
+        state = FdRangeInputBufferBase::Empty{};
+      } else if (splitAt >= ranges.lengthOfFirstRange) {
+        result->fds = mv(ranges.oneFds);
+        state = FdRangeInputBufferBase::FdRange { bytes, mv(ranges.twoFds) };
+      } else {
+        ranges.bytes = bytes;
+        ranges.lengthOfFirstRange -= splitAt;
+      }
+    }
+  }
+  return mv(result);
+}
+
+} // namespace _
+
+RetainableRange::RetainableRange(Badge<_::FdRangeInputBufferBase>,
+    _::FdRangeInputBufferBase& parent, ArrayPtr<byte> range, Array<AutoCloseFd> fds)
+    : parentOrRetainedBytes(&parent),
+      range(range),
+      fds(mv(fds)) {}
+
+RetainableRange::RetainableRange(Badge<_::FdRangeInputBufferBase>,
+    Array<byte> ownBytes, ArrayPtr<byte> range, Array<AutoCloseFd> fds)
+    : parentOrRetainedBytes(mv(ownBytes)),
+      range(range),
+      fds(mv(fds)) {}
+
+void RetainableRange::retainLongTerm() {
+  KJ_SWITCH_ONEOF(parentOrRetainedBytes) {
+    KJ_CASE_ONEOF(parent, _::FdRangeInputBufferBase*) {
+      Array<byte> ownBytes;
+      if (range.size() > parent->allBytes.size() * parent->options.retainRatio) {
+        // Take ownership of our parent's bytes, and allocate a new buffer for the parent.
+        ownBytes = mv(parent->allBytes);
+
+        // Note that at this point the FdRanges don't contain the retained range anymore,
+        // as it was already split off. So we can directly copy the FdRanges to the beginning
+        // of the newly allocated buffer.
+        KJ_SWITCH_ONEOF(parent->state) {
+          KJ_CASE_ONEOF(_, _::FdRangeInputBufferBase::Empty) {
+            // Nothing to do here
+          }
+          KJ_CASE_ONEOF(range, _::FdRangeInputBufferBase::FdRange) {
+            auto newParentBuffer = heapArray<byte>(ownBytes.size());
+            memcpy(newParentBuffer.begin(), range.bytes.begin(), range.bytes.size());
+
+            range.bytes = ArrayPtr<byte>(newParentBuffer.begin(), range.bytes.size());
+
+            parent->allBytes = mv(newParentBuffer);
+          }
+          KJ_CASE_ONEOF(ranges, _::FdRangeInputBufferBase::TwoFdRange) {
+            auto newParentBuffer = heapArray<byte>(ownBytes.size());
+            memcpy(newParentBuffer.begin(), ranges.bytes.begin(), ranges.bytes.size());
+
+            ranges.bytes = ArrayPtr<byte>(newParentBuffer.begin(), ranges.bytes.size());
+
+            parent->allBytes = mv(newParentBuffer);
+          }
+        }
+      } else {
+        // Perform a copy from the parent buffer.
+        ownBytes = heapArray<byte>(range.size());
+        memcpy(ownBytes.begin(), range.begin(), range.size());
+      }
+
+      range = ownBytes;
+      parentOrRetainedBytes = mv(ownBytes);
+    }
+    KJ_CASE_ONEOF(_, Array<byte>) {
+      // Nothing to do here, already retained.
+    }
+  }
+}
+
+} // namespace kj

--- a/c++/src/kj/buffering.h
+++ b/c++/src/kj/buffering.h
@@ -1,0 +1,237 @@
+#pragma once
+
+#include <kj/common.h>
+#include <kj/async.h>
+#include <kj/io.h>
+#include <kj/async-io.h>
+#include <kj/one-of.h>
+#include <kj/debug.h>
+
+KJ_BEGIN_HEADER
+
+namespace kj {
+
+// =======================================================================================
+// Buffered reading helpers
+
+struct FdRangeInputBufferOptions {
+  size_t size;
+  // Size of the buffer in bytes.
+
+  size_t maxFds;
+  // Max number of FDs allowed in a single underlying read.
+
+  double retainRatio = 0.8;
+  // When a `RetainableRange` occupies more than `retainRatio` of the buffer,
+  // `retain()` will transfer ownership of the buffer and allocate a new one instead
+  // of performing a copy.
+};
+
+struct EndOfFile{};
+class RetainableRange;
+
+namespace _ {
+
+class FdRangeInputBufferBase {
+protected:
+  FdRangeInputBufferBase(FdRangeInputBufferOptions options);
+
+  FdRangeInputBufferOptions options;
+  Array<byte> allBytes;
+  Array<AutoCloseFd> fds;
+
+  struct Empty {
+    bool eof = false;
+  };
+  struct FdRange {
+    ArrayPtr<byte> bytes;
+    Array<AutoCloseFd> fds;
+  };
+  struct TwoFdRange {
+    ArrayPtr<byte> bytes;
+    Array<AutoCloseFd> oneFds;
+    Array<AutoCloseFd> twoFds;
+    size_t lengthOfFirstRange;
+  };
+  OneOf<Empty, FdRange, TwoFdRange> state = Empty{};
+
+  ArrayPtr<byte> getByteRange();
+  void setByteRange(ArrayPtr<byte> bytes);
+  bool overflowed();
+
+  struct ReadParams {
+    void* start;
+    size_t max;
+  };
+  ReadParams prepareForRead(size_t min);
+  void handleReadResult(size_t byteCount, Array<AutoCloseFd> fds);
+
+  Own<RetainableRange> split(size_t splitAt);
+
+  friend class ::kj::RetainableRange;
+};
+
+} // namespace _
+
+template<typename Stream>
+class FdRangeInputBuffer : _::FdRangeInputBufferBase {
+  // A buffer of up to two FD ranges that can be filled by reading from a stream.
+  //
+  // An FD range is defined as a range of bytes with FDs associated with the last byte in the range.
+  // FDs being associated with the last byte of the range is for the purpose of the buffering logic,
+  // resulting from the rules of SCM_RIGHTS control messages where a read that includes FDs will not
+  // read past the last byte written by the other side of the socket. One can infer from this rule,
+  // that if the other side of the socket sent multiple messages, any FDs received are part of the
+  // last message in the FD range.
+  //
+  // The buffer is emptied by splitting off prefixes of it. If a split-off prefix includes the last
+  // byte of an FD range with FDs, those FDs are also split off.
+  //
+  // The limit of two buffered FD ranges results from the optimization described in `Handle::append`.
+  // It's necessary to create a new FD range if the existing range already had FDs in it,
+  // otherwise it's safe to extend the existing range.
+  //
+  // It is assumed that when two FD ranges are buffered, once FDs are associated with the second range,
+  // then a complete "message" is present in some prefix of the buffer, and this prefix is >= the
+  // size of the first FD range. The caller must split this prefix out of the buffer
+  // before attempting to read any more bytes into the buffer.
+
+public:
+  KJ_DISALLOW_COPY(FdRangeInputBuffer);
+
+  FdRangeInputBuffer(Stream& stream, FdRangeInputBufferOptions options);
+
+  class Handle final {
+    // A handle to access a non-empty `FdRangeInputBuffer`
+    // Prefixes of the buffer can be split off and retained for long-term usage.
+
+  public:
+    inline ArrayPtr<byte> peek() { return parent.getByteRange(); }
+
+    inline Own<RetainableRange> split(size_t splitAt) { return parent.split(splitAt); }
+    // Splits off the range before splitAt and returns it.
+    // The returned range is consumed from the buffer, such that it will not be viewable through the
+    // Handle again.
+    //
+    // Splitting such that FDs from two underlying reads would be included is an error.
+
+    inline Promise<size_t> append(size_t min) { return parent.tryRead(min); }
+    // Append at least `min` bytes to the end of the range.
+    // Returns the actual # of bytes read, or 0 on EOF.
+    //
+    // If the current range + `min` does not fit in the buffer,
+    // a new buffer (owned by this range) will be allocated.
+    //
+    // As an optimization, if the current range + `min` DOES fit in the buffer AND the buffer has not
+    // overflowed, the underlying `read` call will allow reading up until the end of the buffer
+    // (i.e more than `min`).
+
+  protected:
+    FdRangeInputBuffer& parent;
+
+    Handle(FdRangeInputBuffer& parent) : parent(parent) {};
+    friend class FdRangeInputBuffer;
+  };
+
+  OneOf<EndOfFile, Promise<void>, Handle> tryStartRead();
+  // Start a new top-level read, returning a handle to the buffer if it has some bytes in it.
+  //
+  // If the buffer is empty, returns a promise representing a read operation for as many bytes are
+  // available on the underlying stream up to the capacity of the buffer. Calling `tryStartRead`
+  // again after this promise resolves should either return Handle or EOF
+
+private:
+  Stream& stream;
+  Promise<size_t> tryRead(size_t min);
+};
+
+class RetainableRange final : public Refcounted {
+  // A handle to access a partial range of bytes in an `FdRangeInputBuffer`, that may be used to
+  // retain the range for long-term ownership.
+
+public:
+  KJ_DISALLOW_COPY(RetainableRange);
+
+  inline ArrayPtr<byte> getBytes() { return range; }
+  inline ArrayPtr<AutoCloseFd> getFds() { return fds; }
+
+  void retainLongTerm();
+  // Request ownership of this range from the FdRangeInputBuffer. The buffer may choose to perform
+  // a copy, or transfer ownership of the buffer and allocate a new one to replace it.
+
+
+  RetainableRange(Badge<_::FdRangeInputBufferBase>,
+      _::FdRangeInputBufferBase& parent, ArrayPtr<byte> range, Array<AutoCloseFd> fds);
+  RetainableRange(Badge<_::FdRangeInputBufferBase>,
+      Array<byte> ownBytes, ArrayPtr<byte> range, Array<AutoCloseFd> fds);
+  // Public for kj::refcounted
+
+private:
+  OneOf<_::FdRangeInputBufferBase*, Array<byte>> parentOrRetainedBytes;
+  ArrayPtr<byte> range;
+  Array<AutoCloseFd> fds;
+
+  friend class _::FdRangeInputBufferBase;
+};
+
+// =======================================================================================
+// inline implementation details
+
+template<typename Stream>
+FdRangeInputBuffer<Stream>::FdRangeInputBuffer(Stream& stream, FdRangeInputBufferOptions options)
+    : _::FdRangeInputBufferBase(options), stream(stream) {}
+
+template<typename Stream>
+OneOf<EndOfFile, Promise<void>, typename FdRangeInputBuffer<Stream>::Handle>
+FdRangeInputBuffer<Stream>::tryStartRead() {
+  if (overflowed() && getByteRange().size() > 0) {
+    KJ_FAIL_REQUIRE(
+        "Must read all bytes out of overflow buffer before starting a new top-level read.");
+  }
+
+  KJ_IF_MAYBE(empty, state.tryGet<Empty>()) {
+    if (empty->eof) return EndOfFile{};
+
+    return tryRead(1).ignoreResult();
+  }
+
+  return Handle{ *this };
+}
+
+template<>
+inline Promise<size_t> FdRangeInputBuffer<AsyncInputStream>::tryRead(size_t min) {
+  auto params = prepareForRead(min);
+  return stream.tryRead(params.start, min, params.max).then([this](size_t n) {
+    handleReadResult(n, nullptr);
+    return n;
+  });
+}
+
+template<>
+inline Promise<size_t> FdRangeInputBuffer<AsyncIoStream>::tryRead(size_t min) {
+  auto params = prepareForRead(min);
+  return stream.tryRead(params.start, min, params.max).then([this](size_t n) {
+    handleReadResult(n, nullptr);
+    return n;
+  });
+}
+
+template<>
+inline Promise<size_t> FdRangeInputBuffer<AsyncCapabilityStream>::tryRead(size_t min) {
+  auto params = prepareForRead(min);
+  return stream.tryReadWithFds(params.start, min, params.max, fds.begin(), fds.size())
+      .then([this](auto result) {
+    Array<AutoCloseFd> newFds;
+    if (result.capCount > 0) {
+      newFds = fds.slice(0, result.capCount).attach(mv(fds));
+      fds = heapArray<AutoCloseFd>(options.maxFds);
+    }
+
+    handleReadResult(result.byteCount, mv(newFds));
+    return result.byteCount;
+  });
+}
+
+} // namespace kj
+
+KJ_END_HEADER

--- a/style-guide.md
+++ b/style-guide.md
@@ -351,9 +351,9 @@ Now people can use your template metafunction without the pesky `::Type` or `::v
         template <typename T>
         Wrapper<T> makeWrapper(T&& inner);
         // Wraps `inner` and returns the wrapper.
-  
+
   Should `inner` be taken by reference or by value here? Both might be useful, depending on the use case. The right answer is actually to support both: if the input is an lvalue, take it by reference, but if it's an rvalue, take it by value (move). And as it turns out, if you write your declaration exactly as shown above, this is exactly what you get, because if the input is an lvalue, `T` will implicitly bind to a reference type, whereas if the input is an rvalue or rvalue reference, T will not be a reference.
-  
+
   In general, you should assume KJ code in this pattern uses this rule, so if you are passing in an lvalue but don't actually want it wrapped by reference, wrap it in `kj::mv()`.
 
 * Never use function or method pointers. Prefer templating across functors (like STL does), or for non-templates use `kj::Function` (which will handle this for you).


### PR DESCRIPTION
Capnp's async message reading was particularly syscall heavy, as it read the first segment, segment tables, and each segment in separate calls. This PR introduces buffered readers, that read a batch of messages at once which significantly reduces the number of syscalls required to read messages.

I fixed some of the nits from the first review of this and the flaky test. I'm a bit unhappy that this implementation doesn't make use of `scratchSpace` and is lacking smarts on reusing the read buffer, but I don't think fixing that is going to massively change the structure of the PR so I'm putting up what I have for now.