### PR TITLE
Prefer __is_trivially_constructible etc. intrinsics

### DIFF
--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -1573,12 +1573,12 @@ DynamicValue::Builder::Builder(Builder& other) {
       // Unfortunately canMemcpy() doesn't work on these types due to the use of
       // DisallowConstCopy, but __has_trivial_destructor should detect if any of these types
       // become non-trivial.
-      static_assert(__has_trivial_destructor(Text::Builder) &&
-                    __has_trivial_destructor(Data::Builder) &&
-                    __has_trivial_destructor(DynamicList::Builder) &&
-                    __has_trivial_destructor(DynamicEnum) &&
-                    __has_trivial_destructor(DynamicStruct::Builder) &&
-                    __has_trivial_destructor(AnyPointer::Builder),
+      static_assert(KJ_HAS_TRIVIAL_DESTRUCTOR(Text::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(Data::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicList::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicEnum) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicStruct::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(AnyPointer::Builder),
                     "Assumptions here don't hold.");
       break;
 
@@ -1607,12 +1607,12 @@ DynamicValue::Builder::Builder(Builder&& other) noexcept {
       // Unfortunately __has_trivial_copy doesn't work on these types due to the use of
       // DisallowConstCopy, but __has_trivial_destructor should detect if any of these types
       // become non-trivial.
-      static_assert(__has_trivial_destructor(Text::Builder) &&
-                    __has_trivial_destructor(Data::Builder) &&
-                    __has_trivial_destructor(DynamicList::Builder) &&
-                    __has_trivial_destructor(DynamicEnum) &&
-                    __has_trivial_destructor(DynamicStruct::Builder) &&
-                    __has_trivial_destructor(AnyPointer::Builder),
+      static_assert(KJ_HAS_TRIVIAL_DESTRUCTOR(Text::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(Data::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicList::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicEnum) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicStruct::Builder) &&
+                    KJ_HAS_TRIVIAL_DESTRUCTOR(AnyPointer::Builder),
                     "Assumptions here don't hold.");
       break;
 

--- a/c++/src/kj/arena.h
+++ b/c++/src/kj/arena.h
@@ -134,11 +134,11 @@ private:
 template <typename T, typename... Params>
 T& Arena::allocate(Params&&... params) {
   T& result = *reinterpret_cast<T*>(allocateBytes(
-      sizeof(T), alignof(T), !__has_trivial_destructor(T)));
-  if (!__has_trivial_constructor(T) || sizeof...(Params) > 0) {
+      sizeof(T), alignof(T), !KJ_HAS_TRIVIAL_DESTRUCTOR(T)));
+  if (!KJ_HAS_TRIVIAL_CONSTRUCTOR(T) || sizeof...(Params) > 0) {
     ctor(result, kj::fwd<Params>(params)...);
   }
-  if (!__has_trivial_destructor(T)) {
+  if (!KJ_HAS_TRIVIAL_DESTRUCTOR(T)) {
     setDestructor(&result, &destroyObject<T>);
   }
   return result;
@@ -146,11 +146,11 @@ T& Arena::allocate(Params&&... params) {
 
 template <typename T>
 ArrayPtr<T> Arena::allocateArray(size_t size) {
-  if (__has_trivial_destructor(T)) {
+  if (KJ_HAS_TRIVIAL_DESTRUCTOR(T)) {
     ArrayPtr<T> result =
         arrayPtr(reinterpret_cast<T*>(allocateBytes(
             sizeof(T) * size, alignof(T), false)), size);
-    if (!__has_trivial_constructor(T)) {
+    if (!KJ_HAS_TRIVIAL_CONSTRUCTOR(T)) {
       for (size_t i = 0; i < size; i++) {
         ctor(result[i]);
       }
@@ -165,7 +165,7 @@ ArrayPtr<T> Arena::allocateArray(size_t size) {
         arrayPtr(reinterpret_cast<T*>(reinterpret_cast<byte*>(base) + prefixSize), size);
     setDestructor(base, &destroyArray<T>);
 
-    if (__has_trivial_constructor(T)) {
+    if (KJ_HAS_TRIVIAL_CONSTRUCTOR(T)) {
       tag = size;
     } else {
       // In case of constructor exceptions, we need the tag to end up storing the number of objects
@@ -183,7 +183,7 @@ ArrayPtr<T> Arena::allocateArray(size_t size) {
 template <typename T, typename... Params>
 Own<T> Arena::allocateOwn(Params&&... params) {
   T& result = *reinterpret_cast<T*>(allocateBytes(sizeof(T), alignof(T), false));
-  if (!__has_trivial_constructor(T) || sizeof...(Params) > 0) {
+  if (!KJ_HAS_TRIVIAL_CONSTRUCTOR(T) || sizeof...(Params) > 0) {
     ctor(result, kj::fwd<Params>(params)...);
   }
   return Own<T>(&result, DestructorOnlyDisposer<T>::instance);

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -56,7 +56,7 @@ public:
   // an exception.
 
 private:
-  template <typename T, bool hasTrivialDestructor = __has_trivial_destructor(T)>
+  template <typename T, bool hasTrivialDestructor = KJ_HAS_TRIVIAL_DESTRUCTOR(T)>
   struct Dispose_;
 };
 
@@ -285,8 +285,8 @@ private:
   virtual void disposeImpl(void* firstElement, size_t elementSize, size_t elementCount,
                            size_t capacity, void (*destroyElement)(void*)) const override;
 
-  template <typename T, bool hasTrivialConstructor = __has_trivial_constructor(T),
-                        bool hasNothrowConstructor = __has_nothrow_constructor(T)>
+  template <typename T, bool hasTrivialConstructor = KJ_HAS_TRIVIAL_CONSTRUCTOR(T),
+                        bool hasNothrowConstructor = KJ_HAS_NOTHROW_CONSTRUCTOR(T)>
   struct Allocate_;
 };
 
@@ -417,7 +417,7 @@ public:
     KJ_IREQUIRE(size <= this->size(), "can't use truncate() to expand");
 
     T* target = ptr + size;
-    if (__has_trivial_destructor(T)) {
+    if (KJ_HAS_TRIVIAL_DESTRUCTOR(T)) {
       pos = target;
     } else {
       while (pos > target) {
@@ -427,7 +427,7 @@ public:
   }
 
   void clear() {
-    if (__has_trivial_destructor(T)) {
+    if (KJ_HAS_TRIVIAL_DESTRUCTOR(T)) {
       pos = ptr;
     } else {
       while (pos > ptr) {
@@ -442,7 +442,7 @@ public:
     T* target = ptr + size;
     if (target > pos) {
       // expand
-      if (__has_trivial_constructor(T)) {
+      if (KJ_HAS_TRIVIAL_CONSTRUCTOR(T)) {
         pos = target;
       } else {
         while (pos < target) {
@@ -451,7 +451,7 @@ public:
       }
     } else {
       // truncate
-      if (__has_trivial_destructor(T)) {
+      if (KJ_HAS_TRIVIAL_DESTRUCTOR(T)) {
         pos = target;
       } else {
         while (pos > target) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -422,6 +422,14 @@ KJ_NORETURN(void unreachable());
 // =======================================================================================
 // Template metaprogramming helpers.
 
+#define KJ_HAS_NOTHROW_CONSTRUCTOR __is_nothrow_constructible
+#define KJ_HAS_TRIVIAL_CONSTRUCTOR __is_trivially_constructible
+#if __GNUC__ && !__clang__
+#define KJ_HAS_TRIVIAL_DESTRUCTOR __has_trivial_destructor
+#else
+#define KJ_HAS_TRIVIAL_DESTRUCTOR __is_trivially_destructible
+#endif
+
 template <typename T> struct NoInfer_ { typedef T Type; };
 template <typename T> using NoInfer = typename NoInfer_<T>::Type;
 // Use NoInfer<T>::Type in place of T for a template function parameter to prevent inference of

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -423,10 +423,11 @@ KJ_NORETURN(void unreachable());
 // Template metaprogramming helpers.
 
 #define KJ_HAS_NOTHROW_CONSTRUCTOR __is_nothrow_constructible
-#define KJ_HAS_TRIVIAL_CONSTRUCTOR __is_trivially_constructible
 #if __GNUC__ && !__clang__
+#define KJ_HAS_TRIVIAL_CONSTRUCTOR __has_trivial_constructor
 #define KJ_HAS_TRIVIAL_DESTRUCTOR __has_trivial_destructor
 #else
+#define KJ_HAS_TRIVIAL_CONSTRUCTOR __is_trivially_constructible
 #define KJ_HAS_TRIVIAL_DESTRUCTOR __is_trivially_destructible
 #endif
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -422,12 +422,12 @@ KJ_NORETURN(void unreachable());
 // =======================================================================================
 // Template metaprogramming helpers.
 
-#define KJ_HAS_NOTHROW_CONSTRUCTOR __is_nothrow_constructible
+#define KJ_HAS_TRIVIAL_CONSTRUCTOR __is_trivially_constructible
 #if __GNUC__ && !__clang__
-#define KJ_HAS_TRIVIAL_CONSTRUCTOR __has_trivial_constructor
+#define KJ_HAS_NOTHROW_CONSTRUCTOR __has_nothrow_constructor
 #define KJ_HAS_TRIVIAL_DESTRUCTOR __has_trivial_destructor
 #else
-#define KJ_HAS_TRIVIAL_CONSTRUCTOR __is_trivially_constructible
+#define KJ_HAS_NOTHROW_CONSTRUCTOR __is_nothrow_constructible
 #define KJ_HAS_TRIVIAL_DESTRUCTOR __is_trivially_destructible
 #endif
 


### PR DESCRIPTION
__has_trivial_constructor etc. are deprecated since Clang 15: https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release

> Some type-trait builtins, such as `__has_trivial_assign`, have been documented as deprecated for a while because their semantics don’t mix well with post-C++11 type-traits. Clang now emits deprecation warnings for them under the flag `-Wdeprecated-builtins`.