### PR TITLE
use size when converting between std::string and kj::String

### DIFF
--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -92,14 +92,19 @@ public:
 #endif
 
 #if KJ_COMPILER_SUPPORTS_STL_STRING_INTEROP
-  template <typename T, typename = decltype(instance<T>().c_str())>
-  inline StringPtr(const T& t KJ_LIFETIMEBOUND): StringPtr(t.c_str()) {}
+  template <
+    typename T,
+    typename = decltype(instance<T>().c_str()),
+    typename = decltype(instance<T>().size())>
+  inline StringPtr(const T& t KJ_LIFETIMEBOUND): StringPtr(t.c_str(), t.size()) {}
   // Allow implicit conversion from any class that has a c_str() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for
   // those who don't want it.
-
-  template <typename T, typename = decltype(instance<T>().c_str())>
-  inline operator T() const { return cStr(); }
+  template <
+    typename T,
+    typename = decltype(instance<T>().c_str()),
+    typename = decltype(instance<T>().size())>
+  inline operator T() const { return {cStr(), size()}; }
   // Allow implicit conversion to any class that has a c_str() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for
   // those who don't want it.

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -97,7 +97,7 @@ public:
     typename = decltype(instance<T>().c_str()),
     typename = decltype(instance<T>().size())>
   inline StringPtr(const T& t KJ_LIFETIMEBOUND): StringPtr(t.c_str(), t.size()) {}
-  // Allow implicit conversion from any class that has a c_str() method (namely, std::string).
+  // Allow implicit conversion from any class that has a c_str() and a size() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for
   // those who don't want it.
   template <
@@ -105,7 +105,7 @@ public:
     typename = decltype(instance<T>().c_str()),
     typename = decltype(instance<T>().size())>
   inline operator T() const { return {cStr(), size()}; }
-  // Allow implicit conversion to any class that has a c_str() method (namely, std::string).
+  // Allow implicit conversion to any class that has a c_str() method and a size() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for
   // those who don't want it.
 #endif


### PR DESCRIPTION
Avoids a call to ::strlen(), but will now copy any embedded null characters and beyond.