### PR TITLE
Add `getPreferredExtensions()` to WebSocket class

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2638,7 +2638,7 @@ public:
   uint64_t receivedByteCount() override { return receivedBytes; }
 
   kj::Maybe<kj::String> getPreferredExtensions(ExtensionsContext ctx) override {
-     if (maskKeyGenerator == nullptr) {
+    if (maskKeyGenerator == nullptr) {
       // `this` is the server side of a websocket.
       if (ctx == ExtensionsContext::REQUEST) {
         // The other WebSocket is (going to be) the client side of a WebSocket, i.e. this is a

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -655,10 +655,9 @@ public:
   // certain extensions (e.g. compression settings), then this method returns what those extensions
   // are. For example, matching extensions between standard WebSockets allows pumping to be
   // implemented by pumping raw bytes between network connections, without reading individual frames.
-
+  //
   // A null return value indicates that there is no preference. A non-null return value containing
   // an empty string indicates a preference for no extensions to be applied.
-
 };
 
 class HttpClient {

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -643,6 +643,22 @@ public:
 
   virtual uint64_t sentByteCount() = 0;
   virtual uint64_t receivedByteCount() = 0;
+
+  enum ExtensionsContext {
+    // Indicate whether a Sec-WebSocket-Extension header should be rendered for use in request
+    // headers or response headers.
+    REQUEST,
+    RESPONSE
+  };
+  virtual kj::Maybe<kj::String> getPreferredExtensions(ExtensionsContext ctx) { return nullptr; }
+  // If pumpTo() / tryPumpFrom() is able to be optimized only if the other WebSocket is using
+  // certain extensions (e.g. compression settings), then this method returns what those extensions
+  // are. For example, matching extensions between standard WebSockets allows pumping to be
+  // implemented by pumping raw bytes between network connections, without reading individual frames.
+
+  // A null return value indicates that there is no preference. A non-null return value containing
+  // an empty string indicates a preference for no extensions to be applied.
+
 };
 
 class HttpClient {


### PR DESCRIPTION
As mentioned in the PR to enable compression in Workers, I suspect we don't need to extract the extensions from the websocket. Happy to do that if I'm mistaken, though in that case I may have a follow up question regarding the fact that a KJ websocket is unaware whether it's on the client/server side. This makes it a bit tricky to determine if `inbound` maps to client or server (unless we know for certain whether our websocket is client or server side).