### PR TITLE
Allow file IDs to be omitted when using `capnp eval`.

### DIFF
--- a/c++/src/capnp/compiler/capnp-test.sh
+++ b/c++/src/capnp/compiler/capnp-test.sh
@@ -119,6 +119,9 @@ test_eval 'TestListDefaults.lists.int32ListList[2][0]' 12341234
 
 test "x`$CAPNP eval $SCHEMA -ojson globalPrintableStruct | tr -d '\r'`" = "x{\"someText\": \"foo\"}" || fail eval json "globalPrintableStruct == {someText = \"foo\"}"
 
+$CAPNP eval $TESTDATA/no-file-id.capnp.nobuild foo >/dev/null || fail eval "file without file ID can be parsed"
+test "x`$CAPNP eval $TESTDATA/no-file-id.capnp.nobuild foo | tr -d '\r'`" = 'x"bar"' || fail eval "file without file ID parsed correctly"
+
 $CAPNP compile --no-standard-import --src-prefix="$PREFIX" -ofoo $TESTDATA/errors.capnp.nobuild 2>&1 | sed -e "s,^.*errors[.]capnp[.]nobuild:,file:,g" | tr -d '\r' |
     diff -u $TESTDATA/errors.txt - || fail error output
 

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -249,6 +249,12 @@ public:
     // Default convert to text unless -o is given.
     convertTo = Format::TEXT;
 
+    // When using `capnp eval`, type IDs don't really matter, because `eval` won't actually use
+    // them for anything. When using Cap'n Proto an a config format -- the common use case for
+    // `capnp eval` -- the exercise of adding a file ID to every file is pointless busy work. So,
+    // we don't require it.
+    loader.setFileIdsRequired(false);
+
     kj::MainBuilder builder(context, VERSION_STRING,
           "Prints (or encodes) the value of <name>, which must be defined in <schema-file>.  "
           "<name> must refer to a const declaration, a field of a struct type (prints the default "

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -137,10 +137,14 @@ public:
   kj::Maybe<kj::Array<const byte>> readEmbedFromSearchPath(kj::PathPtr path);
   GlobalErrorReporter& getErrorReporter() { return errorReporter; }
 
+  void setFileIdsRequired(bool value) { fileIdsRequired = value; }
+  bool areFileIdsRequired() { return fileIdsRequired; }
+
 private:
   GlobalErrorReporter& errorReporter;
   kj::Vector<const kj::ReadableDirectory*> searchPath;
   std::unordered_map<FileKey, kj::Own<Module>, FileKeyHash> modules;
+  bool fileIdsRequired = true;
 };
 
 class ModuleLoader::ModuleImpl final: public Module {
@@ -171,7 +175,7 @@ public:
     lex(content, statements, *this);
 
     auto parsed = orphanage.newOrphan<ParsedFile>();
-    parseFile(statements.getStatements(), parsed.get(), *this);
+    parseFile(statements.getStatements(), parsed.get(), *this, loader.areFileIdsRequired());
     return parsed;
   }
 
@@ -280,6 +284,10 @@ void ModuleLoader::addImportPath(const kj::ReadableDirectory& dir) {
 
 kj::Maybe<Module&> ModuleLoader::loadModule(const kj::ReadableDirectory& dir, kj::PathPtr path) {
   return impl->loadModule(dir, path);
+}
+
+void ModuleLoader::setFileIdsRequired(bool value) {
+  return impl->setFileIdsRequired(value);
 }
 
 }  // namespace compiler

--- a/c++/src/capnp/compiler/module-loader.h
+++ b/c++/src/capnp/compiler/module-loader.h
@@ -49,6 +49,10 @@ public:
   // Tries to load a module with the given path inside the given directory. Returns nullptr if the
   // file doesn't exist.
 
+  void setFileIdsRequired(bool value);
+  // Same as SchemaParser::setFileIdsRequired(). If set false, files will not be required to have
+  // a top-level file ID; if missing a random one will be assigned.
+
 private:
   class Impl;
   kj::Own<Impl> impl;

--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -70,7 +70,7 @@ uint64_t generateRandomId() {
 }
 
 void parseFile(List<Statement>::Reader statements, ParsedFile::Builder result,
-               ErrorReporter& errorReporter) {
+               ErrorReporter& errorReporter, bool requiresId) {
   CapnpParser parser(Orphanage::getForMessageContaining(result), errorReporter);
 
   kj::Vector<Orphan<Declaration>> decls(statements.size());
@@ -111,7 +111,7 @@ void parseFile(List<Statement>::Reader statements, ParsedFile::Builder result,
 
     // Don't report missing ID if there was a parse error, because quite often the parse error
     // prevents us from parsing the ID even though it is actually there.
-    if (!errorReporter.hadErrors()) {
+    if (requiresId && !errorReporter.hadErrors()) {
       errorReporter.addError(0, 0,
           kj::str("File does not declare an ID.  I've generated one for you.  Add this line to "
                   "your file: @0x", kj::hex(id), ";"));

--- a/c++/src/capnp/compiler/parser.h
+++ b/c++/src/capnp/compiler/parser.h
@@ -33,7 +33,7 @@ namespace capnp {
 namespace compiler {
 
 void parseFile(List<Statement>::Reader statements, ParsedFile::Builder result,
-               ErrorReporter& errorReporter);
+               ErrorReporter& errorReporter, bool requiresId);
 // Parse a list of statements to build a ParsedFile.
 //
 // If any errors are reported, then the output is not usable.  However, it may be passed on through

--- a/c++/src/capnp/schema-parser-test.c++
+++ b/c++/src/capnp/schema-parser-test.c++
@@ -272,5 +272,27 @@ TEST(SchemaParser, SourceInfo) {
   expectSourceInfo(thud.getSourceInfo(), 0xcca9972702b730b4, "post-comment\n", {});
 }
 
+TEST(SchemaParser, SetFileIdsRequired) {
+  FakeFileReader reader;
+  reader.add("no-file-id.capnp",
+      "const foo :Int32 = 123;\n");
+
+  {
+    SchemaParser parser;
+    parser.setDiskFilesystem(reader);
+
+    KJ_EXPECT_THROW_MESSAGE("File does not declare an ID.",
+        parser.parseDiskFile("no-file-id.capnp", "no-file-id.capnp", nullptr));
+  }
+  {
+    SchemaParser parser;
+    parser.setDiskFilesystem(reader);
+    parser.setFileIdsRequired(false);
+
+    auto fileSchema = parser.parseDiskFile("no-file-id.capnp", "no-file-id.capnp", nullptr);
+    KJ_EXPECT(fileSchema.getNested("foo").asConst().as<int32_t>() == 123);
+  }
+}
+
 }  // namespace
 }  // namespace capnp

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -88,7 +88,7 @@ public:
     compiler::lex(content, statements, *this);
 
     auto parsed = orphanage.newOrphan<compiler::ParsedFile>();
-    compiler::parseFile(statements.getStatements(), parsed.get(), *this);
+    compiler::parseFile(statements.getStatements(), parsed.get(), *this, parser.fileIdsRequired);
     return parsed;
   }
 

--- a/c++/src/capnp/schema-parser.h
+++ b/c++/src/capnp/schema-parser.h
@@ -146,12 +146,27 @@ public:
     return getLoader().getAllLoaded();
   }
 
+  void setFileIdsRequired(bool value) { fileIdsRequired = value; }
+  // By befault, capnp files must declare a file-level type ID (like `@0xbe702824338d3f7f;`).
+  // Use `setFileIdsReqired(false)` to lift this requirement.
+  //
+  // If no ID is specified, a random one will be assigned. This will cause all types declared in
+  // the file to have randomized IDs as well (unless they declare an ID explicitly), which means
+  // that parsing the same file twice will appear to to produce a totally new, incompatible set of
+  // types. In particular, this means that you will not be able to use any interface types in the
+  // file for RPC, since the RPC protocol uses type IDs to identify methods.
+  //
+  // Setting this false is particularly useful when using Cap'n Proto as a config format. Typically
+  // type IDs are irrelevant for config files, and the requirement to specify one is cumbersome.
+  // For this reason, `capnp eval` does not require type ID to be present.
+
 private:
   struct Impl;
   struct DiskFileCompat;
   class ModuleImpl;
   kj::Own<Impl> impl;
   mutable bool hadErrors = false;
+  bool fileIdsRequired = true;
 
   ModuleImpl& getModuleImpl(kj::Own<SchemaFile>&& file) const;
   const SchemaLoader& getLoader() const;

--- a/c++/src/capnp/testdata/no-file-id.capnp.nobuild
+++ b/c++/src/capnp/testdata/no-file-id.capnp.nobuild
@@ -1,0 +1,1 @@
+const foo :Text = "bar";


### PR DESCRIPTION
Assigning file IDs is a pointless exercise when using capnp files as configuration. Typically this involve files that don't even define any types, just constants. The ID does not affect the output of `capnp eval` in any way. So, we should not require file IDs to be present in this case.

Also expose this option on `SchemaParser`, for applications which use that class to parse config.