### PR TITLE
[bazel] Add missing async-coroutine-test -> kj-test dependency

### DIFF
--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -165,7 +165,10 @@ cc_test(
         ":use_coroutines": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    deps = ["//src/kj/compat:kj-http"],
+    deps = [
+        "//src/kj/compat:kj-http",
+        ":kj-test",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
Without this, I got a bunch of linker errors.