### PR TITLE
Implement asynchronous environments

### DIFF
--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -126,6 +126,7 @@ cc_library(
 ) for f in [
     "arena-test.c++",
     "array-test.c++",
+    "async-environment-test.c++",
     "async-io-test.c++",
     "async-queue-test.c++",
     "async-test.c++",

--- a/c++/src/kj/async-environment-test.c++
+++ b/c++/src/kj/async-environment-test.c++
@@ -1,0 +1,264 @@
+// Copyright (c) 2022 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "async.h"
+#include "common.h"
+#include "test.h"
+
+namespace kj {
+namespace {
+
+struct TestEnvironment {
+  TestEnvironment(bool& finalDestructorRan, String stuff)
+      : finalDestructorRan(finalDestructorRan), stuff(kj::mv(stuff)) {}
+  ~TestEnvironment() noexcept(false) {
+    // If `stuff` is empty, assume we are moved-from.
+    if (stuff.size() != 0) {
+      KJ_ASSERT(!finalDestructorRan);
+      finalDestructorRan = true;
+    }
+  }
+  KJ_DISALLOW_COPY(TestEnvironment);
+  TestEnvironment(TestEnvironment&&) = default;
+
+  bool& finalDestructorRan;
+  // Just for testing.
+
+  String stuff;
+  // The simulated user state.
+};
+
+void expectEnvironment() {
+  auto maybeEnvironment = tryGetEnvironment<TestEnvironment>();
+  KJ_EXPECT(maybeEnvironment != nullptr);
+  if (maybeEnvironment != nullptr) {
+    // We want to test the `getEnvironment()` function, too, so no need for KJ_IF_MAYBE.
+    auto& env = getEnvironment<TestEnvironment>();
+    KJ_EXPECT(env.stuff == "foobar"_kj);
+  }
+}
+
+struct DeferredExpectEnvironment {
+  // Helper to ensure lambdas and attachments are destroyed with environments.
+
+  DeferredExpectEnvironment() = default;
+  ~DeferredExpectEnvironment() noexcept(false) {
+    expectEnvironment();
+  }
+  KJ_DISALLOW_COPY(DeferredExpectEnvironment);
+};
+
+Own<DeferredExpectEnvironment> dee() {
+  return heap<DeferredExpectEnvironment>();
+}
+
+template <typename Func>
+void testCase(Func&& func) {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  bool finalDestructorRan = false;
+
+  KJ_EXPECT(tryGetEnvironment<TestEnvironment>() == nullptr);
+
+  {
+    auto promise = runInEnvironment(
+        TestEnvironment(finalDestructorRan, heapString("foobar"_kj)),
+        FunctionParam<Promise<void>()>(fwd<Func>(func)));
+
+    KJ_EXPECT(tryGetEnvironment<TestEnvironment>() == nullptr);
+    if (promise.poll(waitScope)) {
+      KJ_EXPECT(tryGetEnvironment<TestEnvironment>() == nullptr);
+      KJ_EXPECT(!finalDestructorRan);
+      promise.wait(waitScope);
+
+      // The Environment is destroyed after the promise is done.
+      KJ_EXPECT(finalDestructorRan);
+      KJ_EXPECT(tryGetEnvironment<TestEnvironment>() == nullptr);
+    } else {
+      // Test case suspended forever. Just verify that our environment's destructor runs.
+      KJ_EXPECT(!finalDestructorRan);
+      promise = nullptr;
+      KJ_EXPECT(finalDestructorRan);
+    }
+  }
+}
+
+KJ_TEST("Environments are available to synchronous callbacks") {
+  testCase([]() -> kj::Promise<void> {
+    expectEnvironment();
+    return READY_NOW;
+  });
+}
+
+KJ_TEST("Environments are available to evalLater() callbacks") {
+  testCase([]() -> kj::Promise<void> {
+    return evalLater([d=dee()]() {
+      expectEnvironment();
+    });
+  });
+}
+
+KJ_TEST("Environments are available to evalLast() callbacks") {
+  testCase([]() -> kj::Promise<void> {
+    return evalLast([d=dee()]() {
+      expectEnvironment();
+    });
+  });
+}
+
+KJ_TEST("Environments are available in fibers") {
+  testCase([]() -> Promise<void> {
+    return startFiber(64 * 1024, [d=dee()](WaitScope& ws2) {
+      expectEnvironment();
+      _::yield().wait(ws2);
+      expectEnvironment();
+    });
+  });
+}
+
+KJ_TEST("Environments are available in ForkedPromise branch callbacks") {
+  testCase([]() -> Promise<void> {
+    auto paf = newPromiseAndFulfiller<void>();
+
+    auto forked = paf.promise.fork();
+    auto left = forked.addBranch().then([d=dee()]() mutable {
+      expectEnvironment();
+    });
+    auto right = forked.addBranch().then([d=dee(),
+                                          left = kj::mv(left)]() mutable {
+      expectEnvironment();
+      return kj::mv(left);
+    });
+
+    paf.fulfiller->fulfill();
+
+    return kj::mv(right);
+  });
+}
+
+KJ_TEST("Environments are available in .then() callbacks and errorbacks") {
+  testCase([]() -> Promise<void> {
+    auto paf = newPromiseAndFulfiller<void>();
+
+    auto promise = paf.promise.then([d=dee()]() mutable {
+      expectEnvironment();
+    }, [d=dee()](kj::Exception&& exception) {
+      expectEnvironment();
+      KJ_FAIL_EXPECT("should not see exception", exception);
+    });
+
+    paf.fulfiller->fulfill();
+
+    return kj::mv(promise);
+  });
+
+  testCase([]() -> Promise<void> {
+    auto paf = newPromiseAndFulfiller<void>();
+
+    auto promise = paf.promise.then([d=dee()]() mutable {
+      expectEnvironment();
+      KJ_FAIL_EXPECT("should not see success");
+    }, [d=dee()](kj::Exception&& exception) {
+      expectEnvironment();
+    });
+
+    paf.fulfiller->reject(KJ_EXCEPTION(FAILED, "nope"));
+
+    return kj::mv(promise);
+  });
+}
+
+KJ_TEST("Environments are available in .catch_() and eagerlyEvaluate() errorbacks") {
+  testCase([]() -> Promise<void> {
+    auto paf = newPromiseAndFulfiller<void>();
+
+    auto promise = paf.promise.catch_([d=dee()](kj::Exception&& exception) {
+      expectEnvironment();
+    });
+
+    paf.fulfiller->reject(KJ_EXCEPTION(FAILED, "nope"));
+
+    return kj::mv(promise);
+  });
+
+  testCase([]() -> Promise<void> {
+    auto paf = newPromiseAndFulfiller<void>();
+
+    auto promise = paf.promise.eagerlyEvaluate([d=dee()](kj::Exception&& exception) {
+      expectEnvironment();
+    });
+
+    paf.fulfiller->reject(KJ_EXCEPTION(FAILED, "nope"));
+
+    return kj::mv(promise);
+  });
+}
+
+KJ_TEST("Environments are available in .ignoreResult() destructors") {
+  testCase([]() -> Promise<void> {
+    auto paf = newPromiseAndFulfiller<Own<DeferredExpectEnvironment>>();
+
+    auto promise = paf.promise.ignoreResult();
+
+    paf.fulfiller->fulfill(heap<DeferredExpectEnvironment>());
+
+    return kj::mv(promise);
+  });
+}
+
+KJ_TEST("Environments are available in .attach() destructors") {
+  testCase([]() -> Promise<void> {
+    return Promise<void>(READY_NOW).attach(heap<DeferredExpectEnvironment>());
+  });
+}
+
+#if KJ_HAS_COROUTINE
+
+KJ_TEST("Environments are available in coroutines") {
+  testCase([]() -> Promise<void> {
+    expectEnvironment();
+    co_await Promise<void>(READY_NOW);
+    expectEnvironment();
+    co_await evalLater([]() {
+      expectEnvironment();
+    });
+    expectEnvironment();
+  });
+}
+
+KJ_TEST("Environments are available in suspended coroutine destructors") {
+  testCase([]() -> Promise<void> {
+    // Explode if we're destroyed outside an Environment.
+    DeferredExpectEnvironment dee;
+
+    expectEnvironment();
+
+    // Make sure we don't run to completion, which is the coroutine happy path.
+    co_await Promise<void>(NEVER_DONE);
+    KJ_UNREACHABLE;
+  });
+}
+
+#endif  // KJ_HAS_COROUTINE
+
+}  // namespace
+}  // namespace kj

--- a/c++/src/kj/async-environment-test.c++
+++ b/c++/src/kj/async-environment-test.c++
@@ -82,7 +82,7 @@ void syncTestCase(Func&& func) {
 
   auto promise = runInEnvironment(
       TestEnvironment(finalDestructorRan, "foobar"_kj),
-      FunctionParam<Promise<void>()>(fwd<Func>(func)));
+      fwd<Func>(func));
 
   // Purely synchronous functions don't capture the Environment.
   KJ_EXPECT(finalDestructorRan);
@@ -103,7 +103,7 @@ void asyncTestCase(Func&& func) {
   {
     auto promise = runInEnvironment(
         TestEnvironment(finalDestructorRan, "foobar"_kj),
-        FunctionParam<Promise<void>()>(fwd<Func>(func)));
+        fwd<Func>(func));
 
     // Asynchronous functions capture the Environment. Eager promises will drop the Environment
     // after .poll(), and non-eager ones after .wait().
@@ -212,12 +212,12 @@ KJ_TEST("Environments are overridable") {
       expectEnvironment();
       return runInEnvironment(
           TestEnvironment(overrideEnvironmentDestructorRan, "bazqux"_kj),
-          FunctionParam<Promise<void>()>([]() -> Promise<void> {
+          []() -> Promise<void> {
         expectEnvironment("bazqux"_kj);
         return evalLater([]() {
           expectEnvironment("bazqux"_kj);
         });
-      }));
+      });
     }, [d=dee()](kj::Exception&& exception) {
       expectEnvironment();
       KJ_FAIL_EXPECT("should not see exception", exception);

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -342,11 +342,11 @@ public:
 
 }  // namespace _
 
-template <typename E, typename T, typename... Args>
-Promise<T> runInEnvironment(E&& environment, FunctionParam<Promise<T>(Args...)> func) {
+template <typename E, typename Func>
+PromiseForResult<Func, void> runInEnvironment(E&& environment, Func&& func) {
   auto holder = refcounted<_::Environment::Holder<Decay<E>>>(fwd<E>(environment));
   _::Environment::Scope scope(*holder);
-  return evalNow(func);
+  return evalNow(fwd<Func>(func));
 }
 
 template <typename T>

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -301,8 +301,8 @@ protected:
 // -------------------------------------------------------------------
 
 class Environment: public kj::Refcounted {
-  // Base class of Environment::Holder<T>. This class also houses and provides access to the
-  // thread_local reference to the currently-active Environment.
+  // Base class of Environment::Holder<T>. This class also provides access to the current
+  // EventLoop's reference to the currently-active Environment.
 
 public:
   class Scope;
@@ -316,8 +316,6 @@ public:
 
 private:
   Environment() = default;
-
-  static thread_local Maybe<Environment&> current;
 };
 
 class Environment::Scope {

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -348,7 +348,7 @@ template <typename E, typename T, typename... Args>
 Promise<T> runInEnvironment(E&& environment, FunctionParam<Promise<T>(Args...)> func) {
   auto holder = refcounted<_::Environment::Holder<Decay<E>>>(fwd<E>(environment));
   _::Environment::Scope scope(*holder);
-  return evalNow(func).attach(kj::mv(holder));
+  return evalNow(func);
 }
 
 template <typename T>

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1099,8 +1099,6 @@ protected:
   bool isFinished() { return state == FINISHED; }
   void destroy();
 
-  Maybe<Environment&> tryGetStackEnvironment();
-
 private:
   enum { WAITING, RUNNING, CANCELED, FINISHED } state;
 
@@ -1109,6 +1107,10 @@ private:
   Own<FiberStack> stack;
   _::ExceptionOrValue& result;
 
+protected:
+  Maybe<Own<Environment>> environment;
+
+private:
   void run();
   virtual void runImpl(WaitScope& waitScope) = 0;
 
@@ -1132,7 +1134,7 @@ public:
   ~Fiber() noexcept(false) {
     destroy();
     // HACK: Make sure we have an active Environment scope while we destroy the user callbacks.
-    environmentScope.emplace(tryGetStackEnvironment());
+    environmentScope.emplace(environment);
   }
 
   typedef FixVoid<decltype(kj::instance<Func&>()(kj::instance<WaitScope&>()))> ResultType;

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -213,6 +213,8 @@ class Event;
 class XThreadEvent;
 class XThreadPaf;
 
+class Environment;
+
 class PromiseBase {
 public:
   kj::String trace();

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -214,6 +214,7 @@ class XThreadEvent;
 class XThreadPaf;
 
 class Environment;
+class EnvironmentSet;
 
 class PromiseBase {
 public:

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1785,10 +1785,8 @@ EventLoop::EventLoop(EventPort& port)
 
 EventLoop::~EventLoop() noexcept(false) {
   // Destroy all "daemon" tasks, noting that their destructors might register more daemon tasks.
-  while (!daemons->isEmpty()) {
-    auto oldDaemons = kj::mv(daemons);
-    daemons = kj::heap<TaskSet>(_::LoggingErrorHandler::instance);
-  }
+  // This is exactly what `WaitScope::cancelAllDetached()` does; let's use that.
+  WaitScope(*this).cancelAllDetached();
   daemons = nullptr;
 
   KJ_IF_MAYBE(e, executor) {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -440,21 +440,21 @@ namespace _ {
 Environment::~Environment() noexcept(false) {}
 
 Maybe<Own<Environment>> Environment::tryCaptureCurrent() {
-  return current.map([](Environment& environment) {
+  return currentEventLoop().currentEnvironment.map([](Environment& environment) {
     return addRef(environment);
   });
 }
 Maybe<Environment&> Environment::tryGetCurrent() {
-  return current;
+  return currentEventLoop().currentEnvironment;
 }
 
-Environment::Scope::Scope(Maybe<Environment&> environment): previous(Environment::current) {
-  Environment::current = environment;
+Environment::Scope::Scope(Maybe<Environment&> environment)
+    : previous(currentEventLoop().currentEnvironment) {
+  currentEventLoop().currentEnvironment = environment;
 }
 Environment::Scope::~Scope() noexcept(false) {
-  Environment::current = previous;
+  currentEventLoop().currentEnvironment = previous;
 }
-thread_local Maybe<Environment&> Environment::current;
 
 }  // namespace _
 

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1143,7 +1143,7 @@ private:
 
   _::Event* currentlyFiring = nullptr;
 
-  Maybe<_::Environment&> currentEnvironment;
+  Maybe<_::EnvironmentSet&> currentEnvironmentSet;
   // Non-null during the scope of an _::Environment::Scope.
 
   bool turn();
@@ -1165,7 +1165,7 @@ private:
   friend class _::XThreadPaf;
   friend class _::FiberBase;
   friend class _::FiberStack;
-  friend class _::Environment;
+  friend class _::EnvironmentSet;
   friend ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space);
 };
 

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -458,6 +458,21 @@ PromiseForResult<Func, void> evalLast(Func&& func) KJ_WARN_UNUSED_RESULT;
 // callback enqueues new events, then latter callbacks will not execute until those events are
 // drained.
 
+template <typename E, typename T, typename... Args>
+kj::Promise<T> runInEnvironment(E&& environment, FunctionParam<kj::Promise<T>(Args...)> func);
+// Synchronously calls `func`, arranging so that any calls to `getEnvironment()` from within sync
+// _or_ async user code will return a reference to an object constructed from `environment`.
+//
+// Note that Environments never implicitly cross threads.
+
+template <typename T>
+T& getEnvironment();
+template <typename T>
+kj::Maybe<T&> tryGetEnvironment();
+// If the currently-executing code was called by `runInEnvironment()`, or if the currently-executing
+// code was scheduled asynchronously by code called by `runInEnvironment()`, return the current
+// environment downcast as a value of type T.
+
 ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space);
 kj::String getAsyncTrace();
 // If the event loop is currently running in this thread, get a trace back through the promise

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1180,7 +1180,7 @@ class WaitScope {
 
 public:
   inline explicit WaitScope(EventLoop& loop): loop(loop) { loop.enterScope(); }
-  inline ~WaitScope() { if (fiber == nullptr) loop.leaveScope(); }
+  inline ~WaitScope() { if (fiber == nullptr) { cancelAllDetached(); loop.leaveScope(); } }
   KJ_DISALLOW_COPY(WaitScope);
 
   uint poll(uint maxTurnCount = maxValue);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1180,7 +1180,7 @@ class WaitScope {
 
 public:
   inline explicit WaitScope(EventLoop& loop): loop(loop) { loop.enterScope(); }
-  inline ~WaitScope() { if (fiber == nullptr) { cancelAllDetached(); loop.leaveScope(); } }
+  inline ~WaitScope() { if (fiber == nullptr) { loop.leaveScope(); } }
   KJ_DISALLOW_COPY(WaitScope);
 
   uint poll(uint maxTurnCount = maxValue);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1143,6 +1143,9 @@ private:
 
   _::Event* currentlyFiring = nullptr;
 
+  Maybe<_::Environment&> currentEnvironment;
+  // Non-null during the scope of an _::Environment::Scope.
+
   bool turn();
   void setRunnable(bool runnable);
   void enterScope();
@@ -1162,6 +1165,7 @@ private:
   friend class _::XThreadPaf;
   friend class _::FiberBase;
   friend class _::FiberStack;
+  friend class _::Environment;
   friend ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space);
 };
 

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -458,8 +458,8 @@ PromiseForResult<Func, void> evalLast(Func&& func) KJ_WARN_UNUSED_RESULT;
 // callback enqueues new events, then latter callbacks will not execute until those events are
 // drained.
 
-template <typename E, typename T, typename... Args>
-kj::Promise<T> runInEnvironment(E&& environment, FunctionParam<kj::Promise<T>(Args...)> func);
+template <typename E, typename Func>
+PromiseForResult<Func, void> runInEnvironment(E&& environment, Func&& func);
 // Synchronously calls `func`, arranging so that any calls to `getEnvironment()` from within sync
 // _or_ async user code will return a reference to an object constructed from `environment`.
 //


### PR DESCRIPTION
NOTE: This is a working rough draft, but it contains some hacks that I'm not super happy about, specifically around making sure user destructors are run under environments. Nevertheless, review feedback would be useful at this point.

This commit adds a new concept to the kj-async library: Environments.

Environments are ambiently available storage, of a type specified by the user, which "follow" user callbacks scheduled via functions/syntax like evalLater(), promise.then(), startFiber(), co_await, and more.

Environments do not cross threads. Type safety is as safe as kj::downcast<T>() makes it -- in debug mode, you'll probably get an assertion if you set an environment of type T and try to get it later as type U -- but in release mode you're on your own.