### PR TITLE
Support C++20 coroutines

### DIFF
--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -33,11 +33,12 @@
 // TODO(someday): Support coroutines with -fno-exceptions.
 #if !KJ_NO_EXCEPTIONS
 #ifdef __has_include
-// For now, we only support the Coroutines TS.
-//
-// TODO(someday): Also support standardized C++20 Coroutines. The latest VS2019 and GCC 10 both have
-//   support, though MSVC hides it behind /std:c++latest, which brings an ICE with it.
-#if __cpp_coroutines && __has_include(<experimental/coroutine>)
+#if __cpp_coroutines && __has_include(<coroutine>)
+// C++20 Coroutines detected.
+#include <coroutine>
+#define KJ_HAS_COROUTINE 1
+#define KJ_COROUTINE_STD_NAMESPACE std
+#elif __cpp_coroutines && __has_include(<experimental/coroutine>)
 // Coroutines TS detected.
 #include <experimental/coroutine>
 #define KJ_HAS_COROUTINE 1

--- a/kjdoc/tour.md
+++ b/kjdoc/tour.md
@@ -967,7 +967,12 @@ There are some caveats one should be aware of while writing coroutines:
 - Holding a mutex lock across a `co_await` is almost always a bad idea, with essentially the same problems as holding a lock while calling `promise.wait(waitScope)`. This would cause the coroutine to hold the lock for however many turns of the event loop is required to drive the coroutine to release the lock; if I/O is involved, this could cause significant problems. Additionally, a reentrant call to the coroutine on the same thread would deadlock. Instead, if a coroutine must temporarily hold a lock, always keep the lock in a new lexical scope without any `co_await`.
 - Attempting to define (and use) a variable-length array will cause a compile error, because the size of coroutine frames must be knowable at compile-time. The error message that clang emits for this, "Coroutines cannot handle non static allocas yet", suggests this may be relaxed in the future.
 
-As of this writing, KJ does not support actual C++20 coroutines because no compiler appears to have a fully working implementation. Instead, KJ supports Coroutines TS coroutines, which are the experimental precursor to C++20 coroutines. They are functionally the same thing, but enabled with different compiler/linker flags: clang supports them in C++17 with `-fcoroutines-ts`, and MSVC supports them in C++17 with `/await`.
+As of this writing, KJ supports C++20 coroutines and Coroutines TS coroutines, the latter being an experimental precursor to C++20 coroutines. They are functionally the same thing, but enabled with different compiler/linker flags:
+
+- Enable C++20 coroutines by requesting that language standard from your compiler.
+- Enable Coroutines TS coroutines with `-fcoroutines-ts` in C++17 clang, and `/await` in MSVC.
+
+KJ prefers C++20 coroutines when both implementations are available.
 
 ### Unit testing tips
 


### PR DESCRIPTION
This avoids deprecation warnings when using modern clang builds.

Still need to test this in Windows.