### PR TITLE
Fix utf-8 escape sequences parsing for json strings

### DIFF
--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -617,6 +617,17 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("\f{}", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{\v}", root));
   }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw(R"("\u007f")", root);
+    KJ_EXPECT(root.which() == JsonValue::STRING);
+
+    char utf_buffer[] = {127, 0};
+    KJ_EXPECT(kj::str(utf_buffer) == root.getString());
+  }
 }
 
 KJ_TEST("maximum nesting depth") {

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -823,9 +823,9 @@ private:
       if ('0' <= c && c <= '9') {
         codePoint |= c - '0';
       } else if ('a' <= c && c <= 'f') {
-        codePoint |= c - 'a';
+        codePoint |= c - 'a' + 10;
       } else if ('A' <= c && c <= 'F') {
-        codePoint |= c - 'A';
+        codePoint |= c - 'A' + 10;
       } else {
         KJ_FAIL_REQUIRE("Invalid hex digit in unicode escape.", c);
       }


### PR DESCRIPTION
Hex value was converted wrongfully to a code-point value. Test added.