### PR TITLE
kj::Vector<T>::reserve() should always grow by at least doubling the …

### DIFF
--- a/c++/src/kj/table-test.c++
+++ b/c++/src/kj/table-test.c++
@@ -47,7 +47,7 @@ KJ_TEST("_::tryReserveSize() works") {
   {
     Vector<int> vec;
     tryReserveSize(vec, "foo"_kj);
-    KJ_EXPECT(vec.capacity() == 3);
+    KJ_EXPECT(vec.capacity() == 4);  // Vectors always grow by powers of two.
   }
   {
     Vector<int> vec;

--- a/c++/src/kj/vector.h
+++ b/c++/src/kj/vector.h
@@ -123,7 +123,7 @@ public:
 
   inline void reserve(size_t size) {
     if (size > builder.capacity()) {
-      setCapacity(size);
+      grow(size);
     }
   }
 


### PR DESCRIPTION
…current capacity