### PR TITLE
cmake: add ZLIB option

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -46,6 +46,10 @@ set(WITH_OPENSSL "AUTO" CACHE STRING
 # define list of values GUI will offer for the variable
 set_property(CACHE WITH_OPENSSL PROPERTY STRINGS AUTO ON OFF)
 
+set(WITH_ZLIB "AUTO" CACHE STRING
+  "Whether or not to build libkj-gzip by linking against zlib")
+set_property(CACHE WITH_ZLIB PROPERTY STRINGS AUTO ON OFF)
+
 # shadow cache variable original value with ON/OFF,
 # so from now on OpenSSL-specific code just has to check:
 #     if (WITH_OPENSSL)
@@ -62,6 +66,24 @@ elseif (WITH_OPENSSL STREQUAL "AUTO")
   endif()
 elseif (WITH_OPENSSL)
   find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
+endif()
+
+# shadow cache variable original value with ON/OFF,
+# so from now on ZLIB-specific code just has to check:
+#     if (WITH_ZLIB)
+#         ...
+#     endif()
+if(CAPNP_LITE)
+  set(WITH_ZLIB OFF)
+elseif (WITH_ZLIB STREQUAL "AUTO")
+  find_package(ZLIB)
+  if(ZLIB_FOUND)
+    set(WITH_ZLIB ON)
+  else()
+    set(WITH_ZLIB OFF)
+  endif()
+elseif (WITH_ZLIB)
+  find_package(ZLIB REQUIRED)
 endif()
 
 set(WITH_FIBERS "AUTO" CACHE STRING

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -172,8 +172,7 @@ set(kj-http_headers
 if(NOT CAPNP_LITE)
   add_library(kj-http ${kj-http_sources})
   add_library(CapnProto::kj-http ALIAS kj-http)
-  find_package(ZLIB)
-  if(ZLIB_FOUND)
+  if(WITH_ZLIB)
     add_definitions(-D KJ_HAS_ZLIB=1)
     target_link_libraries(kj-http PUBLIC kj-async kj ZLIB::ZLIB)
   else()
@@ -210,26 +209,25 @@ endif()
 
 # kj-gzip ======================================================================
 
-set(kj-gzip_sources
-  compat/gzip.c++
-)
-set(kj-gzip_headers
-  compat/gzip.h
-)
-if(NOT CAPNP_LITE)
-  add_library(kj-gzip ${kj-gzip_sources})
-  add_library(CapnProto::kj-gzip ALIAS kj-gzip)
+if(WITH_ZLIB)
+  set(kj-gzip_sources
+    compat/gzip.c++
+  )
+  set(kj-gzip_headers
+    compat/gzip.h
+  )
+  if(NOT CAPNP_LITE)
+    add_library(kj-gzip ${kj-gzip_sources})
+    add_library(CapnProto::kj-gzip ALIAS kj-gzip)
 
-  find_package(ZLIB)
-  if(ZLIB_FOUND)
     add_definitions(-D KJ_HAS_ZLIB=1)
     target_link_libraries(kj-gzip PUBLIC kj-async kj ZLIB::ZLIB)
-  endif()
 
-  # Ensure the library has a version set to match autotools build
-  set_target_properties(kj-gzip PROPERTIES VERSION ${VERSION})
-  install(TARGETS kj-gzip ${INSTALL_TARGETS_DEFAULT_ARGS})
-  install(FILES ${kj-gzip_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
+    # Ensure the library has a version set to match autotools build
+    set_target_properties(kj-gzip PROPERTIES VERSION ${VERSION})
+    install(TARGETS kj-gzip ${INSTALL_TARGETS_DEFAULT_ARGS})
+    install(FILES ${kj-gzip_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kj/compat")
+  endif()
 endif()
 
 # Tests ========================================================================


### PR DESCRIPTION
Similar, but better than #1137 which is generating an empty `libkj-gzip.a`, whereas this one is just not building it at all if `ZLIB` is disabled (just like the Makefile does, I checked). I added the author @ScatteredRay as a co-author here :+1:.

@harrishancock had a mention there:

> On a related note, do we need to add a find_dependency(ZLIB) call to capnproto/c++/cmake/CapnProtoConfig.cmake.in? Similar to: https://github.com/capnproto/capnproto/blob/master/c%2B%2B/cmake/CapnProtoConfig.cmake.in#L52-L63

I think this is a valid point, but I would need to test it to be sure. I will open another PR if I get to that. This PR has no impact on it however (it just feels like a somehow related bug in CapnProtoConfig.cmake.in), so IMO it could be merged as-is.