### PR TITLE
Fix async-coroutine-test

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3063,6 +3063,13 @@ bool CoroutineBase::AwaiterBase::awaitSuspendImpl(CoroutineBase& coroutineEvent)
   }
 }
 
+// ---------------------------------------------------------
+// Helpers for coCapture()
+
+void throwMultipleCoCaptureInvocations() {
+  KJ_FAIL_REQUIRE("Attempted to invoke CaptureForCoroutine functor multiple times");
+}
+
 }  // namespace _ (private)
 
 #endif  // KJ_HAS_COROUTINE


### PR DESCRIPTION
One of the unit tests checks that multiply-invoking a coCapture()ed function object throws. When I imported the code, I inadvertently broke this test by making it a debug-only check.