### PR TITLE
EzRpc: extend interface to support arbitrary streams

### DIFF
--- a/c++/src/capnp/serialize-async.h
+++ b/c++/src/capnp/serialize-async.h
@@ -103,13 +103,15 @@ public:
 
   virtual kj::Promise<void> end() = 0;
   // Cleanly shut down just the write end of the transport, while keeping the read end open.
-
 };
 
 class AsyncIoMessageStream final: public MessageStream {
   // A MessageStream that wraps an AsyncIoStream.
 public:
+  explicit AsyncIoMessageStream(kj::OneOf<kj::AsyncIoStream*, kj::Own<kj::AsyncIoStream>>&& stream);
   explicit AsyncIoMessageStream(kj::AsyncIoStream& stream);
+
+  kj::AsyncIoStream& getStream();
 
   // Implements MessageStream
   kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
@@ -124,13 +126,18 @@ public:
 
   kj::Promise<void> end() override;
 private:
-  kj::AsyncIoStream& stream;
+  kj::OneOf<kj::AsyncIoStream*, kj::Own<kj::AsyncIoStream>> stream;
+  // The underlying stream, which we may or may not own. Get a reference to
+  // this with getStream, rather than reading it directly.
 };
 
 class AsyncCapabilityMessageStream final: public MessageStream {
   // A MessageStream that wraps an AsyncCapabilityStream.
 public:
+  explicit AsyncCapabilityMessageStream(kj::OneOf<kj::AsyncCapabilityStream*, kj::Own<kj::AsyncCapabilityStream>>&& stream);
   explicit AsyncCapabilityMessageStream(kj::AsyncCapabilityStream& stream);
+
+  kj::AsyncCapabilityStream& getStream();
 
   // Implements MessageStream
   kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
@@ -144,7 +151,9 @@ public:
   kj::Maybe<int> getSendBufferSize() override;
   kj::Promise<void> end() override;
 private:
-  kj::AsyncCapabilityStream& stream;
+  kj::OneOf<kj::AsyncCapabilityStream*, kj::Own<kj::AsyncCapabilityStream>> stream;
+  // The underlying stream, which we may or may not own. Get a reference to
+  // this with getStream, rather than reading it directly.
 };
 
 // -----------------------------------------------------------------------------

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -722,7 +722,7 @@ public:
   // you call this from low-level code, then you are preventing higher-level code from injecting an
   // alternative implementation.  Instead, if your code needs to use network functionality, it
   // should ask for a `Network` as a constructor or method parameter, so that higher-level code can
-  // chose what implementation to use.  The system network is essentially a singleton.  See:
+  // choose what implementation to use.  The system network is essentially a singleton.  See:
   //     http://www.object-oriented-security.org/lets-argue/singletons
   //
   // Code that uses the system network should not make any assumptions about what kinds of

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -575,7 +575,7 @@ struct CompressionParameters {
 };
 
 class WebSocket {
-  // Interface representincg an open WebSocket session.
+  // Interface representing an open WebSocket session.
   //
   // Each side can send and receive data and "close" messages.
   //
@@ -720,7 +720,7 @@ public:
   struct ConnectResponse {
     uint statusCode;
     // Any 2xx response indicates that the CONNECT request was successful without regard to the
-    // standard semantics of the specifix 2xx code.
+    // standard semantics of the specific 2xx code.
     kj::StringPtr statusText;
     const HttpHeaders* headers;
     kj::OneOf<kj::Own<kj::AsyncInputStream>, kj::Own<kj::AsyncIoStream>> connectionOrBody;
@@ -942,7 +942,7 @@ kj::Own<WebSocket> newWebSocket(kj::Own<kj::AsyncIoStream> stream,
 // `maskEntropySource` is used to generate cryptographically-random frame masks. If null, outgoing
 // frames will not be masked. Servers are required NOT to mask their outgoing frames, but clients
 // ARE required to do so. So, on the client side, you MUST specify an entropy source. The mask
-// must be crytographically random if the data being sent on the WebSocket may be malicious. The
+// must be cryptographically random if the data being sent on the WebSocket may be malicious. The
 // purpose of the mask is to prevent badly-written HTTP proxies from interpreting "things that look
 // like HTTP requests" in a message as being actual HTTP requests, which could result in cache
 // poisoning. See RFC6455 section 10.3.


### PR DESCRIPTION
__TL;DR: The whole point is the new API in [ez-rpc.h](https://github.com/capnproto/capnproto/compare/master...JonasVautherin:capnproto:ezrpc-arbitrary-asynciostream?expand=1#diff-548cb29d954120f68618ee55c221ea96b5d73c29a86eefdc1bb2360fba0e851d), check it first, no need to review the rest if the API is bad :+1:.__

This is an exploration around the EzRpc API, to see if it can be extended to support arbitrary streams (enabling e.g. tls, gzip, websocket). It adds:

* An `EzRpcClient` constructor without a stream, which can be set later with `EzRpcClient.setStream()`
* A constructor to create an "empty" `EzRpcServer` (without a stream and without an `acceptLoop`)
* An `EzRpcServer.addStream()` function to add streams to the server object (those streams can come from an external `acceptLoop`).

@kentonv: I really don't want to lose your time with stupid propositions, so feel free to close if this seems useless or convoluted :sweat_smile:.

Note: pretty sure I messed up with the `PromiseAndFulfiller`, happy to get advice there :innocent:.