### PR TITLE
Implements NetworkHttpClient::Connect and fixes for EOF

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -6200,7 +6200,8 @@ private:
       auto pipe = newTwoWayPipe();
 
       kj::Own<kj::AsyncIoStream> io =
-          kj::heap<DelayedEofIoStream>(kj::mv(pipe.ends[0]), task.attach(kj::addRef(*this)));
+          kj::heap<DelayedEofIoStream>(kj::mv(pipe.ends[0]),
+              task.attach(kj::addRef(*this), kj::mv(headersCopy)));
 
       fulfiller->fulfill(HttpClient::ConnectResponse {
         statusCode,


### PR DESCRIPTION
While implementing TCP sockets for workerd I ran into a few things which I fix in this PR:

* NetworkHttpClient::Connect wasn't implemented (Kenton suggested we implement this as a direct TCP connection, I left a link to where he suggested this in a code comment). It works well for direct (non-proxied) connections in workerd.
* Reads of zero bytes (indicating a socket disconnect) weren't working. I narrowed it down to two things: BlockedPumpFrom and DelayedEofIoStream.
  * ~~The former seems to not be handling EOF correctly, though perhaps it is meant to block on EOF by design as well and I should instead fix the code so it's not used in the HTTP CONNECT code path?~~
  * ~~The latter is that ConnectResponseImpl uses a DelayedEofIoStream wrapper, I am not sure why this is used but removing it resolves the EOF issues.~~
  * The solution to the DelayedEofIoStream problem is avoiding the adapter and creating my own `ConnectResponse` which does not use `DelayedEofIoStream` (done in workerd)
  * As for the BlockedPumpFrom, it turned out that was fine, the problem was in HttpServiceAdapter::connect. This is fixed in this PR.

### Test Plan

```
$ bazel test //src/kj/compat:http-test
$ bazel test //src/kj/compat:http-socketpair-test
```