### PR TITLE
Change allowCancellation from a method call to an annotation

### DIFF
--- a/c++/src/capnp/c++.capnp
+++ b/c++/src/capnp/c++.capnp
@@ -24,3 +24,25 @@ $namespace("capnp::annotations");
 
 annotation namespace(file): Text;
 annotation name(field, enumerant, struct, enum, interface, method, param, group, union): Text;
+
+annotation allowCancellation(interface, method, file) :Void;
+# Indicates that the server-side implementation of a method is allowed to be canceled when the
+# client requests cancellation. Without this annotation, once a method call has been delivered to
+# the server-side application code, any requests by the client to cancel it will be ignored, and
+# the method will run to completion anyway. This applies even for local in-process calls.
+#
+# This behavior applies specifically to implementations that inherit from the C++ `Foo::Server`
+# interface. The annotation won't affect DynamicCapability::Server implementations; they must set
+# the cancellation mode at runtime.
+#
+# When applied to an interface rather than an individual method, the annotation applies to all
+# methods in the interface. When applied to a file, it applies to all methods defined in the file.
+#
+# It's generally recommended that this annotation be applied to all methods. However, when doing
+# so, it is important that the server implementation use cancellation-safe code. See:
+#
+#     https://github.com/capnproto/capnproto/blob/master/kjdoc/tour.md#cancellation
+#
+# If your code is not cancellation-safe, then allowing cancellation might give a malicious client
+# an easy way to induce use-after-free or other bugs in your server, by requesting cancellation
+# when not expected.

--- a/c++/src/capnp/c++.capnp.c++
+++ b/c++/src/capnp/c++.capnp.c++
@@ -64,5 +64,36 @@ const ::capnp::_::RawSchema s_f264a779fef191ce = {
   0, 0, nullptr, nullptr, nullptr, { &s_f264a779fef191ce, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<22> b_ac7096ff8cfc9dce = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    206, 157, 252, 140, 255, 150, 112, 172,
+     16,   0,   0,   0,   5,   0,   1,   3,
+    129,  78,  48, 184, 123, 125, 248, 189,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  18,   1,   0,   0,
+     37,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     32,   0,   0,   0,   3,   0,   1,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     99,  97, 112, 110, 112,  47,  99,  43,
+     43,  46,  99,  97, 112, 110, 112,  58,
+     97, 108, 108, 111, 119,  67,  97, 110,
+     99, 101, 108, 108,  97, 116, 105, 111,
+    110,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_ac7096ff8cfc9dce = b_ac7096ff8cfc9dce.words;
+#if !CAPNP_LITE
+const ::capnp::_::RawSchema s_ac7096ff8cfc9dce = {
+  0xac7096ff8cfc9dce, b_ac7096ff8cfc9dce.words, 22, nullptr, nullptr,
+  0, 0, nullptr, nullptr, nullptr, { &s_ac7096ff8cfc9dce, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 }  // namespace schemas
 }  // namespace capnp

--- a/c++/src/capnp/c++.capnp.h
+++ b/c++/src/capnp/c++.capnp.h
@@ -18,6 +18,7 @@ namespace schemas {
 
 CAPNP_DECLARE_SCHEMA(b9c6f99ebf805f2c);
 CAPNP_DECLARE_SCHEMA(f264a779fef191ce);
+CAPNP_DECLARE_SCHEMA(ac7096ff8cfc9dce);
 
 }  // namespace schemas
 }  // namespace capnp

--- a/c++/src/capnp/capability-test.c++
+++ b/c++/src/capnp/capability-test.c++
@@ -1304,10 +1304,8 @@ KJ_TEST("Streaming calls can be canceled") {
 
   auto promise4 = cap.finishStreamRequest().send();
 
-  // Cancel the streaming calls.
-  promise1 = nullptr;
+  // Cancel the doStreamJ() request.
   promise2 = nullptr;
-  promise3 = nullptr;
 
   KJ_EXPECT(server.iSum == 0);
   KJ_EXPECT(server.jSum == 0);
@@ -1321,10 +1319,9 @@ KJ_TEST("Streaming calls can be canceled") {
 
   KJ_EXPECT(!promise4.poll(waitScope));
 
-  // The call to doStreamJ() opted into cancellation so the next call to doStreamI() happens
-  // immediately.
+  // The call to doStreamJ() was canceled, so the next call to doStreamI() happens immediately.
   KJ_EXPECT(server.iSum == 579);
-  KJ_EXPECT(server.jSum == 321);
+  KJ_EXPECT(server.jSum == 0);
 
   KJ_ASSERT_NONNULL(server.fulfiller)->fulfill();
 
@@ -1332,7 +1329,7 @@ KJ_TEST("Streaming calls can be canceled") {
 
   auto result = promise4.wait(waitScope);
   KJ_EXPECT(result.getTotalI() == 579);
-  KJ_EXPECT(result.getTotalJ() == 321);
+  KJ_EXPECT(result.getTotalJ() == 0);
 }
 
 KJ_TEST("Streaming call throwing cascades to following calls") {

--- a/c++/src/capnp/capability-test.c++
+++ b/c++/src/capnp/capability-test.c++
@@ -280,7 +280,7 @@ TEST(Capability, TailCall) {
 }
 
 TEST(Capability, AsyncCancelation) {
-  // Tests allowCancellation().
+  // Tests cancellation.
 
   kj::EventLoop loop;
   kj::WaitScope waitScope(loop);

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -194,7 +194,6 @@ public:
     tailCallPipelineFulfiller = kj::mv(paf.fulfiller);
     return kj::mv(paf.promise);
   }
-  void allowCancellation() override {}
   kj::Own<CallContextHook> addRef() override {
     return kj::addRef(*this);
   }

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -145,10 +145,8 @@ public:
 
 class LocalCallContext final: public CallContextHook, public ResponseHook, public kj::Refcounted {
 public:
-  LocalCallContext(kj::Own<MallocMessageBuilder>&& request, kj::Own<ClientHook> clientRef,
-                   kj::Own<kj::PromiseFulfiller<void>> cancelAllowedFulfiller)
-      : request(kj::mv(request)), clientRef(kj::mv(clientRef)),
-        cancelAllowedFulfiller(kj::mv(cancelAllowedFulfiller)) {}
+  LocalCallContext(kj::Own<MallocMessageBuilder>&& request, kj::Own<ClientHook> clientRef)
+      : request(kj::mv(request)), clientRef(kj::mv(clientRef)) {}
 
   AnyPointer::Reader getParams() override {
     KJ_IF_MAYBE(r, request) {
@@ -196,9 +194,7 @@ public:
     tailCallPipelineFulfiller = kj::mv(paf.fulfiller);
     return kj::mv(paf.promise);
   }
-  void allowCancellation() override {
-    cancelAllowedFulfiller->fulfill();
-  }
+  void allowCancellation() override {}
   kj::Own<CallContextHook> addRef() override {
     return kj::addRef(*this);
   }
@@ -208,7 +204,6 @@ public:
   AnyPointer::Builder responseBuilder = nullptr;  // only valid if `response` is non-null
   kj::Own<ClientHook> clientRef;
   kj::Maybe<kj::Own<kj::PromiseFulfiller<AnyPointer::Pipeline>>> tailCallPipelineFulfiller;
-  kj::Own<kj::PromiseFulfiller<void>> cancelAllowedFulfiller;
 };
 
 class LocalRequest final: public RequestHook {
@@ -221,25 +216,12 @@ public:
   RemotePromise<AnyPointer> send() override {
     KJ_REQUIRE(message.get() != nullptr, "Already called send() on this request.");
 
-    auto cancelPaf = kj::newPromiseAndFulfiller<void>();
-
     auto context = kj::refcounted<LocalCallContext>(
-        kj::mv(message), client->addRef(), kj::mv(cancelPaf.fulfiller));
+        kj::mv(message), client->addRef());
     auto promiseAndPipeline = client->call(interfaceId, methodId, kj::addRef(*context));
 
-    // We have to make sure the call is not canceled unless permitted.  We need to fork the promise
-    // so that if the client drops their copy, the promise isn't necessarily canceled.
-    auto forked = promiseAndPipeline.promise.fork();
-
-    // We daemonize one branch, but only after joining it with the promise that fires if
-    // cancellation is allowed.
-    forked.addBranch()
-        .attach(kj::addRef(*context))
-        .exclusiveJoin(kj::mv(cancelPaf.promise))
-        .detach([](kj::Exception&&) {});  // ignore exceptions
-
     // Now the other branch returns the response from the context.
-    auto promise = forked.addBranch().then([context=kj::mv(context)]() mutable {
+    auto promise = promiseAndPipeline.promise.then([context=kj::mv(context)]() mutable {
       // force response allocation
       auto reader = context->getResults(MessageSize { 0, 0 }).asReader();
 

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -380,6 +380,14 @@ public:
   // In general, this should be the last thing a method implementation calls, and the promise
   // returned from `tailCall()` should then be returned by the method implementation.
 
+  void allowCancellation()
+      KJ_UNAVAILABLE(
+          "As of Cap'n Proto 0.11, allowCancellation must be applied statically using an "
+          "annotation in the schema. See annotations defined in /capnp/c++.capnp. For "
+          "DynamicCapability::Server, use the constructor option (the annotation does not apply "
+          "to DynamicCapability). This change was made to gain a significant performance boost -- "
+          "dynamically allowing cancellation required excessive bookkeeping.");
+
 private:
   CallContextHook* hook;
 
@@ -402,6 +410,14 @@ public:
   // - It would significantly complicate the implementation of streaming.
   // - It wouldn't be particularly useful since streaming calls don't return anything, and they
   //   already compensate for latency.
+
+  void allowCancellation()
+      KJ_UNAVAILABLE(
+          "As of Cap'n Proto 0.11, allowCancellation must be applied statically using an "
+          "annotation in the schema. See annotations defined in /capnp/c++.capnp. For "
+          "DynamicCapability::Server, use the constructor option (the annotation does not apply "
+          "to DynamicCapability). This change was made to gain a significant performance boost -- "
+          "dynamically allowing cancellation required excessive bookkeeping.");
 
 private:
   CallContextHook* hook;
@@ -427,6 +443,13 @@ public:
     // If true, this method was declared as `-> stream;`. No other calls should be permitted until
     // this call finishes, and if this call throws an exception, all future calls will throw the
     // same exception.
+
+    bool allowCancellation = false;
+    // If true, the call can be canceled normally. If false, the immediate caller is responsible
+    // for ensuring that cancellation is prevented and that `context` remains valid until the
+    // call completes normally.
+    //
+    // See the `allowCancellation` annotation defined in `c++.capnp`.
   };
 
   virtual DispatchCallResult dispatchCall(uint64_t interfaceId, uint16_t methodId,

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -380,28 +380,6 @@ public:
   // In general, this should be the last thing a method implementation calls, and the promise
   // returned from `tailCall()` should then be returned by the method implementation.
 
-  void allowCancellation();
-  // Indicate that it is OK for the RPC system to discard its Promise for this call's result if
-  // the caller cancels the call, thereby transitively canceling any asynchronous operations the
-  // call implementation was performing.  This is not done by default because it could represent a
-  // security risk:  applications must be carefully written to ensure that they do not end up in
-  // a bad state if an operation is canceled at an arbitrary point.  However, for long-running
-  // method calls that hold significant resources, prompt cancellation is often useful.
-  //
-  // Keep in mind that asynchronous cancellation cannot occur while the method is synchronously
-  // executing on a local thread.  The method must perform an asynchronous operation or call
-  // `EventLoop::current().evalLater()` to yield control.
-  //
-  // Note:  You might think that we should offer `onCancel()` and/or `isCanceled()` methods that
-  // provide notification when the caller cancels the request without forcefully killing off the
-  // promise chain.  Unfortunately, this composes poorly with promise forking:  the canceled
-  // path may be just one branch of a fork of the result promise.  The other branches still want
-  // the call to continue.  Promise forking is used within the Cap'n Proto implementation -- in
-  // particular each pipelined call forks the result promise.  So, if a caller made a pipelined
-  // call and then dropped the original object, the call should not be canceled, but it would be
-  // excessively complicated for the framework to avoid notififying of cancellation as long as
-  // pipelined calls still exist.
-
 private:
   CallContextHook* hook;
 
@@ -424,8 +402,6 @@ public:
   // - It would significantly complicate the implementation of streaming.
   // - It wouldn't be particularly useful since streaming calls don't return anything, and they
   //   already compensate for latency.
-
-  void allowCancellation();
 
 private:
   CallContextHook* hook;
@@ -456,8 +432,8 @@ public:
   virtual DispatchCallResult dispatchCall(uint64_t interfaceId, uint16_t methodId,
                                           CallContext<AnyPointer, AnyPointer> context) = 0;
   // Call the given method.  `params` is the input struct, and should be released as soon as it
-  // is no longer needed.  `context` may be used to allocate the output struct and deal with
-  // cancellation.
+  // is no longer needed.  `context` may be used to allocate the output struct and other call
+  // logistics.
 
   virtual kj::Maybe<int> getFd() { return nullptr; }
   // If this capability is backed by a file descriptor that is safe to directly expose to clients,
@@ -704,10 +680,6 @@ public:
   // `Promise<void>` is discarded, the call may continue executing if any pipelined calls are
   // waiting for it.
   //
-  // Since the caller of this method chooses the CallContext implementation, it is the caller's
-  // responsibility to ensure that the returned promise is not canceled unless allowed via
-  // the context's `allowCancellation()`.
-  //
   // The call must not begin synchronously; the callee must arrange for the call to begin in a
   // later turn of the event loop. Otherwise, application code may call back and affect the
   // callee's state in an unexpected way.
@@ -762,7 +734,6 @@ public:
   virtual void releaseParams() = 0;
   virtual AnyPointer::Builder getResults(kj::Maybe<MessageSize> sizeHint) = 0;
   virtual kj::Promise<void> tailCall(kj::Own<RequestHook>&& request) = 0;
-  virtual void allowCancellation() = 0;
 
   virtual void setPipeline(kj::Own<PipelineHook>&& pipeline) = 0;
 
@@ -1070,14 +1041,6 @@ template <typename SubParams>
 inline kj::Promise<void> CallContext<Params, Results>::tailCall(
     Request<SubParams, Results>&& tailRequest) {
   return hook->tailCall(kj::mv(tailRequest.hook));
-}
-template <typename Params, typename Results>
-inline void CallContext<Params, Results>::allowCancellation() {
-  hook->allowCancellation();
-}
-template <typename Params>
-inline void StreamingCallContext<Params>::allowCancellation() {
-  hook->allowCancellation();
 }
 
 template <typename Params, typename Results>

--- a/c++/src/capnp/compat/byte-stream.capnp
+++ b/c++/src/capnp/compat/byte-stream.capnp
@@ -1,6 +1,8 @@
 @0x8f5d14e1c273738d;
 
-$import "/capnp/c++.capnp".namespace("capnp");
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("capnp");
+$Cxx.allowCancellation;
 
 interface ByteStream {
   write @0 (bytes :Data) -> stream;

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -665,8 +665,6 @@ public:
   }
 
   kj::Promise<void> request(RequestContext context) override {
-    context.allowCancellation();
-
     return requestImpl(kj::mv(context),
         [&](auto& results, auto& metadata, auto& params, auto& requestBody) {
       class FinalHttpServiceResponseImpl final: public HttpServiceResponseImpl {

--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -24,7 +24,9 @@
 
 using import "byte-stream.capnp".ByteStream;
 
-$import "/capnp/c++.capnp".namespace("capnp");
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("capnp");
+$Cxx.allowCancellation;
 
 interface HttpService {
   request @1 (request :HttpRequest, context :ClientRequestContext)

--- a/c++/src/capnp/dynamic-capability.c++
+++ b/c++/src/capnp/dynamic-capability.c++
@@ -63,7 +63,8 @@ Capability::Server::DispatchCallResult DynamicCapability::Server::dispatchCall(
       return {
         call(method, CallContext<DynamicStruct, DynamicStruct>(*context.hook,
             method.getParamType(), resultType)),
-        resultType.isStreamResult()
+        resultType.isStreamResult(),
+        options.allowCancellation
       };
     } else {
       return internalUnimplemented(

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -584,7 +584,6 @@ public:
   Orphanage getResultsOrphanage(kj::Maybe<MessageSize> sizeHint = nullptr);
   template <typename SubParams>
   kj::Promise<void> tailCall(Request<SubParams, DynamicStruct>&& tailRequest);
-  void allowCancellation();
 
   StructSchema getParamsType() const { return paramType; }
   StructSchema getResultsType() const { return resultType; }
@@ -1657,9 +1656,6 @@ template <typename SubParams>
 inline kj::Promise<void> CallContext<DynamicStruct, DynamicStruct>::tailCall(
     Request<SubParams, DynamicStruct>&& tailRequest) {
   return hook->tailCall(kj::mv(tailRequest.hook));
-}
-inline void CallContext<DynamicStruct, DynamicStruct>::allowCancellation() {
-  hook->allowCancellation();
 }
 
 template <>

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -524,7 +524,16 @@ class DynamicCapability::Server: public Capability::Server {
 public:
   typedef DynamicCapability Serves;
 
+  struct Options {
+    bool allowCancellation = false;
+    // See the `allowCancellation` annotation defined in `c++.capnp`.
+    //
+    // This option applies to all calls made to this server object. The annotation in the schema
+    // is NOT used for dynamic servers.
+  };
+
   Server(InterfaceSchema schema): schema(schema) {}
+  Server(InterfaceSchema schema, Options options): schema(schema), options(options) {}
 
   virtual kj::Promise<void> call(InterfaceSchema::Method method,
                                  CallContext<DynamicStruct, DynamicStruct> context) = 0;
@@ -536,6 +545,7 @@ public:
 
 private:
   InterfaceSchema schema;
+  Options options;
 };
 
 template <>

--- a/c++/src/capnp/membrane-test.c++
+++ b/c++/src/capnp/membrane-test.c++
@@ -90,7 +90,6 @@ protected:
   }
 
   kj::Promise<void> waitForever(WaitForeverContext context) override {
-    context.allowCancellation();
     return kj::NEVER_DONE;
   }
 };
@@ -128,7 +127,7 @@ public:
       return fork.addBranch();
     });
   }
-  
+
   bool shouldResolveBeforeRedirecting() override { return true; }
 
 private:

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -286,10 +286,6 @@ public:
     return inner->tailCall(MembraneRequestHook::wrap(kj::mv(request), *policy, !reverse));
   }
 
-  void allowCancellation() override {
-    inner->allowCancellation();
-  }
-
   kj::Promise<AnyPointer::Pipeline> onTailCall() override {
     return inner->onTailCall().then([this](AnyPointer::Pipeline&& innerPipeline) {
       return AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(

--- a/c++/src/capnp/persistent.capnp.h
+++ b/c++/src/capnp/persistent.capnp.h
@@ -567,6 +567,7 @@ template <typename SturdyRef, typename Owner>
       return {
         save(::capnp::Capability::Server::internalGetTypedContext<
             typename  ::capnp::Persistent<SturdyRef, Owner>::SaveParams, typename  ::capnp::Persistent<SturdyRef, Owner>::SaveResults>(context)),
+        false,
         false
       };
     default:

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -703,7 +703,6 @@ public:
       : callCount(callCount), cancelCount(cancelCount) {}
 
   kj::Promise<void> foo(FooContext context) override {
-    context.allowCancellation();
     ++callCount;
     return kj::Promise<void>(kj::NEVER_DONE)
         .attach(kj::defer([&cancelCount = cancelCount]() { ++cancelCount; }));
@@ -799,7 +798,7 @@ TEST(Rpc, TailCallCancelRace) {
 }
 
 TEST(Rpc, Cancellation) {
-  // Tests allowCancellation().
+  // Tests cancellation.
 
   TestContext context;
 

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -915,7 +915,6 @@ public:
   kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> fulfiller;
 
   kj::Promise<void> doStreamI(DoStreamIContext context) override {
-    context.allowCancellation();
     auto paf = kj::newPromiseAndFulfiller<void>();
     fulfiller = kj::mv(paf.fulfiller);
     return paf.promise.then([this,context]() mutable {

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -369,7 +369,7 @@ public:
       // destructors could come back and mess with the tables.
       kj::Vector<kj::Own<PipelineHook>> pipelinesToRelease;
       kj::Vector<kj::Own<ClientHook>> clientsToRelease;
-      kj::Vector<kj::Promise<kj::Own<RpcResponse>>> tailCallsToRelease;
+      kj::Vector<decltype(Answer::task)> tasksToRelease;
       kj::Vector<kj::Promise<void>> resolveOpsToRelease;
 
       // All current questions complete with exceptions.
@@ -395,12 +395,10 @@ public:
           pipelinesToRelease.add(kj::mv(*p));
         }
 
-        KJ_IF_MAYBE(promise, answer.redirectedResults) {
-          tailCallsToRelease.add(kj::mv(*promise));
-        }
+        tasksToRelease.add(kj::mv(answer.task));
 
         KJ_IF_MAYBE(context, answer.callContext) {
-          context->requestCancel();
+          context->finish();
         }
       });
 
@@ -531,7 +529,17 @@ private:
     kj::Maybe<kj::Own<PipelineHook>> pipeline;
     // Send pipelined calls here.  Becomes null as soon as a `Finish` is received.
 
-    kj::Maybe<kj::Promise<kj::Own<RpcResponse>>> redirectedResults;
+    using Running = kj::Promise<void>;
+    struct Finished {};
+    using Redirected = kj::Promise<kj::Own<RpcResponse>>;
+
+    kj::OneOf<Running, Finished, Redirected> task;
+    // While the RPC is running locally, `task` is a `Promise` representing the task to execute
+    // the RPC.
+    //
+    // When `Finish` is received (and results are not redirected), `task` becomes `Finished`, which
+    // cancels it if it's still running.
+    //
     // For locally-redirected calls (Call.sendResultsTo.yourself), this is a promise for the call
     // result, to be picked up by a subsequent `Return`.
 
@@ -2082,8 +2090,7 @@ private:
                    kj::Own<IncomingRpcMessage>&& request,
                    kj::Array<kj::Maybe<kj::Own<ClientHook>>> capTableArray,
                    const AnyPointer::Reader& params,
-                   bool redirectResults, kj::Own<kj::PromiseFulfiller<void>>&& cancelFulfiller,
-                   uint64_t interfaceId, uint16_t methodId)
+                   bool redirectResults, uint64_t interfaceId, uint16_t methodId)
         : connectionState(kj::addRef(connectionState)),
           answerId(answerId),
           interfaceId(interfaceId),
@@ -2093,8 +2100,7 @@ private:
           paramsCapTable(kj::mv(capTableArray)),
           params(paramsCapTable.imbue(params)),
           returnMessage(nullptr),
-          redirectResults(redirectResults),
-          cancelFulfiller(kj::mv(cancelFulfiller)) {
+          redirectResults(redirectResults) {
       connectionState.callWordsInFlight += requestSize;
     }
 
@@ -2146,7 +2152,7 @@ private:
 
       // Avoid sending results if canceled so that we don't have to figure out whether or not
       // `releaseResultCaps` was set in the already-received `Finish`.
-      if (!(cancellationFlags & CANCEL_REQUESTED) && isFirstResponder()) {
+      if (!receivedFinish && isFirstResponder()) {
         KJ_ASSERT(connectionState->connection.is<Connected>(),
                   "Cancellation should have been requested on disconnect.") {
           return;
@@ -2215,21 +2221,10 @@ private:
       }
     }
 
-    void requestCancel() {
-      // Hints that the caller wishes to cancel this call.  At the next time when cancellation is
-      // deemed safe, the RpcCallContext shall send a canceled Return -- or if it never becomes
-      // safe, the RpcCallContext will send a normal return when the call completes.  Either way
-      // the RpcCallContext is now responsible for cleaning up the entry in the answer table, since
-      // a Finish message was already received.
+    void finish() {
+      // Called when a `Finish` message is received while this object still exists.
 
-      bool previouslyAllowedButNotRequested = cancellationFlags == CANCEL_ALLOWED;
-      cancellationFlags |= CANCEL_REQUESTED;
-
-      if (previouslyAllowedButNotRequested) {
-        // We just set CANCEL_REQUESTED, and CANCEL_ALLOWED was already set previously.  Initiate
-        // the cancellation.
-        cancelFulfiller->fulfill();
-      }
+      receivedFinish = true;
     }
 
     // implements CallContextHook ------------------------------------
@@ -2323,16 +2318,7 @@ private:
       tailCallPipelineFulfiller = kj::mv(paf.fulfiller);
       return kj::mv(paf.promise);
     }
-    void allowCancellation() override {
-      bool previouslyRequestedButNotAllowed = cancellationFlags == CANCEL_REQUESTED;
-      cancellationFlags |= CANCEL_ALLOWED;
-
-      if (previouslyRequestedButNotAllowed) {
-        // We just set CANCEL_ALLOWED, and CANCEL_REQUESTED was already set previously.  Initiate
-        // the cancellation.
-        cancelFulfiller->fulfill();
-      }
-    }
+    void allowCancellation() override {}
     kj::Own<CallContextHook> addRef() override {
       return kj::addRef(*this);
     }
@@ -2362,18 +2348,7 @@ private:
 
     // Cancellation state ----------------------------------
 
-    enum CancellationFlags {
-      CANCEL_REQUESTED = 1,
-      CANCEL_ALLOWED = 2
-    };
-
-    uint8_t cancellationFlags = 0;
-    // When both flags are set, the cancellation process will begin.
-
-    kj::Own<kj::PromiseFulfiller<void>> cancelFulfiller;
-    // Fulfilled when cancellation has been both requested and permitted.  The fulfilled promise is
-    // exclusive-joined with the outermost promise waiting on the call return, so fulfilling it
-    // cancels that promise.
+    bool receivedFinish = false;
 
     kj::UnwindDetector unwindDetector;
 
@@ -2393,7 +2368,7 @@ private:
       // answer table.  Or we might even be responsible for removing the entire answer table
       // entry.
 
-      if (cancellationFlags & CANCEL_REQUESTED) {
+      if (receivedFinish) {
         // Already received `Finish` so it's our job to erase the table entry. We shouldn't have
         // sent results if canceled, so we shouldn't have an export list to deal with.
         KJ_ASSERT(resultExports.size() == 0);
@@ -2682,14 +2657,12 @@ private:
 
     auto payload = call.getParams();
     auto capTableArray = receiveCaps(payload.getCapTable(), message->getAttachedFds());
-    auto cancelPaf = kj::newPromiseAndFulfiller<void>();
 
     AnswerId answerId = call.getQuestionId();
 
     auto context = kj::refcounted<RpcCallContext>(
         *this, answerId, kj::mv(message), kj::mv(capTableArray), payload.getContent(),
-        redirectResults, kj::mv(cancelPaf.fulfiller),
-        call.getInterfaceId(), call.getMethodId());
+        redirectResults, call.getInterfaceId(), call.getMethodId());
 
     // No more using `call` after this point, as it now belongs to the context.
 
@@ -2716,37 +2689,24 @@ private:
       answer.pipeline = kj::mv(promiseAndPipeline.pipeline);
 
       if (redirectResults) {
-        auto resultsPromise = promiseAndPipeline.promise.then(
+        answer.task = promiseAndPipeline.promise.then(
             [context=kj::mv(context)]() mutable {
               return context->consumeRedirectedResponse();
             });
-
-        // If the call that later picks up `redirectedResults` decides to discard it, we need to
-        // make sure our call is not itself canceled unless it has called allowCancellation().
-        // So we fork the promise and join one branch with the cancellation promise, in order to
-        // hold on to it.
-        auto forked = resultsPromise.fork();
-        answer.redirectedResults = forked.addBranch();
-
-        cancelPaf.promise
-            .exclusiveJoin(forked.addBranch().then([](kj::Own<RpcResponse>&&){}))
-            .detach([](kj::Exception&&) {});
       } else {
         // Hack:  Both the success and error continuations need to use the context.  We could
         //   refcount, but both will be destroyed at the same time anyway.
-        RpcCallContext* contextPtr = context;
+        RpcCallContext& contextRef = *context;
 
-        promiseAndPipeline.promise.then(
-            [contextPtr]() {
-              contextPtr->sendReturn();
-            }, [contextPtr](kj::Exception&& exception) {
-              contextPtr->sendErrorReturn(kj::mv(exception));
-            }).catch_([&](kj::Exception&& exception) {
+        answer.task = promiseAndPipeline.promise.then(
+            [context = kj::mv(context)]() mutable {
+              context->sendReturn();
+            }, [&contextRef](kj::Exception&& exception) {
+              contextRef.sendErrorReturn(kj::mv(exception));
+            }).eagerlyEvaluate([&](kj::Exception&& exception) {
               // Handle exceptions that occur in sendReturn()/sendErrorReturn().
               taskFailed(kj::mv(exception));
-            }).attach(kj::mv(context))
-            .exclusiveJoin(kj::mv(cancelPaf.promise))
-            .detach([](kj::Exception&&) {});
+            });
       }
     }
   }
@@ -2807,7 +2767,7 @@ private:
     // pointer into it, so make sure these destructors run later.
     kj::Array<ExportId> exportsToRelease;
     KJ_DEFER(releaseExports(exportsToRelease));
-    kj::Maybe<kj::Promise<kj::Own<RpcResponse>>> promiseToRelease;
+    kj::Maybe<decltype(Answer::task)> promiseToRelease;
 
     KJ_IF_MAYBE(question, questions.find(ret.getAnswerId())) {
       KJ_REQUIRE(question->isAwaitingReturn, "Duplicate Return.") { return; }
@@ -2860,24 +2820,14 @@ private:
 
           case rpc::Return::TAKE_FROM_OTHER_QUESTION:
             KJ_IF_MAYBE(answer, answers.find(ret.getTakeFromOtherQuestion())) {
-              KJ_IF_MAYBE(response, answer->redirectedResults) {
+              KJ_IF_MAYBE(response, answer->task.tryGet<Answer::Redirected>()) {
                 questionRef->fulfill(kj::mv(*response));
-                answer->redirectedResults = nullptr;
+                answer->task = Answer::Finished();
 
                 KJ_IF_MAYBE(context, answer->callContext) {
                   // Send the `Return` message  for the call of which we're taking ownership, so
                   // that the peer knows it can now tear down the call state.
                   context->sendRedirectReturn();
-
-                  // There are three conditions, all of which must be true, before a call is
-                  // canceled:
-                  // 1. The RPC opts in by calling context->allowCancellation().
-                  // 2. We request cancellation with context->requestCancel().
-                  // 3. The final response promise -- which we passed to questionRef->fulfill()
-                  //    above -- must be dropped.
-                  //
-                  // We would like #3 to imply #2. So... we can just make #2 be true.
-                  context->requestCancel();
                 }
               } else {
                 KJ_FAIL_REQUIRE("`Return.takeFromOtherQuestion` referenced a call that did not "
@@ -2903,16 +2853,12 @@ private:
             // Indeed, it does still exist.
 
             // Throw away the result promise.
-            promiseToRelease = kj::mv(answer->redirectedResults);
+            promiseToRelease = kj::mv(answer->task);
 
             KJ_IF_MAYBE(context, answer->callContext) {
               // Send the `Return` message  for the call of which we're taking ownership, so
               // that the peer knows it can now tear down the call state.
               context->sendRedirectReturn();
-
-              // Since the caller has been canceled, make sure the callee that we're tailing to
-              // gets canceled.
-              context->requestCancel();
             }
           }
         }
@@ -2935,6 +2881,7 @@ private:
     KJ_DEFER(releaseExports(exportsToRelease));
     Answer answerToRelease;
     kj::Maybe<kj::Own<PipelineHook>> pipelineToRelease;
+    kj::Maybe<decltype(Answer::task)> promiseToRelease;
 
     KJ_IF_MAYBE(answer, answers.find(finish.getQuestionId())) {
       KJ_REQUIRE(answer->active, "'Finish' for invalid question ID.") { return; }
@@ -2947,11 +2894,15 @@ private:
 
       pipelineToRelease = kj::mv(answer->pipeline);
 
-      // If the call isn't actually done yet, cancel it.  Otherwise, we can go ahead and erase the
-      // question from the table.
       KJ_IF_MAYBE(context, answer->callContext) {
-        context->requestCancel();
+        // Destroying answer->task will probably destroy the call context, but we can't prove that
+        // since it's refcounted. Instead, inform the call context that it is now its job to
+        // clean up the answer table. Then, cancel the task.
+        promiseToRelease = kj::mv(answer->task);
+        answer->task = Answer::Finished();
+        context->finish();
       } else {
+        // The call context is already gone so we can tear down the Answer here.
         answerToRelease = answers.erase(finish.getQuestionId());
       }
     } else {

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -739,9 +739,6 @@ private:
       request.set(params);
       context->releaseParams();
 
-      // We can and should propagate cancellation.
-      context->allowCancellation();
-
       return context->directTailCall(RequestHook::from(kj::mv(request)));
     }
 
@@ -2318,7 +2315,6 @@ private:
       tailCallPipelineFulfiller = kj::mv(paf.fulfiller);
       return kj::mv(paf.promise);
     }
-    void allowCancellation() override {}
     kj::Own<CallContextHook> addRef() override {
       return kj::addRef(*this);
     }

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -1076,7 +1076,6 @@ kj::Promise<void> TestMoreStuffImpl::neverReturn(NeverReturnContext context) {
   // Also attach `cap` to the result struct to make sure that is released.
   context.getResults().setCapCopy(context.getParams().getCap());
 
-  context.allowCancellation();
   return kj::mv(promise);
 }
 
@@ -1119,7 +1118,6 @@ kj::Promise<void> TestMoreStuffImpl::echo(EchoContext context) {
 
 kj::Promise<void> TestMoreStuffImpl::expectCancel(ExpectCancelContext context) {
   auto cap = context.getParams().getCap();
-  context.allowCancellation();
   return loop(0, cap, context);
 }
 

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -338,7 +338,6 @@ public:
   }
 
   kj::Promise<void> doStreamJ(DoStreamJContext context) override {
-    context.allowCancellation();
     jSum += context.getParams().getJ();
 
     if (jShouldThrow) {

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -821,7 +821,7 @@ interface TestCallOrder {
   # The input `expected` is ignored but useful for disambiguating debug logs.
 }
 
-interface TestTailCallee {
+interface TestTailCallee $Cxx.allowCancellation {
   struct TailResult {
     i @0 :UInt32;
     t @1 :Text;
@@ -835,7 +835,7 @@ interface TestTailCaller {
   foo @0 (i :Int32, callee :TestTailCallee) -> TestTailCallee.TailResult;
 }
 
-interface TestStreaming {
+interface TestStreaming $Cxx.allowCancellation {
   doStreamI @0 (i :UInt32) -> stream;
   doStreamJ @1 (j :UInt32) -> stream;
   finishStream @2 () -> (totalI :UInt32, totalJ :UInt32);
@@ -853,7 +853,7 @@ interface TestMoreStuff extends(TestCallOrder) {
   callFooWhenResolved @1 (cap :TestInterface) -> (s: Text);
   # Like callFoo but waits for `cap` to resolve first.
 
-  neverReturn @2 (cap :TestInterface) -> (capCopy :TestInterface);
+  neverReturn @2 (cap :TestInterface) -> (capCopy :TestInterface) $Cxx.allowCancellation;
   # Doesn't return.  You should cancel it.
 
   hold @3 (cap :TestInterface) -> ();
@@ -868,7 +868,7 @@ interface TestMoreStuff extends(TestCallOrder) {
   echo @6 (cap :TestCallOrder) -> (cap :TestCallOrder);
   # Just returns the input cap.
 
-  expectCancel @7 (cap :TestInterface) -> ();
+  expectCancel @7 (cap :TestInterface) -> () $Cxx.allowCancellation;
   # evalLater()-loops forever, holding `cap`.  Must be canceled.
 
   methodWithDefaults @8 (a :Text, b :UInt32 = 123, c :Text = "foo") -> (d :Text, e :Text = "bar");
@@ -900,7 +900,7 @@ interface TestMembrane {
   callIntercept @2 (thing :Thing, tailCall :Bool) -> Result;
   loopback @3 (thing :Thing) -> (thing :Thing);
 
-  waitForever @4 ();
+  waitForever @4 () $Cxx.allowCancellation;
 
   interface Thing {
     passThrough @0 () -> Result;

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -282,10 +282,14 @@ typedef unsigned char byte;
 #elif __GNUC__
 #define KJ_DEPRECATED(reason) \
     __attribute__((deprecated))
-#define KJ_UNAVAILABLE(reason)
+#define KJ_UNAVAILABLE(reason) = delete
+// If the `unavailable` attribute is not supproted, just mark the method deleted, which at least
+// makes it a compile-time error to try to call it. Note that on Clang, marking a method deleted
+// *and* unavailable unfortunately defeats the purpose of the unavailable annotation, as the
+// generic "deleted" error is reported instead.
 #else
 #define KJ_DEPRECATED(reason)
-#define KJ_UNAVAILABLE(reason)
+#define KJ_UNAVAILABLE(reason) = delete
 // TODO(msvc): Again, here, MSVC prefers a prefix, __declspec(deprecated).
 #endif
 


### PR DESCRIPTION
This PR rips out `allowCancellation()`, then re-introduces it as an annotation.

This performs much better -- especially when the annotation is set -- as a lot of bookkeeping can be skipped.

The performance improvement in the local-call http-over-capnp test is ~12%. For the full RPC test, the improvement is more like 5%.

This is a breaking change, but only if people call `allowCancellation()` today, in which case they will get a nice compiler error telling them what changed.

cc @xortive 