### PR TITLE
Introduce buffered reads for RPC message streams.

### DIFF
--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -406,8 +406,10 @@ TEST(TwoPartyNetwork, Abort) {
     msg->send();
   }
 
-  auto reply = KJ_ASSERT_NONNULL(conn->receiveIncomingMessage().wait(ioContext.waitScope));
-  EXPECT_EQ(rpc::Message::ABORT, reply->getBody().getAs<rpc::Message>().which());
+  {
+    auto reply = KJ_ASSERT_NONNULL(conn->receiveIncomingMessage().wait(ioContext.waitScope));
+    EXPECT_EQ(rpc::Message::ABORT, reply->getBody().getAs<rpc::Message>().which());
+  }
 
   EXPECT_TRUE(conn->receiveIncomingMessage().wait(ioContext.waitScope) == nullptr);
 }

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -3426,4 +3426,14 @@ kj::Own<RpcFlowController> RpcFlowController::newVariableWindowController(Window
   return kj::heap<WindowFlowController>(getter);
 }
 
+bool IncomingRpcMessage::isShortLivedRpcMessage(AnyPointer::Reader body) {
+  switch (body.getAs<rpc::Message>().which()) {
+    case rpc::Message::CALL:
+    case rpc::Message::RETURN:
+      return false;
+    default:
+      return true;
+  }
+}
+
 }  // namespace capnp

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -293,6 +293,11 @@ public:
   // Get the total size of the message, for flow control purposes. Although the caller could
   // also call getBody().targetSize(), doing that would walk the message tree, whereas typical
   // implementations can compute the size more cheaply by summing segment sizes.
+
+  static bool isShortLivedRpcMessage(AnyPointer::Reader body);
+  // Helper function which computes whether the standard RpcSystem implementation would consider
+  // the given message body to be short-lived, meaning it will be dropped before the next message
+  // is read. This is useful to implement BufferedMessageStream::IsShortLivedCallback.
 };
 
 class RpcFlowController {


### PR DESCRIPTION
This should improve performance by reducing syscalls needed to read several small messages.

I felt bad about playing "Bring me a rock" on #1528 so I took a shot at writing it. I think this code came out a lot simpler than previous attempts, but please let me know if I missed something important.