### PR TITLE
Issue with coroutine header when using Clang + libstdc++

### DIFF
--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -33,12 +33,12 @@
 // TODO(someday): Support coroutines with -fno-exceptions.
 #if !KJ_NO_EXCEPTIONS
 #ifdef __has_include
-#if __cpp_coroutines && __has_include(<coroutine>)
+#if __cpp_coroutines && (__cpp_impl_coroutine >= 201902L) && __has_include(<coroutine>)
 // C++20 Coroutines detected.
 #include <coroutine>
 #define KJ_HAS_COROUTINE 1
 #define KJ_COROUTINE_STD_NAMESPACE std
-#elif __cpp_coroutines && __has_include(<experimental/coroutine>)
+#elif __cpp_coroutines && (__cpp_coroutines >= 201703L) && __has_include(<experimental/coroutine>)
 // Coroutines TS detected.
 #include <experimental/coroutine>
 #define KJ_HAS_COROUTINE 1

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -33,12 +33,12 @@
 // TODO(someday): Support coroutines with -fno-exceptions.
 #if !KJ_NO_EXCEPTIONS
 #ifdef __has_include
-#if __cpp_coroutines && (__cpp_impl_coroutine >= 201902L) && __has_include(<coroutine>)
+#if (__cpp_impl_coroutine >= 201902L) && __has_include(<coroutine>)
 // C++20 Coroutines detected.
 #include <coroutine>
 #define KJ_HAS_COROUTINE 1
 #define KJ_COROUTINE_STD_NAMESPACE std
-#elif __cpp_coroutines && (__cpp_coroutines >= 201703L) && __has_include(<experimental/coroutine>)
+#elif (__cpp_coroutines >= 201703L) && __has_include(<experimental/coroutine>)
 // Coroutines TS detected.
 #include <experimental/coroutine>
 #define KJ_HAS_COROUTINE 1


### PR DESCRIPTION
To fix the [issue](https://github.com/capnproto/capnproto/issues/1573) we need some more checks in async-prelude.h:
```
#if __cpp_coroutines && (__cpp_impl_coroutine >= 201902L) && __has_include(<coroutine>)
// C++20 Coroutines detected.
#include <coroutine>
...
#elif __cpp_coroutines && (__cpp_coroutines >= 201703L) && __has_include(<experimental/coroutine>)
// Coroutines TS detected.
#include <experimental/coroutine>
...
#endif
```

The first check would cover gcc + libstdc++ and clang (from version 14)
The second check would cover clang + libc++ (up until version 13)