### PR TITLE
Fix restrictPeers allowing public+private, network+local, public+local.

### DIFF
--- a/c++/src/kj/async-io-internal.h
+++ b/c++/src/kj/async-io-internal.h
@@ -25,6 +25,7 @@
 #include "vector.h"
 #include "async-io.h"
 #include <stdint.h>
+#include "one-of.h"
 
 KJ_BEGIN_HEADER
 
@@ -82,6 +83,8 @@ private:
   Vector<CidrRange> denyCidrs;
   bool allowUnix;
   bool allowAbstractUnix;
+  bool allowPublic = false;
+  bool allowNetwork = false;
 
   kj::Maybe<NetworkFilter&> next;
 };

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1200,6 +1200,58 @@ KJ_TEST("NetworkFilter") {
     KJ_EXPECT(allowed4(filter, "1.2.3.1"));
     KJ_EXPECT(!allowed4(filter, "1.2.3.4"));
   }
+
+  // Test combinations of public/private/network/local. At one point these were buggy.
+  {
+    _::NetworkFilter filter({"public", "private"}, {}, base);
+
+    KJ_EXPECT(allowed4(filter, "8.8.8.8"));
+    KJ_EXPECT(!allowed4(filter, "240.1.2.3"));
+
+    KJ_EXPECT(allowed4(filter, "192.168.0.1"));
+    KJ_EXPECT(allowed4(filter, "10.1.2.3"));
+    KJ_EXPECT(allowed4(filter, "127.0.0.1"));
+    KJ_EXPECT(allowed4(filter, "0.0.0.0"));
+
+    KJ_EXPECT(allowed6(filter, "2400:cb00:2048:1::c629:d7a2"));
+    KJ_EXPECT(allowed6(filter, "fc00::1234"));
+    KJ_EXPECT(allowed6(filter, "::1"));
+    KJ_EXPECT(allowed6(filter, "::"));
+  }
+
+  {
+    _::NetworkFilter filter({"network", "local"}, {}, base);
+
+    KJ_EXPECT(allowed4(filter, "8.8.8.8"));
+    KJ_EXPECT(!allowed4(filter, "240.1.2.3"));
+
+    KJ_EXPECT(allowed4(filter, "192.168.0.1"));
+    KJ_EXPECT(allowed4(filter, "10.1.2.3"));
+    KJ_EXPECT(allowed4(filter, "127.0.0.1"));
+    KJ_EXPECT(allowed4(filter, "0.0.0.0"));
+
+    KJ_EXPECT(allowed6(filter, "2400:cb00:2048:1::c629:d7a2"));
+    KJ_EXPECT(allowed6(filter, "fc00::1234"));
+    KJ_EXPECT(allowed6(filter, "::1"));
+    KJ_EXPECT(allowed6(filter, "::"));
+  }
+
+  {
+    _::NetworkFilter filter({"public", "local"}, {}, base);
+
+    KJ_EXPECT(allowed4(filter, "8.8.8.8"));
+    KJ_EXPECT(!allowed4(filter, "240.1.2.3"));
+
+    KJ_EXPECT(!allowed4(filter, "192.168.0.1"));
+    KJ_EXPECT(!allowed4(filter, "10.1.2.3"));
+    KJ_EXPECT(allowed4(filter, "127.0.0.1"));
+    KJ_EXPECT(allowed4(filter, "0.0.0.0"));
+
+    KJ_EXPECT(allowed6(filter, "2400:cb00:2048:1::c629:d7a2"));
+    KJ_EXPECT(!allowed6(filter, "fc00::1234"));
+    KJ_EXPECT(allowed6(filter, "::1"));
+    KJ_EXPECT(allowed6(filter, "::"));
+  }
 }
 
 KJ_TEST("Network::restrictPeers()") {


### PR DESCRIPTION
These were buggy because allowing "public" and "network" were incorrectly implemented by adding 0.0.0.0/0 to the allow list and then adding non-public and non-network ranges to the deny list. If a separate rule tried to allow those ranges, the deny rules would take precedence since they had the same specificity.

Instead we special-case "public" and "network" as boolean flags instead of trying to represent them as CIDR unions.

Fixes https://github.com/cloudflare/workerd/issues/62

cc @dom96 (GitHub won't let me set him as reviewer)