### PR TITLE
Add capnpc-json for dumping code generator requests in json format

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -157,6 +157,18 @@ cc_binary(
     ],
 )
 
+cc_binary(
+    name = "capnpc-json",
+    srcs = [
+        "compiler/capnpc-json.c++",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":capnpc",
+        "//src/capnp/compat:json",
+    ],
+)
+
 # capnp files that are implicitly available for import to any .capnp.
 filegroup(
     name = "capnp_system_library",

--- a/c++/src/capnp/compiler/capnpc-json.c++
+++ b/c++/src/capnp/compiler/capnpc-json.c++
@@ -1,0 +1,72 @@
+// This program is a code generator plugin for `capnp compile` which writes the schema back to
+// stdout in json format. Useful for quickly bootstrapping a compiler plugin in another language
+// with pre-existing support for json.
+
+#include <capnp/schema.capnp.h>
+#include "../serialize.h"
+#include <kj/main.h>
+#include <kj/miniposix.h>
+#include <kj/encoding.h>
+#include <kj/debug.h>
+#include <capnp/compat/json.h>
+
+#ifndef VERSION
+#define VERSION "(unknown)"
+#endif
+
+namespace capnp {
+namespace {
+
+class AnyPointerToBase64: public JsonCodec::Handler<DynamicValue> {
+  void encode(const JsonCodec& codec, ReaderFor<DynamicValue> input, JsonValue::Builder output) const {
+    auto anyPointer = input.as<AnyPointer>();
+    MallocMessageBuilder message;
+    message.setRoot(anyPointer);
+    auto flatArray = messageToFlatArray(message);
+    auto bytes = flatArray.asBytes();
+    auto encoded = kj::encodeBase64(bytes);
+    output.setString(encoded);
+  }
+  Orphan<DynamicValue> decode(const JsonCodec& codec, JsonValue::Reader input, Orphanage orphanage) const {
+    KJ_UNIMPLEMENTED("AnyPointerToBase64::decode");
+  }
+};
+
+class CapnpcJsonMain {
+public:
+  CapnpcJsonMain(kj::ProcessContext& context): context(context) {}
+
+  kj::MainFunc getMain() {
+    return kj::MainBuilder(context, "Cap'n Proto json plugin version " VERSION,
+          "This is a Cap'n Proto compiler plugin which prints the code generator request "
+          "in json format. This is meant to be run using the Cap'n Proto compiler, e.g.:\n"
+          "    capnp compile -ojson foo.capnp")
+        .callAfterParsing(KJ_BIND_METHOD(*this, run))
+        .build();
+  }
+private:
+  kj::ProcessContext& context;
+
+  kj::MainBuilder::Validity run() {
+    ReaderOptions options;
+    options.traversalLimitInWords = 1 << 30; // Don't limit.
+    StreamFdMessageReader reader(STDIN_FILENO, options);
+    auto request = reader.getRoot<schema::CodeGeneratorRequest>();
+
+    AnyPointerToBase64 anyPointerHandler;
+    JsonCodec codec;
+    codec.handleByAnnotation<schema::CodeGeneratorRequest>();
+    codec.addTypeHandler(Type(schema::Type::Which::ANY_POINTER), anyPointerHandler);
+    auto serialized = codec.encode(request);
+
+    kj::FdOutputStream rawOut(STDOUT_FILENO);
+    rawOut.write(serialized.begin(), serialized.size());
+
+    return true;
+  }
+};
+
+} // namespace
+} // namespace capnp
+
+KJ_MAIN(capnp::CapnpcJsonMain);


### PR DESCRIPTION
When bootstrapping a new Cap'n Proto implementation in another language, it can be useful to make the first code-generator in the same language as the language you're planning to write the code generator in (of course). But until the schema.capnp file has been bootstrapped at least once for the library being developed, this is difficult.

You may bootstrap a simple compiler in another language like C++, but then you won't be able to reuse any of the code and be forced to rewrite from scratch in the target language once up and running.

It'd be useful if another included output format existed like capnpc-capnp, to dump the input code generator request in another format that's easier to bootstrap in the target language. JSON is decently popular enough that it's well supported basically everywhere.

This PR adds capnpc-json, an included output plugin that simply dumps the entire code generator request in JSON format to stdout.