### PR TITLE
Simplify http-over-capnp protocol, and other optimizations

### DIFF
--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -418,7 +418,7 @@ public:
         // We already completed a path-shortening. Probably SubstreamCallbackImpl::ended() was
         // eventually called, meaning the substream was ended without redirecting back to us. So,
         // we're at EOF.
-        return uint64_t(0);
+        return kj::constPromise<uint64_t, 0>();
       }
     }
 
@@ -430,7 +430,7 @@ public:
       // works because pumps do not propagate EOF -- the destination can still receive further
       // writes and pumps. Basically our probing pump becomes a no-op, and then we revert to having
       // each write() RPC directly call write() on the inner stream.
-      return size_t(0);
+      return kj::constPromise<size_t, 0>();
     }
 
     kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
@@ -442,7 +442,7 @@ public:
         return kj::mv(*promise);
       } else {
         // There is no shorter path. As with tryRead(), we pretend we get immediate EOF.
-        return uint64_t(0);
+        return kj::constPromise<uint64_t, 0>();
       }
     }
 

--- a/c++/src/capnp/compat/http-over-capnp-perf-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-perf-test.c++
@@ -396,9 +396,9 @@ KJ_TEST("Benchmark HTTP-over-capnp local call") {
 
   // Client and server use different HttpOverCapnpFactory instances to block path-shortening.
   ByteStreamFactory bsFactory;
-  HttpOverCapnpFactory hocFactory(bsFactory, headerIds.clone());
+  HttpOverCapnpFactory hocFactory(bsFactory, headerIds.clone(), HttpOverCapnpFactory::LEVEL_2);
   ByteStreamFactory bsFactory2;
-  HttpOverCapnpFactory hocFactory2(bsFactory2, kj::mv(headerIds));
+  HttpOverCapnpFactory hocFactory2(bsFactory2, kj::mv(headerIds), HttpOverCapnpFactory::LEVEL_2);
 
   auto cap = hocFactory.kjToCapnp(kj::attachRef(service));
   auto roundTrip = hocFactory2.capnpToKj(kj::mv(cap));
@@ -422,9 +422,9 @@ KJ_TEST("Benchmark HTTP-over-capnp full RPC") {
 
   // Client and server use different HttpOverCapnpFactory instances to block path-shortening.
   ByteStreamFactory bsFactory;
-  HttpOverCapnpFactory hocFactory(bsFactory, headerIds.clone());
+  HttpOverCapnpFactory hocFactory(bsFactory, headerIds.clone(), HttpOverCapnpFactory::LEVEL_2);
   ByteStreamFactory bsFactory2;
-  HttpOverCapnpFactory hocFactory2(bsFactory2, kj::mv(headerIds));
+  HttpOverCapnpFactory hocFactory2(bsFactory2, kj::mv(headerIds), HttpOverCapnpFactory::LEVEL_2);
 
   TwoPartyServer server(hocFactory.kjToCapnp(kj::attachRef(service)));
 

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -22,6 +22,10 @@
 #include "http-over-capnp.h"
 #include <kj/test.h>
 
+#ifndef TEST_PEER_OPTIMIZATION_LEVEL
+#define TEST_PEER_OPTIMIZATION_LEVEL HttpOverCapnpFactory::LEVEL_2
+#endif
+
 namespace capnp {
 namespace {
 
@@ -402,8 +406,8 @@ KJ_TEST("HTTP-over-Cap'n-Proto E2E, no path shortening") {
   ByteStreamFactory streamFactory1;
   ByteStreamFactory streamFactory2;
   kj::HttpHeaderTable::Builder tableBuilder;
-  HttpOverCapnpFactory factory1(streamFactory1, tableBuilder);
-  HttpOverCapnpFactory factory2(streamFactory2, tableBuilder);
+  HttpOverCapnpFactory factory1(streamFactory1, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  HttpOverCapnpFactory factory2(streamFactory2, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
   auto headerTable = tableBuilder.build();
 
   runEndToEndTests(timer, *headerTable, factory1, factory2, waitScope);
@@ -416,7 +420,7 @@ KJ_TEST("HTTP-over-Cap'n-Proto E2E, with path shortening") {
 
   ByteStreamFactory streamFactory;
   kj::HttpHeaderTable::Builder tableBuilder;
-  HttpOverCapnpFactory factory(streamFactory, tableBuilder);
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
   auto headerTable = tableBuilder.build();
 
   runEndToEndTests(timer, *headerTable, factory, factory, waitScope);
@@ -438,7 +442,7 @@ KJ_TEST("HTTP-over-Cap'n-Proto 205 bug with HttpClientAdapter") {
 
   ByteStreamFactory streamFactory;
   kj::HttpHeaderTable::Builder tableBuilder;
-  HttpOverCapnpFactory factory(streamFactory, tableBuilder);
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
   auto headerTable = tableBuilder.build();
 
   auto pipe = kj::newTwoWayPipe();
@@ -572,8 +576,8 @@ KJ_TEST("HTTP-over-Cap'n Proto WebSocket, no path shortening") {
   ByteStreamFactory streamFactory1;
   ByteStreamFactory streamFactory2;
   kj::HttpHeaderTable::Builder tableBuilder;
-  HttpOverCapnpFactory factory1(streamFactory1, tableBuilder);
-  HttpOverCapnpFactory factory2(streamFactory2, tableBuilder);
+  HttpOverCapnpFactory factory1(streamFactory1, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  HttpOverCapnpFactory factory2(streamFactory2, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
   auto headerTable = tableBuilder.build();
 
   runWebSocketTests(*headerTable, factory1, factory2, waitScope);
@@ -585,7 +589,7 @@ KJ_TEST("HTTP-over-Cap'n Proto WebSocket, with path shortening") {
 
   ByteStreamFactory streamFactory;
   kj::HttpHeaderTable::Builder tableBuilder;
-  HttpOverCapnpFactory factory(streamFactory, tableBuilder);
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
   auto headerTable = tableBuilder.build();
 
   runWebSocketTests(*headerTable, factory, factory, waitScope);
@@ -620,7 +624,7 @@ KJ_TEST("HttpService isn't destroyed while call outstanding") {
 
   ByteStreamFactory streamFactory;
   kj::HttpHeaderTable::Builder tableBuilder;
-  HttpOverCapnpFactory factory(streamFactory, tableBuilder);
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
   auto headerTable = tableBuilder.build();
 
   bool called = false;

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -435,7 +435,7 @@ class NullInputStream final: public kj::AsyncInputStream {
 
 public:
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    return size_t(0);
+    return kj::constPromise<size_t, 0>();
   }
 
   kj::Maybe<uint64_t> tryGetLength() override {
@@ -443,7 +443,7 @@ public:
   }
 
   kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
-    return uint64_t(0);
+    return kj::constPromise<uint64_t, 0>();
   }
 };
 

--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -27,13 +27,35 @@ using import "byte-stream.capnp".ByteStream;
 $import "/capnp/c++.capnp".namespace("capnp");
 
 interface HttpService {
-  startRequest @0 (request :HttpRequest, context :ClientRequestContext)
-               -> (requestBody :ByteStream, context :ServerRequestContext);
-  # Begin an HTTP request.
+  request @1 (request :HttpRequest, context :ClientRequestContext)
+          -> (requestBody :ByteStream);
+  # Perform an HTTP request.
   #
   # The client sends the request method/url/headers. The server responds with a `ByteStream` where
   # the client can make calls to stream up the request body. `requestBody` will be null in the case
   # that request.bodySize.fixed == 0.
+  #
+  # The server will send a response by invoking a method on `callback`.
+  #
+  # `request()` does not return until the server is completely done processing the request,
+  # including sending the response. The client therefore must use promise pipelining to send the
+  # request body. The client may request cancellation of the HTTP request by canceling the
+  # `request()` call itself.
+
+  startRequest @0 (request :HttpRequest, context :ClientRequestContext)
+               -> (requestBody :ByteStream, context :ServerRequestContext);
+  # DEPRECATED: Older form of `request()`. In this version, the server immediately returns a
+  #   `ServerRequestContext` before it begins processing the request. This version was designed
+  #   before `CallContext::setPipeline()` was introduced. At that time, it was impossible for the
+  #   server to receive data sent to the `requestBody` stream until `startRequest()` had returned
+  #   a stream capability to use, hence the ongoing call on the server side had to be represented
+  #   using a separate capability. Now that we have `CallContext::setPipeline()`, the server can
+  #   begin receiving the request body without returning from the top-level RPC, so we can now use
+  #   `request()` instead of `startRequest()`. The new approach is more intuitive and avoids some
+  #   unnecessary bookkeeping.
+  #
+  #   `HttpOverCapnpFactory` will continue to support both methods. Use the `peerOptimizationLevel`
+  #   constructor parameter to specify which method to use, for backwards-compatibiltiy purposes.
 
   interface ClientRequestContext {
     # Provides callbacks for the server to send the response.
@@ -53,6 +75,8 @@ interface HttpService {
   }
 
   interface ServerRequestContext {
+    # DEPRECATED: Used only with startRequest(); see comments there.
+    #
     # Represents execution of a particular request on the server side.
     #
     # Dropping this object before the request completes will cancel the request.

--- a/c++/src/capnp/compat/http-over-capnp.h
+++ b/c++/src/capnp/compat/http-over-capnp.h
@@ -52,7 +52,21 @@ public:
     friend class HttpOverCapnpFactory;
   };
 
-  HttpOverCapnpFactory(ByteStreamFactory& streamFactory, HeaderIdBundle headerIds);
+  enum OptimizationLevel {
+    // Specifies the protocol optimization level supported by the remote peer. Setting this higher
+    // will improve efficiency but breaks compatibility with older peers that don't implement newer
+    // levels.
+
+    LEVEL_1,
+    // Use startRequest(), the original version of the protocol.
+
+    LEVEL_2
+    // Use request(). This is more efficient than startRequest() but won't work with old peers that
+    // only implement startRequest().
+  };
+
+  HttpOverCapnpFactory(ByteStreamFactory& streamFactory, HeaderIdBundle headerIds,
+                       OptimizationLevel peerOptimizationLevel = LEVEL_1);
 
   kj::Own<kj::HttpService> capnpToKj(capnp::HttpService::Client rpcService);
   capnp::HttpService::Client kjToCapnp(kj::Own<kj::HttpService> service);
@@ -60,6 +74,7 @@ public:
 private:
   ByteStreamFactory& streamFactory;
   const kj::HttpHeaderTable& headerTable;
+  OptimizationLevel peerOptimizationLevel;
   kj::Array<capnp::CommonHeaderName> nameKjToCapnp;
   kj::Array<kj::HttpHeaderId> nameCapnpToKj;
   kj::Array<kj::StringPtr> valueCapnpToKj;

--- a/c++/src/capnp/compat/http-over-capnp.h
+++ b/c++/src/capnp/compat/http-over-capnp.h
@@ -73,6 +73,7 @@ private:
   class ClientRequestContextImpl;
   class KjToCapnpHttpServiceAdapter;
 
+  class HttpServiceResponseImpl;
   class ServerRequestContextImpl;
   class CapnpToKjHttpServiceAdapter;
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -221,7 +221,7 @@ public:
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
     if (minBytes == 0) {
-      return size_t(0);
+      return constPromise<size_t, 0>();
     } else KJ_IF_MAYBE(s, state) {
       return s->tryRead(buffer, minBytes, maxBytes);
     } else {
@@ -260,7 +260,7 @@ public:
 
   Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
     if (amount == 0) {
-      return uint64_t(0);
+      return constPromise<uint64_t, 0>();
     } else KJ_IF_MAYBE(s, state) {
       return s->pumpTo(output, amount);
     } else {
@@ -348,7 +348,7 @@ public:
   Maybe<Promise<uint64_t>> tryPumpFrom(
       AsyncInputStream& input, uint64_t amount) override {
     if (amount == 0) {
-      return Promise<uint64_t>(uint64_t(0));
+      return constPromise<uint64_t, 0>();
     } else KJ_IF_MAYBE(s, state) {
       return s->tryPumpFrom(input, amount);
     } else {
@@ -1416,7 +1416,7 @@ private:
 
       if (input.tryGetLength().orDefault(1) == 0) {
         // Yeah a pump would pump nothing.
-        return Promise<uint64_t>(uint64_t(0));
+        return constPromise<uint64_t, 0>();
       } else {
         // While we *could* just return nullptr here, it would probably then fall back to a normal
         // buffered pump, which would allocate a big old buffer just to find there's nothing to
@@ -1449,7 +1449,7 @@ private:
 
   public:
     Promise<size_t> tryRead(void* readBufferPtr, size_t minBytes, size_t maxBytes) override {
-      return size_t(0);
+      return constPromise<size_t, 0>();
     }
     Promise<ReadResult> tryReadWithFds(void* readBuffer, size_t minBytes, size_t maxBytes,
                                        AutoCloseFd* fdBuffer, size_t maxFds) override {
@@ -1461,7 +1461,7 @@ private:
       return ReadResult { 0, 0 };
     }
     Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
-      return uint64_t(0);
+      return constPromise<uint64_t, 0>();
     }
     void abortRead() override {
       // ignore
@@ -1626,7 +1626,7 @@ public:
   }
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    if (limit == 0) return size_t(0);
+    if (limit == 0) return constPromise<size_t, 0>();
     return inner->tryRead(buffer, kj::min(minBytes, limit), kj::min(maxBytes, limit))
         .then([this,minBytes](size_t actual) {
       decreaseLimit(actual, minBytes);
@@ -1635,7 +1635,7 @@ public:
   }
 
   Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
-    if (limit == 0) return uint64_t(0);
+    if (limit == 0) return constPromise<uint64_t, 0>();
     auto requested = kj::min(amount, limit);
     return inner->pumpTo(output, requested)
         .then([this,requested](uint64_t actual) {
@@ -1853,7 +1853,7 @@ public:
     if (branch.buffer.empty()) {
       KJ_IF_MAYBE(reason, stoppage) {
         if (reason->is<Eof>()) {
-          return uint64_t(0);
+          return constPromise<uint64_t, 0>();
         }
         return cp(reason->get<Exception>());
       }

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -240,7 +240,13 @@ void waitImpl(_::OwnPromiseNode&& node, _::ExceptionOrValue& result, WaitScope& 
 bool pollImpl(_::PromiseNode& node, WaitScope& waitScope, SourceLocation location);
 Promise<void> yield();
 Promise<void> yieldHarder();
+OwnPromiseNode readyNow();
 OwnPromiseNode neverDone();
+
+class ReadyNow {
+public:
+  operator Promise<void>() const;
+};
 
 class NeverDone {
 public:

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -1586,5 +1586,14 @@ KJ_TEST("capture weird alignment in continuation") {
 }
 #endif
 
+KJ_TEST("constPromise") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Promise<int> p = constPromise<int, 123>();
+  int i = p.wait(waitScope);
+  KJ_EXPECT(i == 123);
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2078,6 +2078,22 @@ Promise<void> yieldHarder() {
   return _::PromiseNode::to<Promise<void>>(allocPromise<YieldHarderPromiseNode>());
 }
 
+OwnPromiseNode readyNow() {
+  class ReadyNowPromiseNode: public ImmediatePromiseNodeBase {
+    // This is like `ConstPromiseNode<Void, Void{}>`, but the compiler won't let me pass a literal
+    // value of type `Void` as a template parameter. (Might require C++20?)
+
+  public:
+    void destroy() override {}
+    void get(ExceptionOrValue& output) noexcept override {
+      output.as<Void>() = Void();
+    }
+  };
+
+  static ReadyNowPromiseNode NODE;
+  return OwnPromiseNode(&NODE);
+}
+
 OwnPromiseNode neverDone() {
   return allocPromise<NeverDonePromiseNode>();
 }

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -197,51 +197,6 @@ struct DummyFunctor {
   void operator()() {};
 };
 
-class YieldPromiseNode final: public _::PromiseNode {
-public:
-  void destroy() override { dtor(*this); }
-
-  void onReady(_::Event* event) noexcept override {
-    if (event) event->armBreadthFirst();
-  }
-  void get(_::ExceptionOrValue& output) noexcept override {
-    output.as<_::Void>() = _::Void();
-  }
-  void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
-    builder.add(reinterpret_cast<void*>(&kj::evalLater<DummyFunctor>));
-  }
-};
-
-class YieldHarderPromiseNode final: public _::PromiseNode {
-public:
-  void destroy() override { dtor(*this); }
-
-  void onReady(_::Event* event) noexcept override {
-    if (event) event->armLast();
-  }
-  void get(_::ExceptionOrValue& output) noexcept override {
-    output.as<_::Void>() = _::Void();
-  }
-  void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
-    builder.add(reinterpret_cast<void*>(&kj::evalLast<DummyFunctor>));
-  }
-};
-
-class NeverDonePromiseNode final: public _::PromiseNode {
-public:
-  void destroy() override { dtor(*this); }
-
-  void onReady(_::Event* event) noexcept override {
-    // ignore
-  }
-  void get(_::ExceptionOrValue& output) noexcept override {
-    KJ_FAIL_REQUIRE("Not ready.");
-  }
-  void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
-    builder.add(_::getMethodStartAddress(kj::NEVER_DONE, &_::NeverDone::wait));
-  }
-};
-
 }  // namespace
 
 // =======================================================================================
@@ -2071,11 +2026,43 @@ bool pollImpl(_::PromiseNode& node, WaitScope& waitScope, SourceLocation locatio
 }
 
 Promise<void> yield() {
-  return _::PromiseNode::to<Promise<void>>(allocPromise<YieldPromiseNode>());
+  class YieldPromiseNode final: public _::PromiseNode {
+  public:
+    void destroy() override {}
+
+    void onReady(_::Event* event) noexcept override {
+      if (event) event->armBreadthFirst();
+    }
+    void get(_::ExceptionOrValue& output) noexcept override {
+      output.as<_::Void>() = _::Void();
+    }
+    void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
+      builder.add(reinterpret_cast<void*>(&kj::evalLater<DummyFunctor>));
+    }
+  };
+
+  static YieldPromiseNode NODE;
+  return _::PromiseNode::to<Promise<void>>(OwnPromiseNode(&NODE));
 }
 
 Promise<void> yieldHarder() {
-  return _::PromiseNode::to<Promise<void>>(allocPromise<YieldHarderPromiseNode>());
+  class YieldHarderPromiseNode final: public _::PromiseNode {
+  public:
+    void destroy() override {}
+
+    void onReady(_::Event* event) noexcept override {
+      if (event) event->armLast();
+    }
+    void get(_::ExceptionOrValue& output) noexcept override {
+      output.as<_::Void>() = _::Void();
+    }
+    void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
+      builder.add(reinterpret_cast<void*>(&kj::evalLast<DummyFunctor>));
+    }
+  };
+
+  static YieldHarderPromiseNode NODE;
+  return _::PromiseNode::to<Promise<void>>(OwnPromiseNode(&NODE));
 }
 
 OwnPromiseNode readyNow() {
@@ -2095,7 +2082,23 @@ OwnPromiseNode readyNow() {
 }
 
 OwnPromiseNode neverDone() {
-  return allocPromise<NeverDonePromiseNode>();
+  class NeverDonePromiseNode final: public _::PromiseNode {
+  public:
+    void destroy() override {}
+
+    void onReady(_::Event* event) noexcept override {
+      // ignore
+    }
+    void get(_::ExceptionOrValue& output) noexcept override {
+      KJ_FAIL_REQUIRE("Not ready.");
+    }
+    void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
+      builder.add(_::getMethodStartAddress(kj::NEVER_DONE, &_::NeverDone::wait));
+    }
+  };
+
+  static NeverDonePromiseNode NODE;
+  return OwnPromiseNode(&NODE);
 }
 
 void NeverDone::wait(WaitScope& waitScope, SourceLocation location) const {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -409,7 +409,7 @@ private:
   friend class EventLoop;
 };
 
-constexpr _::Void READY_NOW = _::Void();
+constexpr _::ReadyNow READY_NOW = _::ReadyNow();
 // Use this when you need a Promise<void> that is already fulfilled -- this value can be implicitly
 // cast to `Promise<void>`.
 
@@ -417,6 +417,11 @@ constexpr _::NeverDone NEVER_DONE = _::NeverDone();
 // The opposite of `READY_NOW`, return this when the promise should never resolve.  This can be
 // implicitly converted to any promise type.  You may also call `NEVER_DONE.wait()` to wait
 // forever (useful for servers).
+
+template <typename T, T value>
+Promise<T> constPromise();
+// Construct a Promise which resolves to the given constant value. This function is equivalent to
+// `Promise<T>(value)` except that it avoids an allocation.
 
 template <typename Func>
 PromiseForResult<Func, void> evalLater(Func&& func) KJ_WARN_UNUSED_RESULT;

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -182,7 +182,7 @@ GzipAsyncInputStream::~GzipAsyncInputStream() noexcept(false) {
 }
 
 Promise<size_t> GzipAsyncInputStream::tryRead(void* out, size_t minBytes, size_t maxBytes) {
-  if (maxBytes == 0) return size_t(0);
+  if (maxBytes == 0) return constPromise<size_t, 0>();
 
   return readImpl(reinterpret_cast<byte*>(out), minBytes, maxBytes, 0);
 }

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1668,7 +1668,7 @@ public:
   }
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    return size_t(0);
+    return constPromise<size_t, 0>();
   }
 
   Maybe<uint64_t> tryGetLength() override {
@@ -1687,7 +1687,7 @@ public:
       : HttpEntityBodyReader(inner) {}
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    if (alreadyDone()) return size_t(0);
+    if (alreadyDone()) return constPromise<size_t, 0>();
 
     return inner.tryRead(buffer, minBytes, maxBytes)
         .then([=](size_t amount) {
@@ -1721,7 +1721,7 @@ private:
 
   Promise<size_t> tryReadInternal(void* buffer, size_t minBytes, size_t maxBytes,
                                   size_t alreadyRead) {
-    if (length == 0) return size_t(0);
+    if (length == 0) return constPromise<size_t, 0>();
 
     // We have to set minBytes to 1 here so that if we read any data at all, we update our
     // counter immediately, so that we still know where we are in case of cancellation.
@@ -2148,7 +2148,7 @@ public:
   }
 
   Maybe<Promise<uint64_t>> tryPumpFrom(AsyncInputStream& input, uint64_t amount) override {
-    if (amount == 0) return Promise<uint64_t>(uint64_t(0));
+    if (amount == 0) return constPromise<uint64_t, 0>();
 
     bool overshot = amount > length;
     if (overshot) {
@@ -4609,7 +4609,7 @@ public:
       : expectedLength(expectedLength) {}
 
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    return size_t(0);
+    return constPromise<size_t, 0>();
   }
 
   kj::Maybe<uint64_t> tryGetLength() override {
@@ -4617,7 +4617,7 @@ public:
   }
 
   kj::Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
-    return uint64_t(0);
+    return constPromise<uint64_t, 0>();
   }
 
 private:
@@ -4654,7 +4654,7 @@ public:
   }
 
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    return size_t(0);
+    return constPromise<size_t, 0>();
   }
 
   kj::Maybe<uint64_t> tryGetLength() override {
@@ -4662,7 +4662,7 @@ public:
   }
 
   kj::Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
-    return uint64_t(0);
+    return constPromise<uint64_t, 0>();
   }
 };
 

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -344,7 +344,7 @@ private:
 
   template <typename Func>
   kj::Promise<size_t> sslCall(Func&& func) {
-    if (disconnected) return size_t(0);
+    if (disconnected) return constPromise<size_t, 0>();
 
     auto result = func();
 
@@ -355,7 +355,7 @@ private:
       switch (error) {
         case SSL_ERROR_ZERO_RETURN:
           disconnected = true;
-          return size_t(0);
+          return constPromise<size_t, 0>();
         case SSL_ERROR_WANT_READ:
           return readBuffer.whenReady().then(
               [this,func=kj::mv(func)]() mutable { return sslCall(kj::fwd<Func>(func)); });
@@ -367,7 +367,7 @@ private:
         case SSL_ERROR_SYSCALL:
           if (result == 0) {
             disconnected = true;
-            return size_t(0);
+            return constPromise<size_t, 0>();
           } else {
             // According to documentation we shouldn't get here, because our BIO never returns an
             // "error". But in practice we do get here sometimes when the peer disconnects


### PR DESCRIPTION
Most of the gain here is in the http-over-capnp protocol change. Unfortunately it is backwards-incompatible, so will require a multi-step deployment. The code currently defaults to using the old protocol but provides a way to opt into the new protocol.

This PR provides a 12% or so CPU improvement on the http-over-capnp test.