### PR TITLE
Pin CI to ubuntu-20.04.

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Linux-musl:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: alpine:latest
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
       - name: super-test
         run: ./super-test.sh quick
   Linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -35,7 +35,7 @@ jobs:
         run: |
             ./super-test.sh quick ${{ matrix.compiler }}
   Linux-lock-tracking:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
             # librt is used for timer_create in the unit tests for lock tracking (mutex-test.c++).
             ./super-test.sh quick ${{ matrix.compiler }} cpp-features "${{matrix.features}}" extra-libs "-lrt"
   ManyLinux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +165,7 @@ jobs:
   #       run: |
   #         C:\tools\cygwin\bin\bash -lc 'export PATH=/usr/local/bin:/usr/bin:/bin; cd /cygdrive/d/a/capnproto/capnproto; ./super-test.sh quick'
   Linux-bazel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   Linux-musl:
     runs-on: ubuntu-20.04
-    container: alpine:latest
+    container: alpine:3.16.3
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -42,7 +42,7 @@ jobs:
         run: |
             ./super-test.sh
   MinGW-Wine:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:
@@ -71,7 +71,7 @@ jobs:
         run: |
             ./super-test.sh mingw i686-w64-mingw32
   cmake-packaging:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:
@@ -93,7 +93,7 @@ jobs:
         run: |
             ./super-test.sh cmake-package cmake-static
   Android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -1248,8 +1248,8 @@ KJ_TEST("fiber pool") {
     }
   };
   run();
-  KJ_ASSERT_NONNULL(i1_local);
-  KJ_ASSERT_NONNULL(i2_local);
+  KJ_ASSERT(i1_local != nullptr);
+  KJ_ASSERT(i2_local != nullptr);
   // run the same thing and reuse the fibers
   run();
 }
@@ -1374,6 +1374,12 @@ KJ_TEST("fiber pool limit") {
   // that the second stack doesn't match the previously-deleted stack, because there's a high
   // likelihood that the new stack would be allocated in the same location.
 }
+
+#if __GNUC__ >= 12 && !__clang__
+// The test below intentionally takes a pointer to a stack variable and stores it past the end
+// of the function. This seems to trigger a warning in newer GCCs.
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
 
 KJ_TEST("run event loop on freelisted stacks") {
   if (isLibcContextHandlingKnownBroken()) return;

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -7150,7 +7150,7 @@ kj::Promise<bool> HttpServer::listenHttpCleanDrain(kj::AsyncIoStream& connection
     }
   }
 
-  KJ_ASSERT_NONNULL(srv.get());
+  KJ_ASSERT(srv.get() != nullptr);
 
   return listenHttpCleanDrain(connection, [srv = kj::mv(srv)](SuspendableRequest&) mutable {
     // This factory function will be owned by the Connection object, meaning the Connection object


### PR DESCRIPTION
It looks like GitHub might have just updated ubuntu-latest to ubuntu-22.04, and everything is broken there (mostly because we try to install specific compiler version packages which are no longer available, but there is at least one real error with OpenSSL 3.0). Need to come back to this later.