### PR TITLE
Support OpenSSL 3.0

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -19,12 +19,27 @@ jobs:
         run: apk add autoconf automake bash build-base cmake libtool libucontext-dev linux-headers openssl-dev
       - name: super-test
         run: ./super-test.sh quick
-  Linux:
+  Linux-old:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [g++-7, g++-10, clang-6.0, clang-10]
+        compiler: [g++-7, clang-6.0]
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get install -y build-essential git zlib1g-dev cmake libssl-dev ${{ matrix.compiler }}
+      - name: super-test
+        run: |
+            ./super-test.sh quick ${{ matrix.compiler }}
+  Linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [g++-12, clang-14]
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies

--- a/c++/src/kj/compat/readiness-io.h
+++ b/c++/src/kj/compat/readiness-io.h
@@ -45,6 +45,9 @@ public:
   kj::Promise<void> whenReady();
   // Returns a promise that resolves when read() will return non-null.
 
+  bool isAtEnd() { return eof; }
+  // Returns true if read() would return zero.
+
 private:
   AsyncInputStream& input;
   kj::ForkedPromise<void> pumpTask = nullptr;

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -58,6 +58,14 @@ void throwOpensslError() {
 
   kj::Vector<kj::String> lines;
   while (unsigned long long error = ERR_get_error()) {
+#ifdef SSL_R_UNEXPECTED_EOF_WHILE_READING
+    // OpenSSL 3.0+ reports unexpected disconnects this way.
+    if (ERR_GET_REASON(error) == SSL_R_UNEXPECTED_EOF_WHILE_READING) {
+      kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED,
+          "peer disconnected without gracefully ending TLS session"));
+    }
+#endif
+
     char message[1024];
     ERR_error_string_n(error, message, sizeof(message));
     lines.add(kj::heapString(message));
@@ -366,8 +374,12 @@ private:
           throwOpensslError();
         case SSL_ERROR_SYSCALL:
           if (result == 0) {
+            // OpenSSL pre-3.0 reports unexpected disconnects this way. Note that 3.0+ report it
+            // as SSL_ERROR_SSL with the reason SSL_R_UNEXPECTED_EOF_WHILE_READING, which is
+            // handled in throwOpensslError().
             disconnected = true;
-            return constPromise<size_t, 0>();
+            return KJ_EXCEPTION(DISCONNECTED,
+                "peer disconnected without gracefully ending TLS session");
           } else {
             // According to documentation we shouldn't get here, because our BIO never returns an
             // "error". But in practice we do get here sometimes when the peer disconnects
@@ -404,6 +416,8 @@ private:
 
   static long bioCtrl(BIO* b, int cmd, long num, void* ptr) {
     switch (cmd) {
+      case BIO_CTRL_EOF:
+        return reinterpret_cast<TlsConnection*>(BIO_get_data(b))->readBuffer.isAtEnd();
       case BIO_CTRL_FLUSH:
         return 1;
       case BIO_CTRL_PUSH:

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -410,6 +410,12 @@ private:
       case BIO_CTRL_POP:
         // Informational?
         return 0;
+#ifdef BIO_CTRL_GET_KTLS_SEND
+      case BIO_CTRL_GET_KTLS_SEND:
+      case BIO_CTRL_GET_KTLS_RECV:
+        // TODO(someday): Support kTLS if the underlying stream is a raw socket.
+        return 0;
+#endif
       default:
         KJ_LOG(WARNING, "unimplemented bio_ctrl", cmd);
         return 0;


### PR DESCRIPTION
This is based on #1434, but I went ahead and made KJ treat unexpected EOF as an error -- even with OpenSSL 1.x -- since this is technically important to prevent truncation attacks.

(It turns out that lots of apps than use OpenSSL 1.x are vulnerable to truncation attacks, which is why OpenSSL 3 decided to strengthen the error reporting to make it clearer that this situation _should_ be an error, but this was considered a breaking change. So KJ is not alone in having this bug, but I went ahead and fixed it even when using OpenSSL 1.x.)

NOTE: I'm flying blind here as my local Debian machine is still on OpenSSL 1.x. Gonna do a little CI-driven-development. I'll mark this no longer a draft once I get CI passing...