### PR TITLE
Clarify doc on absolute path imports

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -581,7 +581,9 @@ struct Foo {
 
 The above imports specify relative paths.  If the path begins with a `/`, it is absolute -- in
 this case, the `capnp` tool searches for the file in each of the search path directories specified
-with `-I`.
+with `-I`, where `/` means the root of each import path. So an import statement like this 
+`import /c/d.capnp` would match a file in `/a/b/c/d.capnp` if the search path directory was 
+specified as `/a/b`
 
 ### Annotations
 

--- a/doc/language.md
+++ b/doc/language.md
@@ -581,9 +581,9 @@ struct Foo {
 
 The above imports specify relative paths.  If the path begins with a `/`, it is absolute -- in
 this case, the `capnp` tool searches for the file in each of the search path directories specified
-with `-I`, where `/` means the root of each import path. So an import statement like this 
-`import /c/d.capnp` would match a file in `/a/b/c/d.capnp` if the search path directory was 
-specified as `/a/b`
+with `-I`, appending the path you specify to the path given to the `-I` flag. So, for example,
+if you ran `capnp` with `-Ifoo/bar`, and the import statement is `import "/baz/qux.capnp"`, then
+the compiler would open the file `foo/bar/baz/qux.capnp`.
 
 ### Annotations
 


### PR DESCRIPTION
The current documentation caused confusion with the term "absolute path" in import statements in combination with the search path directories. An example should avoid this confusion.

closes #1595 