### PR TITLE
Fix log for unknown transfer encoding error

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1890,7 +1890,7 @@ kj::Own<kj::AsyncInputStream> HttpInputStreamImpl::getEntityBody(
       return kj::heap<HttpConnectionCloseEntityReader>(*this);
     }
 
-    KJ_FAIL_REQUIRE("unknown transfer encoding", te) { break; };
+    KJ_FAIL_REQUIRE("unknown transfer encoding", *te) { break; };
   }
 
   // #4 and #5


### PR DESCRIPTION
The error message for an unknown transfer-encoding header value includes the pointer value instead of the string itself.  Seems to have been introduced accidentally in PR#1454?

https://github.com/capnproto/capnproto/pull/1454/commits/a267d653340198e268782ac856951ee8a23de107#diff-09d28b46bd98866f20dd7241e02c70338a76fdb59a483ed02d4c16bbe6bcc3a1R1889