### PR TITLE
Introduce RefcountedWrapper to refcount types that don't inherit Refcounted.

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -873,14 +873,9 @@ public:
 
     // We want to keep the stream alive even after EofDetector is destroyed, so we need to create
     // a refcounted AsyncIoStream.
-    struct RefcountedWrapper: public kj::Refcounted {
-      kj::Own<kj::AsyncIoStream> stream;
-      RefcountedWrapper(kj::Own<kj::AsyncIoStream> stream) : stream(kj::mv(stream)) {};
-    };
-    auto& pipeRef = *pipe.ends[1];
-    auto refcounted = kj::refcounted<RefcountedWrapper>(kj::mv(pipe.ends[1]));;
-    kj::Own<kj::AsyncIoStream> ref1 = kj::attachRef(pipeRef, kj::addRef(*refcounted));
-    kj::Own<kj::AsyncIoStream> ref2 = kj::attachRef(pipeRef, kj::mv(refcounted));
+    auto refcounted = kj::refcountedWrapper(kj::mv(pipe.ends[1]));
+    kj::Own<kj::AsyncIoStream> ref1 = refcounted->addWrappedRef();
+    kj::Own<kj::AsyncIoStream> ref2 = refcounted->addWrappedRef();
 
     // We write to the `down` pipe.
     auto pumpTask = ref1->pumpTo(*stream)


### PR DESCRIPTION
Various ad hoc versions of this have appeared all over the place, but many of them -- including the one replaced in this PR -- do more allocation than necessary. By building this into refcounted.h, we can take advantage of friendly knowledge that `Refcounted` itself implements `Disposer`, and that said disposer doesn't care what pointer is passed into it, because it knows it's supposed to dispose itself. So we can set the refcounted wrapper as the disposer on an `Own<T>` pointing at the wrapped object, avoiding the need for an additional allocation that would otherwise be needed if we used `kj::attachRef`.

@dom96 can you review? (GitHub won't let me formally set you as reviewer unless I make you a project member, but it'll still let you approve the PR.)