### PR TITLE
Fix TOCTOU bug when recursively deleting a directory with symlinks.

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -188,7 +188,7 @@ static void rmrfChildrenAndClose(int fd) {
       if (entry->d_type == DT_DIR) {
         int subdirFd;
         KJ_SYSCALL(subdirFd = openat(
-            fd, entry->d_name, O_RDONLY | MAYBE_O_DIRECTORY | MAYBE_O_CLOEXEC));
+            fd, entry->d_name, O_RDONLY | MAYBE_O_DIRECTORY | MAYBE_O_CLOEXEC | O_NOFOLLOW));
         rmrfChildrenAndClose(subdirFd);
         KJ_SYSCALL(unlinkat(fd, entry->d_name, AT_REMOVEDIR));
       } else if (entry->d_type != DT_UNKNOWN) {
@@ -217,7 +217,9 @@ static bool rmrf(int fd, StringPtr path) {
   if (S_ISDIR(stats.st_mode)) {
     int subdirFd;
     KJ_SYSCALL(subdirFd = openat(
-        fd, path.cStr(), O_RDONLY | MAYBE_O_DIRECTORY | MAYBE_O_CLOEXEC)) { return false; }
+        fd, path.cStr(), O_RDONLY | MAYBE_O_DIRECTORY | MAYBE_O_CLOEXEC | O_NOFOLLOW)) {
+      return false;
+    }
     rmrfChildrenAndClose(subdirFd);
     KJ_SYSCALL(unlinkat(fd, path.cStr(), AT_REMOVEDIR)) { return false; }
   } else {

--- a/c++/src/kj/filesystem.h
+++ b/c++/src/kj/filesystem.h
@@ -882,6 +882,13 @@ public:
   // tryRemove() returns false in the specific case that the path doesn't exist. remove() would
   // throw in this case. In all other error cases (like "access denied"), tryRemove() still throws;
   // it is only "does not exist" that produces a false return.
+  //
+  // WARNING: The Windows implementation of recursive deletion is currently not safe to call from a
+  //   privileged process to delete directories writable by unprivileged users, due to a race
+  //   condition in which the user could trick the algorithm into following a symlink and deleting
+  //   everything at the destination. This race condition is not present in the Unix
+  //   implementation. Fixing it for Windows would require rewriting a lot of code to use different
+  //   APIs. If you're interested, see the TODO(security) in filesystem-disk-win32.c++.
 
   // TODO(someday):
   // - Support sockets? There's no openat()-like interface for sockets, so it's hard to support


### PR DESCRIPTION
We don't recurse into symlinks, we just delete the symlink. But it's possible that at the time we checked the file type, it was an actual directory, and then someone swapped it out for a symlink before we tried to recurse into it.

Rust recently fixed the same bug, which they treated as a CVE: https://github.com/rust-lang/rust/security/advisories/GHSA-r9cc-f5pr-p3j2

This is only a security issue if the program doing the deleting is a privileged process, and it is deleting directories which are writable to an attacker.

I am not calling this a CVE in KJ because I feel quite comfortable saying that nobody is using KJ filesystem in this way today. It's likely that literally no one is using the recursive-delete feature at all, and no one except my own projects are even using this entire API.

Note: The same bug presumably exists on Windows, but it appears that fixing it would require switching to entirely different APIs, which I'm not going to do today. Instead, I've left a warning.