### PR TITLE
Fix build with gcc 13 by including <cstdint>

### DIFF
--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -24,7 +24,7 @@
 #include <string>
 #include "vector.h"
 #include <locale.h>
-#include <cstdint>
+#include <stdint.h>
 
 namespace kj {
 namespace _ {  // private

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -24,6 +24,7 @@
 #include <string>
 #include "vector.h"
 #include <locale.h>
+#include <cstdint>
 
 namespace kj {
 namespace _ {  // private


### PR DESCRIPTION
Like other versions before, gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included. Explicitly include it for uint8_t.