### PR TITLE
Change sprintf() -> snprintf() to silence warnings.

### DIFF
--- a/c++/src/benchmark/runner.c++
+++ b/c++/src/benchmark/runner.c++
@@ -186,7 +186,7 @@ TestResult runTest(Product product, TestCase testCase, Mode mode, Reuse reuse,
   }
 
   char itersStr[64];
-  sprintf(itersStr, "%llu", (long long unsigned int)iters);
+  snprintf(itersStr, sizeof(itersStr), "%llu", (long long unsigned int)iters);
   argv[4] = itersStr;
 
   argv[5] = nullptr;

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -40,11 +40,6 @@
 #include <sys/wait.h>
 #endif
 
-#if _MSC_VER && !defined(__clang__)
-#pragma warning(disable: 4996)
-// Warns that sprintf() is buffer-overrunny. Yeah, I know, it's cool.
-#endif
-
 namespace kj {
 namespace _ {  // private
 namespace {
@@ -203,7 +198,7 @@ std::string fileLine(std::string file, int line) {
 
   file += ':';
   char buffer[32];
-  sprintf(buffer, "%d", line);
+  snprintf(buffer, sizeof(buffer), "%d", line);
   file += buffer;
   return file;
 }

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -29,11 +29,6 @@
 
 namespace kj {
 
-#if _MSC_VER && !defined(__clang__)
-#pragma warning(disable: 4996)
-// Warns that sprintf() is buffer-overrunny. We know that, it's cool.
-#endif
-
 namespace {
 bool isHex(const char *s) {
   if (*s == '-') s++;
@@ -525,7 +520,7 @@ kj::String LocalizeRadix(const char* input, const char* radix_pos) {
   // to divuldge the locale's radix character.  No, localeconv() is NOT
   // thread-safe.
   char temp[16];
-  int size = sprintf(temp, "%.1f", 1.5);
+  int size = snprintf(temp, sizeof(temp), "%.1f", 1.5);
   KJ_ASSERT(temp[0] == '1');
   KJ_ASSERT(temp[size-1] == '5');
   KJ_ASSERT(size <= 6);


### PR DESCRIPTION
There were only a couple usages and they are all cases that are formatting a single integer therefore couldn't possibly overrun the buffer. Plus most are in test code. But it's easy enough to call snprintf().

This fixes the mac build, which recently started failing due to a deprecation warning for sprintf().