### PR TITLE
Updated the C# other-lang header to be just 'C#' instead of 'C# (.NET Core)'

### DIFF
--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -14,7 +14,7 @@ project's documentation for details.
 ##### Serialization + RPC
 
 * [C++](cxx.html) by [@kentonv](https://github.com/kentonv)
-* [C# (.NET Core)](https://github.com/c80k/capnproto-dotnetcore) by [@c80k](https://github.com/c80k)
+* [C#](https://github.com/c80k/capnproto-dotnetcore) by [@c80k](https://github.com/c80k)
 * [Erlang](http://ecapnp.astekk.se/) by [@kaos](https://github.com/kaos)
 * [Go](https://github.com/zombiezen/go-capnproto2) by [@zombiezen](https://github.com/zombiezen) (forked from [@glycerine](https://github.com/glycerine)'s serialization-only version, below)
 * [Haskell](https://github.com/zenhack/haskell-capnp) by [@zenhack](https://github.com/zenhack)


### PR DESCRIPTION
Currently, the other languages page on the capnproto website implies that the capnproto implementation for the C# languages only supports .NET Core but as of now that is not the case. [The C# implementation](https://github.com/c80k/capnproto-dotnetcore) supports the .NET Standard 2.0 and has for a while now.