### PR TITLE
Fix obscure UAF with sendForPipeline().

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -639,7 +639,8 @@ public:
           return kj::refcounted<LocalPipeline>(kj::mv(context));
         });
 
-    auto tailPipelinePromise = context->onTailCall().then([](AnyPointer::Pipeline&& pipeline) {
+    auto tailPipelinePromise = context->onTailCall()
+        .then([context = context->addRef()](AnyPointer::Pipeline&& pipeline) {
       return kj::mv(pipeline.hook);
     });
 


### PR DESCRIPTION
`tailPipelinePromise` is returned by `context->onTailCall()`, therefore it must hold a strong ref to the context.

This is hard to trigger, because `tailPipelinePromise` is `exclusiveJoin()`ed with `pipelinePromise`, which itself holds such a ref. So, the only way this promise could still exist after `context` has been dropped is the case where this promise is also imminently going to be canceled. But it is actually possible to wedge a continuation in between that UAFs.

This only seems to kick in with `sendForPipeline()` since in the common case the non-pipeline branch also holds the `context` ref long enough to prevent any issue.