### PR TITLE
Implements StartTLS in HttpConnectSettings and NetworkHttpClient.

### DIFF
--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -1088,6 +1088,12 @@ inline ArrayPtr<const T> AncillaryMessage::asArray() const {
   return arrayPtr(reinterpret_cast<const T*>(data.begin()), data.size() / sizeof(T));
 }
 
+class SecureNetworkWrapper: public kj::Network {
+public:
+  virtual kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
+      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) = 0;
+};
+
 }  // namespace kj
 
 KJ_END_HEADER

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -106,6 +106,7 @@ kj_tls_tests = [
     }),
     deps = [
         ":kj-tls",
+        ":kj-http",
         "//src/kj:kj-test",
     ],
 ) for f in kj_tls_tests]

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -4873,7 +4873,7 @@ private:
   uint& cumulative;
 };
 
-class ConnectionCountingNetwork final: public kj::Network {
+class ConnectionCountingNetwork final: public kj::SecureNetworkWrapper {
 public:
   ConnectionCountingNetwork(kj::Network& inner, uint& count, uint& addrCount)
       : inner(inner), count(count), addrCount(addrCount) {}
@@ -4892,6 +4892,10 @@ public:
       kj::ArrayPtr<const kj::StringPtr> allow,
       kj::ArrayPtr<const kj::StringPtr> deny = nullptr) override {
     KJ_UNIMPLEMENTED("test");
+  }
+  kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
+      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) override {
+    KJ_UNIMPLEMENTED("not tested");
   }
 
 private:

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -5621,10 +5621,10 @@ public:
       return c->get()->connect(host, headers, settings);
     } else {
       auto split = promise.addBranch().then(
-          [this, host=kj::str(host), headers=headers.clone(), settings]()
+          [this, host=kj::str(host), headers=headers.clone(), settings]() mutable
           -> kj::Tuple<kj::Promise<ConnectRequest::Status>,
                        kj::Promise<kj::Own<kj::AsyncIoStream>>> {
-        auto request = KJ_ASSERT_NONNULL(client)->connect(host, headers, settings);
+        auto request = KJ_ASSERT_NONNULL(client)->connect(host, headers, kj::mv(settings));
         return kj::tuple(kj::mv(request.status), kj::mv(request.connection));
       }).split();
 
@@ -5644,7 +5644,7 @@ private:
 class NetworkHttpClient final: public HttpClient, private kj::TaskSet::ErrorHandler {
 public:
   NetworkHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
-                    kj::Network& network, kj::Maybe<kj::Network&> tlsNetwork,
+                    kj::Network& network, kj::Maybe<kj::SecureNetworkWrapper&> tlsNetwork,
                     HttpClientSettings settings)
       : timer(timer),
         responseHeaderTable(responseHeaderTable),
@@ -5689,8 +5689,8 @@ public:
     // https://github.com/capnproto/capnproto/pull/1454#discussion_r900414879
     kj::Maybe<kj::Promise<kj::Own<kj::NetworkAddress>>> addr;
     if (settings.useTls) {
-      addr = KJ_REQUIRE_NONNULL(tlsNetwork, "this HttpClient doesn't support TLS")
-          .parseAddress(host);
+      kj::Network& tlsNet = KJ_REQUIRE_NONNULL(tlsNetwork, "this HttpClient doesn't support TLS");
+      addr = tlsNet.parseAddress(host);
     } else {
       addr = network.parseAddress(host);
     }
@@ -5709,9 +5709,30 @@ public:
       }).attach(kj::mv(address));
     }).split();
 
+    auto connection = kj::newPromisedStream(kj::mv(kj::get<1>(split)));
+
+    #if KJ_HAS_OPENSSL
+    if (!settings.useTls) {
+      KJ_IF_MAYBE(tlsNet, tlsNetwork) {
+        KJ_IF_MAYBE(tlsStarter, settings.tlsStarter) {
+          auto refConnection = kj::refcountedWrapper(kj::mv(connection));
+          connection = refConnection->addWrappedRef();
+          kj::Own<kj::AsyncIoStream> ref1 = refConnection->addWrappedRef();
+          Function<kj::Own<kj::AsyncIoStream>(kj::StringPtr)> cb =
+              [tlsNet, ref1 = kj::mv(ref1)](kj::StringPtr expectedServerHostname) mutable {
+            kj::Promise<kj::Own<kj::AsyncIoStream>> secureStream =
+                tlsNet->wrapClient(kj::mv(ref1), expectedServerHostname);
+            return kj::newPromisedStream(kj::mv(secureStream));
+          };
+          *tlsStarter = kj::mv(cb);
+        }
+      }
+    }
+    #endif
+
     return ConnectRequest {
       kj::mv(kj::get<0>(split)),
-      kj::newPromisedStream(kj::mv(kj::get<1>(split)))
+      kj::mv(connection)
     };
   }
 
@@ -5719,7 +5740,7 @@ private:
   kj::Timer& timer;
   const HttpHeaderTable& responseHeaderTable;
   kj::Network& network;
-  kj::Maybe<kj::Network&> tlsNetwork;
+  kj::Maybe<kj::SecureNetworkWrapper&> tlsNetwork;
   HttpClientSettings settings;
 
   struct Host {
@@ -5814,7 +5835,7 @@ kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& respo
 }
 
 kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
-                                  kj::Network& network, kj::Maybe<kj::Network&> tlsNetwork,
+                                  kj::Network& network, kj::Maybe<kj::SecureNetworkWrapper&> tlsNetwork,
                                   HttpClientSettings settings) {
   return kj::heap<NetworkHttpClient>(
       timer, responseHeaderTable, network, tlsNetwork, kj::mv(settings));

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -660,10 +660,24 @@ public:
   // an empty string indicates a preference for no extensions to be applied.
 };
 
+using TlsStarterCallback = kj::Maybe<kj::Function<kj::Own<kj::AsyncIoStream>(kj::StringPtr)>>;
 struct HttpConnectSettings {
   bool useTls = false;
   // Requests to automatically establish a TLS session over the connection. The remote party
   // will be expected to present a valid certificate matching the requested hostname.
+  kj::Maybe<TlsStarterCallback&> tlsStarter;
+  // This is an output parameter. It doesn't need to be set. But if it is set, then it may get
+  // filled with a callback function. It will get filled with `nullptr` if any of the following
+  // are true:
+  //
+  // * kj is not built with TLS support
+  // * the underlying HttpClient does not support the startTls mechanism
+  // * `useTls` has been set to `true` and so TLS has already been started
+  //
+  // The callback function itself can be used to initiate a TLS handshake on the
+  // connection at any arbitrary point. The function returns an AsyncIoStream that is a secure
+  // TLS stream. This mechanism is required for certain protocols, more info can be found on
+  // https://en.wikipedia.org/wiki/Opportunistic_TLS.
 };
 
 class HttpClient {
@@ -904,7 +918,7 @@ struct HttpClientSettings {
 };
 
 kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
-                                  kj::Network& network, kj::Maybe<kj::Network&> tlsNetwork,
+                                  kj::Network& network, kj::Maybe<kj::SecureNetworkWrapper&> tlsNetwork,
                                   HttpClientSettings settings = HttpClientSettings());
 // Creates a proxy HttpClient that connects to hosts over the given network. The URL must always
 // be an absolute URL; the host is parsed from the URL. This implementation will automatically

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -27,6 +27,8 @@
 
 #include "tls.h"
 
+#include "http.h"
+
 #include <openssl/opensslv.h>
 
 #include <stdlib.h>
@@ -1148,6 +1150,43 @@ KJ_TEST("TLS receiver does not stall on hung client") {
   auto extraAcceptPromise = test.receiver->accept().then(readFromClient);
   KJ_EXPECT(!extraAcceptPromise.poll(test.io.waitScope));
 }
+
+#if !_WIN32 // TODO: Investigate and fix issue on Windows.
+KJ_TEST("NetworkHttpClient connect with tlsStarter") {
+  auto io = kj::setupAsyncIo();
+  auto& waitScope KJ_UNUSED = io.waitScope;
+  auto listener1 = io.provider->getNetwork().parseAddress("localhost", 0)
+      .wait(io.waitScope)->listen();
+
+  auto ignored KJ_UNUSED = listener1->accept().then([](Own<kj::AsyncIoStream> stream) {
+    auto buffer = kj::str("test");
+    return stream->write(buffer.cStr(), buffer.size()).attach(kj::mv(stream), kj::mv(buffer));
+  }).eagerlyEvaluate(nullptr);
+
+  HttpClientSettings clientSettings;
+  kj::TimerImpl clientTimer(kj::origin<kj::TimePoint>());
+  HttpHeaderTable headerTable;
+  TlsContext tls;
+
+  auto tlsNetwork = tls.wrapNetwork(io.provider->getNetwork());
+  auto client = newHttpClient(clientTimer, headerTable,
+      io.provider->getNetwork(), *tlsNetwork, clientSettings);
+  kj::HttpConnectSettings httpConnectSettings = { false, nullptr };
+  kj::TlsStarterCallback tlsStarter;
+  httpConnectSettings.tlsStarter = tlsStarter;
+  auto request = client->connect(
+      kj::str("localhost:", listener1->getPort()), HttpHeaders(headerTable), httpConnectSettings);
+
+  KJ_ASSERT(tlsStarter != nullptr);
+
+  auto buf = kj::heapArray<char>(4);
+  return request.connection->tryRead(buf.begin(), 1, buf.size())
+      .then([buf = kj::mv(buf)](size_t count) {
+    KJ_ASSERT(count == 4);
+    KJ_ASSERT(kj::str(buf.asChars()) == "test");
+  }).attach(kj::mv(request.connection)).wait(io.waitScope);
+}
+#endif
 
 #ifdef KJ_EXTERNAL_TESTS
 KJ_TEST("TLS to capnproto.org") {

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -150,7 +150,7 @@ public:
   // as the client when `connect()` is called or the server if `listen()` is called.
   // `connect()` will athenticate the server as `expectedServerHostname`.
 
-  kj::Own<kj::Network> wrapNetwork(kj::Network& network);
+  kj::Own<kj::SecureNetworkWrapper> wrapNetwork(kj::Network& network);
   // Upgrade a Network to one that automatically upgrades all connections to TLS. The network will
   // only accept addresses of the form "hostname" and "hostname:port" (it does not accept raw IP
   // addresses). It will automatically use SNI and verify certificates based on these hostnames.


### PR DESCRIPTION
* In order to access `TlsContext` from a `TlsNetwork` I needed to introduce a new SecureNetworkWrapper.
* The `tlsStarter` callback API isn't perfect, but seems to be our best idea. If anyone has others please share.

### Test Plan

```
bazel test @capnp-cpp//src/kj/compat:tls-test --config=asan --test_timeout 5
```