### PR TITLE
Fulfill readAbortFulfiller in AsyncPipe destructor.

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -217,6 +217,10 @@ public:
       // Don't std::terminate().
       break;
     }
+
+    KJ_IF_MAYBE(raf, readAbortFulfiller) {
+      raf->get()->fulfill();
+    }
   }
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {


### PR DESCRIPTION
This creates errors like: https://gist.github.com/dom96/c77bccefb73c9bd162bf5028f42853cf.

