### PR TITLE
Fix `Maybe<Own<void>>`

### DIFF
--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -295,6 +295,14 @@ TEST(Memory, OwnVoid) {
     voidPtr = nullptr;
     KJ_EXPECT(destructorCalled);
   }
+
+  {
+    Maybe<Own<void>> maybe;
+    maybe = Own<void>(&maybe, NullDisposer::instance);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(maybe).get() == &maybe);
+    maybe = nullptr;
+    KJ_EXPECT(maybe == nullptr);
+  }
 }
 
 TEST(Memory, OwnConstVoid) {
@@ -348,6 +356,14 @@ TEST(Memory, OwnConstVoid) {
     KJ_EXPECT(!destructorCalled);
     voidPtr = nullptr;
     KJ_EXPECT(destructorCalled);
+  }
+
+  {
+    Maybe<Own<const void>> maybe;
+    maybe = Own<const void>(&maybe, NullDisposer::instance);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(maybe).get() == &maybe);
+    maybe = nullptr;
+    KJ_EXPECT(maybe == nullptr);
   }
 }
 
@@ -433,6 +449,14 @@ KJ_TEST("Own with static disposer") {
     KJ_EXPECT(disposedPtr == nullptr);
   }
   KJ_EXPECT(disposedPtr == &i);
+}
+
+KJ_TEST("Maybe<Own<T>>") {
+  Maybe<Own<int>> m = heap<int>(123);
+  KJ_EXPECT(m != nullptr);
+  Maybe<int&> mRef = m;
+  KJ_EXPECT(KJ_ASSERT_NONNULL(mRef) == 123);
+  KJ_EXPECT(&KJ_ASSERT_NONNULL(mRef) == KJ_ASSERT_NONNULL(m).get());
 }
 
 // TODO(test):  More tests.

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -461,8 +461,14 @@ public:
     return ptr;
   }
 
-  inline operator Maybe<T&>() { return ptr.get(); }
-  inline operator Maybe<const T&>() const { return ptr.get(); }
+  template <typename U = T>
+  inline operator NoInfer<Maybe<U&>>() { return ptr.get(); }
+  template <typename U = T>
+  inline operator NoInfer<Maybe<const U&>>() const { return ptr.get(); }
+  // Implicit conversion to `Maybe<U&>`. The weird templating is to make sure that
+  // `Maybe<Own<void>>` can be instantiated with the compiler complaining about forming references
+  // to void -- the use of templates here will cause SFINAE to kick in and hide these, whereas if
+  // they are not templates then SFINAE isn't applied and so they are considered errors.
 
   inline Maybe& operator=(Maybe&& other) { ptr = kj::mv(other.ptr); return *this; }
 


### PR DESCRIPTION
Without this change there are compiler errors. ~This isn't really the ideal fix (it implies a `Maybe<void>` which obviously doesn't work)... but it fixes the errors without introducing any actual new problems.~ I made it better.