### PR TITLE
Revert "Implements StartTLS in HttpConnectSettings and NetworkHttpClient."

### DIFF
--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -1088,12 +1088,6 @@ inline ArrayPtr<const T> AncillaryMessage::asArray() const {
   return arrayPtr(reinterpret_cast<const T*>(data.begin()), data.size() / sizeof(T));
 }
 
-class SecureNetworkWrapper: public kj::Network {
-public:
-  virtual kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
-      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) = 0;
-};
-
 }  // namespace kj
 
 KJ_END_HEADER

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -106,7 +106,6 @@ kj_tls_tests = [
     }),
     deps = [
         ":kj-tls",
-        ":kj-http",
         "//src/kj:kj-test",
     ],
 ) for f in kj_tls_tests]

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -4873,7 +4873,7 @@ private:
   uint& cumulative;
 };
 
-class ConnectionCountingNetwork final: public kj::SecureNetworkWrapper {
+class ConnectionCountingNetwork final: public kj::Network {
 public:
   ConnectionCountingNetwork(kj::Network& inner, uint& count, uint& addrCount)
       : inner(inner), count(count), addrCount(addrCount) {}
@@ -4892,10 +4892,6 @@ public:
       kj::ArrayPtr<const kj::StringPtr> allow,
       kj::ArrayPtr<const kj::StringPtr> deny = nullptr) override {
     KJ_UNIMPLEMENTED("test");
-  }
-  kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
-      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) override {
-    KJ_UNIMPLEMENTED("not tested");
   }
 
 private:

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -660,24 +660,10 @@ public:
   // an empty string indicates a preference for no extensions to be applied.
 };
 
-using TlsStarterCallback = kj::Maybe<kj::Function<kj::Own<kj::AsyncIoStream>(kj::StringPtr)>>;
 struct HttpConnectSettings {
   bool useTls = false;
   // Requests to automatically establish a TLS session over the connection. The remote party
   // will be expected to present a valid certificate matching the requested hostname.
-  kj::Maybe<TlsStarterCallback&> tlsStarter;
-  // This is an output parameter. It doesn't need to be set. But if it is set, then it may get
-  // filled with a callback function. It will get filled with `nullptr` if any of the following
-  // are true:
-  //
-  // * kj is not built with TLS support
-  // * the underlying HttpClient does not support the startTls mechanism
-  // * `useTls` has been set to `true` and so TLS has already been started
-  //
-  // The callback function itself can be used to initiate a TLS handshake on the
-  // connection at any arbitrary point. The function returns an AsyncIoStream that is a secure
-  // TLS stream. This mechanism is required for certain protocols, more info can be found on
-  // https://en.wikipedia.org/wiki/Opportunistic_TLS.
 };
 
 class HttpClient {
@@ -918,7 +904,7 @@ struct HttpClientSettings {
 };
 
 kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,
-                                  kj::Network& network, kj::Maybe<kj::SecureNetworkWrapper&> tlsNetwork,
+                                  kj::Network& network, kj::Maybe<kj::Network&> tlsNetwork,
                                   HttpClientSettings settings = HttpClientSettings());
 // Creates a proxy HttpClient that connects to hosts over the given network. The URL must always
 // be an absolute URL; the host is parsed from the URL. This implementation will automatically

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -27,8 +27,6 @@
 
 #include "tls.h"
 
-#include "http.h"
-
 #include <openssl/opensslv.h>
 
 #include <stdlib.h>
@@ -1150,43 +1148,6 @@ KJ_TEST("TLS receiver does not stall on hung client") {
   auto extraAcceptPromise = test.receiver->accept().then(readFromClient);
   KJ_EXPECT(!extraAcceptPromise.poll(test.io.waitScope));
 }
-
-#if !_WIN32 // TODO: Investigate and fix issue on Windows.
-KJ_TEST("NetworkHttpClient connect with tlsStarter") {
-  auto io = kj::setupAsyncIo();
-  auto& waitScope KJ_UNUSED = io.waitScope;
-  auto listener1 = io.provider->getNetwork().parseAddress("localhost", 0)
-      .wait(io.waitScope)->listen();
-
-  auto ignored KJ_UNUSED = listener1->accept().then([](Own<kj::AsyncIoStream> stream) {
-    auto buffer = kj::str("test");
-    return stream->write(buffer.cStr(), buffer.size()).attach(kj::mv(stream), kj::mv(buffer));
-  }).eagerlyEvaluate(nullptr);
-
-  HttpClientSettings clientSettings;
-  kj::TimerImpl clientTimer(kj::origin<kj::TimePoint>());
-  HttpHeaderTable headerTable;
-  TlsContext tls;
-
-  auto tlsNetwork = tls.wrapNetwork(io.provider->getNetwork());
-  auto client = newHttpClient(clientTimer, headerTable,
-      io.provider->getNetwork(), *tlsNetwork, clientSettings);
-  kj::HttpConnectSettings httpConnectSettings = { false, nullptr };
-  kj::TlsStarterCallback tlsStarter;
-  httpConnectSettings.tlsStarter = tlsStarter;
-  auto request = client->connect(
-      kj::str("localhost:", listener1->getPort()), HttpHeaders(headerTable), httpConnectSettings);
-
-  KJ_ASSERT(tlsStarter != nullptr);
-
-  auto buf = kj::heapArray<char>(4);
-  return request.connection->tryRead(buf.begin(), 1, buf.size())
-      .then([buf = kj::mv(buf)](size_t count) {
-    KJ_ASSERT(count == 4);
-    KJ_ASSERT(kj::str(buf.asChars()) == "test");
-  }).attach(kj::mv(request.connection)).wait(io.waitScope);
-}
-#endif
 
 #ifdef KJ_EXTERNAL_TESTS
 KJ_TEST("TLS to capnproto.org") {

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -624,10 +624,7 @@ private:
   kj::Own<kj::NetworkAddress> inner;
 };
 
-// =======================================================================================
-// class TlsNetwork
-
-class TlsNetwork final: public kj::SecureNetworkWrapper {
+class TlsNetwork final: public kj::Network {
 public:
   TlsNetwork(TlsContext& tls, kj::Network& inner): tls(tls), inner(inner) {}
   TlsNetwork(TlsContext& tls, kj::Own<kj::Network> inner)
@@ -699,11 +696,6 @@ public:
     //   Or is it better to let people do that via the TlsContext? A neat thing about
     //   restrictPeers() is that it's easy to make user-configurable.
     return kj::heap<TlsNetwork>(tls, inner.restrictPeers(allow, deny));
-  }
-
-  kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
-      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) override {
-    return tls.wrapClient(kj::mv(stream), expectedServerHostname);
   }
 
 private:
@@ -947,7 +939,7 @@ kj::Own<kj::NetworkAddress> TlsContext::wrapAddress(
   return kj::heap<TlsNetworkAddress>(*this, kj::str(expectedServerHostname), kj::mv(address));
 }
 
-kj::Own<kj::SecureNetworkWrapper> TlsContext::wrapNetwork(kj::Network& network) {
+kj::Own<kj::Network> TlsContext::wrapNetwork(kj::Network& network) {
   return kj::heap<TlsNetwork>(*this, network);
 }
 

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -150,7 +150,7 @@ public:
   // as the client when `connect()` is called or the server if `listen()` is called.
   // `connect()` will athenticate the server as `expectedServerHostname`.
 
-  kj::Own<kj::SecureNetworkWrapper> wrapNetwork(kj::Network& network);
+  kj::Own<kj::Network> wrapNetwork(kj::Network& network);
   // Upgrade a Network to one that automatically upgrades all connections to TLS. The network will
   // only accept addresses of the form "hostname" and "hostname:port" (it does not accept raw IP
   // addresses). It will automatically use SNI and verify certificates based on these hostnames.


### PR DESCRIPTION
Reverts capnproto/capnproto#1635

This actually breaks the workerd build and possibly others, due to the breaking API change which I pointed out and which was not, contrary to the PR thread, actually fixed.

cc @dom96