### PR TITLE
Implements StartTLS in HttpConnectSettings and NetworkHttpClient. (Followup)

### DIFF
--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -1088,6 +1088,25 @@ inline ArrayPtr<const T> AncillaryMessage::asArray() const {
   return arrayPtr(reinterpret_cast<const T*>(data.begin()), data.size() / sizeof(T));
 }
 
+class SecureNetworkWrapper {
+public:
+  virtual kj::Promise<kj::Own<kj::AsyncIoStream>> wrapServer(kj::Own<kj::AsyncIoStream> stream) = 0;
+
+  virtual kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
+      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) = 0;
+
+  virtual kj::Promise<kj::AuthenticatedStream> wrapServer(kj::AuthenticatedStream stream) = 0;
+  virtual kj::Promise<kj::AuthenticatedStream> wrapClient(
+      kj::AuthenticatedStream stream, kj::StringPtr expectedServerHostname) = 0;
+
+  virtual kj::Own<kj::ConnectionReceiver> wrapPort(kj::Own<kj::ConnectionReceiver> port) = 0;
+
+  virtual kj::Own<kj::NetworkAddress> wrapAddress(
+      kj::Own<kj::NetworkAddress> address, kj::StringPtr expectedServerHostname) = 0;
+
+  virtual kj::Own<kj::Network> wrapNetwork(kj::Network& network) = 0;
+};
+
 }  // namespace kj
 
 KJ_END_HEADER

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -1089,22 +1089,54 @@ inline ArrayPtr<const T> AncillaryMessage::asArray() const {
 }
 
 class SecureNetworkWrapper {
+  // Abstract interface for a class which implements a "secure" network as a wrapper around an
+  // insecure one. "secure" means:
+  // * Connections to a server will only succeed if it can be verified that the requested hostname
+  //   actually belongs to the responding server.
+  // * No man-in-the-middle attacker can potentially see the bytes sent and received.
+  //
+  // The typical implementation uses TLS. The object in this case could be configured to use cerain
+  // keys, certificates, etc. See kj/compat/tls.h for such an implementation.
+  //
+  // However, an implementation could use some other form of encryption, or might not need to use
+  // encryption at all. For example, imagine a kj::Network that exists only on a single machine,
+  // providing communications between various processes using unix sockets. Perhaps the "hostnames"
+  // are actually PIDs in this case. An implementation of such a network could verify the other
+  // side's identity using an `SCM_CREDENTIALS` auxiliary message, which cannot be forged. Once
+  // verified, there is no need to encrypt since unix sockets cannot be intercepted.
+
 public:
   virtual kj::Promise<kj::Own<kj::AsyncIoStream>> wrapServer(kj::Own<kj::AsyncIoStream> stream) = 0;
+  // Act as the server side of a connection. The given stream is already connected to a client, but
+  // no authentication has occurred. The returned stream represents the secure transport once
+  // established.
 
   virtual kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
       kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) = 0;
+  // Act as the client side of a connection. The given stream is already connecetd to a server, but
+  // no authentication has occurred. This method will verify that the server actually is the given
+  // hostname, then return the stream representing a secure transport to that server.
 
   virtual kj::Promise<kj::AuthenticatedStream> wrapServer(kj::AuthenticatedStream stream) = 0;
   virtual kj::Promise<kj::AuthenticatedStream> wrapClient(
       kj::AuthenticatedStream stream, kj::StringPtr expectedServerHostname) = 0;
+  // Same as above, but implementing kj::AuthenticatedStream, which provides PeerIdentity objects
+  // with more details about the peer. The SecureNetworkWrapper will provide its own implementation
+  // of PeerIdentity with the specific details it is able to authenticate.
 
   virtual kj::Own<kj::ConnectionReceiver> wrapPort(kj::Own<kj::ConnectionReceiver> port) = 0;
+  // Wrap a connection listener. This is equivalent to calling wrapServer() on every connection
+  // received.
 
   virtual kj::Own<kj::NetworkAddress> wrapAddress(
       kj::Own<kj::NetworkAddress> address, kj::StringPtr expectedServerHostname) = 0;
+  // Wrap a NetworkAddress. This is equivalent to calling `wrapClient()` on every connection
+  // formed by calling `connect()` on the address.
 
   virtual kj::Own<kj::Network> wrapNetwork(kj::Network& network) = 0;
+  // Wrap a whole `kj::Network`. This automatically wraps everything constructed using the network.
+  // The network will only accept address strings that can be authenticated, and will automatically
+  // authenticate servers against those addresses when connecting to them.
 };
 
 }  // namespace kj

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -106,6 +106,7 @@ kj_tls_tests = [
     }),
     deps = [
         ":kj-tls",
+        ":kj-http",
         "//src/kj:kj-test",
     ],
 ) for f in kj_tls_tests]

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -660,10 +660,24 @@ public:
   // an empty string indicates a preference for no extensions to be applied.
 };
 
+using TlsStarterCallback = kj::Maybe<kj::Function<kj::Own<kj::AsyncIoStream>(kj::StringPtr)>>;
 struct HttpConnectSettings {
   bool useTls = false;
   // Requests to automatically establish a TLS session over the connection. The remote party
   // will be expected to present a valid certificate matching the requested hostname.
+  kj::Maybe<TlsStarterCallback&> tlsStarter;
+  // This is an output parameter. It doesn't need to be set. But if it is set, then it may get
+  // filled with a callback function. It will get filled with `nullptr` if any of the following
+  // are true:
+  //
+  // * kj is not built with TLS support
+  // * the underlying HttpClient does not support the startTls mechanism
+  // * `useTls` has been set to `true` and so TLS has already been started
+  //
+  // The callback function itself can be used to initiate a TLS handshake on the
+  // connection at any arbitrary point. The function returns an AsyncIoStream that is a secure
+  // TLS stream. This mechanism is required for certain protocols, more info can be found on
+  // https://en.wikipedia.org/wiki/Opportunistic_TLS.
 };
 
 class HttpClient {
@@ -901,6 +915,9 @@ struct HttpClientSettings {
     AUTOMATIC_COMPRESSION, // Automatically includes the compression header in the WebSocket request.
   };
   WebSocketCompressionMode webSocketCompressionMode = NO_COMPRESSION;
+
+  kj::Maybe<SecureNetworkWrapper&> tlsContext;
+  // A reference to a TLS context that will be used when tlsStarter is invoked.
 };
 
 kj::Own<HttpClient> newHttpClient(kj::Timer& timer, const HttpHeaderTable& responseHeaderTable,

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -51,7 +51,7 @@ enum class TlsVersion {
 using TlsErrorHandler = kj::Function<void(kj::Exception&&)>;
 // Use a simple kj::Function for handling errors during parallel accept().
 
-class TlsContext {
+class TlsContext: public kj::SecureNetworkWrapper {
   // TLS system. Allocate one of these, configure it with the proper keys and certificates (or
   // use the defaults), and then use it to wrap the standard KJ network interfaces in
   // implementations that transparently use TLS.


### PR DESCRIPTION
Corrected version of https://github.com/capnproto/capnproto/pull/1635.

For reference, we want to ensure:

* No API breakage
* That kj-http doesn't depend on kj-tls.

This new PR should now ensure this.

### Test Plan

```
bazel test @capnp-cpp//src/kj/compat:tls-test --config=asan --test_timeout 5
```