### PR TITLE
Support kj::addRef(const T&)

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -58,8 +58,8 @@ TEST(Refcount, Basic) {
 }
 
 TEST(Refcount, Const) {
-  // Ensure `kj::addRef` supports argument of type `Own<const T>` and in that
-  // case returns `Own<const T>`
+  // Ensure `kj::addRef` supports argument of type `const T&` and in that case
+  // returns `Own<const T>`
   static_assert(isSameType<
       Own<const SetTrueInDestructor>,
       decltype(kj::addRef(kj::instance<const SetTrueInDestructor&>()))

--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -58,12 +58,13 @@ TEST(Refcount, Basic) {
 }
 
 TEST(Refcount, Const) {
-  // Ensure `kj::addRef` supports argument of type `const T&` and in that case
-  // returns `Own<const T>`
-  static_assert(isSameType<
-      Own<const SetTrueInDestructor>,
-      decltype(kj::addRef(kj::instance<const SetTrueInDestructor&>()))
-  >());
+  static_assert(
+      isSameType<
+          Own<const SetTrueInDestructor>,
+          decltype(kj::addRef(kj::instance<const SetTrueInDestructor&>()))
+      >(),
+      "kj::addRef(const T&) must return Own<const T>"
+  );
 
   bool b = false;
 

--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -57,6 +57,24 @@ TEST(Refcount, Basic) {
 #endif
 }
 
+TEST(Refcount, Const) {
+  // Ensure `kj::addRef` supports argument of type `Own<const T>` and in that
+  // case returns `Own<const T>`
+  static_assert(isSameType<
+      Own<const SetTrueInDestructor>,
+      decltype(kj::addRef(kj::instance<const SetTrueInDestructor&>()))
+  >());
+
+  bool b = false;
+
+  {
+    Own<const SetTrueInDestructor> refConst1 = kj::refcounted<SetTrueInDestructor>(&b);
+    Own<const SetTrueInDestructor> refConst2 = kj::addRef(*refConst1);
+  }
+
+  EXPECT_TRUE(b);
+}
+
 struct SetTrueInDestructor2 {
   // Like above but doesn't inherit Refcounted.
 

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -75,7 +75,8 @@ public:
 
 private:
   mutable uint refcount = 0;
-  // "mutable" because disposeImpl() is const.  Bleh.
+  // "mutable" because disposeImpl() is const and addRefInternal must support const T* arguments.
+  // Bleh.
 
   void disposeImpl(void* pointer) const override;
   template <typename T>
@@ -110,8 +111,8 @@ Own<T> addRef(T& object) {
 
 template <typename T>
 Own<T> Refcounted::addRefInternal(T* object) {
-  Refcounted* refcounted = object;
-  ++refcounted->refcount;
+  const Refcounted* refcounted = object;
+  ++refcounted->refcount; // `refcount` is mutable
   return Own<T>(object, *refcounted);
 }
 


### PR DESCRIPTION
Currently, for a given `T` derived from `kj::Refcounted`, passing a `const T&` to `kj::addRef` does not compile. GCC says:

```
capnproto/c++/src/kj/refcount.h:113:28: error: invalid conversion from ‘const kj::Refcounted*’ to ‘kj::Refcounted*’ [-fpermissive]
  113 |   Refcounted* refcounted = object;
      |                            ^~~~~~
      |                            |
      |                            const kj::Refcounted*
```

But I think it should be fine to `kj::addRef` a `const T` as long as you get a `Own<const T>` in return.