### PR TITLE
Implements tlsStarter for http-over-capnp.

### DIFF
--- a/c++/src/capnp/compat/byte-stream.capnp
+++ b/c++/src/capnp/compat/byte-stream.capnp
@@ -25,6 +25,10 @@ interface ByteStream {
   # While a substream is active, it is an error to call write() on the original stream. Doing so
   # may throw an exception or may arbitrarily interleave bytes with the substream's writes.
 
+  startTls @3 (expectedServerHostname :Text) -> stream;
+  # Client calls this method when it wants to initiate TLS. This ByteStream is not terminated,
+  # the caller should reuse it.
+
   interface SubstreamCallback {
     ended @0 (byteCount :UInt64);
     # `end()` was called on the substream after writing `byteCount` bytes. The `end()` call was

--- a/c++/src/capnp/compat/byte-stream.h
+++ b/c++/src/capnp/compat/byte-stream.h
@@ -24,6 +24,7 @@
 
 #include <capnp/compat/byte-stream.capnp.h>
 #include <kj/async-io.h>
+#include <kj/compat/http.h>
 
 CAPNP_BEGIN_HEADER
 
@@ -54,6 +55,8 @@ class ByteStreamFactory {
 
 public:
   capnp::ByteStream::Client kjToCapnp(kj::Own<kj::AsyncOutputStream> kjStream);
+  capnp::ByteStream::Client kjToCapnp(
+      kj::Own<kj::AsyncOutputStream> kjStream, kj::Maybe<kj::Own<kj::TlsStarterCallback>> tlsStarter);
   kj::Own<kj::AsyncOutputStream> capnpToKj(capnp::ByteStream::Client capnpStream);
 
   kj::Own<ExplicitEndOutputStream> capnpToKjExplicitEnd(capnp::ByteStream::Client capnpStream);

--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -60,7 +60,8 @@ interface HttpService {
   #   constructor parameter to specify which method to use, for backwards-compatibiltiy purposes.
 
   connect @2 (host :Text, headers :List(HttpHeader), down :ByteStream,
-              context :ConnectClientRequestContext, settings :ConnectSettings) -> (up :ByteStream);
+              context :ConnectClientRequestContext, settings :ConnectSettings)
+          -> (up :ByteStream);
   # Setup an HTTP CONNECT proxy tunnel.
   #
   # The client sends the request host/headers together with a `down` ByteStream that will be used


### PR DESCRIPTION
Implements tlsStarter support for CONNECT via http-over-capnp.

### Test Plan

```
$ bazel test @capnp-cpp//src/capnp/compat:http-over-capnp-test --test_timeout 5
$ bazel test //src/capnp/compat:http-over-capnp-test --test_timeout 5
```

and upstream tests.