### PR TITLE
Fix return type of hash operator (`bool` -> `size_t`).

### DIFF
--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -148,7 +148,7 @@ private:
 namespace {
 
 struct SchemaFileHash {
-  inline bool operator()(const SchemaFile* f) const {
+  inline size_t operator()(const SchemaFile* f) const {
     return f->hashCode();
   }
 };


### PR DESCRIPTION
Using `bool` essentially turns the hash map into a bad linked list: lookup is `O(n)`.