### PR TITLE
Fix subtle bug with multi-hop disembargos.

### DIFF
--- a/c++/src/capnp/compat/byte-stream-test.c++
+++ b/c++/src/capnp/compat/byte-stream-test.c++
@@ -307,7 +307,7 @@ KJ_TEST("KJ -> ByteStream RPC -> KJ pipe -> ByteStream RPC -> KJ with shortening
       rpc::twoparty::Side::CLIENT);
   capnp::TwoPartyClient server(*rpcConnection.ends[1],
       serverFactory.kjToCapnp(kj::mv(middlePipe.out)),
-      rpc::twoparty::Side::CLIENT);
+      rpc::twoparty::Side::SERVER);
 
   auto backWrapped = serverFactory.capnpToKj(server.bootstrap().castAs<ByteStream>());
   auto midPumpPormise = middlePipe.in->pumpTo(*backWrapped, 3);
@@ -377,7 +377,7 @@ KJ_TEST("KJ -> ByteStream RPC -> KJ pipe -> ByteStream RPC -> KJ with concurrent
       rpc::twoparty::Side::CLIENT);
   capnp::TwoPartyClient server(*rpcConnection.ends[1],
       serverFactory.kjToCapnp(kj::mv(middlePipe.out)),
-      rpc::twoparty::Side::CLIENT);
+      rpc::twoparty::Side::SERVER);
 
   auto backWrapped = serverFactory.capnpToKj(server.bootstrap().castAs<ByteStream>());
   auto midPumpPormise = middlePipe.in->pumpTo(*backWrapped);
@@ -448,7 +448,7 @@ KJ_TEST("KJ -> KJ pipe -> ByteStream RPC -> KJ pipe -> ByteStream RPC -> KJ with
       rpc::twoparty::Side::CLIENT);
   capnp::TwoPartyClient server(*rpcConnection.ends[1],
       serverFactory.kjToCapnp(kj::mv(middlePipe.out)),
-      rpc::twoparty::Side::CLIENT);
+      rpc::twoparty::Side::SERVER);
 
   auto backWrapped = serverFactory.capnpToKj(server.bootstrap().castAs<ByteStream>());
   auto midPumpPormise = middlePipe.in->pumpTo(*backWrapped);

--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -48,6 +48,7 @@
 // Mark Miller on membranes: http://www.eros-os.org/pipermail/e-lang/2003-January/008434.html
 
 #include "capability.h"
+#include <kj/map.h>
 
 CAPNP_BEGIN_HEADER
 
@@ -183,6 +184,15 @@ public:
   // capability passed into the membrane and then back out.
   //
   // The default implementation simply returns `external`.
+
+private:
+  kj::HashMap<ClientHook*, ClientHook*> wrappers;
+  kj::HashMap<ClientHook*, ClientHook*> reverseWrappers;
+  // Tracks capabilities that already have wrappers instantiated. The maps map from pointer to
+  // inner capability to pointer to wrapper. When a wrapper is destroyed it removes itself from
+  // the map.
+
+  friend class MembraneHook;
 };
 
 Capability::Client membrane(Capability::Client inner, kj::Own<MembranePolicy> policy);

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -1190,6 +1190,82 @@ KJ_TEST("Two-hop embargo") {
   EXPECT_EQ(5, call5.wait(waitScope).getN());
 }
 
+class TestCallOrderImplAsPromise final: public test::TestCallOrder::Server {
+  // This is an implementation of TestCallOrder that presents itself as a promise by implementing
+  // `shortenPath()`, although it never resolves to anything (`shortenPath()` never completes).
+  // This tests deeper code paths in promise resolution and embargo code.
+public:
+  template <typename... Params>
+  TestCallOrderImplAsPromise(Params&&... params): inner(kj::fwd<Params>(params)...) {}
+
+  kj::Promise<void> getCallSequence(GetCallSequenceContext context) override {
+    return inner.getCallSequence(context);
+  }
+
+  kj::Maybe<kj::Promise<Capability::Client>> shortenPath() override {
+    // Make this object appear to be a promise.
+    return kj::Promise<Capability::Client>(kj::NEVER_DONE);
+  }
+
+private:
+  TestCallOrderImpl inner;
+};
+
+KJ_TEST("Two-hop embargo") {
+  // Same as above, but the eventual resolution is itself a promise. This verifies that
+  // handleDisembargo() only waits for the target to resolve back to the capability that the
+  // disembargo should reflect to, but not beyond that.
+
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  int callCount = 0, handleCount = 0;
+
+  // Set up two two-party RPC connections in series. The middle node just proxies requests through.
+  auto frontPipe = kj::newTwoWayPipe();
+  auto backPipe = kj::newTwoWayPipe();
+  TwoPartyClient tpClient(*frontPipe.ends[0]);
+  TwoPartyClient proxyBack(*backPipe.ends[0]);
+  TwoPartyClient proxyFront(*frontPipe.ends[1], proxyBack.bootstrap(), rpc::twoparty::Side::SERVER);
+  TwoPartyClient tpServer(*backPipe.ends[1], kj::heap<TestMoreStuffImpl>(callCount, handleCount),
+      rpc::twoparty::Side::SERVER);
+
+  // Perform some logic that does a bunch of promise pipelining, including passing a capability
+  // from the client to the server and back to the client, and making promise-pipelined calls on
+  // that capability. This should exercise the promise resolution and disembargo code.
+  auto client = tpClient.bootstrap().castAs<test::TestMoreStuff>();
+
+  auto cap = test::TestCallOrder::Client(kj::heap<TestCallOrderImplAsPromise>());
+
+  auto earlyCall = client.getCallSequenceRequest().send();
+
+  auto echoRequest = client.echoRequest();
+  echoRequest.setCap(cap);
+  auto echo = echoRequest.send();
+
+  auto pipeline = echo.getCap();
+
+  auto call0 = getCallSequence(pipeline, 0);
+  auto call1 = getCallSequence(pipeline, 1);
+
+  earlyCall.wait(waitScope);
+
+  auto call2 = getCallSequence(pipeline, 2);
+
+  auto resolved = echo.wait(waitScope).getCap();
+
+  auto call3 = getCallSequence(pipeline, 3);
+  auto call4 = getCallSequence(pipeline, 4);
+  auto call5 = getCallSequence(pipeline, 5);
+
+  EXPECT_EQ(0, call0.wait(waitScope).getN());
+  EXPECT_EQ(1, call1.wait(waitScope).getN());
+  EXPECT_EQ(2, call2.wait(waitScope).getN());
+  EXPECT_EQ(3, call3.wait(waitScope).getN());
+  EXPECT_EQ(4, call4.wait(waitScope).getN());
+  EXPECT_EQ(5, call5.wait(waitScope).getN());
+}
+
 }  // namespace
 }  // namespace _
 }  // namespace capnp

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -1129,6 +1129,67 @@ KJ_TEST("Dropping capability during call doesn't destroy server") {
   KJ_EXPECT(count == 0);
 }
 
+RemotePromise<test::TestCallOrder::GetCallSequenceResults> getCallSequence(
+    test::TestCallOrder::Client& client, uint expected) {
+  auto req = client.getCallSequenceRequest();
+  req.setExpected(expected);
+  return req.send();
+}
+
+KJ_TEST("Two-hop embargo") {
+  // Copied from `TEST(Rpc, Embargo)` in `rpc-test.c++`, adapted to involve a two-hop path through
+  // a proxy. This tests what happens when disembargoes on multiple hops are happening in parallel.
+
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  int callCount = 0, handleCount = 0;
+
+  // Set up two two-party RPC connections in series. The middle node just proxies requests through.
+  auto frontPipe = kj::newTwoWayPipe();
+  auto backPipe = kj::newTwoWayPipe();
+  TwoPartyClient tpClient(*frontPipe.ends[0]);
+  TwoPartyClient proxyBack(*backPipe.ends[0]);
+  TwoPartyClient proxyFront(*frontPipe.ends[1], proxyBack.bootstrap(), rpc::twoparty::Side::SERVER);
+  TwoPartyClient tpServer(*backPipe.ends[1], kj::heap<TestMoreStuffImpl>(callCount, handleCount),
+      rpc::twoparty::Side::SERVER);
+
+  // Perform some logic that does a bunch of promise pipelining, including passing a capability
+  // from the client to the server and back to the client, and making promise-pipelined calls on
+  // that capability. This should exercise the promise resolution and disembargo code.
+  auto client = tpClient.bootstrap().castAs<test::TestMoreStuff>();
+
+  auto cap = test::TestCallOrder::Client(kj::heap<TestCallOrderImpl>());
+
+  auto earlyCall = client.getCallSequenceRequest().send();
+
+  auto echoRequest = client.echoRequest();
+  echoRequest.setCap(cap);
+  auto echo = echoRequest.send();
+
+  auto pipeline = echo.getCap();
+
+  auto call0 = getCallSequence(pipeline, 0);
+  auto call1 = getCallSequence(pipeline, 1);
+
+  earlyCall.wait(waitScope);
+
+  auto call2 = getCallSequence(pipeline, 2);
+
+  auto resolved = echo.wait(waitScope).getCap();
+
+  auto call3 = getCallSequence(pipeline, 3);
+  auto call4 = getCallSequence(pipeline, 4);
+  auto call5 = getCallSequence(pipeline, 5);
+
+  EXPECT_EQ(0, call0.wait(waitScope).getN());
+  EXPECT_EQ(1, call1.wait(waitScope).getN());
+  EXPECT_EQ(2, call2.wait(waitScope).getN());
+  EXPECT_EQ(3, call3.wait(waitScope).getN());
+  EXPECT_EQ(4, call4.wait(waitScope).getN());
+  EXPECT_EQ(5, call5.wait(waitScope).getN());
+}
+
 }  // namespace
 }  // namespace _
 }  // namespace capnp


### PR DESCRIPTION
See commit descriptions and comments.

This could cause the spurious error: `'Disembargo' of type 'senderLoopback' sent to an object that does not point back to the sender.`

The error would also be followed by closing the connection.

/cc @zenhack @dwrensha in case their implementations might have the same bug.