### PR TITLE
[bazel] Fix zlib compilation on macOS

### DIFF
--- a/c++/WORKSPACE
+++ b/c++/WORKSPACE
@@ -30,10 +30,14 @@ cc_library(
     name = "zlib",
     srcs = glob(["*.c"]),
     hdrs = glob(["*.h"]),
+    # Temporary workaround for zlib warnings and mac compilation, should no longer be needed with next release https://github.com/madler/zlib/issues/633
     copts = [
         "-w",
         "-Dverbose=-1",
-    ],
+    ] + select({
+        "@platforms//os:macos": [ "-std=c90" ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 """


### PR DESCRIPTION
The macOS zlib build has been broken with recent versions of XCode, see https://github.com/bazelbuild/bazel/issues/17956 for additional discussion. Changing the C standard version for zlib is a relatively painless workaround. Note that build systems other than bazel link the system zlib and are not affected by this issue.