### PR TITLE
Added getCanceler function to capnp::MembranePolicy

### DIFF
--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -49,6 +49,7 @@
 
 #include "capability.h"
 #include <kj/map.h>
+#include "kj/async.h"
 
 CAPNP_BEGIN_HEADER
 
@@ -192,6 +193,8 @@ public:
   // capability passed into the membrane and then back out.
   //
   // The default implementation simply returns `external`.
+
+  virtual kj::Maybe<kj::Canceler&> getCanceler() { return nullptr; }
 
 private:
   kj::HashMap<ClientHook*, ClientHook*> wrappers;

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -902,6 +902,8 @@ interface TestMembrane {
 
   waitForever @4 () $Cxx.allowCancellation;
 
+  callChained @5 ();
+
   interface Thing {
     passThrough @0 () -> Result;
     intercept @1 () -> Result;

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 # kj ===========================================================================
 
+find_package(Boost REQUIRED)
+
 set(kj_sources_lite
   array.c++
   list.c++
@@ -20,6 +22,7 @@ set(kj_sources_lite
   test-helpers.c++
   units.c++
   encoding.c++
+  observer.c++
 )
 set(kj_sources_heavy
   refcount.c++
@@ -66,6 +69,7 @@ set(kj_headers
   main.h
   win32-api-version.h
   windows-sanity.h
+  observer.h
 )
 set(kj-parse_headers
   parse/common.h
@@ -78,6 +82,8 @@ add_library(kj ${kj_sources})
 add_library(CapnProto::kj ALIAS kj)
 # TODO(cleanup): Use cxx_std_14 once it's safe to require cmake 3.8.
 target_compile_features(kj PUBLIC cxx_generic_lambdas)
+
+target_include_directories(kj PRIVATE ${Boost_INCLUDE_DIRS})
 
 if(UNIX AND NOT ANDROID)
   target_link_libraries(kj PUBLIC pthread)

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -229,6 +229,7 @@ void Canceler::cancel(const Exception& exception) {
       break;
     }
   }
+  cancellationSubject.notify(exception);
 }
 
 void Canceler::release() {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -23,6 +23,7 @@
 
 #include "async-prelude.h"
 #include <kj/exception.h>
+#include <kj/observer.h>
 #include <kj/refcount.h>
 
 KJ_BEGIN_HEADER
@@ -899,6 +900,11 @@ public:
   // Indicates if any previously-wrapped promises are still executing. (If this returns true, then
   // cancel() would be a no-op.)
 
+  template <typename Func>
+  Subscription onCanceled(Func&& observer) {
+    return cancellationSubject.subscribe(fwd<Func>(observer));
+  }
+
 private:
   class AdapterBase {
   public:
@@ -938,6 +944,7 @@ private:
   };
 
   Maybe<AdapterBase&> list;
+  kj::Subject<kj::Exception> cancellationSubject;
 };
 
 template <>

--- a/c++/src/kj/observer.c++
+++ b/c++/src/kj/observer.c++
@@ -1,0 +1,58 @@
+#include "observer.h"
+#include <boost/signals2.hpp> // keep this out of exposed headers
+
+namespace kj {
+
+class SubscriptionBaseImpl : public _::SubscriptionBase {
+public:
+  explicit SubscriptionBaseImpl(boost::signals2::connection&& connection) : connection(mv(connection)) {}
+  boost::signals2::scoped_connection connection;
+};
+
+class VoidSubjectBaseImpl : public _::VoidSubjectBase {
+public:
+  Own<_::SubscriptionBase> subscribe(Function<void()> &&callback) override {
+    auto cb = heap<Function<void()>>(mv(callback));
+    return heap<SubscriptionBaseImpl>(signal.connect([&callback = *cb]() {
+      callback();
+    })).attach(mv(cb));
+  }
+
+  void notify() override {
+    signal();
+  }
+
+private:
+  boost::signals2::signal<void()> signal;
+};
+
+class ParameterSubjectBaseImpl : public _::ParameterSubjectBase {
+public:
+  Own<_::SubscriptionBase> subscribe(Function<void(const void*)>&& callback) override {
+    auto cb = heap<Function<void(const void*)>>(mv(callback));
+    return heap<SubscriptionBaseImpl>(signal.connect([&callback = *cb](const void* event) {
+      callback(event);
+    })).attach(mv(cb));
+  }
+
+  void notify(const void* event) override {
+    signal(event);
+  }
+
+private:
+  boost::signals2::signal<void(const void*)> signal;
+};
+
+namespace _ {
+Own<_::VoidSubjectBase> newVoidSubjectBase() {
+  return heap<VoidSubjectBaseImpl>();
+}
+
+Own<_::ParameterSubjectBase> newParameterSubjectBase() {
+  return heap<ParameterSubjectBaseImpl>();
+}
+}
+
+Subscription::Subscription(Own<_::SubscriptionBase> &&base) : base(mv(base)) {}
+
+}

--- a/c++/src/kj/observer.h
+++ b/c++/src/kj/observer.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "common.h"
+#include "function.h"
+#include "memory.h"
+
+KJ_BEGIN_HEADER
+
+namespace kj {
+
+namespace _ {
+
+class SubscriptionBase {
+public:
+  virtual ~SubscriptionBase() = default;
+};
+
+class VoidSubjectBase {
+public:
+  virtual Own<SubscriptionBase> subscribe(Function<void()> &&callback) = 0;
+
+  virtual void notify() = 0;
+
+  virtual ~VoidSubjectBase() = default;
+};
+
+Own<VoidSubjectBase> newVoidSubjectBase();
+
+class ParameterSubjectBase {
+public:
+  virtual Own<SubscriptionBase> subscribe(Function<void(const void *event)> &&callback) = 0;
+
+  virtual void notify(const void *event) = 0;
+
+  virtual ~ParameterSubjectBase() = default;
+};
+
+Own<ParameterSubjectBase> newParameterSubjectBase();
+
+}
+
+class Subscription {
+public:
+  explicit Subscription(Own<_::SubscriptionBase>&& base);
+  Subscription(Subscription&&) = default;
+private:
+  Own<_::SubscriptionBase> base;
+};
+
+template <typename T>
+class Subject
+{
+public:
+  Subject() : base(_::newParameterSubjectBase()) {}
+  Subscription subscribe(Function<void(const T&)>&& callback) {
+    return Subscription(base->subscribe([callback = mv(callback)](const void* event) mutable {
+      callback(*static_cast<const T*>(event));
+    }));
+  }
+
+  void notify(const T& event) {
+    base->notify(static_cast<const void*>(&event));
+  }
+
+private:
+  Own<_::ParameterSubjectBase> base;
+};
+
+template <>
+class Subject<void>
+{
+public:
+  Subject() : base(_::newVoidSubjectBase()) {}
+
+  Subscription subscribe(Function<void()>&& callback) {
+    return Subscription(base->subscribe(mv(callback)));
+  }
+
+  void notify() {
+    base->notify();
+  }
+
+private:
+  Own<_::VoidSubjectBase> base;
+};
+
+}
+
+KJ_END_HEADER


### PR DESCRIPTION
Permits synchronous (immediate) revocation that does not rely on event loop processing.