### PR TITLE
Implement `joinPromisesFailFast()`

### DIFF
--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -58,6 +58,7 @@ class WaitScope;
 class TaskSet;
 
 Promise<void> joinPromises(Array<Promise<void>>&& promises, SourceLocation location = {});
+Promise<void> joinPromisesFailFast(Array<Promise<void>>&& promises, SourceLocation location = {});
 // Out-of-line <void> specialization of template function defined in async.h.
 
 namespace _ {  // private

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -667,36 +667,134 @@ TEST(Async, ExclusiveJoin) {
 }
 
 TEST(Async, ArrayJoin) {
-  EventLoop loop;
-  WaitScope waitScope(loop);
+  for (auto specificJoinPromisesOverload: {
+    +[](kj::Array<kj::Promise<int>> promises) { return joinPromises(kj::mv(promises)); },
+    +[](kj::Array<kj::Promise<int>> promises) { return joinPromisesFailFast(kj::mv(promises)); }
+  }) {
+    EventLoop loop;
+    WaitScope waitScope(loop);
 
-  auto builder = heapArrayBuilder<Promise<int>>(3);
-  builder.add(123);
-  builder.add(456);
-  builder.add(789);
+    auto builder = heapArrayBuilder<Promise<int>>(3);
+    builder.add(123);
+    builder.add(456);
+    builder.add(789);
 
-  Promise<Array<int>> promise = joinPromises(builder.finish());
+    Promise<Array<int>> promise = specificJoinPromisesOverload(builder.finish());
 
-  auto result = promise.wait(waitScope);
+    auto result = promise.wait(waitScope);
 
-  ASSERT_EQ(3u, result.size());
-  EXPECT_EQ(123, result[0]);
-  EXPECT_EQ(456, result[1]);
-  EXPECT_EQ(789, result[2]);
+    ASSERT_EQ(3u, result.size());
+    EXPECT_EQ(123, result[0]);
+    EXPECT_EQ(456, result[1]);
+    EXPECT_EQ(789, result[2]);
+  }
 }
 
 TEST(Async, ArrayJoinVoid) {
+  for (auto specificJoinPromisesOverload: {
+    +[](kj::Array<kj::Promise<void>> promises) { return joinPromises(kj::mv(promises)); },
+    +[](kj::Array<kj::Promise<void>> promises) { return joinPromisesFailFast(kj::mv(promises)); }
+  }) {
+    EventLoop loop;
+    WaitScope waitScope(loop);
+
+    auto builder = heapArrayBuilder<Promise<void>>(3);
+    builder.add(READY_NOW);
+    builder.add(READY_NOW);
+    builder.add(READY_NOW);
+
+    Promise<void> promise = specificJoinPromisesOverload(builder.finish());
+
+    promise.wait(waitScope);
+  }
+}
+
+struct Pafs {
+  kj::Array<Promise<void>> promises;
+  kj::Array<Own<PromiseFulfiller<void>>> fulfillers;
+};
+
+Pafs makeCompletionCountingPafs(uint count, uint& tasksCompleted) {
+  auto promisesBuilder = heapArrayBuilder<Promise<void>>(count);
+  auto fulfillersBuilder = heapArrayBuilder<Own<PromiseFulfiller<void>>>(count);
+
+  for (auto KJ_UNUSED value: zeroTo(count)) {
+    auto paf = newPromiseAndFulfiller<void>();
+    promisesBuilder.add(paf.promise.then([&tasksCompleted]() {
+      ++tasksCompleted;
+    }));
+    fulfillersBuilder.add(kj::mv(paf.fulfiller));
+  }
+
+  return { promisesBuilder.finish(), fulfillersBuilder.finish() };
+}
+
+TEST(Async, ArrayJoinException) {
   EventLoop loop;
   WaitScope waitScope(loop);
 
-  auto builder = heapArrayBuilder<Promise<void>>(3);
-  builder.add(READY_NOW);
-  builder.add(READY_NOW);
-  builder.add(READY_NOW);
+  uint tasksCompleted = 0;
+  auto pafs = makeCompletionCountingPafs(5, tasksCompleted);
+  auto& fulfillers = pafs.fulfillers;
+  Promise<void> promise = joinPromises(kj::mv(pafs.promises));
 
-  Promise<void> promise = joinPromises(builder.finish());
+  {
+    uint i = 0;
+    KJ_EXPECT(tasksCompleted == 0);
 
-  promise.wait(waitScope);
+    // Joined tasks are not completed early.
+    fulfillers[i++]->fulfill();
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(tasksCompleted == 0);
+
+    fulfillers[i++]->fulfill();
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(tasksCompleted == 0);
+
+    // Rejected tasks do not fail-fast.
+    fulfillers[i++]->reject(KJ_EXCEPTION(FAILED, "Test exception"));
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(tasksCompleted == 0);
+
+    fulfillers[i++]->fulfill();
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(tasksCompleted == 0);
+
+    // The final fulfillment makes the promise ready.
+    fulfillers[i++]->fulfill();
+    KJ_EXPECT_THROW_MESSAGE("Test exception", promise.wait(waitScope));
+    KJ_EXPECT(tasksCompleted == 4);
+  }
+}
+
+TEST(Async, ArrayJoinFailFastException) {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  uint tasksCompleted = 0;
+  auto pafs = makeCompletionCountingPafs(5, tasksCompleted);
+  auto& fulfillers = pafs.fulfillers;
+  Promise<void> promise = joinPromisesFailFast(kj::mv(pafs.promises));
+
+  {
+    uint i = 0;
+    KJ_EXPECT(tasksCompleted == 0);
+
+    // Joined tasks are completed eagerly, not waiting until the join node is awaited.
+    fulfillers[i++]->fulfill();
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(tasksCompleted == i);
+
+    fulfillers[i++]->fulfill();
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(tasksCompleted == i);
+
+    fulfillers[i++]->reject(KJ_EXCEPTION(FAILED, "Test exception"));
+
+    // The first rejection makes the promise ready.
+    KJ_EXPECT_THROW_MESSAGE("Test exception", promise.wait(waitScope));
+    KJ_EXPECT(tasksCompleted == i - 1);
+  }
 }
 
 TEST(Async, Canceler) {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -556,7 +556,18 @@ private:
 
 template <typename T>
 Promise<Array<T>> joinPromises(Array<Promise<T>>&& promises, SourceLocation location = {});
-// Join an array of promises into a promise for an array.
+// Join an array of promises into a promise for an array. Trailing continuations on promises are not
+// evaluated until all promises have settled. Exceptions are propagated only after the last promise
+// has settled.
+//
+// TODO(cleanup): It is likely that `joinPromisesFailFast()` is what everyone should be using.
+//   Deprecate this function.
+
+template <typename T>
+Promise<Array<T>> joinPromisesFailFast(Array<Promise<T>>&& promises, SourceLocation location = {});
+// Join an array of promises into a promise for an array. Trailing continuations on promises are
+// evaluated eagerly. If any promise results in an exception, the exception is immediately
+// propagated to the returned join promise.
 
 // =======================================================================================
 // Hack for creating a lambda that holds an owned pointer.

--- a/kjdoc/tour.md
+++ b/kjdoc/tour.md
@@ -910,9 +910,11 @@ The opposite of forking promises is joining promises. There are two types of joi
 
 For an exclusive join, use `promise.exclusiveJoin(kj::mv(otherPromise))`. The two promises must return the same type. The result is a promise that returns whichever result is produced first, and cancels the other promise at that time. (To exclusively join more than two promises, call `.exclusiveJoin()` multiple times in a chain.)
 
-To perform an inclusive join, use `kj::joinPromises()`. This turns a `kj::Array<kj::Promise<T>>` into a `kj::Promise<kj::Array<T>>`. However, note that `kj::joinPromises()` has a couple common gotchas:
+To perform an inclusive join, use `kj::joinPromises()` or `kj::joinPromisesFailFast()`. These turn a `kj::Array<kj::Promise<T>>` into a `kj::Promise<kj::Array<T>>`. However, note that `kj::joinPromises()` has a couple common gotchas:
 * Trailing continuations on the promises passed to `kj::joinPromises()` are evaluated lazily after all the promises become ready. Use `.eagerlyEvaluate()` on each one to force trailing continuations to happen eagerly. (See earlier discussion under "Background Tasks".)
-* If any promise in the array rejects, the exception will be held until all other promises have completed (or rejected), and only then will the exception propagate. In practice we've found that most uses of `kj::joinPromises()` would prefer "exclusive" or "fail-fast" behavior in the case of an exception, but as of this writing we have not yet introduced a function that does this.
+* If any promise in the array rejects, the exception will be held until all other promises have completed (or rejected), and only then will the exception propagate. In practice we've found that most uses of `kj::joinPromises()` would prefer "exclusive" or "fail-fast" behavior in the case of an exception.
+
+`kj::joinPromisesFailFast()` addresses the gotchas described above: promise continuations are evaluated eagerly, and if any promise results in an exception, the join promise is immediately rejected with that exception.
 
 ### Threads
 


### PR DESCRIPTION
@dom96 and I were recently bitten rather hard by a latent bug in `HttpServiceAdapter::connect()`, in which pump exceptions do not eagerly cancel the returned promise, but instead hang in limbo.

We know roughly what a solution should look like: a fail-fast form of `joinPromises()`. I took a stab at implementing such a thing in this PR, which I called `joinPromisesFailFast()`.

A subsequent commit in the PR uses `joinPromisesFailFast()` to solve a few of the places we know this bug exists. Notably, `HttpServiceAdapter::connect()` required slight adjustments in order to keep tests passing, because exceptions from the pump promises must not cancel the returned promise in the event of an error response.