### PR TITLE
Include additional ws compression error reason

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -3132,7 +3132,7 @@ private:
         case Mode::DECOMPRESS:
           result = inflate(&ctx, Z_SYNC_FLUSH);
           KJ_REQUIRE(result == Z_OK || result == Z_BUF_ERROR || result == Z_STREAM_END,
-                      "Decompression failed", result);
+                      "Decompression failed", result, " with reason", ctx.msg);
           break;
       }
 


### PR DESCRIPTION
Turns out there's a "reason" string for what went wrong when attempting to inflate the compressed data; we should add this to the error.