### PR TITLE
No schema on dynamic set of generic

### DIFF
--- a/c++/src/capnp/dynamic-test.c++
+++ b/c++/src/capnp/dynamic-test.c++
@@ -473,6 +473,40 @@ TEST(DynamicApi, SetDataFromText) {
   EXPECT_EQ(data("foo"), root.get("dataField").as<Data>());
 }
 
+void wrappedEnumListTest(std::string field)
+{
+  MallocMessageBuilder builder;
+  auto root = builder.initRoot<DynamicStruct>(Schema::from<TestAllTypes>());
+  auto wrapper = root.init(field).as<DynamicStruct>();
+  wrapper.set("value", {TestEnum::BAR, TestEnum::FOO});
+  checkList<TestEnum>(wrapper.get("value"), {TestEnum::BAR, TestEnum::FOO});
+}
+
+TEST(DynamicApi, SetWrappedEnumListFromNative) {
+  wrappedEnumListTest("wrappedEnumList");
+}
+
+TEST(DynamicApi, SetGenericWrappedEnumListFromNative) {
+  wrappedEnumListTest("genericWrappedEnumList");
+}
+
+void wrappedStructTest(std::string field)
+{
+  MallocMessageBuilder builder;
+  auto root = builder.initRoot<DynamicStruct>(Schema::from<TestAllTypes>());
+  auto wrapper = root.init(field).as<DynamicStruct>();
+  auto structValue = wrapper.get("value").as<DynamicStruct>();
+  structValue.set("int32Field", 123);
+}
+
+TEST(DynamicApi, SetWrappedStruct) {
+  wrappedStructTest("wrappedStructField");
+}
+
+TEST(DynamicApi, SetGenericWrappedStruct) {
+  wrappedStructTest("genericWrappedStructField");
+}
+
 TEST(DynamicApi, BuilderAssign) {
   MallocMessageBuilder builder;
   auto root = builder.initRoot<DynamicStruct>(Schema::from<TestAllTypes>());

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -38,6 +38,18 @@ enum TestEnum {
   garply @7;
 }
 
+struct GenericWrapper(Type) {
+    value      @0 : Type;
+}
+
+struct WrappedEnumList {
+    value      @0 : List(TestEnum);
+}
+
+struct WrappedStruct {
+    value      @0 : TestAllTypes;
+}
+
 struct TestAllTypes {
   voidField      @0  : Void;
   boolField      @1  : Bool;
@@ -74,6 +86,10 @@ struct TestAllTypes {
   structList    @31 : List(TestAllTypes);
   enumList      @32 : List(TestEnum);
   interfaceList @33 : List(Void);  # TODO
+  wrappedStructField    @34 : WrappedStruct;
+  wrappedEnumList    @35 : WrappedEnumList;
+  genericWrappedStructField    @36 : GenericWrapper(TestAllTypes);
+  genericWrappedEnumList    @37 : GenericWrapper(List(TestEnum));
 }
 
 struct TestDefaults {


### PR DESCRIPTION
These tests demonstrate that you cannot set values for a list of enums via dynamic if it is wrapped in a generic.