### PR TITLE
Add new type ConstString

### DIFF
--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -50,6 +50,7 @@ struct HashCoder {
   inline uint operator*(const Array<char>& s) const { return operator*(s.asBytes()); }
   inline uint operator*(const String& s) const { return operator*(s.asBytes()); }
   inline uint operator*(const StringPtr& s) const { return operator*(s.asBytes()); }
+  inline uint operator*(const ConstString& s) const { return operator*(s.asBytes()); }
 
   inline uint operator*(decltype(nullptr)) const { return 0; }
   inline uint operator*(bool b) const { return b; }

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -379,6 +379,12 @@ KJ_TEST("float stringification and parsing is not locale-dependent") {
     KJ_EXPECT("1.5"_kj.parseAs<double>() == 1.5);
   }
 }
+
+KJ_TEST("ConstString") {
+  kj::ConstString theString = "it's a const string!"_kjc;
+  KJ_EXPECT(theString == "it's a const string!");
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj


### PR DESCRIPTION
This type is useful for cases where you want to store a borrowed StringPtr or an owned String and don't care about mutability of the String itself.