### PR TITLE
fixing memset undefined behavior

### DIFF
--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -917,7 +917,7 @@ public:
 
   void clear() {
     erasedCount = 0;
-    memset(buckets.begin(), 0, buckets.asBytes().size());
+    if (buckets.size() > 0) memset(buckets.begin(), 0, buckets.asBytes().size());
   }
 
   template <typename Row>


### PR DESCRIPTION
while works in practice, it triggers the ubsan. easy to fix and overhead is probably negligible.