### PR TITLE
Fix off-by-one in WebSocket maximum message size.

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2544,7 +2544,7 @@ public:
 
     size_t payloadLen = recvHeader.getPayloadLen();
 
-    KJ_REQUIRE(payloadLen < maxSize, "WebSocket message is too large");
+    KJ_REQUIRE(payloadLen <= maxSize, "WebSocket message is too large");
 
     auto opcode = recvHeader.getOpcode();
     bool isData = opcode < OPCODE_FIRST_CONTROL;


### PR DESCRIPTION
kj::WebSocketImpl::receive(maxSize) should let you receive a message that is at most maxSize bytes, but actually you only get maxSize-1 bytes. This commit makes the obvious fix.