### PR TITLE
Failed optimization: Change RawBrandedSchema::dependencies from a map to an array.

### DIFF
--- a/c++/src/capnp/compat/json.capnp.c++
+++ b/c++/src/capnp/compat/json.capnp.c++
@@ -168,9 +168,19 @@ static const ::capnp::_::RawSchema* const d_a3fa7845f919dd83[] = {
 };
 static const uint16_t m_a3fa7845f919dd83[] = {4, 1, 6, 0, 2, 5, 7, 3};
 static const uint16_t i_a3fa7845f919dd83[] = {0, 1, 2, 3, 4, 5, 6, 7};
+constexpr const ::capnp::_::RawBrandedSchema* bd_a3fa7845f919dd83[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_a3fa7845f919dd83.defaultBrand,
+  &::capnp::schemas::s_e31026e735d69ddf.defaultBrand,
+  &::capnp::schemas::s_a0d9f6eca1c93d48.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_a3fa7845f919dd83 = {
   0xa3fa7845f919dd83, b_a3fa7845f919dd83.words, 152, d_a3fa7845f919dd83, m_a3fa7845f919dd83,
-  3, 8, i_a3fa7845f919dd83, nullptr, nullptr, { &s_a3fa7845f919dd83, nullptr, nullptr, 0, 0, nullptr }, false
+  3, 8, i_a3fa7845f919dd83, nullptr, nullptr, { &s_a3fa7845f919dd83, nullptr, bd_a3fa7845f919dd83, 0, sizeof(bd_a3fa7845f919dd83) / sizeof(bd_a3fa7845f919dd83[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<49> b_e31026e735d69ddf = {
@@ -231,9 +241,13 @@ static const ::capnp::_::RawSchema* const d_e31026e735d69ddf[] = {
 };
 static const uint16_t m_e31026e735d69ddf[] = {0, 1};
 static const uint16_t i_e31026e735d69ddf[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_e31026e735d69ddf[] = {
+  nullptr,
+  &::capnp::schemas::s_a3fa7845f919dd83.defaultBrand,
+};
 const ::capnp::_::RawSchema s_e31026e735d69ddf = {
   0xe31026e735d69ddf, b_e31026e735d69ddf.words, 49, d_e31026e735d69ddf, m_e31026e735d69ddf,
-  1, 2, i_e31026e735d69ddf, nullptr, nullptr, { &s_e31026e735d69ddf, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_e31026e735d69ddf, nullptr, nullptr, { &s_e31026e735d69ddf, nullptr, bd_e31026e735d69ddf, 0, sizeof(bd_e31026e735d69ddf) / sizeof(bd_e31026e735d69ddf[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<54> b_a0d9f6eca1c93d48 = {
@@ -299,9 +313,13 @@ static const ::capnp::_::RawSchema* const d_a0d9f6eca1c93d48[] = {
 };
 static const uint16_t m_a0d9f6eca1c93d48[] = {0, 1};
 static const uint16_t i_a0d9f6eca1c93d48[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_a0d9f6eca1c93d48[] = {
+  nullptr,
+  &::capnp::schemas::s_a3fa7845f919dd83.defaultBrand,
+};
 const ::capnp::_::RawSchema s_a0d9f6eca1c93d48 = {
   0xa0d9f6eca1c93d48, b_a0d9f6eca1c93d48.words, 54, d_a0d9f6eca1c93d48, m_a0d9f6eca1c93d48,
-  1, 2, i_a0d9f6eca1c93d48, nullptr, nullptr, { &s_a0d9f6eca1c93d48, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_a0d9f6eca1c93d48, nullptr, nullptr, { &s_a0d9f6eca1c93d48, nullptr, bd_a0d9f6eca1c93d48, 0, sizeof(bd_a0d9f6eca1c93d48) / sizeof(bd_a0d9f6eca1c93d48[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<21> b_fa5b1fd61c2e7c3d = {
@@ -405,9 +423,12 @@ static const ::capnp::_::AlignedData<35> b_c4df13257bc2ea61 = {
 #if !CAPNP_LITE
 static const uint16_t m_c4df13257bc2ea61[] = {0};
 static const uint16_t i_c4df13257bc2ea61[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c4df13257bc2ea61[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_c4df13257bc2ea61 = {
   0xc4df13257bc2ea61, b_c4df13257bc2ea61.words, 35, nullptr, m_c4df13257bc2ea61,
-  0, 1, i_c4df13257bc2ea61, nullptr, nullptr, { &s_c4df13257bc2ea61, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 1, i_c4df13257bc2ea61, nullptr, nullptr, { &s_c4df13257bc2ea61, nullptr, bd_c4df13257bc2ea61, 0, sizeof(bd_c4df13257bc2ea61) / sizeof(bd_c4df13257bc2ea61[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<22> b_cfa794e8d19a0162 = {
@@ -498,9 +519,13 @@ static const ::capnp::_::AlignedData<51> b_c2f8c20c293e5319 = {
 #if !CAPNP_LITE
 static const uint16_t m_c2f8c20c293e5319[] = {0, 1};
 static const uint16_t i_c2f8c20c293e5319[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c2f8c20c293e5319[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_c2f8c20c293e5319 = {
   0xc2f8c20c293e5319, b_c2f8c20c293e5319.words, 51, nullptr, m_c2f8c20c293e5319,
-  0, 2, i_c2f8c20c293e5319, nullptr, nullptr, { &s_c2f8c20c293e5319, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 2, i_c2f8c20c293e5319, nullptr, nullptr, { &s_c2f8c20c293e5319, nullptr, bd_c2f8c20c293e5319, 0, sizeof(bd_c2f8c20c293e5319) / sizeof(bd_c2f8c20c293e5319[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<21> b_d7d879450a253e4b = {

--- a/c++/src/capnp/compiler/grammar.capnp.c++
+++ b/c++/src/capnp/compiler/grammar.capnp.c++
@@ -77,9 +77,14 @@ static const ::capnp::_::AlignedData<66> b_e75816b56529d464 = {
 #if !CAPNP_LITE
 static const uint16_t m_e75816b56529d464[] = {2, 1, 0};
 static const uint16_t i_e75816b56529d464[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_e75816b56529d464[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_e75816b56529d464 = {
   0xe75816b56529d464, b_e75816b56529d464.words, 66, nullptr, m_e75816b56529d464,
-  0, 3, i_e75816b56529d464, nullptr, nullptr, { &s_e75816b56529d464, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 3, i_e75816b56529d464, nullptr, nullptr, { &s_e75816b56529d464, nullptr, bd_e75816b56529d464, 0, sizeof(bd_e75816b56529d464) / sizeof(bd_e75816b56529d464[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<66> b_991c7a3693d62cf2 = {
@@ -154,9 +159,14 @@ static const ::capnp::_::AlignedData<66> b_991c7a3693d62cf2 = {
 #if !CAPNP_LITE
 static const uint16_t m_991c7a3693d62cf2[] = {2, 1, 0};
 static const uint16_t i_991c7a3693d62cf2[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_991c7a3693d62cf2[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_991c7a3693d62cf2 = {
   0x991c7a3693d62cf2, b_991c7a3693d62cf2.words, 66, nullptr, m_991c7a3693d62cf2,
-  0, 3, i_991c7a3693d62cf2, nullptr, nullptr, { &s_991c7a3693d62cf2, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 3, i_991c7a3693d62cf2, nullptr, nullptr, { &s_991c7a3693d62cf2, nullptr, bd_991c7a3693d62cf2, 0, sizeof(bd_991c7a3693d62cf2) / sizeof(bd_991c7a3693d62cf2[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<66> b_90f2a60678fd2367 = {
@@ -231,9 +241,14 @@ static const ::capnp::_::AlignedData<66> b_90f2a60678fd2367 = {
 #if !CAPNP_LITE
 static const uint16_t m_90f2a60678fd2367[] = {2, 1, 0};
 static const uint16_t i_90f2a60678fd2367[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_90f2a60678fd2367[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_90f2a60678fd2367 = {
   0x90f2a60678fd2367, b_90f2a60678fd2367.words, 66, nullptr, m_90f2a60678fd2367,
-  0, 3, i_90f2a60678fd2367, nullptr, nullptr, { &s_90f2a60678fd2367, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 3, i_90f2a60678fd2367, nullptr, nullptr, { &s_90f2a60678fd2367, nullptr, bd_90f2a60678fd2367, 0, sizeof(bd_90f2a60678fd2367) / sizeof(bd_90f2a60678fd2367[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<262> b_8e207d4dfe54d0de = {
@@ -511,9 +526,27 @@ static const ::capnp::_::RawSchema* const d_8e207d4dfe54d0de[] = {
 };
 static const uint16_t m_8e207d4dfe54d0de[] = {13, 11, 10, 15, 9, 3, 14, 6, 12, 2, 1, 5, 8, 4, 7, 0};
 static const uint16_t i_8e207d4dfe54d0de[] = {0, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 8, 9};
+constexpr const ::capnp::_::RawBrandedSchema* bd_8e207d4dfe54d0de[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  &::capnp::schemas::s_c90246b71adedbaa.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_aee8397040b0df7a.defaultBrand,
+  &::capnp::schemas::s_aa28e1400d793359.defaultBrand,
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+};
 const ::capnp::_::RawSchema s_8e207d4dfe54d0de = {
   0x8e207d4dfe54d0de, b_8e207d4dfe54d0de.words, 262, d_8e207d4dfe54d0de, m_8e207d4dfe54d0de,
-  5, 16, i_8e207d4dfe54d0de, nullptr, nullptr, { &s_8e207d4dfe54d0de, nullptr, nullptr, 0, 0, nullptr }, false
+  5, 16, i_8e207d4dfe54d0de, nullptr, nullptr, { &s_8e207d4dfe54d0de, nullptr, bd_8e207d4dfe54d0de, 0, sizeof(bd_8e207d4dfe54d0de) / sizeof(bd_8e207d4dfe54d0de[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<65> b_c90246b71adedbaa = {
@@ -591,9 +624,14 @@ static const ::capnp::_::RawSchema* const d_c90246b71adedbaa[] = {
 };
 static const uint16_t m_c90246b71adedbaa[] = {1, 0, 2};
 static const uint16_t i_c90246b71adedbaa[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c90246b71adedbaa[] = {
+  nullptr,
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+};
 const ::capnp::_::RawSchema s_c90246b71adedbaa = {
   0xc90246b71adedbaa, b_c90246b71adedbaa.words, 65, d_c90246b71adedbaa, m_c90246b71adedbaa,
-  2, 3, i_c90246b71adedbaa, nullptr, nullptr, { &s_c90246b71adedbaa, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 3, i_c90246b71adedbaa, nullptr, nullptr, { &s_c90246b71adedbaa, nullptr, bd_c90246b71adedbaa, 0, sizeof(bd_c90246b71adedbaa) / sizeof(bd_c90246b71adedbaa[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<55> b_aee8397040b0df7a = {
@@ -661,9 +699,13 @@ static const ::capnp::_::RawSchema* const d_aee8397040b0df7a[] = {
 };
 static const uint16_t m_aee8397040b0df7a[] = {0, 1};
 static const uint16_t i_aee8397040b0df7a[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_aee8397040b0df7a[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  &::capnp::schemas::s_c90246b71adedbaa.defaultBrand,
+};
 const ::capnp::_::RawSchema s_aee8397040b0df7a = {
   0xaee8397040b0df7a, b_aee8397040b0df7a.words, 55, d_aee8397040b0df7a, m_aee8397040b0df7a,
-  2, 2, i_aee8397040b0df7a, nullptr, nullptr, { &s_aee8397040b0df7a, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_aee8397040b0df7a, nullptr, nullptr, { &s_aee8397040b0df7a, nullptr, bd_aee8397040b0df7a, 0, sizeof(bd_aee8397040b0df7a) / sizeof(bd_aee8397040b0df7a[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<49> b_aa28e1400d793359 = {
@@ -725,9 +767,13 @@ static const ::capnp::_::RawSchema* const d_aa28e1400d793359[] = {
 };
 static const uint16_t m_aa28e1400d793359[] = {1, 0};
 static const uint16_t i_aa28e1400d793359[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_aa28e1400d793359[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+};
 const ::capnp::_::RawSchema s_aa28e1400d793359 = {
   0xaa28e1400d793359, b_aa28e1400d793359.words, 49, d_aa28e1400d793359, m_aa28e1400d793359,
-  2, 2, i_aa28e1400d793359, nullptr, nullptr, { &s_aa28e1400d793359, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_aa28e1400d793359, nullptr, nullptr, { &s_aa28e1400d793359, nullptr, bd_aa28e1400d793359, 0, sizeof(bd_aa28e1400d793359) / sizeof(bd_aa28e1400d793359[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<677> b_96efe787c17e83bb = {
@@ -1427,9 +1473,53 @@ static const ::capnp::_::RawSchema* const d_96efe787c17e83bb[] = {
 };
 static const uint16_t m_96efe787c17e83bb[] = {18, 3, 40, 37, 39, 22, 41, 34, 31, 32, 24, 25, 26, 23, 35, 36, 33, 28, 29, 30, 27, 21, 9, 6, 5, 10, 11, 13, 7, 15, 1, 16, 17, 20, 19, 0, 2, 38, 4, 12, 14, 8};
 static const uint16_t i_96efe787c17e83bb[] = {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 39, 40, 41, 0, 1, 2, 3, 4, 5, 6, 38};
+constexpr const ::capnp::_::RawBrandedSchema* bd_96efe787c17e83bb[] = {
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+  &::capnp::schemas::s_89f0c973c103ae96.defaultBrand,
+  &::capnp::schemas::s_96efe787c17e83bb.defaultBrand,
+  &::capnp::schemas::s_d00489d473826290.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_e93164a80bfe2ccf.defaultBrand,
+  &::capnp::schemas::s_b348322a8dcf0d0c.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_8f2622208fb358c8.defaultBrand,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_992a90eaf30235d3.defaultBrand,
+  &::capnp::schemas::s_eb971847d617c0b9.defaultBrand,
+  &::capnp::schemas::s_9cb9e86e3198037f.defaultBrand,
+  &::capnp::schemas::s_991c7a3693d62cf2.defaultBrand,
+  &::capnp::schemas::s_d00489d473826290.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_d5e71144af1ce175.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_96efe787c17e83bb = {
   0x96efe787c17e83bb, b_96efe787c17e83bb.words, 677, d_96efe787c17e83bb, m_96efe787c17e83bb,
-  12, 42, i_96efe787c17e83bb, nullptr, nullptr, { &s_96efe787c17e83bb, nullptr, nullptr, 0, 0, nullptr }, false
+  12, 42, i_96efe787c17e83bb, nullptr, nullptr, { &s_96efe787c17e83bb, nullptr, bd_96efe787c17e83bb, 0, sizeof(bd_96efe787c17e83bb) / sizeof(bd_96efe787c17e83bb[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<67> b_d5e71144af1ce175 = {
@@ -1505,9 +1595,14 @@ static const ::capnp::_::AlignedData<67> b_d5e71144af1ce175 = {
 #if !CAPNP_LITE
 static const uint16_t m_d5e71144af1ce175[] = {2, 0, 1};
 static const uint16_t i_d5e71144af1ce175[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d5e71144af1ce175[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_d5e71144af1ce175 = {
   0xd5e71144af1ce175, b_d5e71144af1ce175.words, 67, nullptr, m_d5e71144af1ce175,
-  0, 3, i_d5e71144af1ce175, nullptr, nullptr, { &s_d5e71144af1ce175, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 3, i_d5e71144af1ce175, nullptr, nullptr, { &s_d5e71144af1ce175, nullptr, bd_d5e71144af1ce175, 0, sizeof(bd_d5e71144af1ce175) / sizeof(bd_d5e71144af1ce175[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<45> b_d00489d473826290 = {
@@ -1565,9 +1660,13 @@ static const ::capnp::_::RawSchema* const d_d00489d473826290[] = {
 };
 static const uint16_t m_d00489d473826290[] = {0, 1};
 static const uint16_t i_d00489d473826290[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d00489d473826290[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  &::capnp::schemas::s_fb5aeed95cdf6af9.defaultBrand,
+};
 const ::capnp::_::RawSchema s_d00489d473826290 = {
   0xd00489d473826290, b_d00489d473826290.words, 45, d_d00489d473826290, m_d00489d473826290,
-  2, 2, i_d00489d473826290, nullptr, nullptr, { &s_d00489d473826290, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_d00489d473826290, nullptr, nullptr, { &s_d00489d473826290, nullptr, bd_d00489d473826290, 0, sizeof(bd_d00489d473826290) / sizeof(bd_d00489d473826290[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<53> b_fb5aeed95cdf6af9 = {
@@ -1633,9 +1732,13 @@ static const ::capnp::_::RawSchema* const d_fb5aeed95cdf6af9[] = {
 };
 static const uint16_t m_fb5aeed95cdf6af9[] = {1, 0};
 static const uint16_t i_fb5aeed95cdf6af9[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_fb5aeed95cdf6af9[] = {
+  nullptr,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+};
 const ::capnp::_::RawSchema s_fb5aeed95cdf6af9 = {
   0xfb5aeed95cdf6af9, b_fb5aeed95cdf6af9.words, 53, d_fb5aeed95cdf6af9, m_fb5aeed95cdf6af9,
-  2, 2, i_fb5aeed95cdf6af9, nullptr, nullptr, { &s_fb5aeed95cdf6af9, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_fb5aeed95cdf6af9, nullptr, nullptr, { &s_fb5aeed95cdf6af9, nullptr, bd_fb5aeed95cdf6af9, 0, sizeof(bd_fb5aeed95cdf6af9) / sizeof(bd_fb5aeed95cdf6af9[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<28> b_94099c3f9eb32d6b = {
@@ -1787,9 +1890,16 @@ static const ::capnp::_::RawSchema* const d_b3f66e7a79d81bcd[] = {
 };
 static const uint16_t m_b3f66e7a79d81bcd[] = {3, 0, 2, 4, 1};
 static const uint16_t i_b3f66e7a79d81bcd[] = {0, 1, 4, 2, 3};
+constexpr const ::capnp::_::RawBrandedSchema* bd_b3f66e7a79d81bcd[] = {
+  &::capnp::schemas::s_fffe08a9a697d2a5.defaultBrand,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_b3f66e7a79d81bcd = {
   0xb3f66e7a79d81bcd, b_b3f66e7a79d81bcd.words, 102, d_b3f66e7a79d81bcd, m_b3f66e7a79d81bcd,
-  2, 5, i_b3f66e7a79d81bcd, nullptr, nullptr, { &s_b3f66e7a79d81bcd, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 5, i_b3f66e7a79d81bcd, nullptr, nullptr, { &s_b3f66e7a79d81bcd, nullptr, bd_b3f66e7a79d81bcd, 0, sizeof(bd_b3f66e7a79d81bcd) / sizeof(bd_b3f66e7a79d81bcd[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<110> b_fffe08a9a697d2a5 = {
@@ -1914,9 +2024,17 @@ static const ::capnp::_::RawSchema* const d_fffe08a9a697d2a5[] = {
 };
 static const uint16_t m_fffe08a9a697d2a5[] = {2, 3, 5, 0, 4, 1};
 static const uint16_t i_fffe08a9a697d2a5[] = {0, 1, 2, 3, 4, 5};
+constexpr const ::capnp::_::RawBrandedSchema* bd_fffe08a9a697d2a5[] = {
+  &::capnp::schemas::s_e75816b56529d464.defaultBrand,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  &::capnp::schemas::s_d00489d473826290.defaultBrand,
+  &::capnp::schemas::s_e5104515fd88ea47.defaultBrand,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_fffe08a9a697d2a5 = {
   0xfffe08a9a697d2a5, b_fffe08a9a697d2a5.words, 110, d_fffe08a9a697d2a5, m_fffe08a9a697d2a5,
-  4, 6, i_fffe08a9a697d2a5, nullptr, nullptr, { &s_fffe08a9a697d2a5, nullptr, nullptr, 0, 0, nullptr }, false
+  4, 6, i_fffe08a9a697d2a5, nullptr, nullptr, { &s_fffe08a9a697d2a5, nullptr, bd_fffe08a9a697d2a5, 0, sizeof(bd_fffe08a9a697d2a5) / sizeof(bd_fffe08a9a697d2a5[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<51> b_e5104515fd88ea47 = {
@@ -1980,9 +2098,13 @@ static const ::capnp::_::RawSchema* const d_e5104515fd88ea47[] = {
 };
 static const uint16_t m_e5104515fd88ea47[] = {0, 1};
 static const uint16_t i_e5104515fd88ea47[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_e5104515fd88ea47[] = {
+  nullptr,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+};
 const ::capnp::_::RawSchema s_e5104515fd88ea47 = {
   0xe5104515fd88ea47, b_e5104515fd88ea47.words, 51, d_e5104515fd88ea47, m_e5104515fd88ea47,
-  2, 2, i_e5104515fd88ea47, nullptr, nullptr, { &s_e5104515fd88ea47, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_e5104515fd88ea47, nullptr, nullptr, { &s_e5104515fd88ea47, nullptr, bd_e5104515fd88ea47, 0, sizeof(bd_e5104515fd88ea47) / sizeof(bd_e5104515fd88ea47[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<65> b_89f0c973c103ae96 = {
@@ -2060,9 +2182,14 @@ static const ::capnp::_::RawSchema* const d_89f0c973c103ae96[] = {
 };
 static const uint16_t m_89f0c973c103ae96[] = {2, 1, 0};
 static const uint16_t i_89f0c973c103ae96[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_89f0c973c103ae96[] = {
+  nullptr,
+  &::capnp::schemas::s_991c7a3693d62cf2.defaultBrand,
+  &::capnp::schemas::s_991c7a3693d62cf2.defaultBrand,
+};
 const ::capnp::_::RawSchema s_89f0c973c103ae96 = {
   0x89f0c973c103ae96, b_89f0c973c103ae96.words, 65, d_89f0c973c103ae96, m_89f0c973c103ae96,
-  2, 3, i_89f0c973c103ae96, nullptr, nullptr, { &s_89f0c973c103ae96, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 3, i_89f0c973c103ae96, nullptr, nullptr, { &s_89f0c973c103ae96, nullptr, bd_89f0c973c103ae96, 0, sizeof(bd_89f0c973c103ae96) / sizeof(bd_89f0c973c103ae96[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<34> b_e93164a80bfe2ccf = {
@@ -2109,9 +2236,12 @@ static const ::capnp::_::RawSchema* const d_e93164a80bfe2ccf[] = {
 };
 static const uint16_t m_e93164a80bfe2ccf[] = {0};
 static const uint16_t i_e93164a80bfe2ccf[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_e93164a80bfe2ccf[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+};
 const ::capnp::_::RawSchema s_e93164a80bfe2ccf = {
   0xe93164a80bfe2ccf, b_e93164a80bfe2ccf.words, 34, d_e93164a80bfe2ccf, m_e93164a80bfe2ccf,
-  2, 1, i_e93164a80bfe2ccf, nullptr, nullptr, { &s_e93164a80bfe2ccf, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 1, i_e93164a80bfe2ccf, nullptr, nullptr, { &s_e93164a80bfe2ccf, nullptr, bd_e93164a80bfe2ccf, 0, sizeof(bd_e93164a80bfe2ccf) / sizeof(bd_e93164a80bfe2ccf[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<49> b_b348322a8dcf0d0c = {
@@ -2173,9 +2303,13 @@ static const ::capnp::_::RawSchema* const d_b348322a8dcf0d0c[] = {
 };
 static const uint16_t m_b348322a8dcf0d0c[] = {0, 1};
 static const uint16_t i_b348322a8dcf0d0c[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_b348322a8dcf0d0c[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+};
 const ::capnp::_::RawSchema s_b348322a8dcf0d0c = {
   0xb348322a8dcf0d0c, b_b348322a8dcf0d0c.words, 49, d_b348322a8dcf0d0c, m_b348322a8dcf0d0c,
-  2, 2, i_b348322a8dcf0d0c, nullptr, nullptr, { &s_b348322a8dcf0d0c, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_b348322a8dcf0d0c, nullptr, nullptr, { &s_b348322a8dcf0d0c, nullptr, bd_b348322a8dcf0d0c, 0, sizeof(bd_b348322a8dcf0d0c) / sizeof(bd_b348322a8dcf0d0c[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<43> b_8f2622208fb358c8 = {
@@ -2232,9 +2366,13 @@ static const ::capnp::_::RawSchema* const d_8f2622208fb358c8[] = {
 };
 static const uint16_t m_8f2622208fb358c8[] = {1, 0};
 static const uint16_t i_8f2622208fb358c8[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_8f2622208fb358c8[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  &::capnp::schemas::s_d0d1a21de617951f.defaultBrand,
+};
 const ::capnp::_::RawSchema s_8f2622208fb358c8 = {
   0x8f2622208fb358c8, b_8f2622208fb358c8.words, 43, d_8f2622208fb358c8, m_8f2622208fb358c8,
-  3, 2, i_8f2622208fb358c8, nullptr, nullptr, { &s_8f2622208fb358c8, nullptr, nullptr, 0, 0, nullptr }, false
+  3, 2, i_8f2622208fb358c8, nullptr, nullptr, { &s_8f2622208fb358c8, nullptr, bd_8f2622208fb358c8, 0, sizeof(bd_8f2622208fb358c8) / sizeof(bd_8f2622208fb358c8[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<51> b_d0d1a21de617951f = {
@@ -2298,9 +2436,13 @@ static const ::capnp::_::RawSchema* const d_d0d1a21de617951f[] = {
 };
 static const uint16_t m_d0d1a21de617951f[] = {0, 1};
 static const uint16_t i_d0d1a21de617951f[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d0d1a21de617951f[] = {
+  nullptr,
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+};
 const ::capnp::_::RawSchema s_d0d1a21de617951f = {
   0xd0d1a21de617951f, b_d0d1a21de617951f.words, 51, d_d0d1a21de617951f, m_d0d1a21de617951f,
-  2, 2, i_d0d1a21de617951f, nullptr, nullptr, { &s_d0d1a21de617951f, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_d0d1a21de617951f, nullptr, nullptr, { &s_d0d1a21de617951f, nullptr, bd_d0d1a21de617951f, 0, sizeof(bd_d0d1a21de617951f) / sizeof(bd_d0d1a21de617951f[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<40> b_992a90eaf30235d3 = {
@@ -2353,9 +2495,12 @@ static const ::capnp::_::RawSchema* const d_992a90eaf30235d3[] = {
 };
 static const uint16_t m_992a90eaf30235d3[] = {0};
 static const uint16_t i_992a90eaf30235d3[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_992a90eaf30235d3[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+};
 const ::capnp::_::RawSchema s_992a90eaf30235d3 = {
   0x992a90eaf30235d3, b_992a90eaf30235d3.words, 40, d_992a90eaf30235d3, m_992a90eaf30235d3,
-  2, 1, i_992a90eaf30235d3, nullptr, nullptr, { &s_992a90eaf30235d3, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 1, i_992a90eaf30235d3, nullptr, nullptr, { &s_992a90eaf30235d3, nullptr, bd_992a90eaf30235d3, 0, sizeof(bd_992a90eaf30235d3) / sizeof(bd_992a90eaf30235d3[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<42> b_eb971847d617c0b9 = {
@@ -2411,9 +2556,13 @@ static const ::capnp::_::RawSchema* const d_eb971847d617c0b9[] = {
 };
 static const uint16_t m_eb971847d617c0b9[] = {0, 1};
 static const uint16_t i_eb971847d617c0b9[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_eb971847d617c0b9[] = {
+  &::capnp::schemas::s_b3f66e7a79d81bcd.defaultBrand,
+  &::capnp::schemas::s_c6238c7d62d65173.defaultBrand,
+};
 const ::capnp::_::RawSchema s_eb971847d617c0b9 = {
   0xeb971847d617c0b9, b_eb971847d617c0b9.words, 42, d_eb971847d617c0b9, m_eb971847d617c0b9,
-  3, 2, i_eb971847d617c0b9, nullptr, nullptr, { &s_eb971847d617c0b9, nullptr, nullptr, 0, 0, nullptr }, false
+  3, 2, i_eb971847d617c0b9, nullptr, nullptr, { &s_eb971847d617c0b9, nullptr, bd_eb971847d617c0b9, 0, sizeof(bd_eb971847d617c0b9) / sizeof(bd_eb971847d617c0b9[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<51> b_c6238c7d62d65173 = {
@@ -2477,9 +2626,13 @@ static const ::capnp::_::RawSchema* const d_c6238c7d62d65173[] = {
 };
 static const uint16_t m_c6238c7d62d65173[] = {1, 0};
 static const uint16_t i_c6238c7d62d65173[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c6238c7d62d65173[] = {
+  nullptr,
+  &::capnp::schemas::s_b3f66e7a79d81bcd.defaultBrand,
+};
 const ::capnp::_::RawSchema s_c6238c7d62d65173 = {
   0xc6238c7d62d65173, b_c6238c7d62d65173.words, 51, d_c6238c7d62d65173, m_c6238c7d62d65173,
-  2, 2, i_c6238c7d62d65173, nullptr, nullptr, { &s_c6238c7d62d65173, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_c6238c7d62d65173, nullptr, nullptr, { &s_c6238c7d62d65173, nullptr, bd_c6238c7d62d65173, 0, sizeof(bd_c6238c7d62d65173) / sizeof(bd_c6238c7d62d65173[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<230> b_9cb9e86e3198037f = {
@@ -2722,9 +2875,24 @@ static const ::capnp::_::RawSchema* const d_9cb9e86e3198037f[] = {
 };
 static const uint16_t m_9cb9e86e3198037f[] = {12, 2, 3, 4, 6, 1, 8, 9, 10, 11, 5, 7, 0};
 static const uint16_t i_9cb9e86e3198037f[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9cb9e86e3198037f[] = {
+  &::capnp::schemas::s_8e207d4dfe54d0de.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_9cb9e86e3198037f = {
   0x9cb9e86e3198037f, b_9cb9e86e3198037f.words, 230, d_9cb9e86e3198037f, m_9cb9e86e3198037f,
-  2, 13, i_9cb9e86e3198037f, nullptr, nullptr, { &s_9cb9e86e3198037f, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 13, i_9cb9e86e3198037f, nullptr, nullptr, { &s_9cb9e86e3198037f, nullptr, bd_9cb9e86e3198037f, 0, sizeof(bd_9cb9e86e3198037f) / sizeof(bd_9cb9e86e3198037f[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<34> b_84e4f3f5a807605c = {
@@ -2770,9 +2938,12 @@ static const ::capnp::_::RawSchema* const d_84e4f3f5a807605c[] = {
 };
 static const uint16_t m_84e4f3f5a807605c[] = {0};
 static const uint16_t i_84e4f3f5a807605c[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_84e4f3f5a807605c[] = {
+  &::capnp::schemas::s_96efe787c17e83bb.defaultBrand,
+};
 const ::capnp::_::RawSchema s_84e4f3f5a807605c = {
   0x84e4f3f5a807605c, b_84e4f3f5a807605c.words, 34, d_84e4f3f5a807605c, m_84e4f3f5a807605c,
-  1, 1, i_84e4f3f5a807605c, nullptr, nullptr, { &s_84e4f3f5a807605c, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_84e4f3f5a807605c, nullptr, nullptr, { &s_84e4f3f5a807605c, nullptr, bd_84e4f3f5a807605c, 0, sizeof(bd_84e4f3f5a807605c) / sizeof(bd_84e4f3f5a807605c[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 }  // namespace schemas

--- a/c++/src/capnp/compiler/lexer.capnp.c++
+++ b/c++/src/capnp/compiler/lexer.capnp.c++
@@ -209,9 +209,21 @@ static const ::capnp::_::RawSchema* const d_91cc55cd57de5419[] = {
 };
 static const uint16_t m_91cc55cd57de5419[] = {9, 6, 8, 3, 0, 2, 4, 5, 7, 1};
 static const uint16_t i_91cc55cd57de5419[] = {0, 1, 2, 3, 4, 5, 6, 9, 7, 8};
+constexpr const ::capnp::_::RawBrandedSchema* bd_91cc55cd57de5419[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_91cc55cd57de5419.defaultBrand,
+  &::capnp::schemas::s_91cc55cd57de5419.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_91cc55cd57de5419 = {
   0x91cc55cd57de5419, b_91cc55cd57de5419.words, 195, d_91cc55cd57de5419, m_91cc55cd57de5419,
-  1, 10, i_91cc55cd57de5419, nullptr, nullptr, { &s_91cc55cd57de5419, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 10, i_91cc55cd57de5419, nullptr, nullptr, { &s_91cc55cd57de5419, nullptr, bd_91cc55cd57de5419, 0, sizeof(bd_91cc55cd57de5419) / sizeof(bd_91cc55cd57de5419[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<119> b_c6725e678d60fa37 = {
@@ -343,9 +355,17 @@ static const ::capnp::_::RawSchema* const d_c6725e678d60fa37[] = {
 };
 static const uint16_t m_c6725e678d60fa37[] = {2, 3, 5, 1, 4, 0};
 static const uint16_t i_c6725e678d60fa37[] = {1, 2, 0, 3, 4, 5};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c6725e678d60fa37[] = {
+  &::capnp::schemas::s_91cc55cd57de5419.defaultBrand,
+  nullptr,
+  &::capnp::schemas::s_c6725e678d60fa37.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_c6725e678d60fa37 = {
   0xc6725e678d60fa37, b_c6725e678d60fa37.words, 119, d_c6725e678d60fa37, m_c6725e678d60fa37,
-  2, 6, i_c6725e678d60fa37, nullptr, nullptr, { &s_c6725e678d60fa37, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 6, i_c6725e678d60fa37, nullptr, nullptr, { &s_c6725e678d60fa37, nullptr, bd_c6725e678d60fa37, 0, sizeof(bd_c6725e678d60fa37) / sizeof(bd_c6725e678d60fa37[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<38> b_9e69a92512b19d18 = {
@@ -395,9 +415,12 @@ static const ::capnp::_::RawSchema* const d_9e69a92512b19d18[] = {
 };
 static const uint16_t m_9e69a92512b19d18[] = {0};
 static const uint16_t i_9e69a92512b19d18[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9e69a92512b19d18[] = {
+  &::capnp::schemas::s_91cc55cd57de5419.defaultBrand,
+};
 const ::capnp::_::RawSchema s_9e69a92512b19d18 = {
   0x9e69a92512b19d18, b_9e69a92512b19d18.words, 38, d_9e69a92512b19d18, m_9e69a92512b19d18,
-  1, 1, i_9e69a92512b19d18, nullptr, nullptr, { &s_9e69a92512b19d18, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_9e69a92512b19d18, nullptr, nullptr, { &s_9e69a92512b19d18, nullptr, bd_9e69a92512b19d18, 0, sizeof(bd_9e69a92512b19d18) / sizeof(bd_9e69a92512b19d18[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<40> b_a11f97b9d6c73dd4 = {
@@ -449,9 +472,12 @@ static const ::capnp::_::RawSchema* const d_a11f97b9d6c73dd4[] = {
 };
 static const uint16_t m_a11f97b9d6c73dd4[] = {0};
 static const uint16_t i_a11f97b9d6c73dd4[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_a11f97b9d6c73dd4[] = {
+  &::capnp::schemas::s_c6725e678d60fa37.defaultBrand,
+};
 const ::capnp::_::RawSchema s_a11f97b9d6c73dd4 = {
   0xa11f97b9d6c73dd4, b_a11f97b9d6c73dd4.words, 40, d_a11f97b9d6c73dd4, m_a11f97b9d6c73dd4,
-  1, 1, i_a11f97b9d6c73dd4, nullptr, nullptr, { &s_a11f97b9d6c73dd4, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_a11f97b9d6c73dd4, nullptr, nullptr, { &s_a11f97b9d6c73dd4, nullptr, bd_a11f97b9d6c73dd4, 0, sizeof(bd_a11f97b9d6c73dd4) / sizeof(bd_a11f97b9d6c73dd4[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 }  // namespace schemas

--- a/c++/src/capnp/persistent.capnp.c++
+++ b/c++/src/capnp/persistent.capnp.c++
@@ -68,9 +68,9 @@ static const ::capnp::_::RawSchema* const d_c8cb212fcd9f5691[] = {
   &s_f76fba59183073a5,
 };
 static const uint16_t m_c8cb212fcd9f5691[] = {0};
-KJ_CONSTEXPR(const) ::capnp::_::RawBrandedSchema::Dependency bd_c8cb212fcd9f5691[] = {
-  { 33554432,  ::capnp::Persistent< ::capnp::AnyPointer,  ::capnp::AnyPointer>::SaveParams::_capnpPrivate::brand() },
-  { 50331648,  ::capnp::Persistent< ::capnp::AnyPointer,  ::capnp::AnyPointer>::SaveResults::_capnpPrivate::brand() },
+constexpr const ::capnp::_::RawBrandedSchema* bd_c8cb212fcd9f5691[] = {
+   ::capnp::Persistent< ::capnp::AnyPointer,  ::capnp::AnyPointer>::SaveParams::_capnpPrivate::brand(),
+   ::capnp::Persistent< ::capnp::AnyPointer,  ::capnp::AnyPointer>::SaveResults::_capnpPrivate::brand(),
 };
 const ::capnp::_::RawSchema s_c8cb212fcd9f5691 = {
   0xc8cb212fcd9f5691, b_c8cb212fcd9f5691.words, 54, d_c8cb212fcd9f5691, m_c8cb212fcd9f5691,
@@ -118,9 +118,12 @@ static const ::capnp::_::AlignedData<35> b_f76fba59183073a5 = {
 #if !CAPNP_LITE
 static const uint16_t m_f76fba59183073a5[] = {0};
 static const uint16_t i_f76fba59183073a5[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_f76fba59183073a5[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_f76fba59183073a5 = {
   0xf76fba59183073a5, b_f76fba59183073a5.words, 35, nullptr, m_f76fba59183073a5,
-  0, 1, i_f76fba59183073a5, nullptr, nullptr, { &s_f76fba59183073a5, nullptr, nullptr, 0, 0, nullptr }, true
+  0, 1, i_f76fba59183073a5, nullptr, nullptr, { &s_f76fba59183073a5, nullptr, bd_f76fba59183073a5, 0, sizeof(bd_f76fba59183073a5) / sizeof(bd_f76fba59183073a5[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<36> b_b76848c18c40efbf = {
@@ -165,9 +168,12 @@ static const ::capnp::_::AlignedData<36> b_b76848c18c40efbf = {
 #if !CAPNP_LITE
 static const uint16_t m_b76848c18c40efbf[] = {0};
 static const uint16_t i_b76848c18c40efbf[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_b76848c18c40efbf[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_b76848c18c40efbf = {
   0xb76848c18c40efbf, b_b76848c18c40efbf.words, 36, nullptr, m_b76848c18c40efbf,
-  0, 1, i_b76848c18c40efbf, nullptr, nullptr, { &s_b76848c18c40efbf, nullptr, nullptr, 0, 0, nullptr }, true
+  0, 1, i_b76848c18c40efbf, nullptr, nullptr, { &s_b76848c18c40efbf, nullptr, bd_b76848c18c40efbf, 0, sizeof(bd_b76848c18c40efbf) / sizeof(bd_b76848c18c40efbf[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<22> b_f622595091cafb67 = {

--- a/c++/src/capnp/persistent.capnp.h
+++ b/c++/src/capnp/persistent.capnp.h
@@ -48,7 +48,7 @@ struct Persistent {
     CAPNP_DECLARE_INTERFACE_HEADER(c8cb212fcd9f5691)
     static const ::capnp::_::RawBrandedSchema::Scope brandScopes[];
     static const ::capnp::_::RawBrandedSchema::Binding brandBindings[];
-    static const ::capnp::_::RawBrandedSchema::Dependency brandDependencies[];
+    static const ::capnp::_::RawBrandedSchema* const brandDependencies[];
     static const ::capnp::_::RawBrandedSchema specificBrand;
     static constexpr ::capnp::_::RawBrandedSchema const* brand() { return ::capnp::_::ChooseBrand<_capnpPrivate, SturdyRef, Owner>::brand(); }
   };
@@ -68,6 +68,7 @@ struct Persistent<SturdyRef, Owner>::SaveParams {
     #if !CAPNP_LITE
     static const ::capnp::_::RawBrandedSchema::Scope brandScopes[];
     static const ::capnp::_::RawBrandedSchema::Binding brandBindings[];
+    static const ::capnp::_::RawBrandedSchema* const brandDependencies[];
     static const ::capnp::_::RawBrandedSchema specificBrand;
     static constexpr ::capnp::_::RawBrandedSchema const* brand() { return ::capnp::_::ChooseBrand<_capnpPrivate, SturdyRef, Owner>::brand(); }
     #endif  // !CAPNP_LITE
@@ -87,6 +88,7 @@ struct Persistent<SturdyRef, Owner>::SaveResults {
     #if !CAPNP_LITE
     static const ::capnp::_::RawBrandedSchema::Scope brandScopes[];
     static const ::capnp::_::RawBrandedSchema::Binding brandBindings[];
+    static const ::capnp::_::RawBrandedSchema* const brandDependencies[];
     static const ::capnp::_::RawBrandedSchema specificBrand;
     static constexpr ::capnp::_::RawBrandedSchema const* brand() { return ::capnp::_::ChooseBrand<_capnpPrivate, SturdyRef, Owner>::brand(); }
     #endif  // !CAPNP_LITE
@@ -455,9 +457,13 @@ const ::capnp::_::RawBrandedSchema::Binding Persistent<SturdyRef, Owner>::SavePa
   ::capnp::_::brandBindingFor<Owner>(),
 };
 template <typename SturdyRef, typename Owner>
+const ::capnp::_::RawBrandedSchema* const Persistent<SturdyRef, Owner>::SaveParams::_capnpPrivate::brandDependencies[] = {
+  nullptr,
+};
+template <typename SturdyRef, typename Owner>
 const ::capnp::_::RawBrandedSchema Persistent<SturdyRef, Owner>::SaveParams::_capnpPrivate::specificBrand = {
-  &::capnp::schemas::s_f76fba59183073a5, brandScopes, nullptr,
-  1, 0, nullptr
+  &::capnp::schemas::s_f76fba59183073a5, brandScopes, brandDependencies,
+  1, 1, nullptr
 };
 #endif  // !CAPNP_LITE
 
@@ -538,9 +544,13 @@ const ::capnp::_::RawBrandedSchema::Binding Persistent<SturdyRef, Owner>::SaveRe
   ::capnp::_::brandBindingFor<Owner>(),
 };
 template <typename SturdyRef, typename Owner>
+const ::capnp::_::RawBrandedSchema* const Persistent<SturdyRef, Owner>::SaveResults::_capnpPrivate::brandDependencies[] = {
+  nullptr,
+};
+template <typename SturdyRef, typename Owner>
 const ::capnp::_::RawBrandedSchema Persistent<SturdyRef, Owner>::SaveResults::_capnpPrivate::specificBrand = {
-  &::capnp::schemas::s_b76848c18c40efbf, brandScopes, nullptr,
-  1, 0, nullptr
+  &::capnp::schemas::s_b76848c18c40efbf, brandScopes, brandDependencies,
+  1, 1, nullptr
 };
 #endif  // !CAPNP_LITE
 
@@ -607,9 +617,9 @@ const ::capnp::_::RawBrandedSchema::Binding Persistent<SturdyRef, Owner>::_capnp
   ::capnp::_::brandBindingFor<Owner>(),
 };
 template <typename SturdyRef, typename Owner>
-const ::capnp::_::RawBrandedSchema::Dependency Persistent<SturdyRef, Owner>::_capnpPrivate::brandDependencies[] = {
-  { 33554432,  ::capnp::Persistent<SturdyRef, Owner>::SaveParams::_capnpPrivate::brand() },
-  { 50331648,  ::capnp::Persistent<SturdyRef, Owner>::SaveResults::_capnpPrivate::brand() },
+const ::capnp::_::RawBrandedSchema* const Persistent<SturdyRef, Owner>::_capnpPrivate::brandDependencies[] = {
+   ::capnp::Persistent<SturdyRef, Owner>::SaveParams::_capnpPrivate::brand(),
+   ::capnp::Persistent<SturdyRef, Owner>::SaveResults::_capnpPrivate::brand(),
 };
 template <typename SturdyRef, typename Owner>
 const ::capnp::_::RawBrandedSchema Persistent<SturdyRef, Owner>::_capnpPrivate::specificBrand = {

--- a/c++/src/capnp/raw-schema.h
+++ b/c++/src/capnp/raw-schema.h
@@ -90,8 +90,6 @@ struct RawBrandedSchema {
   const Scope* scopes;
   // Array of enclosing scopes for which generic variables have been bound, sorted by type ID.
 
-  typedef const RawBrandedSchema* Dependency;
-
   const RawBrandedSchema* const* dependencies;
   // Array of dependencies arranged by member index. More specifically:
   // - For structs, dependenciesByIndex[fieldIndex] is the dependency type used by the given
@@ -105,36 +103,6 @@ struct RawBrandedSchema {
 
   uint32_t scopeCount;
   uint32_t dependencyCount;
-
-  enum class DepKind {
-    // Component of a Dependency::location. Specifies what sort of dependency this is.
-
-    INVALID,
-    // Mostly defined to ensure that zero is not a valid location.
-
-    FIELD,
-    // Binding needed for a field's type. The index is the field index (NOT ordinal!).
-
-    METHOD_PARAMS,
-    // Bindings needed for a method's params type. The index is the method number.
-
-    METHOD_RESULTS,
-    // Bindings needed for a method's results type. The index is the method ordinal.
-
-    SUPERCLASS,
-    // Bindings needed for a superclass type. The index is the superclass's index in the
-    // "extends" list.
-
-    CONST_TYPE
-    // Bindings needed for the type of a constant. The index is zero.
-  };
-
-  static inline uint makeDepLocation(DepKind kind, uint index) {
-    // Make a number representing the location of a particular dependency within its parent
-    // schema.
-
-    return (static_cast<uint>(kind) << 24) | index;
-  }
 
   class Initializer {
   public:

--- a/c++/src/capnp/raw-schema.h
+++ b/c++/src/capnp/raw-schema.h
@@ -90,14 +90,18 @@ struct RawBrandedSchema {
   const Scope* scopes;
   // Array of enclosing scopes for which generic variables have been bound, sorted by type ID.
 
-  struct Dependency {
-    uint location;
-    const RawBrandedSchema* schema;
-  };
+  typedef const RawBrandedSchema* Dependency;
 
-  const Dependency* dependencies;
-  // Map of branded schemas for dependencies of this type, given our brand. Only dependencies that
-  // are branded are included in this map; if a dependency is missing, use its `defaultBrand`.
+  const RawBrandedSchema* const* dependencies;
+  // Array of dependencies arranged by member index. More specifically:
+  // - For structs, dependenciesByIndex[fieldIndex] is the dependency type used by the given
+  //   field, or null if the field is a built-in type. Note that this uses the field index, NOT
+  //   the ordinal (in order to handle groups well).
+  // - For interfaces, dependenciesByIndex[methodOrdinal*2] is the parameters type, and
+  //   [methodOrdinal*2+1] is the results type. dependenciesByIndex[methodOrdinal*2] and up
+  //   correspond to superclasses (the `extends` list).
+  // - For constants, this points to a single-element array which contains a pointer to the
+  //   constant's type, or null if it's a built-in type.
 
   uint32_t scopeCount;
   uint32_t dependencyCount;

--- a/c++/src/capnp/rpc-twoparty.capnp.c++
+++ b/c++/src/capnp/rpc-twoparty.capnp.c++
@@ -84,9 +84,12 @@ static const ::capnp::_::RawSchema* const d_d20b909fee733a8e[] = {
 };
 static const uint16_t m_d20b909fee733a8e[] = {0};
 static const uint16_t i_d20b909fee733a8e[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d20b909fee733a8e[] = {
+  &::capnp::schemas::s_9fd69ebc87b9719c.defaultBrand,
+};
 const ::capnp::_::RawSchema s_d20b909fee733a8e = {
   0xd20b909fee733a8e, b_d20b909fee733a8e.words, 33, d_d20b909fee733a8e, m_d20b909fee733a8e,
-  1, 1, i_d20b909fee733a8e, nullptr, nullptr, { &s_d20b909fee733a8e, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_d20b909fee733a8e, nullptr, nullptr, { &s_d20b909fee733a8e, nullptr, bd_d20b909fee733a8e, 0, sizeof(bd_d20b909fee733a8e) / sizeof(bd_d20b909fee733a8e[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<34> b_b88d09a9c5f39817 = {
@@ -129,9 +132,12 @@ static const ::capnp::_::AlignedData<34> b_b88d09a9c5f39817 = {
 #if !CAPNP_LITE
 static const uint16_t m_b88d09a9c5f39817[] = {0};
 static const uint16_t i_b88d09a9c5f39817[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_b88d09a9c5f39817[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_b88d09a9c5f39817 = {
   0xb88d09a9c5f39817, b_b88d09a9c5f39817.words, 34, nullptr, m_b88d09a9c5f39817,
-  0, 1, i_b88d09a9c5f39817, nullptr, nullptr, { &s_b88d09a9c5f39817, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 1, i_b88d09a9c5f39817, nullptr, nullptr, { &s_b88d09a9c5f39817, nullptr, bd_b88d09a9c5f39817, 0, sizeof(bd_b88d09a9c5f39817) / sizeof(bd_b88d09a9c5f39817[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<18> b_89f389b6fd4082c1 = {
@@ -260,9 +266,14 @@ static const ::capnp::_::AlignedData<65> b_95b29059097fca83 = {
 #if !CAPNP_LITE
 static const uint16_t m_95b29059097fca83[] = {0, 1, 2};
 static const uint16_t i_95b29059097fca83[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_95b29059097fca83[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_95b29059097fca83 = {
   0x95b29059097fca83, b_95b29059097fca83.words, 65, nullptr, m_95b29059097fca83,
-  0, 3, i_95b29059097fca83, nullptr, nullptr, { &s_95b29059097fca83, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 3, i_95b29059097fca83, nullptr, nullptr, { &s_95b29059097fca83, nullptr, bd_95b29059097fca83, 0, sizeof(bd_95b29059097fca83) / sizeof(bd_95b29059097fca83[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<65> b_9d263a3630b7ebee = {
@@ -336,9 +347,14 @@ static const ::capnp::_::AlignedData<65> b_9d263a3630b7ebee = {
 #if !CAPNP_LITE
 static const uint16_t m_9d263a3630b7ebee[] = {2, 0, 1};
 static const uint16_t i_9d263a3630b7ebee[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9d263a3630b7ebee[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_9d263a3630b7ebee = {
   0x9d263a3630b7ebee, b_9d263a3630b7ebee.words, 65, nullptr, m_9d263a3630b7ebee,
-  0, 3, i_9d263a3630b7ebee, nullptr, nullptr, { &s_9d263a3630b7ebee, nullptr, nullptr, 0, 0, nullptr }, true
+  0, 3, i_9d263a3630b7ebee, nullptr, nullptr, { &s_9d263a3630b7ebee, nullptr, bd_9d263a3630b7ebee, 0, sizeof(bd_9d263a3630b7ebee) / sizeof(bd_9d263a3630b7ebee[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 }  // namespace schemas

--- a/c++/src/capnp/rpc.capnp.c++
+++ b/c++/src/capnp/rpc.capnp.c++
@@ -257,9 +257,25 @@ static const ::capnp::_::RawSchema* const d_91b79f1f808db032[] = {
 };
 static const uint16_t m_91b79f1f808db032[] = {1, 11, 8, 2, 13, 4, 12, 9, 7, 10, 6, 5, 3, 0};
 static const uint16_t i_91b79f1f808db032[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+constexpr const ::capnp::_::RawBrandedSchema* bd_91b79f1f808db032[] = {
+  &::capnp::schemas::s_91b79f1f808db032.defaultBrand,
+  &::capnp::schemas::s_d625b7063acf691a.defaultBrand,
+  &::capnp::schemas::s_836a53ce789d4cd4.defaultBrand,
+  &::capnp::schemas::s_9e19b28d3db3573a.defaultBrand,
+  &::capnp::schemas::s_d37d2eb2c2f80e63.defaultBrand,
+  &::capnp::schemas::s_bbc29655fa89086e.defaultBrand,
+  &::capnp::schemas::s_ad1a6c0d7dd07497.defaultBrand,
+  nullptr,
+  &::capnp::schemas::s_e94ccf8031176ec4.defaultBrand,
+  nullptr,
+  &::capnp::schemas::s_9c6a046bfbc1ac5a.defaultBrand,
+  &::capnp::schemas::s_d4c9b56290554016.defaultBrand,
+  &::capnp::schemas::s_fbe1980490e001af.defaultBrand,
+  &::capnp::schemas::s_f964368b0fbd3711.defaultBrand,
+};
 const ::capnp::_::RawSchema s_91b79f1f808db032 = {
   0x91b79f1f808db032, b_91b79f1f808db032.words, 232, d_91b79f1f808db032, m_91b79f1f808db032,
-  12, 14, i_91b79f1f808db032, nullptr, nullptr, { &s_91b79f1f808db032, nullptr, nullptr, 0, 0, nullptr }, true
+  12, 14, i_91b79f1f808db032, nullptr, nullptr, { &s_91b79f1f808db032, nullptr, bd_91b79f1f808db032, 0, sizeof(bd_91b79f1f808db032) / sizeof(bd_91b79f1f808db032[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<51> b_e94ccf8031176ec4 = {
@@ -319,9 +335,13 @@ static const ::capnp::_::AlignedData<51> b_e94ccf8031176ec4 = {
 #if !CAPNP_LITE
 static const uint16_t m_e94ccf8031176ec4[] = {1, 0};
 static const uint16_t i_e94ccf8031176ec4[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_e94ccf8031176ec4[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_e94ccf8031176ec4 = {
   0xe94ccf8031176ec4, b_e94ccf8031176ec4.words, 51, nullptr, m_e94ccf8031176ec4,
-  0, 2, i_e94ccf8031176ec4, nullptr, nullptr, { &s_e94ccf8031176ec4, nullptr, nullptr, 0, 0, nullptr }, true
+  0, 2, i_e94ccf8031176ec4, nullptr, nullptr, { &s_e94ccf8031176ec4, nullptr, bd_e94ccf8031176ec4, 0, sizeof(bd_e94ccf8031176ec4) / sizeof(bd_e94ccf8031176ec4[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<155> b_836a53ce789d4cd4 = {
@@ -490,9 +510,20 @@ static const ::capnp::_::RawSchema* const d_836a53ce789d4cd4[] = {
 };
 static const uint16_t m_836a53ce789d4cd4[] = {6, 2, 3, 7, 8, 4, 0, 5, 1};
 static const uint16_t i_836a53ce789d4cd4[] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+constexpr const ::capnp::_::RawBrandedSchema* bd_836a53ce789d4cd4[] = {
+  nullptr,
+  &::capnp::schemas::s_95bc14545813fbc1.defaultBrand,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_9a0e61223d96743b.defaultBrand,
+  &::capnp::schemas::s_dae8b0f61aab5f99.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_836a53ce789d4cd4 = {
   0x836a53ce789d4cd4, b_836a53ce789d4cd4.words, 155, d_836a53ce789d4cd4, m_836a53ce789d4cd4,
-  3, 9, i_836a53ce789d4cd4, nullptr, nullptr, { &s_836a53ce789d4cd4, nullptr, nullptr, 0, 0, nullptr }, true
+  3, 9, i_836a53ce789d4cd4, nullptr, nullptr, { &s_836a53ce789d4cd4, nullptr, bd_836a53ce789d4cd4, 0, sizeof(bd_836a53ce789d4cd4) / sizeof(bd_836a53ce789d4cd4[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<65> b_dae8b0f61aab5f99 = {
@@ -569,9 +600,14 @@ static const ::capnp::_::RawSchema* const d_dae8b0f61aab5f99[] = {
 };
 static const uint16_t m_dae8b0f61aab5f99[] = {0, 2, 1};
 static const uint16_t i_dae8b0f61aab5f99[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_dae8b0f61aab5f99[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_dae8b0f61aab5f99 = {
   0xdae8b0f61aab5f99, b_dae8b0f61aab5f99.words, 65, d_dae8b0f61aab5f99, m_dae8b0f61aab5f99,
-  1, 3, i_dae8b0f61aab5f99, nullptr, nullptr, { &s_dae8b0f61aab5f99, nullptr, nullptr, 0, 0, nullptr }, true
+  1, 3, i_dae8b0f61aab5f99, nullptr, nullptr, { &s_dae8b0f61aab5f99, nullptr, bd_dae8b0f61aab5f99, 0, sizeof(bd_dae8b0f61aab5f99) / sizeof(bd_dae8b0f61aab5f99[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<164> b_9e19b28d3db3573a = {
@@ -748,9 +784,20 @@ static const ::capnp::_::RawSchema* const d_9e19b28d3db3573a[] = {
 };
 static const uint16_t m_9e19b28d3db3573a[] = {7, 0, 4, 3, 8, 1, 2, 5, 6};
 static const uint16_t i_9e19b28d3db3573a[] = {2, 3, 4, 5, 6, 7, 0, 1, 8};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9e19b28d3db3573a[] = {
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_9a0e61223d96743b.defaultBrand,
+  &::capnp::schemas::s_d625b7063acf691a.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_9e19b28d3db3573a = {
   0x9e19b28d3db3573a, b_9e19b28d3db3573a.words, 164, d_9e19b28d3db3573a, m_9e19b28d3db3573a,
-  2, 9, i_9e19b28d3db3573a, nullptr, nullptr, { &s_9e19b28d3db3573a, nullptr, nullptr, 0, 0, nullptr }, true
+  2, 9, i_9e19b28d3db3573a, nullptr, nullptr, { &s_9e19b28d3db3573a, nullptr, bd_9e19b28d3db3573a, 0, sizeof(bd_9e19b28d3db3573a) / sizeof(bd_9e19b28d3db3573a[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<50> b_d37d2eb2c2f80e63 = {
@@ -809,9 +856,13 @@ static const ::capnp::_::AlignedData<50> b_d37d2eb2c2f80e63 = {
 #if !CAPNP_LITE
 static const uint16_t m_d37d2eb2c2f80e63[] = {0, 1};
 static const uint16_t i_d37d2eb2c2f80e63[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d37d2eb2c2f80e63[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_d37d2eb2c2f80e63 = {
   0xd37d2eb2c2f80e63, b_d37d2eb2c2f80e63.words, 50, nullptr, m_d37d2eb2c2f80e63,
-  0, 2, i_d37d2eb2c2f80e63, nullptr, nullptr, { &s_d37d2eb2c2f80e63, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 2, i_d37d2eb2c2f80e63, nullptr, nullptr, { &s_d37d2eb2c2f80e63, nullptr, bd_d37d2eb2c2f80e63, 0, sizeof(bd_d37d2eb2c2f80e63) / sizeof(bd_d37d2eb2c2f80e63[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<64> b_bbc29655fa89086e = {
@@ -888,9 +939,14 @@ static const ::capnp::_::RawSchema* const d_bbc29655fa89086e[] = {
 };
 static const uint16_t m_bbc29655fa89086e[] = {1, 2, 0};
 static const uint16_t i_bbc29655fa89086e[] = {1, 2, 0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_bbc29655fa89086e[] = {
+  nullptr,
+  &::capnp::schemas::s_8523ddc40b86b8b0.defaultBrand,
+  &::capnp::schemas::s_d625b7063acf691a.defaultBrand,
+};
 const ::capnp::_::RawSchema s_bbc29655fa89086e = {
   0xbbc29655fa89086e, b_bbc29655fa89086e.words, 64, d_bbc29655fa89086e, m_bbc29655fa89086e,
-  2, 3, i_bbc29655fa89086e, nullptr, nullptr, { &s_bbc29655fa89086e, nullptr, nullptr, 0, 0, nullptr }, true
+  2, 3, i_bbc29655fa89086e, nullptr, nullptr, { &s_bbc29655fa89086e, nullptr, bd_bbc29655fa89086e, 0, sizeof(bd_bbc29655fa89086e) / sizeof(bd_bbc29655fa89086e[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<48> b_ad1a6c0d7dd07497 = {
@@ -947,9 +1003,13 @@ static const ::capnp::_::AlignedData<48> b_ad1a6c0d7dd07497 = {
 #if !CAPNP_LITE
 static const uint16_t m_ad1a6c0d7dd07497[] = {0, 1};
 static const uint16_t i_ad1a6c0d7dd07497[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_ad1a6c0d7dd07497[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_ad1a6c0d7dd07497 = {
   0xad1a6c0d7dd07497, b_ad1a6c0d7dd07497.words, 48, nullptr, m_ad1a6c0d7dd07497,
-  0, 2, i_ad1a6c0d7dd07497, nullptr, nullptr, { &s_ad1a6c0d7dd07497, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 2, i_ad1a6c0d7dd07497, nullptr, nullptr, { &s_ad1a6c0d7dd07497, nullptr, bd_ad1a6c0d7dd07497, 0, sizeof(bd_ad1a6c0d7dd07497) / sizeof(bd_ad1a6c0d7dd07497[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<41> b_f964368b0fbd3711 = {
@@ -1003,9 +1063,13 @@ static const ::capnp::_::RawSchema* const d_f964368b0fbd3711[] = {
 };
 static const uint16_t m_f964368b0fbd3711[] = {1, 0};
 static const uint16_t i_f964368b0fbd3711[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_f964368b0fbd3711[] = {
+  &::capnp::schemas::s_95bc14545813fbc1.defaultBrand,
+  &::capnp::schemas::s_d562b4df655bdd4d.defaultBrand,
+};
 const ::capnp::_::RawSchema s_f964368b0fbd3711 = {
   0xf964368b0fbd3711, b_f964368b0fbd3711.words, 41, d_f964368b0fbd3711, m_f964368b0fbd3711,
-  2, 2, i_f964368b0fbd3711, nullptr, nullptr, { &s_f964368b0fbd3711, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_f964368b0fbd3711, nullptr, nullptr, { &s_f964368b0fbd3711, nullptr, bd_f964368b0fbd3711, 0, sizeof(bd_f964368b0fbd3711) / sizeof(bd_f964368b0fbd3711[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<81> b_d562b4df655bdd4d = {
@@ -1098,9 +1162,15 @@ static const ::capnp::_::RawSchema* const d_d562b4df655bdd4d[] = {
 };
 static const uint16_t m_d562b4df655bdd4d[] = {2, 3, 1, 0};
 static const uint16_t i_d562b4df655bdd4d[] = {0, 1, 2, 3};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d562b4df655bdd4d[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_d562b4df655bdd4d = {
   0xd562b4df655bdd4d, b_d562b4df655bdd4d.words, 81, d_d562b4df655bdd4d, m_d562b4df655bdd4d,
-  1, 4, i_d562b4df655bdd4d, nullptr, nullptr, { &s_d562b4df655bdd4d, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 4, i_d562b4df655bdd4d, nullptr, nullptr, { &s_d562b4df655bdd4d, nullptr, bd_d562b4df655bdd4d, 0, sizeof(bd_d562b4df655bdd4d) / sizeof(bd_d562b4df655bdd4d[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<64> b_9c6a046bfbc1ac5a = {
@@ -1176,9 +1246,14 @@ static const ::capnp::_::RawSchema* const d_9c6a046bfbc1ac5a[] = {
 };
 static const uint16_t m_9c6a046bfbc1ac5a[] = {0, 2, 1};
 static const uint16_t i_9c6a046bfbc1ac5a[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9c6a046bfbc1ac5a[] = {
+  nullptr,
+  &::capnp::schemas::s_95bc14545813fbc1.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_9c6a046bfbc1ac5a = {
   0x9c6a046bfbc1ac5a, b_9c6a046bfbc1ac5a.words, 64, d_9c6a046bfbc1ac5a, m_9c6a046bfbc1ac5a,
-  1, 3, i_9c6a046bfbc1ac5a, nullptr, nullptr, { &s_9c6a046bfbc1ac5a, nullptr, nullptr, 0, 0, nullptr }, true
+  1, 3, i_9c6a046bfbc1ac5a, nullptr, nullptr, { &s_9c6a046bfbc1ac5a, nullptr, bd_9c6a046bfbc1ac5a, 0, sizeof(bd_9c6a046bfbc1ac5a) / sizeof(bd_9c6a046bfbc1ac5a[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<64> b_d4c9b56290554016 = {
@@ -1251,9 +1326,14 @@ static const ::capnp::_::AlignedData<64> b_d4c9b56290554016 = {
 #if !CAPNP_LITE
 static const uint16_t m_d4c9b56290554016[] = {2, 1, 0};
 static const uint16_t i_d4c9b56290554016[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d4c9b56290554016[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_d4c9b56290554016 = {
   0xd4c9b56290554016, b_d4c9b56290554016.words, 64, nullptr, m_d4c9b56290554016,
-  0, 3, i_d4c9b56290554016, nullptr, nullptr, { &s_d4c9b56290554016, nullptr, nullptr, 0, 0, nullptr }, true
+  0, 3, i_d4c9b56290554016, nullptr, nullptr, { &s_d4c9b56290554016, nullptr, bd_d4c9b56290554016, 0, sizeof(bd_d4c9b56290554016) / sizeof(bd_d4c9b56290554016[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<63> b_fbe1980490e001af = {
@@ -1328,9 +1408,14 @@ static const ::capnp::_::RawSchema* const d_fbe1980490e001af[] = {
 };
 static const uint16_t m_fbe1980490e001af[] = {2, 0, 1};
 static const uint16_t i_fbe1980490e001af[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_fbe1980490e001af[] = {
+  nullptr,
+  &::capnp::schemas::s_95bc14545813fbc1.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_fbe1980490e001af = {
   0xfbe1980490e001af, b_fbe1980490e001af.words, 63, d_fbe1980490e001af, m_fbe1980490e001af,
-  1, 3, i_fbe1980490e001af, nullptr, nullptr, { &s_fbe1980490e001af, nullptr, nullptr, 0, 0, nullptr }, true
+  1, 3, i_fbe1980490e001af, nullptr, nullptr, { &s_fbe1980490e001af, nullptr, bd_fbe1980490e001af, 0, sizeof(bd_fbe1980490e001af) / sizeof(bd_fbe1980490e001af[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<50> b_95bc14545813fbc1 = {
@@ -1392,9 +1477,13 @@ static const ::capnp::_::RawSchema* const d_95bc14545813fbc1[] = {
 };
 static const uint16_t m_95bc14545813fbc1[] = {0, 1};
 static const uint16_t i_95bc14545813fbc1[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_95bc14545813fbc1[] = {
+  nullptr,
+  &::capnp::schemas::s_d800b1d6cd6f1ca0.defaultBrand,
+};
 const ::capnp::_::RawSchema s_95bc14545813fbc1 = {
   0x95bc14545813fbc1, b_95bc14545813fbc1.words, 50, d_95bc14545813fbc1, m_95bc14545813fbc1,
-  1, 2, i_95bc14545813fbc1, nullptr, nullptr, { &s_95bc14545813fbc1, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_95bc14545813fbc1, nullptr, nullptr, { &s_95bc14545813fbc1, nullptr, bd_95bc14545813fbc1, 0, sizeof(bd_95bc14545813fbc1) / sizeof(bd_95bc14545813fbc1[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<52> b_9a0e61223d96743b = {
@@ -1458,9 +1547,13 @@ static const ::capnp::_::RawSchema* const d_9a0e61223d96743b[] = {
 };
 static const uint16_t m_9a0e61223d96743b[] = {1, 0};
 static const uint16_t i_9a0e61223d96743b[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9a0e61223d96743b[] = {
+  nullptr,
+  &::capnp::schemas::s_8523ddc40b86b8b0.defaultBrand,
+};
 const ::capnp::_::RawSchema s_9a0e61223d96743b = {
   0x9a0e61223d96743b, b_9a0e61223d96743b.words, 52, d_9a0e61223d96743b, m_9a0e61223d96743b,
-  1, 2, i_9a0e61223d96743b, nullptr, nullptr, { &s_9a0e61223d96743b, nullptr, nullptr, 0, 0, nullptr }, true
+  1, 2, i_9a0e61223d96743b, nullptr, nullptr, { &s_9a0e61223d96743b, nullptr, bd_9a0e61223d96743b, 0, sizeof(bd_9a0e61223d96743b) / sizeof(bd_9a0e61223d96743b[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<130> b_8523ddc40b86b8b0 = {
@@ -1603,9 +1696,18 @@ static const ::capnp::_::RawSchema* const d_8523ddc40b86b8b0[] = {
 };
 static const uint16_t m_8523ddc40b86b8b0[] = {6, 0, 4, 3, 1, 2, 5};
 static const uint16_t i_8523ddc40b86b8b0[] = {0, 1, 2, 3, 4, 5, 6};
+constexpr const ::capnp::_::RawBrandedSchema* bd_8523ddc40b86b8b0[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_d800b1d6cd6f1ca0.defaultBrand,
+  &::capnp::schemas::s_d37007fde1f0027d.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_8523ddc40b86b8b0 = {
   0x8523ddc40b86b8b0, b_8523ddc40b86b8b0.words, 130, d_8523ddc40b86b8b0, m_8523ddc40b86b8b0,
-  2, 7, i_8523ddc40b86b8b0, nullptr, nullptr, { &s_8523ddc40b86b8b0, nullptr, nullptr, 0, 0, nullptr }, true
+  2, 7, i_8523ddc40b86b8b0, nullptr, nullptr, { &s_8523ddc40b86b8b0, nullptr, bd_8523ddc40b86b8b0, 0, sizeof(bd_8523ddc40b86b8b0) / sizeof(bd_8523ddc40b86b8b0[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<57> b_d800b1d6cd6f1ca0 = {
@@ -1674,9 +1776,13 @@ static const ::capnp::_::RawSchema* const d_d800b1d6cd6f1ca0[] = {
 };
 static const uint16_t m_d800b1d6cd6f1ca0[] = {0, 1};
 static const uint16_t i_d800b1d6cd6f1ca0[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d800b1d6cd6f1ca0[] = {
+  nullptr,
+  &::capnp::schemas::s_f316944415569081.defaultBrand,
+};
 const ::capnp::_::RawSchema s_d800b1d6cd6f1ca0 = {
   0xd800b1d6cd6f1ca0, b_d800b1d6cd6f1ca0.words, 57, d_d800b1d6cd6f1ca0, m_d800b1d6cd6f1ca0,
-  1, 2, i_d800b1d6cd6f1ca0, nullptr, nullptr, { &s_d800b1d6cd6f1ca0, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_d800b1d6cd6f1ca0, nullptr, nullptr, { &s_d800b1d6cd6f1ca0, nullptr, bd_d800b1d6cd6f1ca0, 0, sizeof(bd_d800b1d6cd6f1ca0) / sizeof(bd_d800b1d6cd6f1ca0[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<50> b_f316944415569081 = {
@@ -1735,9 +1841,13 @@ static const ::capnp::_::AlignedData<50> b_f316944415569081 = {
 #if !CAPNP_LITE
 static const uint16_t m_f316944415569081[] = {1, 0};
 static const uint16_t i_f316944415569081[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_f316944415569081[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_f316944415569081 = {
   0xf316944415569081, b_f316944415569081.words, 50, nullptr, m_f316944415569081,
-  0, 2, i_f316944415569081, nullptr, nullptr, { &s_f316944415569081, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 2, i_f316944415569081, nullptr, nullptr, { &s_f316944415569081, nullptr, bd_f316944415569081, 0, sizeof(bd_f316944415569081) / sizeof(bd_f316944415569081[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<49> b_d37007fde1f0027d = {
@@ -1795,9 +1905,13 @@ static const ::capnp::_::AlignedData<49> b_d37007fde1f0027d = {
 #if !CAPNP_LITE
 static const uint16_t m_d37007fde1f0027d[] = {0, 1};
 static const uint16_t i_d37007fde1f0027d[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d37007fde1f0027d[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_d37007fde1f0027d = {
   0xd37007fde1f0027d, b_d37007fde1f0027d.words, 49, nullptr, m_d37007fde1f0027d,
-  0, 2, i_d37007fde1f0027d, nullptr, nullptr, { &s_d37007fde1f0027d, nullptr, nullptr, 0, 0, nullptr }, true
+  0, 2, i_d37007fde1f0027d, nullptr, nullptr, { &s_d37007fde1f0027d, nullptr, bd_d37007fde1f0027d, 0, sizeof(bd_d37007fde1f0027d) / sizeof(bd_d37007fde1f0027d[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<100> b_d625b7063acf691a = {
@@ -1909,9 +2023,16 @@ static const ::capnp::_::RawSchema* const d_d625b7063acf691a[] = {
 };
 static const uint16_t m_d625b7063acf691a[] = {2, 1, 0, 4, 3};
 static const uint16_t i_d625b7063acf691a[] = {0, 1, 2, 3, 4};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d625b7063acf691a[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_b28c96e23f4cbd58.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_d625b7063acf691a = {
   0xd625b7063acf691a, b_d625b7063acf691a.words, 100, d_d625b7063acf691a, m_d625b7063acf691a,
-  1, 5, i_d625b7063acf691a, nullptr, nullptr, { &s_d625b7063acf691a, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 5, i_d625b7063acf691a, nullptr, nullptr, { &s_d625b7063acf691a, nullptr, bd_d625b7063acf691a, 0, sizeof(bd_d625b7063acf691a) / sizeof(bd_d625b7063acf691a[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<37> b_b28c96e23f4cbd58 = {

--- a/c++/src/capnp/schema-test.c++
+++ b/c++/src/capnp/schema-test.c++
@@ -395,6 +395,15 @@ KJ_TEST("StructSchema::hasNoCapabilites()") {
   KJ_EXPECT(Schema::from<test::TestCycleBWithCaps>().mayContainCapabilities());
 }
 
+KJ_TEST("StructSchema::Field::getType() benchmark") {
+  auto schema = Schema::from<test::TestAllTypes>();
+  auto field = schema.getFieldByName("structField");
+
+  doBenchmark([&]() {
+    KJ_ASSERT(field.getType() == schema);
+  });
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp

--- a/c++/src/capnp/schema.c++
+++ b/c++/src/capnp/schema.c++
@@ -268,15 +268,15 @@ Schema::BrandArgumentList Schema::getBrandArgumentsAtScope(uint64_t scopeId) con
 kj::Array<uint64_t> Schema::getGenericScopeIds() const {
   if (!getProto().getIsGeneric())
     return nullptr;
-  
+
   auto result = kj::heapArray<uint64_t>(raw->scopeCount);
   for (auto iScope: kj::indices(result)) {
     result[iScope] = raw->scopes[iScope].typeId;
   }
-  
+
   return result;
 }
-	
+
 
 StructSchema Schema::asStruct() const {
   KJ_REQUIRE(getProto().isStruct(), "Tried to use non-struct schema as a struct.",
@@ -528,7 +528,6 @@ bool StructSchema::isStreamResult() const {
 }
 
 Type StructSchema::Field::getType() const {
-  auto proto = getProto();
   uint location = _::RawBrandedSchema::makeDepLocation(_::RawBrandedSchema::DepKind::FIELD, index);
 
   switch (proto.which()) {

--- a/c++/src/capnp/schema.capnp.c++
+++ b/c++/src/capnp/schema.capnp.c++
@@ -246,9 +246,25 @@ static const ::capnp::_::RawSchema* const d_e682ab4cf923a417[] = {
 };
 static const uint16_t m_e682ab4cf923a417[] = {11, 5, 10, 1, 2, 8, 6, 0, 9, 13, 4, 12, 3, 7};
 static const uint16_t i_e682ab4cf923a417[] = {6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 12, 13};
+constexpr const ::capnp::_::RawBrandedSchema* bd_e682ab4cf923a417[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_debf55bbfa0fc242.defaultBrand,
+  &::capnp::schemas::s_f1c8950dab257542.defaultBrand,
+  nullptr,
+  &::capnp::schemas::s_9ea0b19b37fb4435.defaultBrand,
+  &::capnp::schemas::s_b54ab3364333f598.defaultBrand,
+  &::capnp::schemas::s_e82753cff0c2218f.defaultBrand,
+  &::capnp::schemas::s_b18aa5ac7a0d9420.defaultBrand,
+  &::capnp::schemas::s_ec1619d4400a0290.defaultBrand,
+  &::capnp::schemas::s_b9521bccf10fa3b1.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_e682ab4cf923a417 = {
   0xe682ab4cf923a417, b_e682ab4cf923a417.words, 225, d_e682ab4cf923a417, m_e682ab4cf923a417,
-  8, 14, i_e682ab4cf923a417, nullptr, nullptr, { &s_e682ab4cf923a417, nullptr, nullptr, 0, 0, nullptr }, true
+  8, 14, i_e682ab4cf923a417, nullptr, nullptr, { &s_e682ab4cf923a417, nullptr, bd_e682ab4cf923a417, 0, sizeof(bd_e682ab4cf923a417) / sizeof(bd_e682ab4cf923a417[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<34> b_b9521bccf10fa3b1 = {
@@ -291,9 +307,12 @@ static const ::capnp::_::AlignedData<34> b_b9521bccf10fa3b1 = {
 #if !CAPNP_LITE
 static const uint16_t m_b9521bccf10fa3b1[] = {0};
 static const uint16_t i_b9521bccf10fa3b1[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_b9521bccf10fa3b1[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_b9521bccf10fa3b1 = {
   0xb9521bccf10fa3b1, b_b9521bccf10fa3b1.words, 34, nullptr, m_b9521bccf10fa3b1,
-  0, 1, i_b9521bccf10fa3b1, nullptr, nullptr, { &s_b9521bccf10fa3b1, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 1, i_b9521bccf10fa3b1, nullptr, nullptr, { &s_b9521bccf10fa3b1, nullptr, bd_b9521bccf10fa3b1, 0, sizeof(bd_b9521bccf10fa3b1) / sizeof(bd_b9521bccf10fa3b1[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<49> b_debf55bbfa0fc242 = {
@@ -351,9 +370,13 @@ static const ::capnp::_::AlignedData<49> b_debf55bbfa0fc242 = {
 #if !CAPNP_LITE
 static const uint16_t m_debf55bbfa0fc242[] = {1, 0};
 static const uint16_t i_debf55bbfa0fc242[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_debf55bbfa0fc242[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_debf55bbfa0fc242 = {
   0xdebf55bbfa0fc242, b_debf55bbfa0fc242.words, 49, nullptr, m_debf55bbfa0fc242,
-  0, 2, i_debf55bbfa0fc242, nullptr, nullptr, { &s_debf55bbfa0fc242, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 2, i_debf55bbfa0fc242, nullptr, nullptr, { &s_debf55bbfa0fc242, nullptr, bd_debf55bbfa0fc242, 0, sizeof(bd_debf55bbfa0fc242) / sizeof(bd_debf55bbfa0fc242[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<72> b_f38e1de3041357ae = {
@@ -437,9 +460,14 @@ static const ::capnp::_::RawSchema* const d_f38e1de3041357ae[] = {
 };
 static const uint16_t m_f38e1de3041357ae[] = {1, 0, 2};
 static const uint16_t i_f38e1de3041357ae[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_f38e1de3041357ae[] = {
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_c2ba9038898e1fa2.defaultBrand,
+};
 const ::capnp::_::RawSchema s_f38e1de3041357ae = {
   0xf38e1de3041357ae, b_f38e1de3041357ae.words, 72, d_f38e1de3041357ae, m_f38e1de3041357ae,
-  1, 3, i_f38e1de3041357ae, nullptr, nullptr, { &s_f38e1de3041357ae, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 3, i_f38e1de3041357ae, nullptr, nullptr, { &s_f38e1de3041357ae, nullptr, bd_f38e1de3041357ae, 0, sizeof(bd_f38e1de3041357ae) / sizeof(bd_f38e1de3041357ae[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<36> b_c2ba9038898e1fa2 = {
@@ -484,9 +512,12 @@ static const ::capnp::_::AlignedData<36> b_c2ba9038898e1fa2 = {
 #if !CAPNP_LITE
 static const uint16_t m_c2ba9038898e1fa2[] = {0};
 static const uint16_t i_c2ba9038898e1fa2[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c2ba9038898e1fa2[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_c2ba9038898e1fa2 = {
   0xc2ba9038898e1fa2, b_c2ba9038898e1fa2.words, 36, nullptr, m_c2ba9038898e1fa2,
-  0, 1, i_c2ba9038898e1fa2, nullptr, nullptr, { &s_c2ba9038898e1fa2, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 1, i_c2ba9038898e1fa2, nullptr, nullptr, { &s_c2ba9038898e1fa2, nullptr, bd_c2ba9038898e1fa2, 0, sizeof(bd_c2ba9038898e1fa2) / sizeof(bd_c2ba9038898e1fa2[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<134> b_9ea0b19b37fb4435 = {
@@ -634,9 +665,18 @@ static const ::capnp::_::RawSchema* const d_9ea0b19b37fb4435[] = {
 };
 static const uint16_t m_9ea0b19b37fb4435[] = {0, 4, 5, 6, 3, 1, 2};
 static const uint16_t i_9ea0b19b37fb4435[] = {0, 1, 2, 3, 4, 5, 6};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9ea0b19b37fb4435[] = {
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_d1958f7dba521926.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_9aad50a41f4af45f.defaultBrand,
+};
 const ::capnp::_::RawSchema s_9ea0b19b37fb4435 = {
   0x9ea0b19b37fb4435, b_9ea0b19b37fb4435.words, 134, d_9ea0b19b37fb4435, m_9ea0b19b37fb4435,
-  3, 7, i_9ea0b19b37fb4435, nullptr, nullptr, { &s_9ea0b19b37fb4435, nullptr, nullptr, 0, 0, nullptr }, true
+  3, 7, i_9ea0b19b37fb4435, nullptr, nullptr, { &s_9ea0b19b37fb4435, nullptr, bd_9ea0b19b37fb4435, 0, sizeof(bd_9ea0b19b37fb4435) / sizeof(bd_9ea0b19b37fb4435[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<37> b_b54ab3364333f598 = {
@@ -686,9 +726,12 @@ static const ::capnp::_::RawSchema* const d_b54ab3364333f598[] = {
 };
 static const uint16_t m_b54ab3364333f598[] = {0};
 static const uint16_t i_b54ab3364333f598[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_b54ab3364333f598[] = {
+  &::capnp::schemas::s_978a7cebdc549a4d.defaultBrand,
+};
 const ::capnp::_::RawSchema s_b54ab3364333f598 = {
   0xb54ab3364333f598, b_b54ab3364333f598.words, 37, d_b54ab3364333f598, m_b54ab3364333f598,
-  2, 1, i_b54ab3364333f598, nullptr, nullptr, { &s_b54ab3364333f598, nullptr, nullptr, 0, 0, nullptr }, true
+  2, 1, i_b54ab3364333f598, nullptr, nullptr, { &s_b54ab3364333f598, nullptr, bd_b54ab3364333f598, 0, sizeof(bd_b54ab3364333f598) / sizeof(bd_b54ab3364333f598[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<57> b_e82753cff0c2218f = {
@@ -759,9 +802,13 @@ static const ::capnp::_::RawSchema* const d_e82753cff0c2218f[] = {
 };
 static const uint16_t m_e82753cff0c2218f[] = {0, 1};
 static const uint16_t i_e82753cff0c2218f[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_e82753cff0c2218f[] = {
+  &::capnp::schemas::s_9500cce23b334d80.defaultBrand,
+  &::capnp::schemas::s_a9962a9ed0a4d7f8.defaultBrand,
+};
 const ::capnp::_::RawSchema s_e82753cff0c2218f = {
   0xe82753cff0c2218f, b_e82753cff0c2218f.words, 57, d_e82753cff0c2218f, m_e82753cff0c2218f,
-  3, 2, i_e82753cff0c2218f, nullptr, nullptr, { &s_e82753cff0c2218f, nullptr, nullptr, 0, 0, nullptr }, true
+  3, 2, i_e82753cff0c2218f, nullptr, nullptr, { &s_e82753cff0c2218f, nullptr, bd_e82753cff0c2218f, 0, sizeof(bd_e82753cff0c2218f) / sizeof(bd_e82753cff0c2218f[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<47> b_b18aa5ac7a0d9420 = {
@@ -822,9 +869,13 @@ static const ::capnp::_::RawSchema* const d_b18aa5ac7a0d9420[] = {
 };
 static const uint16_t m_b18aa5ac7a0d9420[] = {0, 1};
 static const uint16_t i_b18aa5ac7a0d9420[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_b18aa5ac7a0d9420[] = {
+  &::capnp::schemas::s_d07378ede1f9cc60.defaultBrand,
+  &::capnp::schemas::s_ce23dcd2d7b00c9b.defaultBrand,
+};
 const ::capnp::_::RawSchema s_b18aa5ac7a0d9420 = {
   0xb18aa5ac7a0d9420, b_b18aa5ac7a0d9420.words, 47, d_b18aa5ac7a0d9420, m_b18aa5ac7a0d9420,
-  3, 2, i_b18aa5ac7a0d9420, nullptr, nullptr, { &s_b18aa5ac7a0d9420, nullptr, nullptr, 0, 0, nullptr }, true
+  3, 2, i_b18aa5ac7a0d9420, nullptr, nullptr, { &s_b18aa5ac7a0d9420, nullptr, bd_b18aa5ac7a0d9420, 0, sizeof(bd_b18aa5ac7a0d9420) / sizeof(bd_b18aa5ac7a0d9420[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<228> b_ec1619d4400a0290 = {
@@ -1065,9 +1116,24 @@ static const ::capnp::_::RawSchema* const d_ec1619d4400a0290[] = {
 };
 static const uint16_t m_ec1619d4400a0290[] = {12, 2, 3, 4, 6, 1, 8, 9, 10, 11, 5, 7, 0};
 static const uint16_t i_ec1619d4400a0290[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+constexpr const ::capnp::_::RawBrandedSchema* bd_ec1619d4400a0290[] = {
+  &::capnp::schemas::s_d07378ede1f9cc60.defaultBrand,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_ec1619d4400a0290 = {
   0xec1619d4400a0290, b_ec1619d4400a0290.words, 228, d_ec1619d4400a0290, m_ec1619d4400a0290,
-  2, 13, i_ec1619d4400a0290, nullptr, nullptr, { &s_ec1619d4400a0290, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 13, i_ec1619d4400a0290, nullptr, nullptr, { &s_ec1619d4400a0290, nullptr, bd_ec1619d4400a0290, 0, sizeof(bd_ec1619d4400a0290) / sizeof(bd_ec1619d4400a0290[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<114> b_9aad50a41f4af45f = {
@@ -1196,9 +1262,18 @@ static const ::capnp::_::RawSchema* const d_9aad50a41f4af45f[] = {
 };
 static const uint16_t m_9aad50a41f4af45f[] = {2, 1, 3, 5, 0, 6, 4};
 static const uint16_t i_9aad50a41f4af45f[] = {4, 5, 0, 1, 2, 3, 6};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9aad50a41f4af45f[] = {
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_f1c8950dab257542.defaultBrand,
+  nullptr,
+  &::capnp::schemas::s_c42305476bb4746f.defaultBrand,
+  &::capnp::schemas::s_cafccddb68db1d11.defaultBrand,
+  &::capnp::schemas::s_bb90d5c287870be6.defaultBrand,
+};
 const ::capnp::_::RawSchema s_9aad50a41f4af45f = {
   0x9aad50a41f4af45f, b_9aad50a41f4af45f.words, 114, d_9aad50a41f4af45f, m_9aad50a41f4af45f,
-  4, 7, i_9aad50a41f4af45f, nullptr, nullptr, { &s_9aad50a41f4af45f, nullptr, nullptr, 0, 0, nullptr }, true
+  4, 7, i_9aad50a41f4af45f, nullptr, nullptr, { &s_9aad50a41f4af45f, nullptr, bd_9aad50a41f4af45f, 0, sizeof(bd_9aad50a41f4af45f) / sizeof(bd_9aad50a41f4af45f[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<25> b_97b14cbe7cfec712 = {
@@ -1230,9 +1305,12 @@ static const ::capnp::_::AlignedData<25> b_97b14cbe7cfec712 = {
 };
 ::capnp::word const* const bp_97b14cbe7cfec712 = b_97b14cbe7cfec712.words;
 #if !CAPNP_LITE
+constexpr const ::capnp::_::RawBrandedSchema* bd_97b14cbe7cfec712[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_97b14cbe7cfec712 = {
   0x97b14cbe7cfec712, b_97b14cbe7cfec712.words, 25, nullptr, nullptr,
-  0, 0, nullptr, nullptr, nullptr, { &s_97b14cbe7cfec712, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 0, nullptr, nullptr, nullptr, { &s_97b14cbe7cfec712, nullptr, bd_97b14cbe7cfec712, 0, sizeof(bd_97b14cbe7cfec712) / sizeof(bd_97b14cbe7cfec712[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<80> b_c42305476bb4746f = {
@@ -1326,9 +1404,15 @@ static const ::capnp::_::RawSchema* const d_c42305476bb4746f[] = {
 };
 static const uint16_t m_c42305476bb4746f[] = {2, 3, 0, 1};
 static const uint16_t i_c42305476bb4746f[] = {0, 1, 2, 3};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c42305476bb4746f[] = {
+  nullptr,
+  &::capnp::schemas::s_d07378ede1f9cc60.defaultBrand,
+  &::capnp::schemas::s_ce23dcd2d7b00c9b.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_c42305476bb4746f = {
   0xc42305476bb4746f, b_c42305476bb4746f.words, 80, d_c42305476bb4746f, m_c42305476bb4746f,
-  3, 4, i_c42305476bb4746f, nullptr, nullptr, { &s_c42305476bb4746f, nullptr, nullptr, 0, 0, nullptr }, true
+  3, 4, i_c42305476bb4746f, nullptr, nullptr, { &s_c42305476bb4746f, nullptr, bd_c42305476bb4746f, 0, sizeof(bd_c42305476bb4746f) / sizeof(bd_c42305476bb4746f[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<32> b_cafccddb68db1d11 = {
@@ -1372,9 +1456,12 @@ static const ::capnp::_::RawSchema* const d_cafccddb68db1d11[] = {
 };
 static const uint16_t m_cafccddb68db1d11[] = {0};
 static const uint16_t i_cafccddb68db1d11[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_cafccddb68db1d11[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_cafccddb68db1d11 = {
   0xcafccddb68db1d11, b_cafccddb68db1d11.words, 32, d_cafccddb68db1d11, m_cafccddb68db1d11,
-  1, 1, i_cafccddb68db1d11, nullptr, nullptr, { &s_cafccddb68db1d11, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_cafccddb68db1d11, nullptr, nullptr, { &s_cafccddb68db1d11, nullptr, bd_cafccddb68db1d11, 0, sizeof(bd_cafccddb68db1d11) / sizeof(bd_cafccddb68db1d11[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<50> b_bb90d5c287870be6 = {
@@ -1436,9 +1523,13 @@ static const ::capnp::_::RawSchema* const d_bb90d5c287870be6[] = {
 };
 static const uint16_t m_bb90d5c287870be6[] = {1, 0};
 static const uint16_t i_bb90d5c287870be6[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_bb90d5c287870be6[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_bb90d5c287870be6 = {
   0xbb90d5c287870be6, b_bb90d5c287870be6.words, 50, d_bb90d5c287870be6, m_bb90d5c287870be6,
-  1, 2, i_bb90d5c287870be6, nullptr, nullptr, { &s_bb90d5c287870be6, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_bb90d5c287870be6, nullptr, nullptr, { &s_bb90d5c287870be6, nullptr, bd_bb90d5c287870be6, 0, sizeof(bd_bb90d5c287870be6) / sizeof(bd_bb90d5c287870be6[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<69> b_978a7cebdc549a4d = {
@@ -1519,9 +1610,14 @@ static const ::capnp::_::RawSchema* const d_978a7cebdc549a4d[] = {
 };
 static const uint16_t m_978a7cebdc549a4d[] = {2, 1, 0};
 static const uint16_t i_978a7cebdc549a4d[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_978a7cebdc549a4d[] = {
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_f1c8950dab257542.defaultBrand,
+};
 const ::capnp::_::RawSchema s_978a7cebdc549a4d = {
   0x978a7cebdc549a4d, b_978a7cebdc549a4d.words, 69, d_978a7cebdc549a4d, m_978a7cebdc549a4d,
-  1, 3, i_978a7cebdc549a4d, nullptr, nullptr, { &s_978a7cebdc549a4d, nullptr, nullptr, 0, 0, nullptr }, true
+  1, 3, i_978a7cebdc549a4d, nullptr, nullptr, { &s_978a7cebdc549a4d, nullptr, bd_978a7cebdc549a4d, 0, sizeof(bd_978a7cebdc549a4d) / sizeof(bd_978a7cebdc549a4d[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<48> b_a9962a9ed0a4d7f8 = {
@@ -1581,9 +1677,13 @@ static const ::capnp::_::RawSchema* const d_a9962a9ed0a4d7f8[] = {
 };
 static const uint16_t m_a9962a9ed0a4d7f8[] = {1, 0};
 static const uint16_t i_a9962a9ed0a4d7f8[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_a9962a9ed0a4d7f8[] = {
+  nullptr,
+  &::capnp::schemas::s_903455f06065422b.defaultBrand,
+};
 const ::capnp::_::RawSchema s_a9962a9ed0a4d7f8 = {
   0xa9962a9ed0a4d7f8, b_a9962a9ed0a4d7f8.words, 48, d_a9962a9ed0a4d7f8, m_a9962a9ed0a4d7f8,
-  1, 2, i_a9962a9ed0a4d7f8, nullptr, nullptr, { &s_a9962a9ed0a4d7f8, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_a9962a9ed0a4d7f8, nullptr, nullptr, { &s_a9962a9ed0a4d7f8, nullptr, bd_a9962a9ed0a4d7f8, 0, sizeof(bd_a9962a9ed0a4d7f8) / sizeof(bd_a9962a9ed0a4d7f8[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<155> b_9500cce23b334d80 = {
@@ -1752,9 +1852,19 @@ static const ::capnp::_::RawSchema* const d_9500cce23b334d80[] = {
 };
 static const uint16_t m_9500cce23b334d80[] = {4, 1, 7, 0, 5, 2, 6, 3};
 static const uint16_t i_9500cce23b334d80[] = {0, 1, 2, 3, 4, 5, 6, 7};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9500cce23b334d80[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_f1c8950dab257542.defaultBrand,
+  &::capnp::schemas::s_903455f06065422b.defaultBrand,
+  &::capnp::schemas::s_903455f06065422b.defaultBrand,
+  &::capnp::schemas::s_b9521bccf10fa3b1.defaultBrand,
+};
 const ::capnp::_::RawSchema s_9500cce23b334d80 = {
   0x9500cce23b334d80, b_9500cce23b334d80.words, 155, d_9500cce23b334d80, m_9500cce23b334d80,
-  3, 8, i_9500cce23b334d80, nullptr, nullptr, { &s_9500cce23b334d80, nullptr, nullptr, 0, 0, nullptr }, true
+  3, 8, i_9500cce23b334d80, nullptr, nullptr, { &s_9500cce23b334d80, nullptr, bd_9500cce23b334d80, 0, sizeof(bd_9500cce23b334d80) / sizeof(bd_9500cce23b334d80[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<269> b_d07378ede1f9cc60 = {
@@ -2039,9 +2149,30 @@ static const ::capnp::_::RawSchema* const d_d07378ede1f9cc60[] = {
 };
 static const uint16_t m_d07378ede1f9cc60[] = {18, 1, 13, 15, 10, 11, 3, 4, 5, 2, 17, 14, 16, 12, 7, 8, 9, 6, 0};
 static const uint16_t i_d07378ede1f9cc60[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d07378ede1f9cc60[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_87e739250a60ea97.defaultBrand,
+  &::capnp::schemas::s_9e0e78711a7f87a9.defaultBrand,
+  &::capnp::schemas::s_ac3a6f60ef4cc6d3.defaultBrand,
+  &::capnp::schemas::s_ed8bca69f7fb0cbf.defaultBrand,
+  &::capnp::schemas::s_c2573fe8a23e49f1.defaultBrand,
+};
 const ::capnp::_::RawSchema s_d07378ede1f9cc60 = {
   0xd07378ede1f9cc60, b_d07378ede1f9cc60.words, 269, d_d07378ede1f9cc60, m_d07378ede1f9cc60,
-  5, 19, i_d07378ede1f9cc60, nullptr, nullptr, { &s_d07378ede1f9cc60, nullptr, nullptr, 0, 0, nullptr }, false
+  5, 19, i_d07378ede1f9cc60, nullptr, nullptr, { &s_d07378ede1f9cc60, nullptr, bd_d07378ede1f9cc60, 0, sizeof(bd_d07378ede1f9cc60) / sizeof(bd_d07378ede1f9cc60[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<33> b_87e739250a60ea97 = {
@@ -2086,9 +2217,12 @@ static const ::capnp::_::RawSchema* const d_87e739250a60ea97[] = {
 };
 static const uint16_t m_87e739250a60ea97[] = {0};
 static const uint16_t i_87e739250a60ea97[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_87e739250a60ea97[] = {
+  &::capnp::schemas::s_d07378ede1f9cc60.defaultBrand,
+};
 const ::capnp::_::RawSchema s_87e739250a60ea97 = {
   0x87e739250a60ea97, b_87e739250a60ea97.words, 33, d_87e739250a60ea97, m_87e739250a60ea97,
-  1, 1, i_87e739250a60ea97, nullptr, nullptr, { &s_87e739250a60ea97, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_87e739250a60ea97, nullptr, nullptr, { &s_87e739250a60ea97, nullptr, bd_87e739250a60ea97, 0, sizeof(bd_87e739250a60ea97) / sizeof(bd_87e739250a60ea97[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<47> b_9e0e78711a7f87a9 = {
@@ -2148,9 +2282,13 @@ static const ::capnp::_::RawSchema* const d_9e0e78711a7f87a9[] = {
 };
 static const uint16_t m_9e0e78711a7f87a9[] = {1, 0};
 static const uint16_t i_9e0e78711a7f87a9[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9e0e78711a7f87a9[] = {
+  nullptr,
+  &::capnp::schemas::s_903455f06065422b.defaultBrand,
+};
 const ::capnp::_::RawSchema s_9e0e78711a7f87a9 = {
   0x9e0e78711a7f87a9, b_9e0e78711a7f87a9.words, 47, d_9e0e78711a7f87a9, m_9e0e78711a7f87a9,
-  2, 2, i_9e0e78711a7f87a9, nullptr, nullptr, { &s_9e0e78711a7f87a9, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_9e0e78711a7f87a9, nullptr, nullptr, { &s_9e0e78711a7f87a9, nullptr, bd_9e0e78711a7f87a9, 0, sizeof(bd_9e0e78711a7f87a9) / sizeof(bd_9e0e78711a7f87a9[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<47> b_ac3a6f60ef4cc6d3 = {
@@ -2210,9 +2348,13 @@ static const ::capnp::_::RawSchema* const d_ac3a6f60ef4cc6d3[] = {
 };
 static const uint16_t m_ac3a6f60ef4cc6d3[] = {1, 0};
 static const uint16_t i_ac3a6f60ef4cc6d3[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_ac3a6f60ef4cc6d3[] = {
+  nullptr,
+  &::capnp::schemas::s_903455f06065422b.defaultBrand,
+};
 const ::capnp::_::RawSchema s_ac3a6f60ef4cc6d3 = {
   0xac3a6f60ef4cc6d3, b_ac3a6f60ef4cc6d3.words, 47, d_ac3a6f60ef4cc6d3, m_ac3a6f60ef4cc6d3,
-  2, 2, i_ac3a6f60ef4cc6d3, nullptr, nullptr, { &s_ac3a6f60ef4cc6d3, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_ac3a6f60ef4cc6d3, nullptr, nullptr, { &s_ac3a6f60ef4cc6d3, nullptr, bd_ac3a6f60ef4cc6d3, 0, sizeof(bd_ac3a6f60ef4cc6d3) / sizeof(bd_ac3a6f60ef4cc6d3[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<48> b_ed8bca69f7fb0cbf = {
@@ -2273,9 +2415,13 @@ static const ::capnp::_::RawSchema* const d_ed8bca69f7fb0cbf[] = {
 };
 static const uint16_t m_ed8bca69f7fb0cbf[] = {1, 0};
 static const uint16_t i_ed8bca69f7fb0cbf[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_ed8bca69f7fb0cbf[] = {
+  nullptr,
+  &::capnp::schemas::s_903455f06065422b.defaultBrand,
+};
 const ::capnp::_::RawSchema s_ed8bca69f7fb0cbf = {
   0xed8bca69f7fb0cbf, b_ed8bca69f7fb0cbf.words, 48, d_ed8bca69f7fb0cbf, m_ed8bca69f7fb0cbf,
-  2, 2, i_ed8bca69f7fb0cbf, nullptr, nullptr, { &s_ed8bca69f7fb0cbf, nullptr, nullptr, 0, 0, nullptr }, false
+  2, 2, i_ed8bca69f7fb0cbf, nullptr, nullptr, { &s_ed8bca69f7fb0cbf, nullptr, bd_ed8bca69f7fb0cbf, 0, sizeof(bd_ed8bca69f7fb0cbf) / sizeof(bd_ed8bca69f7fb0cbf[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<46> b_c2573fe8a23e49f1 = {
@@ -2336,9 +2482,14 @@ static const ::capnp::_::RawSchema* const d_c2573fe8a23e49f1[] = {
 };
 static const uint16_t m_c2573fe8a23e49f1[] = {2, 1, 0};
 static const uint16_t i_c2573fe8a23e49f1[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c2573fe8a23e49f1[] = {
+  &::capnp::schemas::s_8e3b5f79fe593656.defaultBrand,
+  &::capnp::schemas::s_9dd1f724f4614a85.defaultBrand,
+  &::capnp::schemas::s_baefc9120c56e274.defaultBrand,
+};
 const ::capnp::_::RawSchema s_c2573fe8a23e49f1 = {
   0xc2573fe8a23e49f1, b_c2573fe8a23e49f1.words, 46, d_c2573fe8a23e49f1, m_c2573fe8a23e49f1,
-  4, 3, i_c2573fe8a23e49f1, nullptr, nullptr, { &s_c2573fe8a23e49f1, nullptr, nullptr, 0, 0, nullptr }, false
+  4, 3, i_c2573fe8a23e49f1, nullptr, nullptr, { &s_c2573fe8a23e49f1, nullptr, bd_c2573fe8a23e49f1, 0, sizeof(bd_c2573fe8a23e49f1) / sizeof(bd_c2573fe8a23e49f1[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<81> b_8e3b5f79fe593656 = {
@@ -2431,9 +2582,15 @@ static const ::capnp::_::RawSchema* const d_8e3b5f79fe593656[] = {
 };
 static const uint16_t m_8e3b5f79fe593656[] = {0, 3, 2, 1};
 static const uint16_t i_8e3b5f79fe593656[] = {0, 1, 2, 3};
+constexpr const ::capnp::_::RawBrandedSchema* bd_8e3b5f79fe593656[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_8e3b5f79fe593656 = {
   0x8e3b5f79fe593656, b_8e3b5f79fe593656.words, 81, d_8e3b5f79fe593656, m_8e3b5f79fe593656,
-  1, 4, i_8e3b5f79fe593656, nullptr, nullptr, { &s_8e3b5f79fe593656, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 4, i_8e3b5f79fe593656, nullptr, nullptr, { &s_8e3b5f79fe593656, nullptr, bd_8e3b5f79fe593656, 0, sizeof(bd_8e3b5f79fe593656) / sizeof(bd_8e3b5f79fe593656[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<50> b_9dd1f724f4614a85 = {
@@ -2495,9 +2652,13 @@ static const ::capnp::_::RawSchema* const d_9dd1f724f4614a85[] = {
 };
 static const uint16_t m_9dd1f724f4614a85[] = {1, 0};
 static const uint16_t i_9dd1f724f4614a85[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_9dd1f724f4614a85[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_9dd1f724f4614a85 = {
   0x9dd1f724f4614a85, b_9dd1f724f4614a85.words, 50, d_9dd1f724f4614a85, m_9dd1f724f4614a85,
-  1, 2, i_9dd1f724f4614a85, nullptr, nullptr, { &s_9dd1f724f4614a85, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_9dd1f724f4614a85, nullptr, nullptr, { &s_9dd1f724f4614a85, nullptr, bd_9dd1f724f4614a85, 0, sizeof(bd_9dd1f724f4614a85) / sizeof(bd_9dd1f724f4614a85[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<37> b_baefc9120c56e274 = {
@@ -2546,9 +2707,12 @@ static const ::capnp::_::RawSchema* const d_baefc9120c56e274[] = {
 };
 static const uint16_t m_baefc9120c56e274[] = {0};
 static const uint16_t i_baefc9120c56e274[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_baefc9120c56e274[] = {
+  nullptr,
+};
 const ::capnp::_::RawSchema s_baefc9120c56e274 = {
   0xbaefc9120c56e274, b_baefc9120c56e274.words, 37, d_baefc9120c56e274, m_baefc9120c56e274,
-  1, 1, i_baefc9120c56e274, nullptr, nullptr, { &s_baefc9120c56e274, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_baefc9120c56e274, nullptr, nullptr, { &s_baefc9120c56e274, nullptr, bd_baefc9120c56e274, 0, sizeof(bd_baefc9120c56e274) / sizeof(bd_baefc9120c56e274[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<43> b_903455f06065422b = {
@@ -2603,9 +2767,12 @@ static const ::capnp::_::RawSchema* const d_903455f06065422b[] = {
 };
 static const uint16_t m_903455f06065422b[] = {0};
 static const uint16_t i_903455f06065422b[] = {0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_903455f06065422b[] = {
+  &::capnp::schemas::s_abd73485a9636bc9.defaultBrand,
+};
 const ::capnp::_::RawSchema s_903455f06065422b = {
   0x903455f06065422b, b_903455f06065422b.words, 43, d_903455f06065422b, m_903455f06065422b,
-  1, 1, i_903455f06065422b, nullptr, nullptr, { &s_903455f06065422b, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 1, i_903455f06065422b, nullptr, nullptr, { &s_903455f06065422b, nullptr, bd_903455f06065422b, 0, sizeof(bd_903455f06065422b) / sizeof(bd_903455f06065422b[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<67> b_abd73485a9636bc9 = {
@@ -2684,9 +2851,14 @@ static const ::capnp::_::RawSchema* const d_abd73485a9636bc9[] = {
 };
 static const uint16_t m_abd73485a9636bc9[] = {1, 2, 0};
 static const uint16_t i_abd73485a9636bc9[] = {1, 2, 0};
+constexpr const ::capnp::_::RawBrandedSchema* bd_abd73485a9636bc9[] = {
+  nullptr,
+  &::capnp::schemas::s_c863cd16969ee7fc.defaultBrand,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_abd73485a9636bc9 = {
   0xabd73485a9636bc9, b_abd73485a9636bc9.words, 67, d_abd73485a9636bc9, m_abd73485a9636bc9,
-  1, 3, i_abd73485a9636bc9, nullptr, nullptr, { &s_abd73485a9636bc9, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 3, i_abd73485a9636bc9, nullptr, nullptr, { &s_abd73485a9636bc9, nullptr, bd_abd73485a9636bc9, 0, sizeof(bd_abd73485a9636bc9) / sizeof(bd_abd73485a9636bc9[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<49> b_c863cd16969ee7fc = {
@@ -2747,9 +2919,13 @@ static const ::capnp::_::RawSchema* const d_c863cd16969ee7fc[] = {
 };
 static const uint16_t m_c863cd16969ee7fc[] = {1, 0};
 static const uint16_t i_c863cd16969ee7fc[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_c863cd16969ee7fc[] = {
+  nullptr,
+  &::capnp::schemas::s_d07378ede1f9cc60.defaultBrand,
+};
 const ::capnp::_::RawSchema s_c863cd16969ee7fc = {
   0xc863cd16969ee7fc, b_c863cd16969ee7fc.words, 49, d_c863cd16969ee7fc, m_c863cd16969ee7fc,
-  1, 2, i_c863cd16969ee7fc, nullptr, nullptr, { &s_c863cd16969ee7fc, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 2, i_c863cd16969ee7fc, nullptr, nullptr, { &s_c863cd16969ee7fc, nullptr, bd_c863cd16969ee7fc, 0, sizeof(bd_c863cd16969ee7fc) / sizeof(bd_c863cd16969ee7fc[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<305> b_ce23dcd2d7b00c9b = {
@@ -3063,9 +3239,30 @@ static const ::capnp::_::AlignedData<305> b_ce23dcd2d7b00c9b = {
 #if !CAPNP_LITE
 static const uint16_t m_ce23dcd2d7b00c9b[] = {18, 1, 13, 15, 10, 11, 3, 4, 5, 2, 17, 14, 16, 12, 7, 8, 9, 6, 0};
 static const uint16_t i_ce23dcd2d7b00c9b[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
+constexpr const ::capnp::_::RawBrandedSchema* bd_ce23dcd2d7b00c9b[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_ce23dcd2d7b00c9b = {
   0xce23dcd2d7b00c9b, b_ce23dcd2d7b00c9b.words, 305, nullptr, m_ce23dcd2d7b00c9b,
-  0, 19, i_ce23dcd2d7b00c9b, nullptr, nullptr, { &s_ce23dcd2d7b00c9b, nullptr, nullptr, 0, 0, nullptr }, true
+  0, 19, i_ce23dcd2d7b00c9b, nullptr, nullptr, { &s_ce23dcd2d7b00c9b, nullptr, bd_ce23dcd2d7b00c9b, 0, sizeof(bd_ce23dcd2d7b00c9b) / sizeof(bd_ce23dcd2d7b00c9b[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<63> b_f1c8950dab257542 = {
@@ -3141,9 +3338,14 @@ static const ::capnp::_::RawSchema* const d_f1c8950dab257542[] = {
 };
 static const uint16_t m_f1c8950dab257542[] = {2, 0, 1};
 static const uint16_t i_f1c8950dab257542[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_f1c8950dab257542[] = {
+  nullptr,
+  &::capnp::schemas::s_ce23dcd2d7b00c9b.defaultBrand,
+  &::capnp::schemas::s_903455f06065422b.defaultBrand,
+};
 const ::capnp::_::RawSchema s_f1c8950dab257542 = {
   0xf1c8950dab257542, b_f1c8950dab257542.words, 63, d_f1c8950dab257542, m_f1c8950dab257542,
-  2, 3, i_f1c8950dab257542, nullptr, nullptr, { &s_f1c8950dab257542, nullptr, nullptr, 0, 0, nullptr }, true
+  2, 3, i_f1c8950dab257542, nullptr, nullptr, { &s_f1c8950dab257542, nullptr, bd_f1c8950dab257542, 0, sizeof(bd_f1c8950dab257542) / sizeof(bd_f1c8950dab257542[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<54> b_d1958f7dba521926 = {
@@ -3280,9 +3482,14 @@ static const ::capnp::_::AlignedData<63> b_d85d305b7d839963 = {
 #if !CAPNP_LITE
 static const uint16_t m_d85d305b7d839963[] = {0, 2, 1};
 static const uint16_t i_d85d305b7d839963[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_d85d305b7d839963[] = {
+  nullptr,
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_d85d305b7d839963 = {
   0xd85d305b7d839963, b_d85d305b7d839963.words, 63, nullptr, m_d85d305b7d839963,
-  0, 3, i_d85d305b7d839963, nullptr, nullptr, { &s_d85d305b7d839963, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 3, i_d85d305b7d839963, nullptr, nullptr, { &s_d85d305b7d839963, nullptr, bd_d85d305b7d839963, 0, sizeof(bd_d85d305b7d839963) / sizeof(bd_d85d305b7d839963[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<98> b_bfc546f6210ad7ce = {
@@ -3395,9 +3602,15 @@ static const ::capnp::_::RawSchema* const d_bfc546f6210ad7ce[] = {
 };
 static const uint16_t m_bfc546f6210ad7ce[] = {2, 0, 1, 3};
 static const uint16_t i_bfc546f6210ad7ce[] = {0, 1, 2, 3};
+constexpr const ::capnp::_::RawBrandedSchema* bd_bfc546f6210ad7ce[] = {
+  &::capnp::schemas::s_e682ab4cf923a417.defaultBrand,
+  &::capnp::schemas::s_cfea0eb02e810062.defaultBrand,
+  &::capnp::schemas::s_d85d305b7d839963.defaultBrand,
+  &::capnp::schemas::s_f38e1de3041357ae.defaultBrand,
+};
 const ::capnp::_::RawSchema s_bfc546f6210ad7ce = {
   0xbfc546f6210ad7ce, b_bfc546f6210ad7ce.words, 98, d_bfc546f6210ad7ce, m_bfc546f6210ad7ce,
-  4, 4, i_bfc546f6210ad7ce, nullptr, nullptr, { &s_bfc546f6210ad7ce, nullptr, nullptr, 0, 0, nullptr }, true
+  4, 4, i_bfc546f6210ad7ce, nullptr, nullptr, { &s_bfc546f6210ad7ce, nullptr, bd_bfc546f6210ad7ce, 0, sizeof(bd_bfc546f6210ad7ce) / sizeof(bd_bfc546f6210ad7ce[0]), nullptr }, true
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<74> b_cfea0eb02e810062 = {
@@ -3483,9 +3696,14 @@ static const ::capnp::_::RawSchema* const d_cfea0eb02e810062[] = {
 };
 static const uint16_t m_cfea0eb02e810062[] = {1, 0, 2};
 static const uint16_t i_cfea0eb02e810062[] = {0, 1, 2};
+constexpr const ::capnp::_::RawBrandedSchema* bd_cfea0eb02e810062[] = {
+  nullptr,
+  nullptr,
+  &::capnp::schemas::s_ae504193122357e5.defaultBrand,
+};
 const ::capnp::_::RawSchema s_cfea0eb02e810062 = {
   0xcfea0eb02e810062, b_cfea0eb02e810062.words, 74, d_cfea0eb02e810062, m_cfea0eb02e810062,
-  1, 3, i_cfea0eb02e810062, nullptr, nullptr, { &s_cfea0eb02e810062, nullptr, nullptr, 0, 0, nullptr }, false
+  1, 3, i_cfea0eb02e810062, nullptr, nullptr, { &s_cfea0eb02e810062, nullptr, bd_cfea0eb02e810062, 0, sizeof(bd_cfea0eb02e810062) / sizeof(bd_cfea0eb02e810062[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<52> b_ae504193122357e5 = {
@@ -3546,9 +3764,13 @@ static const ::capnp::_::AlignedData<52> b_ae504193122357e5 = {
 #if !CAPNP_LITE
 static const uint16_t m_ae504193122357e5[] = {0, 1};
 static const uint16_t i_ae504193122357e5[] = {0, 1};
+constexpr const ::capnp::_::RawBrandedSchema* bd_ae504193122357e5[] = {
+  nullptr,
+  nullptr,
+};
 const ::capnp::_::RawSchema s_ae504193122357e5 = {
   0xae504193122357e5, b_ae504193122357e5.words, 52, nullptr, m_ae504193122357e5,
-  0, 2, i_ae504193122357e5, nullptr, nullptr, { &s_ae504193122357e5, nullptr, nullptr, 0, 0, nullptr }, false
+  0, 2, i_ae504193122357e5, nullptr, nullptr, { &s_ae504193122357e5, nullptr, bd_ae504193122357e5, 0, sizeof(bd_ae504193122357e5) / sizeof(bd_ae504193122357e5[0]), nullptr }, false
 };
 #endif  // !CAPNP_LITE
 }  // namespace schemas

--- a/c++/src/capnp/schema.h
+++ b/c++/src/capnp/schema.h
@@ -181,9 +181,9 @@ private:
   //
   // TODO(someday): Public interface for iterating over all bindings?
 
-  Schema getDependency(uint64_t id, uint location) const;
-  // Look up schema for a particular dependency of this schema. `location` is the dependency
-  // location number as defined in _::RawBrandedSchema.
+  Schema getIndexedDependency(uint location) const;
+  // Get a dependency based on RawBrandedSchema::dependencies. `location` is the index into that
+  // array.
 
   Type interpretType(schema::Type::Reader proto, uint location) const;
   // Interpret a schema::Type in the given location within the schema, compiling it into a
@@ -815,10 +815,6 @@ template <> inline schema::Type::Which Schema::from<float>() { return schema::Ty
 template <> inline schema::Type::Which Schema::from<double>() { return schema::Type::FLOAT64; }
 template <> inline schema::Type::Which Schema::from<Text>() { return schema::Type::TEXT; }
 template <> inline schema::Type::Which Schema::from<Data>() { return schema::Type::DATA; }
-
-inline Schema Schema::getDependency(uint64_t id) const {
-  return getDependency(id, 0);
-}
 
 inline bool Schema::isBranded() const {
   return raw != &raw->generic->defaultBrand;

--- a/c++/src/capnp/stringify-test.c++
+++ b/c++/src/capnp/stringify-test.c++
@@ -701,6 +701,18 @@ TEST(Stringify, Generics) {
   EXPECT_EQ("(foo = \"abcd\", bar = [123, 456])", kj::str(root));
 }
 
+KJ_TEST("Stringification benchmark") {
+  MallocMessageBuilder builder;
+  auto root = builder.initRoot<TestAllTypes>();
+  initTestMessage(root);
+  auto reader = root.asReader();
+  auto size = kj::toCharSequence(reader).size();
+
+  doBenchmark([&]() {
+    KJ_ASSERT(kj::toCharSequence(reader).size() == size);
+  });
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp


### PR DESCRIPTION
The array is indexed by the field number, so that lookups no longer require a binary search.

This is meant to be a better alternative to #1659.

However, my benchmarks that I added show no measurable speed difference at all.

It turns out all the time is really spent evaluating `proto.getSlot().getType()`. Memoizing *that* doubles the performance of `getType()`. :facepalm: 

I'm putting up this PR just to save it in case I decide later it's a good idea for some other reason.