### PR TITLE
Clarify that retroactive unionization is not forward-compatible.

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -738,7 +738,15 @@ without changing the [canonical](encoding.html#canonicalization) encoding of a m
 
 * A field can be moved into a group or a union, as long as the group/union and all other fields
   within it are new.  In other words, a field can be replaced with a group or union containing an
-  equivalent field and some new fields.
+  equivalent field and some new fields.  Note that when creating a union this way, this particular
+  change is not fully forwards-compatible: if you create a message where one of the union's new
+  fields are set, and the message is read by an old program that dosen't know about the union, then
+  it may expect the original field to be present, and if it tries to read that field, may see a
+  garbage value or throw an exception. To avoid this problem, make sure to only use the new union
+  members when talking to programs that know about the union. This caveat only applies when moving
+  an existing field into a new union; adding new fields to an existing union does not create a
+  problem, because existing programs should already know to check the union's tag (although they
+  may or may not behave reasonably when the tag has a value they don't recognize).
 
 * A non-generic type can be made [generic](#generic-types), and new generic parameters may be
   added to an existing generic type. Other types used inside the body of the newly-generic type can


### PR DESCRIPTION
Fixes #1694.