### PR TITLE
Improve WebSocket protocol error handling.

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1889,9 +1889,9 @@ KJ_TEST("WebSocket masked") {
 
 class WebSocketErrorCatcher : public WebSocketErrorHandler {
 public:
-  kj::Vector<kj::HttpHeaders::ProtocolError> errors;
+  kj::Vector<kj::WebSocket::ProtocolError> errors;
 
-  kj::Exception handleWebSocketProtocolError(kj::HttpHeaders::ProtocolError protocolError) {
+  kj::Exception handleWebSocketProtocolError(kj::WebSocket::ProtocolError protocolError) {
     errors.add(kj::mv(protocolError));
     return KJ_EXCEPTION(FAILED, protocolError.description);
   }

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -25,6 +25,7 @@
 #include <kj/debug.h>
 #include <kj/test.h>
 #include <kj/encoding.h>
+#include <kj/vector.h>
 #include <map>
 
 #if KJ_HTTP_TEST_USE_OS_PIPE
@@ -1886,6 +1887,148 @@ KJ_TEST("WebSocket masked") {
   serverTask.wait(waitScope);
 }
 
+class WebSocketErrorCatcher : public WebSocketErrorHandler {
+public:
+  kj::Vector<kj::HttpHeaders::ProtocolError> errors;
+
+  kj::Exception handleWebSocketProtocolError(kj::HttpHeaders::ProtocolError protocolError) {
+    errors.add(kj::mv(protocolError));
+    return KJ_EXCEPTION(FAILED, protocolError.description);
+  }
+};
+
+KJ_TEST("WebSocket unexpected RSV bits") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  WebSocketErrorCatcher errorCatcher;
+  auto client = kj::mv(pipe.ends[0]);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+
+  byte DATA[] = {
+    0x01, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',
+
+    0xF0, 0x05, 'w', 'o', 'r', 'l', 'd'  // all RSV bits set, plus FIN
+  };
+
+  auto clientTask = client->write(DATA, sizeof(DATA));
+
+  {
+    bool gotException = false;
+    auto serverTask = server->receive().then([](auto&& m) {}, [&gotException](kj::Exception&& ex) { gotException = true; });
+    serverTask.wait(waitScope);
+    KJ_ASSERT(gotException);
+    KJ_ASSERT(errorCatcher.errors.size() == 1);
+    KJ_ASSERT(errorCatcher.errors[0].statusCode == 1002);
+  }
+
+  clientTask.wait(waitScope);
+}
+
+KJ_TEST("WebSocket unexpected continuation frame") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  WebSocketErrorCatcher errorCatcher;
+  auto client = kj::mv(pipe.ends[0]);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+
+  byte DATA[] = {
+    0x80, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',  // Continuation frame with no start frame, plus FIN
+  };
+
+  auto clientTask = client->write(DATA, sizeof(DATA));
+
+  {
+    bool gotException = false;
+    auto serverTask = server->receive().then([](auto&& m) {}, [&gotException](kj::Exception&& ex) { gotException = true; });
+    serverTask.wait(waitScope);
+    KJ_ASSERT(gotException);
+    KJ_ASSERT(errorCatcher.errors.size() == 1);
+    KJ_ASSERT(errorCatcher.errors[0].statusCode == 1002);
+  }
+
+  clientTask.wait(waitScope);
+}
+
+KJ_TEST("WebSocket missing continuation frame") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  WebSocketErrorCatcher errorCatcher;
+  auto client = kj::mv(pipe.ends[0]);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+
+  byte DATA[] = {
+    0x01, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',  // Start frame
+    0x01, 0x06, 'w', 'o', 'r', 'l', 'd', '!',  // Another start frame
+  };
+
+  auto clientTask = client->write(DATA, sizeof(DATA));
+
+  {
+    bool gotException = false;
+    auto serverTask = server->receive().then([](auto&& m) {}, [&gotException](kj::Exception&& ex) { gotException = true; });
+    serverTask.wait(waitScope);
+    KJ_ASSERT(gotException);
+    KJ_ASSERT(errorCatcher.errors.size() == 1);
+  }
+
+  clientTask.wait(waitScope);
+}
+
+KJ_TEST("WebSocket fragmented control frame") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  WebSocketErrorCatcher errorCatcher;
+  auto client = kj::mv(pipe.ends[0]);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+
+  byte DATA[] = {
+    0x09, 0x04, 'd', 'a', 't', 'a'  // Fragmented ping frame
+  };
+
+  auto clientTask = client->write(DATA, sizeof(DATA));
+
+  {
+    bool gotException = false;
+    auto serverTask = server->receive().then([](auto&& m) {}, [&gotException](kj::Exception&& ex) { gotException = true; });
+    serverTask.wait(waitScope);
+    KJ_ASSERT(gotException);
+    KJ_ASSERT(errorCatcher.errors.size() == 1);
+    KJ_ASSERT(errorCatcher.errors[0].statusCode == 1002);
+  }
+
+  clientTask.wait(waitScope);
+}
+
+KJ_TEST("WebSocket unknown opcode") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  WebSocketErrorCatcher errorCatcher;
+  auto client = kj::mv(pipe.ends[0]);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+
+  byte DATA[] = {
+    0x85, 0x04, 'd', 'a', 't', 'a'  // 5 is a reserved opcode
+  };
+
+  auto clientTask = client->write(DATA, sizeof(DATA));
+
+  {
+    bool gotException = false;
+    auto serverTask = server->receive().then([](auto&& m) {}, [&gotException](kj::Exception&& ex) { gotException = true; });
+    serverTask.wait(waitScope);
+    KJ_ASSERT(gotException);
+    KJ_ASSERT(errorCatcher.errors.size() == 1);
+    KJ_ASSERT(errorCatcher.errors[0].statusCode == 1002);
+  }
+
+  clientTask.wait(waitScope);
+}
+
 KJ_TEST("WebSocket unsolicited pong") {
   KJ_HTTP_TEST_SETUP_IO;
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
@@ -2200,9 +2343,10 @@ KJ_TEST("WebSocket maximum message size") {
   KJ_HTTP_TEST_SETUP_IO;
   auto pipe =KJ_HTTP_TEST_CREATE_2PIPE;
 
+  WebSocketErrorCatcher errorCatcher;
   FakeEntropySource maskGenerator;
   auto client = newWebSocket(kj::mv(pipe.ends[0]), maskGenerator);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
 
   size_t maxSize = 100;
   auto biggestAllowedString = kj::strArray(kj::repeat(kj::StringPtr("A"), maxSize), "");
@@ -2220,6 +2364,8 @@ KJ_TEST("WebSocket maximum message size") {
 
   {
     KJ_EXPECT_THROW_MESSAGE("too large", server->receive(maxSize).wait(waitScope));
+    KJ_ASSERT(errorCatcher.errors.size() == 1);
+    KJ_ASSERT(errorCatcher.errors[0].statusCode == 1009);
   }
 }
 

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2542,7 +2542,7 @@ public:
     auto& recvHeader = *reinterpret_cast<Header*>(recvData.begin());
     if (recvHeader.hasRsv2or3()) {
       throw errorHandler.handleWebSocketProtocolError({
-        1002, "Protocol error", "Received frame had RSV bits 2 or 3 set", nullptr,
+        1002, "Received frame had RSV bits 2 or 3 set",
       });
     }
 
@@ -2551,8 +2551,7 @@ public:
     size_t payloadLen = recvHeader.getPayloadLen();
     if (payloadLen > maxSize) {
       throw errorHandler.handleWebSocketProtocolError({
-        1009, "WebSocket message is too large",
-        kj::str("Message is too large: ", payloadLen, " > ", maxSize), nullptr
+        1009, kj::str("Message is too large: ", payloadLen, " > ", maxSize)
       });
     }
 
@@ -2561,7 +2560,7 @@ public:
     if (opcode == OPCODE_CONTINUATION) {
       if (fragments.empty()) {
         throw errorHandler.handleWebSocketProtocolError({
-          1002, "Protocol error", "Unexpected continuation frame", nullptr
+          1002, "Unexpected continuation frame"
         });
       }
 
@@ -2569,7 +2568,7 @@ public:
     } else if (isData) {
       if (!fragments.empty()) {
         throw errorHandler.handleWebSocketProtocolError({
-          1002, "Protocol error", "Missing continuation frame", nullptr
+          1002, "Missing continuation frame"
         });
       }
     }
@@ -2617,7 +2616,7 @@ public:
       // Fragmented message, and this isn't the final fragment.
       if (!isData) {
         throw errorHandler.handleWebSocketProtocolError({
-          1002, "Protocol error", "Received fragmented control frame", nullptr
+          1002, "Received fragmented control frame"
         });
       }
 
@@ -2713,7 +2712,7 @@ public:
           return receive(maxSize);
         default:
           throw errorHandler.handleWebSocketProtocolError({
-            1002, "Protocol error", kj::str("Unknown opcode ", opcode), nullptr
+            1002, kj::str("Unknown opcode ", opcode)
           });
       }
     };
@@ -5423,7 +5422,7 @@ HttpClient::WebSocketResponse HttpClientErrorHandler::handleWebSocketProtocolErr
 }
 
 kj::Exception WebSocketErrorHandler::handleWebSocketProtocolError(
-      HttpHeaders::ProtocolError protocolError) {
+      WebSocket::ProtocolError protocolError) {
   return KJ_EXCEPTION(FAILED, kj::str("code=", protocolError.statusCode,
                                         ": ", protocolError.description));
 }

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -24,6 +24,7 @@
 #include "url.h"
 #include <kj/debug.h>
 #include <kj/parse/char.h>
+#include <kj/string.h>
 #include <unordered_map>
 #include <stdlib.h>
 #include <kj/encoding.h>
@@ -2426,16 +2427,18 @@ public:
 
 // =======================================================================================
 
-class WebSocketImpl final: public WebSocket {
+class WebSocketImpl final: public WebSocket, private WebSocketErrorHandler {
 public:
   WebSocketImpl(kj::Own<kj::AsyncIoStream> stream,
                 kj::Maybe<EntropySource&> maskKeyGenerator,
                 kj::Maybe<CompressionParameters> compressionConfigParam = nullptr,
+                kj::Maybe<WebSocketErrorHandler&> errorHandler = nullptr,
                 kj::Array<byte> buffer = kj::heapArray<byte>(4096),
                 kj::ArrayPtr<byte> leftover = nullptr,
                 kj::Maybe<kj::Promise<void>> waitBeforeSend = nullptr)
       : stream(kj::mv(stream)), maskKeyGenerator(maskKeyGenerator),
         compressionConfig(kj::mv(compressionConfigParam)),
+        errorHandler(errorHandler),
         sendingPong(kj::mv(waitBeforeSend)),
         recvBuffer(kj::mv(buffer)), recvData(leftover) {
 #if KJ_HAS_ZLIB
@@ -2537,23 +2540,38 @@ public:
     }
 
     auto& recvHeader = *reinterpret_cast<Header*>(recvData.begin());
-    KJ_REQUIRE(!recvHeader.hasRsv2or3(), "RSV bits 2 and 3 must be 0, as we do not currently "
-        "support an extension that would set these bits");
+    if (recvHeader.hasRsv2or3()) {
+      throw errorHandler.orDefault(*this).handleWebSocketProtocolError({
+        1002, "Protocol error", "Received frame had RSV bits 2 or 3 set", nullptr,
+      });
+    }
 
     recvData = recvData.slice(headerSize, recvData.size());
 
     size_t payloadLen = recvHeader.getPayloadLen();
-
-    KJ_REQUIRE(payloadLen <= maxSize, "WebSocket message is too large");
+    if (payloadLen > maxSize) {
+      throw errorHandler.orDefault(*this).handleWebSocketProtocolError({
+        1009, "WebSocket message is too large",
+        kj::str("Message is too large: ", payloadLen, " > ", maxSize), nullptr
+      });
+    }
 
     auto opcode = recvHeader.getOpcode();
     bool isData = opcode < OPCODE_FIRST_CONTROL;
     if (opcode == OPCODE_CONTINUATION) {
-      KJ_REQUIRE(!fragments.empty(), "unexpected continuation frame in WebSocket");
+      if (fragments.empty()) {
+        throw errorHandler.orDefault(*this).handleWebSocketProtocolError({
+          1002, "Protocol error", "Unexpected continuation frame", nullptr
+        });
+      }
 
       opcode = fragmentOpcode;
     } else if (isData) {
-      KJ_REQUIRE(fragments.empty(), "expected continuation frame in WebSocket");
+      if (!fragments.empty()) {
+        throw errorHandler.orDefault(*this).handleWebSocketProtocolError({
+          1002, "Protocol error", "Missing continuation frame", nullptr
+        });
+      }
     }
 
     bool isFin = recvHeader.isFin();
@@ -2597,7 +2615,11 @@ public:
       }
     } else {
       // Fragmented message, and this isn't the final fragment.
-      KJ_REQUIRE(isData, "WebSocket control frame cannot be fragmented");
+      if (!isData) {
+        throw errorHandler.orDefault(*this).handleWebSocketProtocolError({
+          1002, "Protocol error", "Received fragmented control frame", nullptr
+        });
+      }
 
       message = kj::heapArray<byte>(payloadLen);
       payloadTarget = message.begin();
@@ -2690,7 +2712,9 @@ public:
           // Unsolicited pong. Ignore.
           return receive(maxSize);
         default:
-          KJ_FAIL_REQUIRE("unknown WebSocket opcode", opcode);
+          throw errorHandler.orDefault(*this).handleWebSocketProtocolError({
+            1002, "Protocol error", kj::str("Unknown opcode ", opcode), nullptr
+          });
       }
     };
 
@@ -3196,6 +3220,7 @@ private:
   kj::Own<kj::AsyncIoStream> stream;
   kj::Maybe<EntropySource&> maskKeyGenerator;
   kj::Maybe<CompressionParameters> compressionConfig;
+  kj::Maybe<WebSocketErrorHandler&> errorHandler;
 #if KJ_HAS_ZLIB
   kj::Maybe<ZlibContext> compressionContext;
   kj::Maybe<ZlibContext> decompressionContext;
@@ -3394,11 +3419,13 @@ private:
 kj::Own<WebSocket> upgradeToWebSocket(
     kj::Own<kj::AsyncIoStream> stream, HttpInputStreamImpl& httpInput, HttpOutputStream& httpOutput,
     kj::Maybe<EntropySource&> maskKeyGenerator,
-    kj::Maybe<CompressionParameters> compressionConfig = nullptr) {
+    kj::Maybe<CompressionParameters> compressionConfig = nullptr,
+    kj::Maybe<WebSocketErrorHandler&> errorHandler = nullptr) {
   // Create a WebSocket upgraded from an HTTP stream.
   auto releasedBuffer = httpInput.releaseBuffer();
   return kj::heap<WebSocketImpl>(kj::mv(stream), maskKeyGenerator,
-                                 kj::mv(compressionConfig), kj::mv(releasedBuffer.buffer),
+                                 kj::mv(compressionConfig), errorHandler,
+                                 kj::mv(releasedBuffer.buffer),
                                  releasedBuffer.leftover, httpOutput.flush());
 }
 
@@ -3406,8 +3433,9 @@ kj::Own<WebSocket> upgradeToWebSocket(
 
 kj::Own<WebSocket> newWebSocket(kj::Own<kj::AsyncIoStream> stream,
                                 kj::Maybe<EntropySource&> maskKeyGenerator,
-                                kj::Maybe<CompressionParameters> compressionConfig) {
-  return kj::heap<WebSocketImpl>(kj::mv(stream), maskKeyGenerator, kj::mv(compressionConfig));
+                                kj::Maybe<CompressionParameters> compressionConfig,
+                                kj::Maybe<WebSocketErrorHandler&> errorHandler) {
+  return kj::heap<WebSocketImpl>(kj::mv(stream), maskKeyGenerator, kj::mv(compressionConfig), errorHandler);
 }
 
 static kj::Promise<void> pumpWebSocketLoop(WebSocket& from, WebSocket& to) {
@@ -5392,6 +5420,12 @@ HttpClient::WebSocketResponse HttpClientErrorHandler::handleWebSocketProtocolErr
   return HttpClient::WebSocketResponse {
     response.statusCode, response.statusText, response.headers, kj::mv(response.body)
   };
+}
+
+kj::Exception WebSocketErrorHandler::handleWebSocketProtocolError(
+      HttpHeaders::ProtocolError protocolError) {
+  return KJ_EXCEPTION(FAILED, kj::str("code=", protocolError.statusCode,
+                                        ": ", protocolError.description));
 }
 
 class PausableReadAsyncIoStream::PausableRead {
@@ -7589,7 +7623,8 @@ private:
     auto deferNoteClosed = kj::defer([this]() { webSocketOrConnectClosed = true; });
     kj::Own<kj::AsyncIoStream> ownStream(&stream, kj::NullDisposer::instance);
     return upgradeToWebSocket(ownStream.attach(kj::mv(deferNoteClosed)),
-                              httpInput, httpOutput, nullptr, kj::mv(acceptedParameters));
+                              httpInput, httpOutput, nullptr, kj::mv(acceptedParameters),
+                             server.settings.webSocketErrorHandler);
   }
 
   kj::Promise<bool> sendError(HttpHeaders::ProtocolError protocolError) {

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -614,6 +614,19 @@ public:
   // resolves, but send() or receive() will throw DISCONNECTED when appropriate. See also
   // kj::AsyncOutputStream::whenWriteDisconnected().)
 
+  struct ProtocolError {
+    // Represents a protocol error, such as a bad opcode or oversize message.
+
+    uint statusCode;
+    // Suggested WebSocket status code that should be used when returning an error to the client.
+    //
+    // Most errors are 1002; an oversize message will be 1009.
+
+    kj::StringPtr description;
+    // An error description safe for all the world to see. This should be at most 123 bytes so that
+    // it can be used as the body of a Close frame (RFC 6455 sections 5.5 and 5.5.1).
+  };
+
   struct Close {
     uint16_t code;
     kj::String reason;
@@ -993,7 +1006,7 @@ struct HttpClientSettings {
 
 class WebSocketErrorHandler {
 public:
-  virtual kj::Exception handleWebSocketProtocolError(HttpHeaders::ProtocolError protocolError);
+  virtual kj::Exception handleWebSocketProtocolError(WebSocket::ProtocolError protocolError);
   // Handles low-level protocol errors in received WebSocket data.
   //
   // This is called when the WebSocket peer sends us bad data *after* a successful WebSocket


### PR DESCRIPTION
Currently, there's no good way to distinguish between WebSocket errors caused by the peer sending invalid data and WebSocket errors from other causes: they all result in FAILED-type exceptions.

This commit lets WebSocket users define a custom error handler for peer-caused errors. It only allows for customizing the thrown exception.