### PR TITLE
rpc.capnp: add a note clarifying the 4-way race

### DIFF
--- a/c++/src/capnp/rpc.capnp
+++ b/c++/src/capnp/rpc.capnp
@@ -738,6 +738,10 @@ struct Disembargo {
   # is expected that people sending messages to P will shortly start sending them to R instead and
   # drop P. P is at end-of-life anyway, so it doesn't matter if it ignores chances to further
   # optimize its path.
+  #
+  # Note well: the Tribble 4-way race condition does not require each vat to be *distinct*; as long
+  # as each resolution crosses a network boundary the race can occur -- so this concerns even level
+  # 1 implementations, not just level 3 implementations.
 
   target @0 :MessageTarget;
   # What is to be disembargoed.


### PR DESCRIPTION
I had for some time been under the mistaken impression that this could only occur in a scenario involving >2 *distinct* vats, and thus assumed it did not concern level 1 implementations. This patch adds some more comments calling out the fact that this is not the case.