### PR TITLE
Fix non-monotonic time on Intel Mac machines

### DIFF
--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -110,9 +110,17 @@ Maybe<uint64_t> TimerImpl::timeoutToNextEvent(TimePoint start, Duration unit, ui
 }
 
 void TimerImpl::advanceTo(TimePoint newTime) {
+  // On Macs running an Intel processor, it has been observed that clock_gettime 
+  // may return non monotonic time, even when CLOCK_MONOTONIC is used.
+  // This workaround is to avoid the assert triggering on these machines.
+  // See also https://github.com/capnproto/capnproto/issues/1693
+#if __APPLE__ && defined(__x86_64__)
+  time = std::max(time, newTime);
+#else
   KJ_REQUIRE(newTime >= time, "can't advance backwards in time") { return; }
-
   time = newTime;
+#endif
+
   for (;;) {
     auto front = impl->timers.begin();
     if (front == impl->timers.end() || (*front)->time > time) {


### PR DESCRIPTION
It has been observed that in rare circumstances, clock_gettime may return a non monotonic timestamp even when using CLOCK_MONOTONIC. This triggers the assertion in "advanceTo", breaking applications built on top of the KJ library.
This commit removes the assertion for those platforms on which the problem has been observed (only Mac with x86 processor).