### PR TITLE
Add kj::rawPtr()

### DIFF
--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -571,6 +571,19 @@ template <typename T>
 const HeapDisposer<T> HeapDisposer<T>::instance = HeapDisposer<T>();
 #endif
 
+template <typename T, void(*F)(T*)>
+class CustomDisposer: public Disposer {
+public:
+  static const CustomDisposer instance;
+
+  void disposeImpl(void* pointer) const override {
+    (*F)(reinterpret_cast<T*>(pointer));
+  }
+};
+
+template <typename T, void(*F)(T*)>
+const CustomDisposer<T, F> CustomDisposer<T, F>::instance = CustomDisposer<T, F>();
+
 }  // namespace _ (private)
 
 template <typename T, typename... Params>
@@ -593,6 +606,16 @@ Own<Decay<T>> heap(T&& orig) {
   typedef Decay<T> T2;
   return Own<T2>(new T2(kj::fwd<T>(orig)), _::HeapDisposer<T2>::instance);
 }
+
+#if __cplusplus > 201402L
+template <auto F, typename T>
+Own<T> disposeWith(T* ptr) {
+  // Associate a pre-allocated raw pointer with a corresponding disposal function.
+  // The first template parameter should be a function pointer e.g. disposeWith<freeInt>(new int(0)).
+
+  return Own<T>(ptr, _::CustomDisposer<T, F>::instance);
+}
+#endif
 
 template <typename T, typename... Attachments>
 Own<Decay<T>> attachVal(T&& value, Attachments&&... attachments);


### PR DESCRIPTION
It'd be nice to have a convenient way of creating `kj::Own`s for resources allocated by C APIs like `getaddrinfo`.

This is more of a suggestion. If there is already a way to do this or a suggested alternative approach, I'm all ears.