### PR TITLE
Fix stack traces through coroutines

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -35,9 +35,9 @@
 #include <intrin.h>
 #endif
 
-KJ_BEGIN_HEADER
-
 #include <kj/list.h>
+
+KJ_BEGIN_HEADER
 
 namespace kj {
 namespace _ {  // private

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2952,36 +2952,34 @@ void CoroutineBase::unhandled_exception() {
   // we're being destroyed, in which case we propagate it back to our disposer. Note that all
   // unhandled exceptions end up here, not just ones after the first co_await.
 
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([] { throw; })) {
-    KJ_IF_MAYBE(disposalResults, maybeDisposalResults) {
-      // Exception during coroutine destruction. Only record the first one.
-      if (disposalResults->exception == nullptr) {
-        disposalResults->exception = kj::mv(*exception);
-      }
-    } else if (isWaiting()) {
-      // Exception during coroutine execution.
-      resultRef.addException(kj::mv(*exception));
-      scheduleResumption();
-    } else {
-      // Okay, what could this mean? We've already been fulfilled or rejected, but we aren't being
-      // destroyed yet. The only possibility is that we are unwinding the coroutine frame due to a
-      // successful completion, and something in the frame threw. We can't already be rejected,
-      // because rejecting a coroutine involves throwing, which would have unwound the frame prior
-      // to setting `waiting = false`.
-      //
-      // Since we know we're unwinding due to a successful completion, we also know that whatever
-      // Event we may have armed has not yet fired, because we haven't had a chance to return to
-      // the event loop.
+  auto exception = getCaughtExceptionAsKj();
 
-      // final_suspend() has not been called.
-      KJ_IASSERT(!coroutine.done());
-
-      // Since final_suspend() hasn't been called, whatever Event is waiting on us has not fired,
-      // and will see this exception.
-      resultRef.addException(kj::mv(*exception));
+  KJ_IF_MAYBE(disposalResults, maybeDisposalResults) {
+    // Exception during coroutine destruction. Only record the first one.
+    if (disposalResults->exception == nullptr) {
+      disposalResults->exception = kj::mv(exception);
     }
+  } else if (isWaiting()) {
+    // Exception during coroutine execution.
+    resultRef.addException(kj::mv(exception));
+    scheduleResumption();
   } else {
-    KJ_UNREACHABLE;
+    // Okay, what could this mean? We've already been fulfilled or rejected, but we aren't being
+    // destroyed yet. The only possibility is that we are unwinding the coroutine frame due to a
+    // successful completion, and something in the frame threw. We can't already be rejected,
+    // because rejecting a coroutine involves throwing, which would have unwound the frame prior
+    // to setting `waiting = false`.
+    //
+    // Since we know we're unwinding due to a successful completion, we also know that whatever
+    // Event we may have armed has not yet fired, because we haven't had a chance to return to
+    // the event loop.
+
+    // final_suspend() has not been called.
+    KJ_IASSERT(!coroutine.done());
+
+    // Since final_suspend() hasn't been called, whatever Event is waiting on us has not fired,
+    // and will see this exception.
+    resultRef.addException(kj::mv(exception));
   }
 }
 

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -1162,13 +1162,13 @@ ExceptionCallback& getExceptionCallback() {
 }
 
 void throwFatalException(kj::Exception&& exception, uint ignoreCount) {
-  exception.extendTrace(ignoreCount + 1);
+  if (ignoreCount != (uint)kj::maxValue) exception.extendTrace(ignoreCount + 1);
   getExceptionCallback().onFatalException(kj::mv(exception));
   abort();
 }
 
 void throwRecoverableException(kj::Exception&& exception, uint ignoreCount) {
-  exception.extendTrace(ignoreCount + 1);
+  if (ignoreCount != (uint)kj::maxValue) exception.extendTrace(ignoreCount + 1);
   getExceptionCallback().onRecoverableException(kj::mv(exception));
 }
 

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -836,6 +836,15 @@ void Exception::wrapContext(const char* file, int line, String&& description) {
 }
 
 void Exception::extendTrace(uint ignoreCount, uint limit) {
+  if (isFullTrace) {
+    // Awkward: extendTrace() was called twice without truncating in between. This should probably
+    // be an error, but historically we didn't check for this so I'm hesitant to make it an error
+    // now. We shouldn't actually extend the trace, though, as our current trace is presumably
+    // rooted in main() and it'd be weird to append frames "above" that.
+    // TODO(cleanup): Abort here and see what breaks?
+    return;
+  }
+
   KJ_STACK_ARRAY(void*, newTraceSpace, kj::min(kj::size(trace), limit) + ignoreCount + 1,
       sizeof(trace)/sizeof(trace[0]) + 8, 128);
 
@@ -847,10 +856,26 @@ void Exception::extendTrace(uint ignoreCount, uint limit) {
     // Copy the rest into our trace.
     memcpy(trace + traceCount, newTrace.begin(), newTrace.asBytes().size());
     traceCount += newTrace.size();
+    isFullTrace = true;
   }
 }
 
 void Exception::truncateCommonTrace() {
+  if (isFullTrace) {
+    // We're truncating the common portion of the full trace, turning it back into a limited
+    // trace.
+    isFullTrace = false;
+  } else {
+    // If the trace was never extended in the first place, trying to truncate it is at best a waste
+    // of time and at worst might remove information for no reason. So, don't.
+    //
+    // This comes up in particular in coroutines, when the exception originated from a co_awaited
+    // promise. In that case we manually add the one relevant frame to the trace, rather than
+    // call extendTrace() just to have to truncate most of it again a moment later in the
+    // unhandled_exception() callback.
+    return;
+  }
+
   if (traceCount > 0) {
     // Create a "reference" stack trace that is a little bit deeper than the one in the exception.
     void* refTraceSpace[sizeof(this->trace) / sizeof(this->trace[0]) + 4];
@@ -888,6 +913,9 @@ void Exception::truncateCommonTrace() {
 }
 
 void Exception::addTrace(void* ptr) {
+  // TODO(cleanup): Abort here if isFullTrace is true, and see what breaks. This method only makes
+  // sense to call on partial traces.
+
   if (traceCount < kj::size(trace)) {
     trace[traceCount++] = ptr;
   }

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -144,6 +144,19 @@ private:
   void* trace[32];
   uint traceCount;
 
+  bool isFullTrace = false;
+  // Is `trace` a full trace to the top of the stack (or as close as we could get before we ran
+  // out of space)? If this is false, then `trace` is instead a partial trace covering just the
+  // frames between where the exception was thrown and where it was caught.
+  //
+  // extendTrace() transitions this to true, and truncateCommonTrace() changes it back to false.
+  //
+  // In theory, an exception should only hold a full trace when it is in the process of being
+  // thrown via the C++ exception handling mechanism -- extendTrace() is called before the throw
+  // and truncateCommonTrace() after it is caught. Note that when exceptions propagate through
+  // async promises, the trace is extended one frame at a time instead, so isFullTrace should
+  // remain false.
+
   friend class ExceptionImpl;
 };
 


### PR DESCRIPTION
When an exception propagated through a coroutine, the trace simply skipped the coroutine altogether, rather than reporting the locations of the co_awaits.

I've tested this manually but it's hard to write a unit test since KJ currently cannot symbolize stacks without outside help.