### PR TITLE
Fix tls-test on Windows

### DIFF
--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -702,7 +702,7 @@ void expectInvalidCert(kj::StringPtr hostname, TlsCertificate cert, kj::StringPt
   auto clientPromise = e.wrap(test.tlsClient.wrapClient(kj::mv(pipe.ends[0]), hostname));
   auto serverPromise = e.wrap(test.tlsServer.wrapServer(kj::mv(pipe.ends[1])));
 
-  KJ_EXPECT_THROW_MESSAGE(message, clientPromise.wait(test.io.waitScope));
+  KJ_EXPECT_THROW_MESSAGE(message, clientPromise.wait(test.io.waitScope), message);
 }
 
 // OpenSSL 3.0 changed error messages

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -716,7 +716,7 @@ void expectInvalidCert(kj::StringPtr hostname, TlsCertificate cert,
       }
     }
 
-    KJ_FAIL_EXPECT("exception didn't contain expected messag", message,
+    KJ_FAIL_EXPECT("exception didn't contain expected message", message,
         altMessage.orDefault(nullptr), e);
   }).wait(test.io.waitScope);
 }

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -92,32 +92,54 @@ private:
   else KJ_FAIL_EXPECT("failed: expected " #cond, _kjCondition, ##__VA_ARGS__)
 #endif
 
-#define KJ_EXPECT_THROW_RECOVERABLE(type, code) \
+#if _MSC_VER && !defined(__clang__)
+#define KJ_EXPECT_THROW_RECOVERABLE(type, code, ...) \
+  do { \
+    KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+      KJ_INDIRECT_EXPAND(KJ_EXPECT, (e->getType() == ::kj::Exception::Type::type, \
+          "code threw wrong exception type: " #code, *e, __VA_ARGS__)); \
+    } else { \
+      KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("code did not throw: " #code, __VA_ARGS__)); \
+    } \
+  } while (false)
+
+#define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code, ...) \
+  do { \
+    KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+      KJ_INDIRECT_EXPAND(KJ_EXPECT, (::kj::_::hasSubstring(e->getDescription(), message), \
+          "exception description didn't contain expected substring", *e, __VA_ARGS__)); \
+    } else { \
+      KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("code did not throw: " #code, __VA_ARGS__)); \
+    } \
+  } while (false)
+#else
+#define KJ_EXPECT_THROW_RECOVERABLE(type, code, ...) \
   do { \
     KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
       KJ_EXPECT(e->getType() == ::kj::Exception::Type::type, \
-          "code threw wrong exception type: " #code, *e); \
+          "code threw wrong exception type: " #code, *e, ##__VA_ARGS__); \
     } else { \
-      KJ_FAIL_EXPECT("code did not throw: " #code); \
+      KJ_FAIL_EXPECT("code did not throw: " #code, ##__VA_ARGS__); \
     } \
   } while (false)
 
-#define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code) \
+#define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code, ...) \
   do { \
     KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
       KJ_EXPECT(::kj::_::hasSubstring(e->getDescription(), message), \
-          "exception description didn't contain expected substring", *e); \
+          "exception description didn't contain expected substring", *e, ##__VA_ARGS__); \
     } else { \
-      KJ_FAIL_EXPECT("code did not throw: " #code); \
+      KJ_FAIL_EXPECT("code did not throw: " #code, ##__VA_ARGS__); \
     } \
   } while (false)
+#endif
 
 #if KJ_NO_EXCEPTIONS
-#define KJ_EXPECT_THROW(type, code) \
+#define KJ_EXPECT_THROW(type, code, ...) \
   do { \
     KJ_EXPECT(::kj::_::expectFatalThrow(::kj::Exception::Type::type, nullptr, [&]() { code; })); \
   } while (false)
-#define KJ_EXPECT_THROW_MESSAGE(message, code) \
+#define KJ_EXPECT_THROW_MESSAGE(message, code, ...) \
   do { \
     KJ_EXPECT(::kj::_::expectFatalThrow(nullptr, kj::StringPtr(message), [&]() { code; })); \
   } while (false)


### PR DESCRIPTION
For some reason our CI seems to declare (in the header) that it is v3, but the text it produces looks like v1. Maybe the header is a different version than the library? I don't actually care. Let's match both messages.