### PR TITLE
Fix MSVC build with /Zc:preprocessor

### DIFF
--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -122,7 +122,7 @@ KJ_BEGIN_HEADER
 
 namespace kj {
 
-#if _MSC_VER && !defined(__clang__)
+#if KJ_MSVC_TRADITIONAL_CPP
 // MSVC does __VA_ARGS__ differently from GCC:
 // - A trailing comma before an empty __VA_ARGS__ is removed automatically, whereas GCC wants
 //   you to request this behavior with "##__VA_ARGS__".
@@ -283,14 +283,14 @@ namespace kj {
       KJ_UNIQUE_NAME(_kjContext)(KJ_UNIQUE_NAME(_kjContextFunc))
 
 #define KJ_REQUIRE_NONNULL(value, ...) \
-  (*({ \
+  (*[&] { \
     auto _kj_result = ::kj::_::readMaybe(value); \
     if (KJ_UNLIKELY(!_kj_result)) { \
       ::kj::_::Debug::Fault(__FILE__, __LINE__, ::kj::Exception::Type::FAILED, \
                             #value " != nullptr", #__VA_ARGS__, ##__VA_ARGS__).fatal(); \
     } \
-    kj::mv(_kj_result); \
-  }))
+    return _kj_result; \
+  }())
 
 #define KJ_EXCEPTION(type, ...) \
   ::kj::Exception(::kj::Exception::Type::type, __FILE__, __LINE__, \

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -77,7 +77,7 @@ private:
   } KJ_UNIQUE_NAME(testCase); \
   void KJ_UNIQUE_NAME(TestCase)::run()
 
-#if _MSC_VER && !defined(__clang__)
+#if KJ_MSVC_TRADITIONAL_CPP
 #define KJ_INDIRECT_EXPAND(m, vargs) m vargs
 #define KJ_FAIL_EXPECT(...) \
   KJ_INDIRECT_EXPAND(KJ_LOG, (ERROR , __VA_ARGS__));


### PR DESCRIPTION
https://github.com/capnproto/capnproto/issues/1307#issuecomment-1182584709

Since MSVC does not support the gcc/clang statement expression extension, change KJ_REQUIRE_NONNULL to use the conformant iife strategy.