### PR TITLE
KJ_IF_MAYBE's variable can no longer be implicitly converted to a raw pointer

### DIFF
--- a/c++/src/capnp/arena.c++
+++ b/c++/src/capnp/arena.c++
@@ -127,7 +127,7 @@ SegmentReader* ReaderArena::tryGetSegment(SegmentId id) {
     KJ_IF_MAYBE(segment, s->find(id.value)) {
       return *segment;
     }
-    segments = s;
+    segments = &*s;
   }
 
   kj::ArrayPtr<const word> newSegment = message->getSegment(id.value);

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -1157,7 +1157,7 @@ kj::Promise<void*> CapabilityServerSetBase::getLocalServerInternal(Capability::C
   // Get the most-resolved-so-far version of the hook.
   for (;;) {
     KJ_IF_MAYBE(h, hook->getResolved()) {
-      hook = h;
+      hook = &*h;
     } else {
       break;
     }

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -722,7 +722,7 @@ private:
           result[current->node.getId()] = params;
         }
         KJ_IF_MAYBE(p, current->parent) {
-          current = p;
+          current = &*p;
         } else {
           return result;
         }

--- a/c++/src/capnp/compiler/compiler.c++
+++ b/c++/src/capnp/compiler/compiler.c++
@@ -885,7 +885,7 @@ Compiler::Node::resolve(kj::StringPtr name) {
     return p->resolve(name);
   } else KJ_IF_MAYBE(b, module->getCompiler().lookupBuiltin(name)) {
     ResolveResult result;
-    result.init<ResolvedDecl>(ResolvedDecl { b->id, b->genericParamCount, 0, b->kind, b, nullptr });
+    result.init<ResolvedDecl>(ResolvedDecl { b->id, b->genericParamCount, 0, b->kind, &*b, nullptr });
     return result;
   } else {
     return nullptr;

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -790,7 +790,7 @@ struct WireHelpers {
 
     const word* ptr;
     KJ_IF_MAYBE(p, followFars(ref, ref->target(segment), segment)) {
-      ptr = p;
+      ptr = &*p;
     } else {
       return result;
     }
@@ -1969,7 +1969,7 @@ struct WireHelpers {
 
     const word* ptr;
     KJ_IF_MAYBE(p, WireHelpers::followFars(src, srcTarget, srcSegment)) {
-      ptr = p;
+      ptr = &*p;
     } else {
       goto useDefault;
     }
@@ -2190,7 +2190,7 @@ struct WireHelpers {
 
     const word* ptr;
     KJ_IF_MAYBE(p, followFars(ref, refTarget, segment)) {
-      ptr = p;
+      ptr = &*p;
     } else {
       goto useDefault;
     }
@@ -2281,7 +2281,7 @@ struct WireHelpers {
 
     const word* ptr;
     KJ_IF_MAYBE(p, followFars(ref, refTarget, segment)) {
-      ptr = p;
+      ptr = &*p;
     } else {
       goto useDefault;
     }
@@ -2453,7 +2453,7 @@ struct WireHelpers {
     } else {
       const word* ptr;
       KJ_IF_MAYBE(p, followFars(ref, refTarget, segment)) {
-        ptr = p;
+        ptr = &*p;
       } else {
         goto useDefault;
       }
@@ -2508,7 +2508,7 @@ struct WireHelpers {
     } else {
       const word* ptr;
       KJ_IF_MAYBE(p, followFars(ref, refTarget, segment)) {
-        ptr = p;
+        ptr = &*p;
       } else {
         goto useDefault;
       }

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -857,7 +857,7 @@ private:
         // Remove self from the import table, if the table is still pointing at us.
         KJ_IF_MAYBE(import, connectionState->imports.find(importId)) {
           KJ_IF_MAYBE(i, import->importClient) {
-            if (i == this) {
+            if (&*i == this) {
               connectionState->imports.erase(importId);
             }
           }
@@ -1009,7 +1009,7 @@ private:
         // object may actually outlive the import.
         KJ_IF_MAYBE(import, connectionState->imports.find(*id)) {
           KJ_IF_MAYBE(c, import->appClient) {
-            if (c == this) {
+            if (&*c == this) {
               import->appClient = nullptr;
             }
           }
@@ -1254,7 +1254,7 @@ private:
     ClientHook* inner = &cap;
     for (;;) {
       KJ_IF_MAYBE(resolved, inner->getResolved()) {
-        inner = resolved;
+        inner = &*resolved;
       } else {
         break;
       }
@@ -1343,7 +1343,7 @@ private:
     ClientHook* ptr = &client;
     for (;;) {
       KJ_IF_MAYBE(inner, ptr->getResolved()) {
-        ptr = inner;
+        ptr = &*inner;
       } else {
         break;
       }
@@ -2348,7 +2348,7 @@ private:
         if (ptr == resolution.returnedCap.get()) {
           return kj::mv(resolution.unwrapped);
         } else KJ_IF_MAYBE(r, ptr->getResolved()) {
-          ptr = r;
+          ptr = &*r;
         } else {
           break;
         }

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -206,7 +206,7 @@ ParsedSchema SchemaParser::parseDiskFile(
   auto lock = impl->compat.lockExclusive();
   DiskFileCompat* compat;
   KJ_IF_MAYBE(c, *lock) {
-    compat = c;
+    compat = &*c;
   } else {
     compat = &lock->emplace();
   }

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2276,8 +2276,8 @@ public:
 #else
     #error "please implement for your compiler"
 #endif
+    KJ_IASSERT(result.value != nullptr, "Neither exception nor value present.");
     auto value = kj::_::readMaybe(result.value);
-    KJ_IASSERT(value != nullptr, "Neither exception nor value present.");
     return U(kj::mv(*value));
   }
 

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -2785,7 +2785,7 @@ KJ_TEST("Userland tee pump cancellation implies write cancellation") {
   KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
     leftPipe.out = nullptr;
   })) {
-    KJ_FAIL_EXPECT("write promises were not canceled", exception);
+    KJ_FAIL_EXPECT("write promises were not canceled", *exception);
   }
 }
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -394,7 +394,7 @@ private:
 
   void endState(AsyncIoStream& obj) {
     KJ_IF_MAYBE(s, state) {
-      if (s == &obj) {
+      if (&*s == &obj) {
         state = nullptr;
       }
     }
@@ -1932,7 +1932,7 @@ private:
   private:
     void detach() {
       KJ_IF_MAYBE(sink, sinkLink) {
-        if (sink == this) {
+        if (&*sink == this) {
           sinkLink = nullptr;
         }
       }

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -894,7 +894,7 @@ void XThreadEvent::ensureDoneOrCanceled() {
 
     const EventLoop* loop;
     KJ_IF_MAYBE(l, lock->loop) {
-      loop = l;
+      loop = &*l;
     } else {
       // Target event loop is already dead, so we know it's already working on transitioning all
       // events to the DONE state. We can just wait.
@@ -1035,7 +1035,7 @@ void XThreadEvent::sendReply() {
       auto lock = e->impl->state.lockExclusive();
       KJ_IF_MAYBE(l, lock->loop) {
         lock->replies.add(*this);
-        replyLoop = l;
+        replyLoop = &*l;
       } else {
         // Calling thread exited without cancelling the promise. This is UB. In fact,
         // `replyExecutor` is probably already destroyed and we are in use-after-free territory
@@ -1286,7 +1286,7 @@ void Executor::send(_::XThreadEvent& event, bool sync) const {
   auto lock = impl->state.lockExclusive();
   const EventLoop* loop;
   KJ_IF_MAYBE(l, lock->loop) {
-    loop = l;
+    loop = &*l;
   } else {
     event.setDisconnected();
     return;
@@ -1935,7 +1935,7 @@ void waitImpl(_::OwnPromiseNode&& node, _::ExceptionOrValue& result, WaitScope& 
         "This WaitScope can only be used within the fiber that created it.");
 
     node->setSelfPointer(&node);
-    node->onReady(fiber);
+    node->onReady(&*fiber);
 
     fiber->currentInner = node;
     KJ_DEFER(fiber->currentInner = nullptr);

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -87,7 +87,7 @@ TEST(Common, Maybe) {
       const int& ref = m.orDefault([&]() -> int& { return notUsedForRef; });
 
       EXPECT_EQ(ref, *v);
-      EXPECT_EQ(&ref, v);
+      EXPECT_EQ(&ref, &*v);
 
       const int& ref2 = m.orDefault([notUsed = 5]() -> int { return notUsed; });
       EXPECT_NE(&ref, &ref2);
@@ -196,12 +196,12 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(m == nullptr);
     EXPECT_TRUE(m != nullptr);
     KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&i, v);
+      EXPECT_EQ(&i, &*v);
     } else {
       ADD_FAILURE();
     }
     KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&i, v);
+      EXPECT_EQ(&i, &*v);
     } else {
       ADD_FAILURE();
     }
@@ -228,12 +228,12 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(m == nullptr);
     EXPECT_TRUE(m != nullptr);
     KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&i, v);
+      EXPECT_EQ(&i, &*v);
     } else {
       ADD_FAILURE();
     }
     KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&i, v);
+      EXPECT_EQ(&i, &*v);
     } else {
       ADD_FAILURE();
     }
@@ -246,12 +246,12 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(m == nullptr);
     EXPECT_TRUE(m != nullptr);
     KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&i, v);
+      EXPECT_EQ(&i, &*v);
     } else {
       ADD_FAILURE();
     }
     KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&i, v);
+      EXPECT_EQ(&i, &*v);
     } else {
       ADD_FAILURE();
     }
@@ -279,12 +279,12 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(m == nullptr);
     EXPECT_TRUE(m != nullptr);
     KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &*v);
     } else {
       ADD_FAILURE();
     }
     KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &*v);
     } else {
       ADD_FAILURE();
     }
@@ -306,12 +306,12 @@ TEST(Common, Maybe) {
     EXPECT_FALSE(m == nullptr);
     EXPECT_TRUE(m != nullptr);
     KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &*v);
     } else {
       ADD_FAILURE();
     }
     KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &*v);
     } else {
       ADD_FAILURE();
     }
@@ -439,7 +439,7 @@ TEST(Common, MaybeConstness) {
 //  const Maybe<int&> cmi2 = cmi;    // shouldn't compile!  Transitive const violation.
 
   KJ_IF_MAYBE(i2, cmi) {
-    EXPECT_EQ(&i, i2);
+    EXPECT_EQ(&i, &*i2);
   } else {
     ADD_FAILURE();
   }
@@ -449,7 +449,7 @@ TEST(Common, MaybeConstness) {
   const Maybe<const int&> cmci2 = cmci;
 
   KJ_IF_MAYBE(i2, cmci2) {
-    EXPECT_EQ(&i, i2);
+    EXPECT_EQ(&i, &*i2);
   } else {
     ADD_FAILURE();
   }
@@ -581,7 +581,7 @@ TEST(Common, Downcast) {
   EXPECT_TRUE(dynamicDowncastIfAvailable<Baz>(foo) == nullptr);
 #else
   KJ_IF_MAYBE(m, dynamicDowncastIfAvailable<Bar>(foo)) {
-    EXPECT_EQ(&bar, m);
+    EXPECT_EQ(&bar, &*m);
   } else {
     KJ_FAIL_ASSERT("Dynamic downcast returned null.");
   }

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -3626,7 +3626,7 @@ private:
 
   void endState(WebSocket& obj) {
     KJ_IF_MAYBE(s, state) {
-      if (s == &obj) {
+      if (&*s == &obj) {
         state = nullptr;
       }
     }
@@ -5995,7 +5995,7 @@ public:
           Function<kj::Promise<void>(kj::StringPtr)> cb =
               [wrapper, ref1 = transitConnectionRef->addWrappedRef()](
               kj::StringPtr expectedServerHostname) mutable {
-            ref1->startTls(wrapper, expectedServerHostname);
+            ref1->startTls(&*wrapper, expectedServerHostname);
             return kj::READY_NOW;
           };
           connection = transitConnectionRef->addWrappedRef();

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -818,7 +818,7 @@ TlsContext::TlsContext(Options options) {
   // honor options.sniCallback
   KJ_IF_MAYBE(sni, options.sniCallback) {
     SSL_CTX_set_tlsext_servername_callback(ctx, &SniCallback::callback);
-    SSL_CTX_set_tlsext_servername_arg(ctx, sni);
+    SSL_CTX_set_tlsext_servername_arg(ctx, &*sni);
   }
 
   KJ_IF_MAYBE(timeout, options.acceptTimeout) {

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -229,7 +229,7 @@ NullableValue<T> readMaybe(EncodingResult<T>&& value) {
 }
 
 template <typename T>
-T* readMaybe(EncodingResult<T>& value) {
+ExplicitPtr<T> readMaybe(EncodingResult<T>& value) {
   if (value.hadErrors) {
     return nullptr;
   } else {
@@ -238,7 +238,7 @@ T* readMaybe(EncodingResult<T>& value) {
 }
 
 template <typename T>
-const T* readMaybe(const EncodingResult<T>& value) {
+ExplicitPtr<const T> readMaybe(const EncodingResult<T>& value) {
   if (value.hadErrors) {
     return nullptr;
   } else {

--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -224,7 +224,7 @@ KJ_TEST("InFlightExceptionIterator works") {
       } catch (const kj::Exception& e) {
         InFlightExceptionIterator iter;
         KJ_IF_MAYBE(e2, iter.next()) {
-          KJ_EXPECT(e2 == &e, e2->getDescription());
+          KJ_EXPECT(&*e2 == &e, e2->getDescription());
         } else {
           KJ_FAIL_EXPECT("missing first exception");
         }

--- a/c++/src/kj/list.h
+++ b/c++/src/kj/list.h
@@ -107,7 +107,7 @@ public:
     (element.*link).next = head;
     (element.*link).prev = &head;
     KJ_IF_MAYBE(oldHead, head) {
-      (oldHead->*link).prev = &(element.*link).next;
+      ((&*oldHead)->*link).prev = &(element.*link).next;
     } else {
       tail = &(element.*link).next;
     }
@@ -119,7 +119,7 @@ public:
     if ((element.*link).prev == nullptr) _::throwRemovedNotPresent();
     *((element.*link).prev) = (element.*link).next;
     KJ_IF_MAYBE(n, (element.*link).next) {
-      (n->*link).prev = (element.*link).prev;
+      ((&*n)->*link).prev = (element.*link).prev;
     } else {
       if (tail != &((element.*link).next)) _::throwRemovedWrongList();
       tail = (element.*link).prev;
@@ -175,19 +175,19 @@ public:
 
   MaybeConstT& operator*() {
     KJ_IREQUIRE(current != nullptr, "tried to dereference end of list");
-    return *_::readMaybe(current);
+    return _::readMaybe(current).operator*();
   }
   const T& operator*() const {
     KJ_IREQUIRE(current != nullptr, "tried to dereference end of list");
-    return *_::readMaybe(current);
+    return _::readMaybe(current).operator*();
   }
   MaybeConstT* operator->() {
     KJ_IREQUIRE(current != nullptr, "tried to dereference end of list");
-    return _::readMaybe(current);
+    return _::readMaybe(current).operator->();
   }
   const T* operator->() const {
     KJ_IREQUIRE(current != nullptr, "tried to dereference end of list");
-    return _::readMaybe(current);
+    return _::readMaybe(current).operator->();
   }
 
   inline ListIterator& operator++() {
@@ -203,10 +203,10 @@ public:
   }
 
   inline bool operator==(const ListIterator& other) const {
-    return _::readMaybe(current) == _::readMaybe(other.current);
+    return _::readMaybe(current).operator->() == _::readMaybe(other.current).operator->();
   }
   inline bool operator!=(const ListIterator& other) const {
-    return _::readMaybe(current) != _::readMaybe(other.current);
+    return _::readMaybe(current).operator->() != _::readMaybe(other.current).operator->();
   }
 
 private:

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -422,8 +422,11 @@ public:
   inline const Own<T, D>&& operator*() const && { return kj::mv(value); }
   inline Own<T, D>* operator->() { return &value; }
   inline const Own<T, D>* operator->() const { return &value; }
-  inline operator Own<T, D>*() { return value ? &value : nullptr; }
-  inline operator const Own<T, D>*() const { return value ? &value : nullptr; }
+
+  inline explicit operator Own<T, D>*() { return value ? &value : nullptr; }
+  inline explicit operator const Own<T, D>*() const { return value ? &value : nullptr; }
+
+  inline explicit operator bool() const { return value != nullptr; }
 
 private:
   Own<T, D> value;
@@ -432,9 +435,11 @@ private:
 template <typename T, typename D>
 OwnOwn<T, D> readMaybe(Maybe<Own<T, D>>&& maybe) { return OwnOwn<T, D>(kj::mv(maybe.ptr)); }
 template <typename T, typename D>
-Own<T, D>* readMaybe(Maybe<Own<T, D>>& maybe) { return maybe.ptr ? &maybe.ptr : nullptr; }
+ExplicitPtr<Own<T, D>> readMaybe(Maybe<Own<T, D>>& maybe) {
+  return maybe.ptr ? &maybe.ptr : nullptr;
+}
 template <typename T, typename D>
-const Own<T, D>* readMaybe(const Maybe<Own<T, D>>& maybe) {
+ExplicitPtr<const Own<T, D>> readMaybe(const Maybe<Own<T, D>>& maybe) {
   return maybe.ptr ? &maybe.ptr : nullptr;
 }
 
@@ -544,9 +549,9 @@ private:
   template <typename U, typename D2>
   friend _::OwnOwn<U, D2> _::readMaybe(Maybe<Own<U, D2>>&& maybe);
   template <typename U, typename D2>
-  friend Own<U, D2>* _::readMaybe(Maybe<Own<U, D2>>& maybe);
+  friend _::ExplicitPtr<Own<U, D2>> _::readMaybe(Maybe<Own<U, D2>>& maybe);
   template <typename U, typename D2>
-  friend const Own<U, D2>* _::readMaybe(const Maybe<Own<U, D2>>& maybe);
+  friend _::ExplicitPtr<const Own<U, D2>> _::readMaybe(const Maybe<Own<U, D2>>& maybe);
 };
 
 namespace _ {  // private

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -220,7 +220,7 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
   auto spec = timeout.map([](Duration d) { return toRelativeTimespec(d); });
   struct timespec* specp = nullptr;
   KJ_IF_MAYBE(s, spec) {
-    specp = s;
+    specp = &*s;
   }
 
   switch (exclusivity) {
@@ -358,7 +358,7 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
         KJ_IF_MAYBE(waiter, nextWaiter) {
           nextWaiter = waiter->next;
 
-          if (waiter != waiterToSkip && checkPredicate(*waiter)) {
+          if (&*waiter != waiterToSkip && checkPredicate(*waiter)) {
             // This waiter's predicate now evaluates true, so wake it up.
             if (waiter->hasTimeout) {
               // In this case we need to be careful to make sure the target thread isn't already


### PR DESCRIPTION
This converts a very common mistake we have observed over the years into a compile-time error. See commit messages for further details.