### PR TITLE
Fixes for Darwin, second go

### DIFF
--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -127,7 +127,7 @@ public:
 private:
   ReaderOptions options;
 
-#if defined(__EMSCRIPTEN__) || (defined(__APPLE__) && defined(__ppc__))
+#if defined(__EMSCRIPTEN__) || (defined(__APPLE__) && (defined(__ppc__) || defined(__i386__)))
   static constexpr size_t arenaSpacePadding = 19;
 #else
   static constexpr size_t arenaSpacePadding = 18;

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -618,7 +618,7 @@ template <> constexpr bool isIntegral<unsigned long long>() { return true; }
 template <typename T>
 struct CanConvert_ {
   static int sfinae(T);
-  static bool sfinae(...);
+  static char sfinae(...);
 };
 
 template <typename T, typename U>

--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -114,7 +114,7 @@ void TimerImpl::advanceTo(TimePoint newTime) {
   // may return non monotonic time, even when CLOCK_MONOTONIC is used.
   // This workaround is to avoid the assert triggering on these machines.
   // See also https://github.com/capnproto/capnproto/issues/1693
-#if __APPLE__ && defined(__x86_64__)
+#if __APPLE__ && (defined(__x86_64__) || defined(__POWERPC__))
   time = std::max(time, newTime);
 #else
   KJ_REQUIRE(newTime >= time, "can't advance backwards in time") { return; }


### PR DESCRIPTION
@kentonv Turned out that `i386` (i.e. specifically 32-bit Intel) also needs the same arena fix.
Other two commits address issues already discussed.

For mutices, I requested @catap to take a look, and hopefully we will come up with a solution for them soon.