### PR TITLE
Expose Win32 handle in AsyncIoStream interface

### DIFF
--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -352,6 +352,10 @@ public:
     *length = socklen;
   }
 
+  Maybe<void*> getWin32Handle() const {
+    return reinterpret_cast<void*>(fd);
+  }
+
 private:
   Own<Win32EventPort::IoObserver> observer;
 

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -169,6 +169,10 @@ public:
   virtual kj::Maybe<int> getFd() const { return nullptr; }
   // Get the underlying Unix file descriptor, if any. Returns nullptr if this object actually
   // isn't wrapping a file descriptor.
+
+  virtual Maybe<void*> getWin32Handle() const { return nullptr; }
+  // Get the underlying Win32 HANDLE, if any. Returns nullptr if this object actually isn't
+  // wrapping a handle.
 };
 
 Promise<uint64_t> unoptimizedPumpTo(


### PR DESCRIPTION
This commit adds a function to AsyncIoStream that helps in the interoperability of the class with other libraries. It allows to reclaim ownership of a file descriptor from an AsyncIoStream. This can allow for example to use KJ ConnectionReceiver, but then use the file descriptors natively, or pass them to another library.