### PR TITLE
Improve error string for WebSocket protocol errors.

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -5428,8 +5428,7 @@ HttpClient::WebSocketResponse HttpClientErrorHandler::handleWebSocketProtocolErr
 
 kj::Exception WebSocketErrorHandler::handleWebSocketProtocolError(
       WebSocket::ProtocolError protocolError) {
-  return KJ_EXCEPTION(FAILED, kj::str("code=", protocolError.statusCode,
-                                        ": ", protocolError.description));
+  return KJ_EXCEPTION(FAILED, "WebSocket protocol error", protocolError.statusCode, protocolError.description);
 }
 
 class PausableReadAsyncIoStream::PausableRead {


### PR DESCRIPTION
Most KJ errors are space-separated; "code=N" was atypical. This confused things that parse exception messages expect the usual format.