### PR TITLE
Fix Clang 16 build

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -12,13 +12,17 @@ on:
 jobs:
   Linux-musl:
     runs-on: ubuntu-20.04
-    container: alpine:3.16.3
+    # We depend on both clang and libc++. Alpine Linux 3.17 seems to be the first version to include
+    # a libc++ package (based on LLVM 15), but building capnproto failed when I tried it.
+    # Alpine Linux 3.18's libc++ package is from LLVM 16, however, and worked out-of-the-box, so
+    # Clang 16 appears to be the earliest Clang version we can run easily on Alpine Linux.
+    container: alpine:3.18.2
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: apk add autoconf automake bash build-base cmake libtool libucontext-dev linux-headers openssl-dev
+        run: apk add autoconf automake bash build-base cmake libtool libucontext-dev linux-headers openssl-dev clang16 libc++-dev
       - name: super-test
-        run: ./super-test.sh quick
+        run: ./super-test.sh quick clang-16
   Linux-old:
     runs-on: ubuntu-20.04
     strategy:

--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -1063,7 +1063,7 @@ private:
         // Pumping from some other kind of stream. Optimize the pump by reading from the input
         // directly into outgoing RPC messages.
         size_t size = kj::min(remaining, 8192);
-        auto req = capnpStream->writeRequest(MessageSize { 8 + size / sizeof(word) });
+        auto req = capnpStream->writeRequest(MessageSize { 8 + size / sizeof(word), 0 });
 
         auto orphanage = Orphanage::getForMessageContaining(
             capnp::ByteStream::WriteParams::Builder(req));

--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -701,7 +701,6 @@ void NodeTranslator::compileNode(Declaration::Reader decl, schema::Node::Builder
 }
 
 static kj::StringPtr getExpressionTargetName(Expression::Reader exp) {
-  kj::StringPtr targetName;
   switch (exp.which()) {
     case Expression::ABSOLUTE_NAME:
       return exp.getAbsoluteName().getValue();

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1843,7 +1843,9 @@ public:
     }
     return true;
   }
+#if !__cpp_impl_three_way_comparison
   inline bool operator!=(const ArrayPtr& other) const { return !(*this == other); }
+#endif
 
   template <typename U>
   inline bool operator==(const ArrayPtr<U>& other) const {
@@ -1853,8 +1855,10 @@ public:
     }
     return true;
   }
+#if !__cpp_impl_three_way_comparison
   template <typename U>
   inline bool operator!=(const ArrayPtr<U>& other) const { return !(*this == other); }
+#endif
 
   template <typename... Attachments>
   Array<T> attach(Attachments&&... attachments) const KJ_WARN_UNUSED_RESULT;

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -278,14 +278,18 @@ public:
   inline bool operator!=(decltype(nullptr)) const { return content.size() > 1; }
 
   inline bool operator==(const StringPtr& other) const { return StringPtr(*this) == other; }
+#if !__cpp_impl_three_way_comparison
   inline bool operator!=(const StringPtr& other) const { return StringPtr(*this) != other; }
+#endif
   inline bool operator< (const StringPtr& other) const { return StringPtr(*this) <  other; }
   inline bool operator> (const StringPtr& other) const { return StringPtr(*this) >  other; }
   inline bool operator<=(const StringPtr& other) const { return StringPtr(*this) <= other; }
   inline bool operator>=(const StringPtr& other) const { return StringPtr(*this) >= other; }
 
   inline bool operator==(const String& other) const { return StringPtr(*this) == StringPtr(other); }
+#if !__cpp_impl_three_way_comparison
   inline bool operator!=(const String& other) const { return StringPtr(*this) != StringPtr(other); }
+#endif
   inline bool operator< (const String& other) const { return StringPtr(*this) <  StringPtr(other); }
   inline bool operator> (const String& other) const { return StringPtr(*this) >  StringPtr(other); }
   inline bool operator<=(const String& other) const { return StringPtr(*this) <= StringPtr(other); }
@@ -295,7 +299,9 @@ public:
   // -Wambiguous-reversed-operator, due to the stupidity...)
 
   inline bool operator==(const ConstString& other) const { return StringPtr(*this) == StringPtr(other); }
+#if !__cpp_impl_three_way_comparison
   inline bool operator!=(const ConstString& other) const { return StringPtr(*this) != StringPtr(other); }
+#endif
   inline bool operator< (const ConstString& other) const { return StringPtr(*this) <  StringPtr(other); }
   inline bool operator> (const ConstString& other) const { return StringPtr(*this) >  StringPtr(other); }
   inline bool operator<=(const ConstString& other) const { return StringPtr(*this) <= StringPtr(other); }
@@ -372,21 +378,27 @@ public:
   inline bool operator!=(decltype(nullptr)) const { return content.size() > 1; }
 
   inline bool operator==(const StringPtr& other) const { return StringPtr(*this) == other; }
+#if !__cpp_impl_three_way_comparison
   inline bool operator!=(const StringPtr& other) const { return StringPtr(*this) != other; }
+#endif
   inline bool operator< (const StringPtr& other) const { return StringPtr(*this) <  other; }
   inline bool operator> (const StringPtr& other) const { return StringPtr(*this) >  other; }
   inline bool operator<=(const StringPtr& other) const { return StringPtr(*this) <= other; }
   inline bool operator>=(const StringPtr& other) const { return StringPtr(*this) >= other; }
 
   inline bool operator==(const String& other) const { return StringPtr(*this) == StringPtr(other); }
+#if !__cpp_impl_three_way_comparison
   inline bool operator!=(const String& other) const { return StringPtr(*this) != StringPtr(other); }
+#endif
   inline bool operator< (const String& other) const { return StringPtr(*this) <  StringPtr(other); }
   inline bool operator> (const String& other) const { return StringPtr(*this) >  StringPtr(other); }
   inline bool operator<=(const String& other) const { return StringPtr(*this) <= StringPtr(other); }
   inline bool operator>=(const String& other) const { return StringPtr(*this) >= StringPtr(other); }
 
   inline bool operator==(const ConstString& other) const { return StringPtr(*this) == StringPtr(other); }
+#if !__cpp_impl_three_way_comparison
   inline bool operator!=(const ConstString& other) const { return StringPtr(*this) != StringPtr(other); }
+#endif
   inline bool operator< (const ConstString& other) const { return StringPtr(*this) <  StringPtr(other); }
   inline bool operator> (const ConstString& other) const { return StringPtr(*this) >  StringPtr(other); }
   inline bool operator<=(const ConstString& other) const { return StringPtr(*this) <= StringPtr(other); }


### PR DESCRIPTION
This PR:
- fixes a couple compiler warnings
- disables a few `operator!=()` implementations in C++20 mode to get Clang 16 working
- and ports our Musl build to Clang 16 -- partly to prove that Clang 16 works, and partly because we will soon need to when we require coroutines (GCC ICEs on our coroutines).