### PR TITLE
Support EV_TRIGGER as a fallback; disable KJ_USE_KQUEUE on old macOS

### DIFF
--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -1065,7 +1065,11 @@ void UnixEventPort::captureChildExit() {
 void UnixEventPort::wake() const {
   // Trigger our user event.
   struct kevent event;
+#if defined(NOTE_TRIGGER)
   EV_SET(&event, 0, EVFILT_USER, 0, NOTE_TRIGGER, 0, nullptr);
+#elif defined(EV_TRIGGER)
+  EV_SET(&event, 0, EVFILT_USER, EV_TRIGGER, 0, 0, nullptr);
+#endif
   KJ_SYSCALL(kevent(kqueueFd, &event, 1, nullptr, 0, nullptr));
 }
 

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -1069,6 +1069,8 @@ void UnixEventPort::wake() const {
   EV_SET(&event, 0, EVFILT_USER, 0, NOTE_TRIGGER, 0, nullptr);
 #elif defined(EV_TRIGGER)
   EV_SET(&event, 0, EVFILT_USER, EV_TRIGGER, 0, 0, nullptr);
+#else
+#error "neither NOTE_TRIGGER nor EV_TRIGGER is defined; we need at least one of these"
 #endif
   KJ_SYSCALL(kevent(kqueueFd, &event, 1, nullptr, 0, nullptr));
 }

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -31,14 +31,20 @@
 #include <kj/io.h>
 #include <signal.h>
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 KJ_BEGIN_HEADER
 
 #if !defined(KJ_USE_EPOLL) && !defined(KJ_USE_KQUEUE)
 #if __linux__
 // Default to epoll on Linux.
 #define KJ_USE_EPOLL 1
-#elif __APPLE__ || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __DragonFly__
-// MacOS and BSDs prefer kqueue() for event notification.
+#elif (__APPLE__ && (MAC_OS_X_VERSION_MIN_REQUIRED > 1050)) \
+  || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __DragonFly__
+// MacOS and BSDs prefer kqueue() for event notification, however MacOS prior
+// to 10.6.x does not have NOTE_TRIGGER.
 #define KJ_USE_KQUEUE 1
 #endif
 #endif


### PR DESCRIPTION
@kentonv I ran tests, this works fine.

On 1.0.0 with this patch applied, 1041 test(s) passed, 4 test(s) failed.