### PR TITLE
Support coroutines on Windows as well

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -124,11 +124,11 @@ jobs:
             echo "Activate conda base environment"
             call activate base
             echo "Building Cap'n Proto with ${{ matrix.target }}"
-            cmake -Hc++ -Bbuild-output ${{ matrix.arch }} -G "${{ matrix.target }}" -DCMAKE_BUILD_TYPE=debug -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%" -DCMAKE_INSTALL_PREFIX=%CD%\capnproto-c++-install
+            cmake -Hc++ -Bbuild-output ${{ matrix.arch }} -G "${{ matrix.target }}" -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_STANDARD=20 -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%" -DCMAKE_INSTALL_PREFIX=%CD%\capnproto-c++-install
             cmake --build build-output --config debug --target install
 
             echo "Building Cap'n Proto samples with ${{ matrix.target }}"
-            cmake -Hc++/samples -Bbuild-output-samples ${{ matrix.arch }} -G "${{ matrix.target }}" -DCMAKE_BUILD_TYPE=debug -DCMAKE_PREFIX_PATH=%CD%\capnproto-c++-install
+            cmake -Hc++/samples -Bbuild-output-samples ${{ matrix.arch }} -G "${{ matrix.target }}" -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_STANDARD=20 -DCMAKE_PREFIX_PATH=%CD%\capnproto-c++-install
             cmake --build build-output-samples --config debug
 
             cd build-output\src

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.6)
 project("Cap'n Proto" CXX)
 set(VERSION 1.1-dev)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -16,6 +16,10 @@ if(NOT HAS_CXX14)
   message(SEND_ERROR "Requires a C++14 compiler and standard library.")
 endif()
 
+if(MSVC)
+  add_compile_options(/Zc:__cplusplus)
+endif()
+
 # these arguments are passed to all install(TARGETS) calls
 set(INSTALL_TARGETS_DEFAULT_ARGS
   EXPORT CapnProtoTargets

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -32,7 +32,12 @@
 //
 // TODO(someday): Support coroutines with -fno-exceptions.
 #if !KJ_NO_EXCEPTIONS
-#ifdef __has_include
+#if defined(_MSC_VER) && (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705) && !defined(__clang__)
+// On Windows, we only support C++20 coroutines, not TS coroutines.
+#include <coroutine>
+#define KJ_HAS_COROUTINE 1
+#define KJ_COROUTINE_STD_NAMESPACE std
+#elif defined(__has_include)
 #if (__cpp_impl_coroutine >= 201902L) && __has_include(<coroutine>)
 // C++20 Coroutines detected.
 #include <coroutine>

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2983,7 +2983,12 @@ void CoroutineBase::unhandled_exception() {
     // the event loop.
 
     // final_suspend() has not been called.
+#if _MSC_VER && !defined(__clang__)
+    // See comment at `finalSuspendCalled`'s definition.
+    KJ_IASSERT(!finalSuspendCalled);
+#else
     KJ_IASSERT(!coroutine.done());
+#endif
 
     // Since final_suspend() hasn't been called, whatever Event is waiting on us has not fired,
     // and will see this exception.


### PR DESCRIPTION
The detection of the availability of coroutines relies on the __has_inclide macro, which is not available on Windows. Thus, coroutines cannot be used in Windows, despite KJ's implementation being standard compliant.

This commit checks whether the compiler is MSVC, and if the version is recent enough to support coroutines, it sets KJ_HAS_COROUTINE to 1.