### PR TITLE
Define KJ_MSVC_TRADITIONAL_CPP also in Release

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -323,10 +323,11 @@ KJ_NORETURN(void unreachable());
 
 }  // namespace _ (private)
 
-#ifdef KJ_DEBUG
 #if _MSC_VER && !defined(__clang__) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
 #define KJ_MSVC_TRADITIONAL_CPP 1
 #endif
+
+#ifdef KJ_DEBUG
 #if KJ_MSVC_TRADITIONAL_CPP
 #define KJ_IREQUIRE(condition, ...) \
     if (KJ_LIKELY(condition)); else ::kj::_::inlineRequireFailure( \


### PR DESCRIPTION
The code in common.h for the definition of KJ_MSVC_TRADITIONAL_CPP was
active only in debug. However, it is used in debug.h even when not in
debug. Thus, while the fix worked for debug builds, it did not work
for release builds.

This was probably undetected because CI builds only Debug for MSVC.