### PR TITLE
Remove no-exceptions mode.

### DIFF
--- a/c++/src/capnp/encoding-test.c++
+++ b/c++/src/capnp/encoding-test.c++
@@ -647,9 +647,7 @@ TEST(Encoding, ListUpgrade) {
   {
     kj::Maybe<kj::Exception> e = kj::runCatchingExceptions([&]() {
       reader.getAnyPointerField().getAs<List<uint32_t>>();
-#if !KJ_NO_EXCEPTIONS
       ADD_FAILURE() << "Should have thrown an exception.";
-#endif
     });
 
     KJ_EXPECT(e != nullptr, "Should have thrown an exception.");
@@ -755,9 +753,7 @@ TEST(Encoding, BitListUpgrade) {
   {
     kj::Maybe<kj::Exception> e = kj::runCatchingExceptions([&]() {
       root.getAnyPointerField().getAs<List<test::TestLists::Struct1>>();
-#if !KJ_NO_EXCEPTIONS
       ADD_FAILURE() << "Should have thrown an exception.";
-#endif
     });
 
     KJ_EXPECT(e != nullptr, "Should have thrown an exception.");
@@ -768,9 +764,7 @@ TEST(Encoding, BitListUpgrade) {
   {
     kj::Maybe<kj::Exception> e = kj::runCatchingExceptions([&]() {
       reader.getAnyPointerField().getAs<List<test::TestLists::Struct1>>();
-#if !KJ_NO_EXCEPTIONS
       ADD_FAILURE() << "Should have thrown an exception.";
-#endif
     });
 
     KJ_EXPECT(e != nullptr, "Should have thrown an exception.");

--- a/c++/src/capnp/membrane-test.c++
+++ b/c++/src/capnp/membrane-test.c++
@@ -391,20 +391,14 @@ KJ_TEST("revoke membrane") {
 
   paf.fulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "foobar"));
 
-  // TRICKY: We need to use .ignoreResult().wait() below because when compiling with
-  //   -fno-exceptions, void waits throw recoverable exceptions while non-void waits necessarily
-  //   throw fatal exceptions... but testing for fatal exceptions when exceptions are disabled
-  //   involves fork()ing the process to run the code so if it has side effects on file descriptors
-  //   then we'll get in a bad state...
-
   KJ_ASSERT(callPromise.poll(env.waitScope));
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("foobar", callPromise.ignoreResult().wait(env.waitScope));
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("foobar", callPromise.wait(env.waitScope));
 
   KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("foobar",
-      env.membraned.makeThingRequest().send().ignoreResult().wait(env.waitScope));
+      env.membraned.makeThingRequest().send().wait(env.waitScope));
 
   KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("foobar",
-      thing.passThroughRequest().send().ignoreResult().wait(env.waitScope));
+      thing.passThroughRequest().send().wait(env.waitScope));
 }
 
 }  // namespace

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -1404,8 +1404,7 @@ KJ_TEST("when OutgoingRpcMessage::send() throws, we don't leak exports") {
 
         ++interceptCount;
         if (shouldThrowFromSend) {
-          kj::throwRecoverableException(KJ_EXCEPTION(FAILED, "intercepted"));
-          return false;  // only matters when -fno-exceptions
+          kj::throwFatalException(KJ_EXCEPTION(FAILED, "intercepted"));
         }
       }
     }

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -449,9 +449,7 @@ TEST(Serialize, RejectTooManySegments) {
 
   kj::Maybe<kj::Exception> e = kj::runCatchingExceptions([&]() {
     InputStreamMessageReader reader(input);
-#if !KJ_NO_EXCEPTIONS
     ADD_FAILURE() << "Should have thrown an exception.";
-#endif
   });
 
   KJ_EXPECT(e != nullptr, "Should have thrown an exception.");
@@ -470,9 +468,7 @@ TEST(Serialize, RejectHugeMessage) {
 
   kj::Maybe<kj::Exception> e = kj::runCatchingExceptions([&]() {
     InputStreamMessageReader reader(input, options);
-#if !KJ_NO_EXCEPTIONS
     ADD_FAILURE() << "Should have thrown an exception.";
-#endif
   });
 
   KJ_EXPECT(e != nullptr, "Should have thrown an exception.");

--- a/c++/src/kj/arena-test.c++
+++ b/c++/src/kj/arena-test.c++
@@ -148,8 +148,6 @@ TEST(Arena, OwnArray) {
   EXPECT_EQ(0, TestObject::count);
 }
 
-#ifndef KJ_NO_EXCEPTIONS
-
 TEST(Arena, ObjectThrow) {
   TestObject::count = 0;
   TestObject::throwAt = 1;
@@ -177,8 +175,6 @@ TEST(Arena, ArrayThrow) {
 
   EXPECT_EQ(0, TestObject::count);
 }
-
-#endif
 
 TEST(Arena, Alignment) {
   Arena arena;

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -122,7 +122,6 @@ TEST(Array, ComplexConstructor) {
   EXPECT_EQ(0, TestObject::count);
 }
 
-#if !KJ_NO_EXCEPTIONS
 TEST(Array, ThrowingConstructor) {
   TestObject::count = 0;
   TestObject::throwAt = 16;
@@ -144,7 +143,6 @@ TEST(Array, ThrowingDestructor) {
   EXPECT_ANY_THROW(array = nullptr);
   EXPECT_EQ(0, TestObject::count);
 }
-#endif  // !KJ_NO_EXCEPTIONS
 
 TEST(Array, AraryBuilder) {
   TestObject::count = 0;
@@ -260,7 +258,6 @@ TEST(Array, AraryBuilderAddAll) {
   EXPECT_EQ(0, TestObject::count);
   EXPECT_EQ(0, TestObject::copiedCount);
 
-#if !KJ_NO_EXCEPTIONS
   {
     // Complex case, exceptions occur.
     TestObject::count = 0;
@@ -284,7 +281,6 @@ TEST(Array, AraryBuilderAddAll) {
   }
   EXPECT_EQ(0, TestObject::count);
   EXPECT_EQ(0, TestObject::copiedCount);
-#endif  // !KJ_NO_EXCEPTIONS
 }
 
 TEST(Array, HeapCopy) {

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -413,7 +413,6 @@ TEST(Async, SeparateFulfillerDiscarded) {
       pair.promise.wait(waitScope));
 }
 
-#if !KJ_NO_EXCEPTIONS
 TEST(Async, SeparateFulfillerDiscardedDuringUnwind) {
   EventLoop loop;
   WaitScope waitScope(loop);
@@ -427,7 +426,6 @@ TEST(Async, SeparateFulfillerDiscardedDuringUnwind) {
   KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(
       "test exception", pair.promise.wait(waitScope));
 }
-#endif
 
 TEST(Async, SeparateFulfillerMemoryLeak) {
   auto paf = kj::newPromiseAndFulfiller<void>();

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -130,10 +130,7 @@ TEST(Async, Exception) {
 
   Promise<int> promise = evalLater(
       [&]() -> int { KJ_FAIL_ASSERT("foo") { return 123; } });
-  EXPECT_TRUE(kj::runCatchingExceptions([&]() {
-    // wait() only returns when compiling with -fno-exceptions.
-    EXPECT_EQ(123, promise.wait(waitScope));
-  }) != nullptr);
+  KJ_EXPECT_THROW_MESSAGE("foo", promise.wait(waitScope));
 }
 
 TEST(Async, HandleException) {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -219,9 +219,7 @@ public:
   // exception to the returned promise.
   //
   // Either `func` or `errorHandler` may, of course, throw an exception, in which case the promise
-  // is broken.  When compiled with -fno-exceptions, the framework will still detect when a
-  // recoverable exception was thrown inside of a continuation and will consider the promise
-  // broken even though a (presumably garbage) result was returned.
+  // is broken.
   //
   // If the returned promise is destroyed before the callback runs, the callback will be canceled
   // (it will never run).
@@ -273,10 +271,7 @@ public:
   // server-side code generally cannot use wait(), because it has to be able to accept multiple
   // requests at once.
   //
-  // If the promise is rejected, `wait()` throws an exception.  If the program was compiled without
-  // exceptions (-fno-exceptions), this will usually abort.  In this case you really should first
-  // use `then()` to set an appropriate handler for the exception case, so that the promise you
-  // actually wait on never throws.
+  // If the promise is rejected, `wait()` throws an exception.
   //
   // `waitScope` is an object proving that the caller is in a scope where wait() is allowed.  By
   // convention, any function which might call wait(), or which might call another function which

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -28,15 +28,11 @@
 KJ_BEGIN_HEADER
 
 #ifndef KJ_USE_FIBERS
-  #if __BIONIC__ || __FreeBSD__ || __OpenBSD__ || KJ_NO_EXCEPTIONS
+  #if __BIONIC__ || __FreeBSD__ || __OpenBSD__
     // These platforms don't support fibers.
     #define KJ_USE_FIBERS 0
   #else
     #define KJ_USE_FIBERS 1
-  #endif
-#else
-  #if KJ_NO_EXCEPTIONS && KJ_USE_FIBERS
-    #error "Fibers cannot be enabled when exceptions are disabled."
   #endif
 #endif
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -130,8 +130,8 @@ typedef unsigned char byte;
 // Common macros, especially for common yet compiler-specific features.
 
 // Detect whether RTTI and exceptions are enabled, assuming they are unless we have specific
-// evidence to the contrary.  Clients can always define KJ_NO_RTTI or KJ_NO_EXCEPTIONS explicitly
-// to override these checks.
+// evidence to the contrary.  Clients can always define KJ_NO_RTTI explicitly to override the
+// check. As of version 2, exceptions are required, so this produces an error otherwise.
 
 // TODO: Ideally we'd use __cpp_exceptions/__cpp_rtti not being defined as the first pass since
 //   that is the standard compliant way. However, it's unclear how to use those macros (or any
@@ -141,22 +141,22 @@ typedef unsigned char byte;
   #if !defined(KJ_NO_RTTI) && !__has_feature(cxx_rtti)
     #define KJ_NO_RTTI 1
   #endif
-  #if !defined(KJ_NO_EXCEPTIONS) && !__has_feature(cxx_exceptions)
-    #define KJ_NO_EXCEPTIONS 1
+  #if !__has_feature(cxx_exceptions)
+    #error "KJ requires C++ exceptions, please enable them"
   #endif
 #elif defined(__GNUC__)
   #if !defined(KJ_NO_RTTI) && !__GXX_RTTI
     #define KJ_NO_RTTI 1
   #endif
-  #if !defined(KJ_NO_EXCEPTIONS) && !__EXCEPTIONS
-    #define KJ_NO_EXCEPTIONS 1
+  #if !__EXCEPTIONS
+    #error "KJ requires C++ exceptions, please enable them"
   #endif
 #elif defined(_MSC_VER)
   #if !defined(KJ_NO_RTTI) && !defined(_CPPRTTI)
     #define KJ_NO_RTTI 1
   #endif
-  #if !defined(KJ_NO_EXCEPTIONS) && !defined(_CPPUNWIND)
-    #define KJ_NO_EXCEPTIONS 1
+  #if !defined(_CPPUNWIND)
+    #error "KJ requires C++ exceptions, please enable them"
   #endif
 #endif
 

--- a/c++/src/kj/compat/gtest.h
+++ b/c++/src/kj/compat/gtest.h
@@ -100,13 +100,8 @@ private:
 
 #define ADD_FAILURE() ::kj::AddFailureAdapter(__FILE__, __LINE__)
 
-#if KJ_NO_EXCEPTIONS
-#define EXPECT_ANY_THROW(code) \
-    KJ_EXPECT(::kj::_::expectFatalThrow(nullptr, nullptr, [&]() { code; }))
-#else
 #define EXPECT_ANY_THROW(code) \
     KJ_EXPECT(::kj::runCatchingExceptions([&]() { code; }) != nullptr)
-#endif
 
 #define EXPECT_NONFATAL_FAILURE(code) \
   EXPECT_TRUE(kj::runCatchingExceptions([&]() { code; }) != nullptr);

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -2247,13 +2247,7 @@ KJ_TEST("WebSocket pump byte counting") {
   pumpTask.wait(waitScope);
 
   // The eventual receiver gets a disconnect exception.
-  // (Note: We don't use KJ_EXPECT_THROW here because under -fno-exceptions it forks and we lose
-  // state.)
-  receiveTask.then([](auto) {
-    KJ_FAIL_EXPECT("expected exception");
-  }, [](kj::Exception&& e) {
-    KJ_EXPECT(e.getType() == kj::Exception::Type::DISCONNECTED);
-  }).wait(waitScope);
+  KJ_EXPECT_THROW(DISCONNECTED, receiveTask.wait(waitScope));
 
   KJ_EXPECT(server1->receivedByteCount() == 3);
 #if KJ_NO_RTTI

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -153,16 +153,7 @@ public:
     }
     text += '\n';
     flush();
-#if KJ_NO_EXCEPTIONS
-    if (outputPipe >= 0) {
-      // This is a child process.  We got what we want, now exit quickly without writing any
-      // additional messages, with a status code that the parent will interpret as "exited in the
-      // way we expected".
-      _exit(74);
-    }
-#else
     throw MockException();
-#endif
   }
 
   void logMessage(LogSeverity severity, const char* file, int line, int contextDepth,
@@ -184,14 +175,10 @@ public:
   EXPECT_EQ(expText, text); \
 } while(0)
 
-#if KJ_NO_EXCEPTIONS
-#define EXPECT_FATAL(code) if (mockCallback.forkForDeathTest()) { code; abort(); }
-#else
 #define EXPECT_FATAL(code) \
   try { code; KJ_FAIL_EXPECT("expected exception"); } \
   catch (MockException e) {} \
   catch (...) { KJ_FAIL_EXPECT("wrong exception"); }
-#endif
 
 std::string fileLine(std::string file, int line) {
   file = trimSourceFilename(file.c_str()).cStr();
@@ -313,7 +300,6 @@ TEST(Debug, Catch) {
     }
   }
 
-#if !KJ_NO_EXCEPTIONS
   {
     // Catch fatal as kj::Exception.
     Maybe<Exception> exception = kj::runCatchingExceptions([&](){
@@ -348,7 +334,6 @@ TEST(Debug, Catch) {
       EXPECT_EQ(fileLine(__FILE__, line) + ": failed: foo", text);
     }
   }
-#endif
 }
 
 int mockSyscall(int i, int error = 0) {

--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -47,11 +47,7 @@ TEST(Exception, RunCatchingExceptions) {
     recovered = true;
   });
 
-#if KJ_NO_EXCEPTIONS
-  EXPECT_TRUE(recovered);
-#else
   EXPECT_FALSE(recovered);
-#endif
 
   KJ_IF_MAYBE(ex, e) {
     EXPECT_EQ("foo", ex->getDescription());
@@ -60,7 +56,6 @@ TEST(Exception, RunCatchingExceptions) {
   }
 }
 
-#if !KJ_NO_EXCEPTIONS
 TEST(Exception, RunCatchingExceptionsStdException) {
   Maybe<Exception> e = kj::runCatchingExceptions([&]() {
     throw std::logic_error("foo");
@@ -88,12 +83,6 @@ TEST(Exception, RunCatchingExceptionsOtherException) {
     ADD_FAILURE() << "Expected exception";
   }
 }
-#endif
-
-#if !KJ_NO_EXCEPTIONS
-// We skip this test when exceptions are disabled because making it no-exceptions-safe defeats
-// the purpose of the test: recoverable exceptions won't throw inside a destructor in the first
-// place.
 
 class ThrowingDestructor: public UnwindDetector {
 public:
@@ -130,7 +119,6 @@ TEST(Exception, UnwindDetector) {
     ADD_FAILURE() << "Expected exception";
   }
 }
-#endif
 
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) || \
     KJ_HAS_COMPILER_FEATURE(address_sanitizer) || \
@@ -144,7 +132,6 @@ TEST(Exception, ExceptionCallbackMustBeOnStack) {
 #endif
 #endif  // !__MINGW32__
 
-#if !KJ_NO_EXCEPTIONS
 TEST(Exception, ScopeSuccessFail) {
   bool success = false;
   bool failure = false;
@@ -176,7 +163,6 @@ TEST(Exception, ScopeSuccessFail) {
   EXPECT_FALSE(success);
   EXPECT_TRUE(failure);
 }
-#endif
 
 #if __GNUG__ || defined(__clang__)
 kj::String testStackTrace() __attribute__((noinline));
@@ -214,7 +200,6 @@ KJ_TEST("getStackTrace() returns correct line number, not line + 1") {
   KJ_ASSERT(strstr(trace.cStr(), wrong.cStr()) == nullptr, trace, wrong);
 }
 
-#if !KJ_NO_EXCEPTIONS
 KJ_TEST("InFlightExceptionIterator works") {
   bool caught = false;
   try {
@@ -247,7 +232,6 @@ KJ_TEST("InFlightExceptionIterator works") {
 
   KJ_EXPECT(caught);
 }
-#endif
 
 KJ_TEST("computeRelativeTrace") {
   auto testCase = [](uint expectedPrefix,

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -271,10 +271,15 @@ ExceptionCallback& getExceptionCallback();
 KJ_NOINLINE KJ_NORETURN(void throwFatalException(kj::Exception&& exception, uint ignoreCount = 0));
 // Invoke the exception callback to throw the given fatal exception.  If the exception callback
 // returns, abort.
+//
+// TODO(2.0): Rename this to `throwException()`.
 
 KJ_NOINLINE void throwRecoverableException(kj::Exception&& exception, uint ignoreCount = 0);
 // Invoke the exception callback to throw the given recoverable exception.  If the exception
 // callback returns, return normally.
+//
+// TODO(2.0): Rename this to `throwExceptionUnlessUnwinding()`. (Or, can we fix the unwind problem
+//   and be able to remove this entirely?)
 
 // =======================================================================================
 
@@ -285,6 +290,9 @@ Maybe<Exception> runCatchingExceptions(Func&& func);
 // Executes the given function (usually, a lambda returning nothing) catching any exceptions that
 // are thrown.  Returns the Exception if there was one, or null if the operation completed normally.
 // Non-KJ exceptions will be wrapped.
+//
+// TODO(2.0): Remove this. Introduce KJ_CATCH() macro which uses getCaughtExceptionAsKj() to handle
+//   exception coercion and stack trace management. Then use try/KJ_CATCH everywhere.
 
 kj::Exception getCaughtExceptionAsKj();
 // Call from the catch block of a try/catch to get a `kj::Exception` representing the exception

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -208,16 +208,15 @@ public:
   // producing garbage output.  This method _should_ throw the exception, but is allowed to simply
   // return if garbage output is acceptable.
   //
-  // The global default implementation throws an exception unless the library was compiled with
-  // -fno-exceptions, in which case it logs an error and returns.
+  // The global default implementation throws an exception, unless we're currently in a destructor
+  // unwinding due to another exception being thrown, in which case it logs an error and returns.
 
   virtual void onFatalException(Exception&& exception);
   // Called when an exception has been raised and the calling code cannot continue.  If this method
   // returns normally, abort() will be called.  The method must throw the exception to avoid
   // aborting.
   //
-  // The global default implementation throws an exception unless the library was compiled with
-  // -fno-exceptions, in which case it logs an error and returns.
+  // The global default implementation throws an exception.
 
   virtual void logMessage(LogSeverity severity, const char* file, int line, int contextDepth,
                           String&& text);
@@ -286,9 +285,6 @@ Maybe<Exception> runCatchingExceptions(Func&& func);
 // Executes the given function (usually, a lambda returning nothing) catching any exceptions that
 // are thrown.  Returns the Exception if there was one, or null if the operation completed normally.
 // Non-KJ exceptions will be wrapped.
-//
-// If exception are disabled (e.g. with -fno-exceptions), this will still detect whether any
-// recoverable exceptions occurred while running the function and will return those.
 
 kj::Exception getCaughtExceptionAsKj();
 // Call from the catch block of a try/catch to get a `kj::Exception` representing the exception

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -783,7 +783,7 @@ public:
     return true;
   }
 
-  kj::Maybe<Array<wchar_t>> createNamedTemporary(
+  Array<wchar_t> createNamedTemporary(
       PathPtr finalName, WriteMode mode, Path& kjTempPath,
       Function<BOOL(const wchar_t*)> tryCreate) const {
     // Create a temporary file which will eventually replace `finalName`.
@@ -794,14 +794,12 @@ public:
     // not checked in advance, since it needs to be checked atomically. In the case of
     // ERROR_*_EXISTS, tryCreate() will be called again with a new path.
     //
-    // Returns the temporary path that succeeded. Only returns nullptr if there was an exception
-    // but we're compiled with -fno-exceptions.
+    // Returns the temporary path that succeeded.
     //
     // The optional parameter `kjTempPath` is filled in with the KJ Path of the temporary.
 
     if (finalName.size() == 0) {
-      KJ_FAIL_REQUIRE("can't replace self") { break; }
-      return nullptr;
+      KJ_FAIL_REQUIRE("can't replace self");
     }
 
     static uint counter = 0;
@@ -826,14 +824,13 @@ public:
         }
         KJ_FALLTHROUGH;
       default:
-        KJ_FAIL_WIN32("create(path)", error, path) { break; }
-        return nullptr;
+        KJ_FAIL_WIN32("create(path)", error, path);
     }
 
     return kj::mv(path);
   }
 
-  kj::Maybe<Array<wchar_t>> createNamedTemporary(
+  Array<wchar_t> createNamedTemporary(
       PathPtr finalName, WriteMode mode, Function<BOOL(const wchar_t*)> tryCreate) const {
     Path dummy = nullptr;
     return createNamedTemporary(finalName, mode, dummy, kj::mv(tryCreate));
@@ -887,21 +884,17 @@ public:
     // Either we don't have CREATE mode or the target already exists. We need to perform a
     // replacement instead.
 
-    KJ_IF_MAYBE(tempPath, createNamedTemporary(path, mode, kj::mv(tryCreate))) {
-      if (tryCommitReplacement(path, *tempPath, mode)) {
-        return true;
-      } else {
-        KJ_WIN32_HANDLE_ERRORS(DeleteFileW(tempPath->begin())) {
-          case ERROR_FILE_NOT_FOUND:
-            // meh
-            break;
-          default:
-            KJ_FAIL_WIN32("DeleteFile(tempPath)", error, dbgStr(*tempPath));
-        }
-        return false;
-      }
+    auto tempPath = createNamedTemporary(path, mode, kj::mv(tryCreate));
+    if (tryCommitReplacement(path, tempPath, mode)) {
+      return true;
     } else {
-      // threw, but exceptions are disabled
+      KJ_WIN32_HANDLE_ERRORS(DeleteFileW(tempPath.begin())) {
+        case ERROR_FILE_NOT_FOUND:
+          // meh
+          break;
+        default:
+          KJ_FAIL_WIN32("DeleteFile(tempPath)", error, dbgStr(tempPath));
+      }
       return false;
     }
   }
@@ -1023,26 +1016,22 @@ public:
         // delete the old thing.
 
         if (has(mode, WriteMode::MODIFY)) {
-          KJ_IF_MAYBE(tempName,
+          auto tempName =
               createNamedTemporary(toPath, WriteMode::CREATE, [&](const wchar_t* tempName2) {
             return MoveFileW(wToPath.begin(), tempName2);
-          })) {
-            KJ_WIN32_HANDLE_ERRORS(MoveFileW(fromPath.begin(), wToPath.begin())) {
-              default:
-                // Try to move back.
-                MoveFileW(tempName->begin(), wToPath.begin());
-                KJ_FAIL_WIN32("MoveFile", error, dbgStr(fromPath), dbgStr(wToPath)) {
-                  return false;
-                }
-            }
-
-            // Succeeded, delete temporary.
-            rmrf(*tempName);
-            return true;
-          } else {
-            // createNamedTemporary() threw exception but exceptions are disabled.
-            return false;
+          });
+          KJ_WIN32_HANDLE_ERRORS(MoveFileW(fromPath.begin(), wToPath.begin())) {
+            default:
+              // Try to move back.
+              MoveFileW(tempName.begin(), wToPath.begin());
+              KJ_FAIL_WIN32("MoveFile", error, dbgStr(fromPath), dbgStr(wToPath)) {
+                return false;
+              }
           }
+
+          // Succeeded, delete temporary.
+          rmrf(tempName);
+          return true;
         } else {
           // Not MODIFY, so no overwrite allowed. If the file really does exist, we need to return
           // false.
@@ -1149,7 +1138,7 @@ public:
 
   Own<Directory::Replacer<File>> replaceFile(PathPtr path, WriteMode mode) const {
     HANDLE newHandle_;
-    KJ_IF_MAYBE(temp, createNamedTemporary(path, mode,
+    auto temp = createNamedTemporary(path, mode,
         [&](const wchar_t* candidatePath) {
       newHandle_ = CreateFileW(
           candidatePath,
@@ -1160,19 +1149,15 @@ public:
           FILE_ATTRIBUTE_NORMAL,
           NULL);
       return newHandle_ != INVALID_HANDLE_VALUE;
-    })) {
-      AutoCloseHandle newHandle(newHandle_);
-      return heap<ReplacerImpl<File>>(newDiskFile(kj::mv(newHandle)), *this, kj::mv(*temp),
-                                      path.clone(), mode);
-    } else {
-      // threw, but exceptions are disabled
-      return heap<BrokenReplacer<File>>(newInMemoryFile(nullClock()));
-    }
+    });
+    AutoCloseHandle newHandle(newHandle_);
+    return heap<ReplacerImpl<File>>(newDiskFile(kj::mv(newHandle)), *this, kj::mv(temp),
+                                    path.clone(), mode);
   }
 
   Own<const File> createTemporary() const {
     HANDLE newHandle_;
-    KJ_IF_MAYBE(temp, createNamedTemporary(Path("unnamed"), WriteMode::CREATE,
+    createNamedTemporary(Path("unnamed"), WriteMode::CREATE,
         [&](const wchar_t* candidatePath) {
       newHandle_ = CreateFileW(
           candidatePath,
@@ -1183,13 +1168,9 @@ public:
           FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE,
           NULL);
       return newHandle_ != INVALID_HANDLE_VALUE;
-    })) {
-      AutoCloseHandle newHandle(newHandle_);
-      return newDiskFile(kj::mv(newHandle));
-    } else {
-      // threw, but exceptions are disabled
-      return newInMemoryFile(nullClock());
-    }
+    });
+    AutoCloseHandle newHandle(newHandle_);
+    return newDiskFile(kj::mv(newHandle));
   }
 
   Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) const {
@@ -1209,35 +1190,28 @@ public:
 
   Own<Directory::Replacer<Directory>> replaceSubdir(PathPtr path, WriteMode mode) const {
     Path kjTempPath = nullptr;
-    KJ_IF_MAYBE(temp, createNamedTemporary(path, mode, kjTempPath,
+    auto temp = createNamedTemporary(path, mode, kjTempPath,
         [&](const wchar_t* candidatePath) {
       return CreateDirectoryW(candidatePath, makeSecAttr(mode));
-    })) {
-      HANDLE subdirHandle_;
-      KJ_WIN32_HANDLE_ERRORS(subdirHandle_ = CreateFileW(
-          temp->begin(),
-          GENERIC_READ,
-          FILE_SHARE_READ | FILE_SHARE_WRITE,
-          NULL,
-          OPEN_EXISTING,
-          FILE_FLAG_BACKUP_SEMANTICS,  // apparently, this flag is required for directories
-          NULL)) {
-        default:
-          KJ_FAIL_WIN32("CreateFile(just-created-temporary, OPEN_EXISTING)", error, path) {
-            goto fail;
-          }
-      }
-
-      AutoCloseHandle subdirHandle(subdirHandle_);
-      return heap<ReplacerImpl<Directory>>(
-          newDiskDirectory(kj::mv(subdirHandle),
-              KJ_ASSERT_NONNULL(dirPath).append(kj::mv(kjTempPath))),
-          *this, kj::mv(*temp), path.clone(), mode);
-    } else {
-      // threw, but exceptions are disabled
-    fail:
-      return heap<BrokenReplacer<Directory>>(newInMemoryDirectory(nullClock()));
+    });
+    HANDLE subdirHandle_;
+    KJ_WIN32_HANDLE_ERRORS(subdirHandle_ = CreateFileW(
+        temp.begin(),
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS,  // apparently, this flag is required for directories
+        NULL)) {
+      default:
+        KJ_FAIL_WIN32("CreateFile(just-created-temporary, OPEN_EXISTING)", error, path);
     }
+
+    AutoCloseHandle subdirHandle(subdirHandle_);
+    return heap<ReplacerImpl<Directory>>(
+        newDiskDirectory(kj::mv(subdirHandle),
+            KJ_ASSERT_NONNULL(dirPath).append(kj::mv(kjTempPath))),
+        *this, kj::mv(temp), path.clone(), mode);
   }
 
   bool trySymlink(PathPtr linkpath, StringPtr content, WriteMode mode) const {

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -61,14 +61,7 @@ StringPtr TopLevelProcessContext::getProgramName() {
 void TopLevelProcessContext::exit() {
   int exitCode = hadErrors ? 1 : 0;
   if (cleanShutdown) {
-#if KJ_NO_EXCEPTIONS
-    // This is the best we can do.
-    warning("warning: KJ_CLEAN_SHUTDOWN may not work correctly when compiled "
-            "with -fno-exceptions.");
-    ::exit(exitCode);
-#else
     throw CleanShutdownException { exitCode };
-#endif
   }
   _exit(exitCode);
 }
@@ -215,9 +208,7 @@ int runMainAndExit(ProcessContext& context, MainFunc&& func, int argc, char* arg
   setStandardIoMode(STDOUT_FILENO);
   setStandardIoMode(STDERR_FILENO);
 
-#if !KJ_NO_EXCEPTIONS
   try {
-#endif
     KJ_ASSERT(argc > 0);
 
     KJ_STACK_ARRAY(StringPtr, params, argc - 1, 8, 32);
@@ -231,11 +222,9 @@ int runMainAndExit(ProcessContext& context, MainFunc&& func, int argc, char* arg
       context.error(str("*** Uncaught exception ***\n", *exception));
     }
     context.exit();
-#if !KJ_NO_EXCEPTIONS
   } catch (const TopLevelProcessContext::CleanShutdownException& e) {
     return e.exitCode;
   }
-#endif
   KJ_CLANG_KNOWS_THIS_IS_UNREACHABLE_BUT_GCC_DOESNT
 }
 

--- a/c++/src/kj/map-test.c++
+++ b/c++/src/kj/map-test.c++
@@ -164,7 +164,6 @@ KJ_TEST("TreeMap range") {
   }
 }
 
-#if !KJ_NO_EXCEPTIONS
 KJ_TEST("HashMap findOrCreate throws") {
   HashMap<int, String> m;
   try {
@@ -183,7 +182,6 @@ KJ_TEST("HashMap findOrCreate throws") {
 
   KJ_EXPECT(KJ_ASSERT_NONNULL(m.find(1)) == "ok");
 }
-#endif
 
 template <typename MapType>
 void testEraseAll(MapType& m) {

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -216,7 +216,6 @@ TEST(Mutex, When) {
     KJ_EXPECT(*value.lockShared() == 101);
   }
 
-#if !KJ_NO_EXCEPTIONS
   {
     // Throw from predicate.
     KJ_EXPECT_THROW_MESSAGE("oops threw", value.when([](uint n) -> bool {
@@ -256,7 +255,6 @@ TEST(Mutex, When) {
     });
     KJ_EXPECT(m == 654);
   }
-#endif
 }
 
 TEST(Mutex, WhenWithTimeout) {
@@ -338,7 +336,6 @@ TEST(Mutex, WhenWithTimeout) {
     KJ_EXPECT(m == 56);
   }
 
-#if !KJ_NO_EXCEPTIONS
   {
     // Throw from predicate.
     KJ_EXPECT_THROW_MESSAGE("oops threw", value.when([](uint n) -> bool {
@@ -385,7 +382,6 @@ TEST(Mutex, WhenWithTimeout) {
     }, LONG_TIMEOUT);
     KJ_EXPECT(m == 654);
   }
-#endif
 }
 
 TEST(Mutex, WhenWithTimeoutPreciseTiming) {
@@ -515,13 +511,7 @@ TEST(Mutex, LazyException) {
         return space.construct(456);
       });
 
-  // Unfortunately, the results differ depending on whether exceptions are enabled.
-  // TODO(someday):  Fix this?  Does it matter?
-#if KJ_NO_EXCEPTIONS
-  EXPECT_EQ(123, i);
-#else
   EXPECT_EQ(456, i);
-#endif
 }
 
 class OnlyTouchUnderLock {

--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -42,7 +42,7 @@ TEST(OneOf, Basic) {
   EXPECT_FALSE(var.is<String>());
 
   EXPECT_EQ(123, var.get<int>());
-#if !KJ_NO_EXCEPTIONS && defined(KJ_DEBUG)
+#ifdef KJ_DEBUG
   EXPECT_ANY_THROW(var.get<float>());
   EXPECT_ANY_THROW(var.get<String>());
 #endif

--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -50,7 +50,7 @@ TEST(Refcount, Basic) {
   ref2 = Own<SetTrueInDestructor>();
   EXPECT_TRUE(b);
 
-#if defined(KJ_DEBUG) && !KJ_NO_EXCEPTIONS
+#ifdef KJ_DEBUG
   b = false;
   SetTrueInDestructor obj(&b);
   EXPECT_ANY_THROW(addRef(obj));

--- a/c++/src/kj/test-test.c++
+++ b/c++/src/kj/test-test.c++
@@ -90,11 +90,9 @@ KJ_TEST("expect exit from exit") {
   KJ_EXPECT_EXIT(nullptr, _exit(42));
 }
 
-#if !KJ_NO_EXCEPTIONS
 KJ_TEST("expect exit from thrown exception") {
   KJ_EXPECT_EXIT(1, throw std::logic_error("test error"));
 }
-#endif
 
 KJ_TEST("expect signal from abort") {
   KJ_EXPECT_SIGNAL(SIGABRT, abort());

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -134,19 +134,8 @@ private:
   } while (false)
 #endif
 
-#if KJ_NO_EXCEPTIONS
-#define KJ_EXPECT_THROW(type, code, ...) \
-  do { \
-    KJ_EXPECT(::kj::_::expectFatalThrow(::kj::Exception::Type::type, nullptr, [&]() { code; })); \
-  } while (false)
-#define KJ_EXPECT_THROW_MESSAGE(message, code, ...) \
-  do { \
-    KJ_EXPECT(::kj::_::expectFatalThrow(nullptr, kj::StringPtr(message), [&]() { code; })); \
-  } while (false)
-#else
 #define KJ_EXPECT_THROW KJ_EXPECT_THROW_RECOVERABLE
 #define KJ_EXPECT_THROW_MESSAGE KJ_EXPECT_THROW_RECOVERABLE_MESSAGE
-#endif
 
 #define KJ_EXPECT_EXIT(statusCode, code) \
   do { \
@@ -171,14 +160,6 @@ private:
 namespace _ {  // private
 
 bool hasSubstring(kj::StringPtr haystack, kj::StringPtr needle);
-
-#if KJ_NO_EXCEPTIONS
-bool expectFatalThrow(Maybe<Exception::Type> type, Maybe<StringPtr> message,
-                      Function<void()> code);
-// Expects that the given code will throw a fatal exception matching the given type and/or message.
-// Since exceptions are disabled, the test will fork() and run in a subprocess. On Windows, where
-// fork() is not available, this always returns true.
-#endif
 
 bool expectExit(Maybe<int> statusCode, FunctionParam<void()> code) noexcept;
 // Expects that the given code will exit with a given statusCode.

--- a/super-test.sh
+++ b/super-test.sh
@@ -531,15 +531,10 @@ if [ "x`uname`" = xLinux ]; then
 fi
 
 echo "========================================================================="
-echo "Testing with -fno-rtti and -fno-exceptions"
+echo "Testing with -fno-rtti"
 echo "========================================================================="
 
-# GCC miscompiles capnpc-c++ when -fno-exceptions and -O2 are specified together. The
-# miscompilation happens in one specific inlined call site of Array::dispose(), but this method
-# is inlined in hundreds of other places without issue, so I have no idea how to narrow down the
-# bug. Clang works fine. So, for now, we disable optimizations on GCC for -fno-exceptions tests.
-
-doit ./configure --disable-shared CXXFLAGS="$CXXFLAGS -fno-rtti -fno-exceptions $DISABLE_OPTIMIZATION_IF_GCC"
+doit ./configure --disable-shared CXXFLAGS="$CXXFLAGS -fno-rtti"
 doit make -j$PARALLEL check
 
 if [ "x`uname`" = xLinux ]; then


### PR DESCRIPTION
Also delete `kj::mvCapture()` as a drive-by.