### PR TITLE
blob.h: Fix invalid operands to binary expression

### DIFF
--- a/c++/src/capnp/blob.h
+++ b/c++/src/capnp/blob.h
@@ -173,8 +173,8 @@ inline kj::StringPtr KJ_STRINGIFY(Text::Builder builder) {
   return builder.asString();
 }
 
-inline bool operator==(const char* a, const Text::Builder& b) { return a == b.asString(); }
-inline bool operator!=(const char* a, const Text::Builder& b) { return a != b.asString(); }
+inline bool operator==(const char* a, const Text::Builder& b) { return b.asString() == a; }
+inline bool operator!=(const char* a, const Text::Builder& b) { return b.asString() != a; }
 
 inline Text::Builder::operator kj::StringPtr() const {
   return kj::StringPtr(content.begin(), content.size() - 1);


### PR DESCRIPTION
Fix #1622, #1752

With LLVM 17 and gnu++20, blob.h got 'invalid operands to binary expression' error.
This PR will fix that by swapping the elements.

```
capnproto/c++/src/capnp/blob.h:176:74: error: invalid operands to binary expression ('const char *' and 'kj::StringPtr')
  176 | inline bool operator==(const char* a, const Text::Builder& b) { return a == b.asString(); }
      |                                                                        ~ ^  ~~~~~~~~~~~~
```