### PR TITLE
kj/common: remove obsolete comments on minValue and maxValue.

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -777,15 +777,11 @@ static KJ_CONSTEXPR(const) MaxValue_ maxValue = MaxValue_();
 // A special constant which, when cast to an integer type, takes on the maximum possible value of
 // that type.  This is useful to use as e.g. a parameter to a function because it will be robust
 // in the face of changes to the parameter's type.
-//
-// `char` is not supported, but `signed char` and `unsigned char` are.
 
 static KJ_CONSTEXPR(const) MinValue_ minValue = MinValue_();
 // A special constant which, when cast to an integer type, takes on the minimum possible value
 // of that type.  This is useful to use as e.g. a parameter to a function because it will be robust
 // in the face of changes to the parameter's type.
-//
-// `char` is not supported, but `signed char` and `unsigned char` are.
 
 template <typename T>
 inline bool operator==(T t, MaxValue_) { return t == Decay<T>(maxValue); }


### PR DESCRIPTION
Type cast to char was supported since commit 98f9c8fca5c49f.

Signed-off-by: Jianyong Chen <baluschch@gmail.com>
