### PR TITLE
PROOF OF CONCEPT: This adds emscripten support in a commit to be able to at least compile and run tests via node(needs more testing)

### DIFF
--- a/bootstrap-emscripten.sh
+++ b/bootstrap-emscripten.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -ex
+
+FIRST_ARG=$1
+SDK_INSTALL_DIR=${FIRST_ARG:=${HOME}}
+MESON_PREFIXES_INI_FILE=meson/cross/emscripten_constants.ini
+EMSCRIPTEN_VERSION=3.1.42
+
+
+create_cross_emscripten_sdk_constants() {
+    echo "[constants]" > ${MESON_PREFIXES_INI_FILE}
+    echo "emsdk_prefix = '${SDK_INSTALL_DIR}/emsdk/'" >> ${MESON_PREFIXES_INI_FILE}
+    echo "emscripten_prefix = emsdk_prefix + '/upstream/emscripten/'" >> ${MESON_PREFIXES_INI_FILE}
+    echo "wasm_bin_prefix = emsdk_prefix + '/upstream/bin/'"  >> ${MESON_PREFIXES_INI_FILE}
+}
+
+
+create_cross_emscripten_sdk_constants
+if [ -d "${SDK_INSTALL_DIR}/emsdk" ] && [ ! -f "${SDK_INSTALL_DIR}/.installing_emsdk" ]; then
+    exit 0
+fi
+
+
+cleanup() {
+    local rv=$?
+    if [ ${rv} -eq 0 ]; then
+        rm -rf ${SDK_INSTALL_DIR}/.installing_emsdk
+    else
+        rm -rf ${SDK_INSTALL_DIR}/emsdk
+        rm ${PREFIXES_INI_FILE}
+        rm ${CONAN_PREFIXES_INI_FILE}
+    fi
+    cd ${OLDDIR}
+}
+
+
+setup_conan
+rm -rf "${SDK_INSTALL_DIR}/emsdk"
+touch ${SDK_INSTALL_DIR}/.installing_emsdk
+trap cleanup EXIT
+OLDDIR=${PWD}
+cd ${SDK_INSTALL_DIR}
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install ${EMSCRIPTEN_VERSION}
+./emsdk activate ${EMSCRIPTEN_VERSION}

--- a/c++/meson.build
+++ b/c++/meson.build
@@ -1,0 +1,55 @@
+EXE_EXTENSION = {'emscripten': 'html',
+                 'windows': 'exe'}
+
+cpp_comp = meson.get_compiler('cpp', native: false)
+build_machine_cpp_comp = meson.get_compiler('cpp', native: true)
+
+libucontext_dep = dependency('libucontext',
+                             required: false,
+                             native: false)
+
+build_machine_libucontext_dep = (not meson.is_cross_build() ? libucontext_dep :
+                                   dependency('libucontext',
+                                              required: false,
+                                              native: true))
+
+
+_capnp_fibers_found = (host_machine.system() == 'windows' or
+                       host_machine.system() == 'cygwin' or
+                       libucontext_dep.found())
+
+_build_machine_capnp_fibers_found = _capnp_fibers_found
+if meson.is_cross_build()
+  _build_machine_capnp_fibers_found = (build_machine.system() == 'windows' or
+                       build_machine.system() == 'cygwin' or
+                       libucontext_dep.found())
+endif
+
+_with_libucontext = libucontext_dep.found()
+with_fibers = get_option('with_fibers').disable_if(
+                          not _capnp_fibers_found and
+                          not cpp_comp.has_function('makecontext') and
+                          not libucontext_dep.found(),
+                          error_message: 'Missing makecontext, getcontext, setcontext or swapcontext symbol in libc and no libucontext found: KJ will not be able to build with fibers. set -Dwith_fibers=disabled')
+
+
+threads_dep = declare_dependency()
+build_machine_threads_dep = dependency('threads', native: true)
+if cpp_comp.get_id() == 'msvc'
+  add_project_arguments('/wo4503')
+else
+  add_project_arguments(['-Wno-strict-aliasing',
+                         '-Wno-sign-compare',
+                         '-Wno-unused-parameter'],
+                        language: 'cpp',
+                        native: false)
+  if not (host_machine.system() == 'android')
+    threads_dep = dependency('threads')
+  endif
+  if host_machine.system() == 'emscripten'
+      threads_dep = declare_dependency(compile_args: '-pthread', link_args: '-pthread')
+  endif
+endif
+
+
+subdir('src')

--- a/c++/src/capnp/blob.h
+++ b/c++/src/capnp/blob.h
@@ -173,8 +173,8 @@ inline kj::StringPtr KJ_STRINGIFY(Text::Builder builder) {
   return builder.asString();
 }
 
-inline bool operator==(const char* a, const Text::Builder& b) { return a == b.asString(); }
-inline bool operator!=(const char* a, const Text::Builder& b) { return a != b.asString(); }
+inline bool operator==(const char* a, const Text::Builder& b) { return kj::StringPtr(a) == b.asString(); }
+inline bool operator!=(const char* a, const Text::Builder& b) { return kj::StringPtr(a) != b.asString(); }
 
 inline Text::Builder::operator kj::StringPtr() const {
   return kj::StringPtr(content.begin(), content.size() - 1);

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -22,7 +22,7 @@
 #include "json.h"
 #include <capnp/test-util.h>
 #include <capnp/compat/json.capnp.h>
-#include <capnp/compat/json-test.capnp.h>
+#include <capnp/json-test.capnp.h>
 #include <kj/debug.h>
 #include <kj/string.h>
 #include <kj/test.h>

--- a/c++/src/capnp/meson.build
+++ b/c++/src/capnp/meson.build
@@ -1,0 +1,414 @@
+# capnp ========================================================================
+
+capnp_sources_lite = [
+  'c++.capnp.c++',
+  'blob.c++',
+  'arena.c++',
+  'layout.c++',
+  'list.c++',
+  'any.c++',
+  'message.c++',
+  'schema.capnp.c++',
+  'stream.capnp.c++',
+  'serialize.c++',
+  'serialize-packed.c++']
+
+capnp_sources_heavy = [
+  'schema.c++',
+  'schema-loader.c++',
+  'dynamic.c++',
+  'stringify.c++']
+
+capnp_sources = capnp_sources_lite + capnp_sources_heavy
+
+capnp_headers = [
+  'c++.capnp.h',
+  'common.h',
+  'blob.h',
+  'endian.h',
+  'layout.h',
+  'orphan.h',
+  'list.h',
+  'any.h',
+  'message.h',
+  'capability.h',
+  'membrane.h',
+  'dynamic.h',
+  'schema.h',
+  'schema.capnp.h',
+  'stream.capnp.h',
+  'schema-lite.h',
+  'schema-loader.h',
+  'schema-parser.h',
+  'pretty-print.h',
+  'serialize.h',
+  'serialize-async.h',
+  'serialize-packed.h',
+  'serialize-text.h',
+  'pointer-helpers.h',
+  'generated-header-support.h',
+  'raw-schema.h']
+
+capnp_compat_headers = 'compat/std-iterator.h'
+
+capnp_schemas = [
+  'c++.capnp',
+  'schema.capnp',
+  'stream.capnp']
+
+install_lib = not get_option('_meson_nested_invocation')
+
+capnp_lib = library('capnp',
+                    capnp_sources,
+                    dependencies: [kj_dep],
+                    include_directories: '..',
+                    implicit_include_directories: false,
+                    install: install_lib)
+
+build_machine_capnp_lib = capnp_lib
+if meson.is_cross_build()
+  build_machine_capnp_lib = library('bm_capnp',
+                    capnp_sources,
+                    dependencies: [build_machine_kj_dep],
+                    include_directories: '..',
+                    implicit_include_directories: false,
+                    native: true)
+endif
+
+
+capnp_dep = declare_dependency(link_with: capnp_lib,
+                               dependencies: kj_dep,
+                               include_directories: '..')
+
+build_machine_capnp_dep = capnp_dep
+if meson.is_cross_build()
+  build_machine_capnp_dep = declare_dependency(link_with: build_machine_capnp_lib,
+                                               dependencies: build_machine_kj_dep,
+                                               include_directories: '..')
+endif
+
+
+capnp_rpc_sources = [
+  'serialize-async.c++',
+  'capability.c++',
+  'membrane.c++',
+  'dynamic-capability.c++',
+  'rpc.c++',
+  'rpc.capnp.c++',
+  'rpc-twoparty.c++',
+  'rpc-twoparty.capnp.c++',
+  'persistent.capnp.c++',
+  'ez-rpc.c++']
+
+capnp_rpc_headers = [
+  'rpc-prelude.h',
+  'rpc.h',
+  'rpc-twoparty.h',
+  'rpc.capnp.h',
+  'rpc-twoparty.capnp.h',
+  'persistent.capnp.h',
+  'ez-rpc.h']
+
+capnp_rpc_schemas = [
+  'rpc.capnp',
+  'rpc-twoparty.capnp',
+  'persistent.capnp']
+
+capnp_rpc_lib = library('capnp-rpc', capnp_rpc_sources, include_directories: '..',
+                        dependencies: [capnp_dep, kj_async_dep, kj_dep],
+                        implicit_include_directories: false,
+                        install: install_lib)
+build_machine_capnp_rpc_lib = capnp_rpc_lib
+if meson.is_cross_build()
+  build_machine_capnp_rpc_lib = library('bm_capnp-rpc',
+                                        capnp_rpc_sources,
+                                        include_directories: '..',
+                        dependencies: [build_machine_capnp_dep, build_machine_kj_async_dep, build_machine_kj_dep],
+                        implicit_include_directories: false,
+                        native: true)
+endif
+
+capnp_rpc_dep = declare_dependency(link_with: capnp_rpc_lib,
+                                   dependencies:[capnp_dep, kj_async_dep, kj_dep],
+                                   include_directories: '..')
+build_machine_capnp_rpc_dep = capnp_rpc_dep
+if meson.is_cross_build()
+  build_machine_capnp_rpc_dep = declare_dependency(link_with: build_machine_capnp_rpc_lib,
+                                   dependencies:[build_machine_capnp_dep, build_machine_kj_async_dep,
+                                                 build_machine_kj_dep],
+                                   include_directories: '..')
+endif
+
+
+# capnp-json ========================================================================
+
+capnp_json_sources = [
+  'compat/json.c++',
+  'compat/json.capnp.c++'
+]
+
+capnp_json_headers = [
+  'compat/json.h',
+  'compat/json.capnp.h'
+]
+
+capnp_json_schemas = 'compat/json.capnp'
+
+capnp_json_lib = library('capnp-json', capnp_json_sources,
+                         dependencies:[capnp_dep, kj_async_dep, kj_dep],
+                         implicit_include_directories: false,
+                         install: install_lib)
+
+build_machine_capnp_json_lib = capnp_json_lib
+if meson.is_cross_build()
+  build_machine_capnp_json_lib = library(
+    'bm_capnp-json', capnp_json_sources,
+    dependencies:[build_machine_capnp_dep, build_machine_kj_async_dep,
+                  build_machine_kj_dep],
+    implicit_include_directories: false,
+    native: true)
+endif
+
+
+capnp_json_dep = declare_dependency(link_with: capnp_json_lib,
+                                    include_directories: '..',
+                                    dependencies:[capnp_dep, kj_async_dep, kj_dep])
+
+build_machine_capnp_json_dep = capnp_json_dep
+if meson.is_cross_build()
+  build_machine_capnp_json_dep = declare_dependency(link_with: build_machine_capnp_json_lib,
+                                                    include_directories: '..',
+                                    dependencies:[build_machine_capnp_dep, build_machine_kj_async_dep, build_machine_kj_dep])
+endif
+
+
+capnp_websocket_sources = 'compat/websocket-rpc.c++'
+capnp_websocket_headers = 'compat/websocket-rpc.h'
+
+
+capnp_websocket_lib = library('capnp-websocket', capnp_websocket_sources,
+                              dependencies:[capnp_dep, capnp_rpc_dep, kj_http_dep,
+                                            kj_async_dep, kj_dep],
+                              implicit_include_directories: false,
+                              install: install_lib)
+
+build_machine_capnp_websocket_lib = capnp_websocket_lib
+if meson.is_cross_build()
+  build_machine_capnp_websocket_lib = library('bm_capnp-websocket', capnp_websocket_sources,
+                              dependencies:[build_machine_capnp_dep, build_machine_capnp_rpc_dep,
+                                            build_machine_kj_http_dep,
+                                            build_machine_kj_async_dep, build_machine_kj_dep],
+                              implicit_include_directories: false,
+                              native: true)
+endif
+
+capnp_websocket_dep = declare_dependency(link_with: capnp_websocket_lib,
+                                         include_directories: '..',
+                                         dependencies: [capnp_dep,
+                                                        capnp_rpc_dep,
+                                                        kj_http_dep,
+                                                        kj_async_dep, kj_dep])
+
+build_machine_capnp_websocket_dep = capnp_websocket_dep
+if meson.is_cross_build()
+  build_machine_capnp_websocket_dep = declare_dependency(link_with: build_machine_capnp_websocket_lib,
+                                         include_directories: '..',
+                                         dependencies: [build_machine_capnp_dep,
+                                                        build_machine_capnp_rpc_dep,
+                                                        build_machine_kj_http_dep,
+                                                        build_machine_kj_async_dep,
+                                                        build_machine_kj_dep])
+endif
+
+if install_lib
+  install_headers(capnp_headers +
+                capnp_schemas +
+                capnp_rpc_schemas +
+                capnp_rpc_headers +
+                capnp_json_headers +
+                capnp_json_schemas +
+                capnp_websocket_headers,
+                subdir: 'capnp',
+                preserve_path: true)
+endif
+
+# Tools/Compilers: target is build machine ==============================================================
+capnpc_sources = [
+  'compiler/type-id.c++',
+  'compiler/error-reporter.c++',
+  'compiler/lexer.capnp.c++',
+  'compiler/lexer.c++',
+  'compiler/grammar.capnp.c++',
+  'compiler/parser.c++',
+  'compiler/generics.c++',
+  'compiler/node-translator.c++',
+  'compiler/compiler.c++',
+  'schema-parser.c++',
+  'serialize-text.c++']
+
+
+capnpc_lib = library('capnpc', capnpc_sources,
+                     dependencies: [capnp_dep, kj_dep],
+                     include_directories: '..',
+                     implicit_include_directories: false,
+                     native: false,
+                     install: install_lib)
+
+# install_symlink('capnpc',
+#                 install_dir: get_option('bindir'),
+#                 pointing_to: 'capnp')
+#
+build_machine_capnpc_lib = capnpc_lib
+if meson.is_cross_build()
+  build_machine_capnpc_lib =library(
+    'bm_capnpc', capnpc_sources,
+    dependencies: [build_machine_capnp_dep, build_machine_kj_dep],
+    include_directories: '..',
+    implicit_include_directories: false,
+    native: true)
+endif
+
+capnpc_dep = declare_dependency(link_with: capnpc_lib,
+                                include_directories: '..',
+                                dependencies: [capnp_dep,
+                                               kj_dep])
+
+build_machine_capnpc_dep = capnpc_dep
+if meson.is_cross_build()
+  build_machine_capnpc_dep = declare_dependency(
+    link_with: build_machine_capnpc_lib,
+    include_directories: '..',
+    dependencies: [build_machine_capnp_dep,
+                   build_machine_kj_dep])
+endif
+
+
+capnp_include_dir = get_option('prefix') / get_option('includedir')
+project_version = meson.project_version()
+capnpc = executable('capnpc', sources: ['compiler/module-loader.c++',
+                                        'compiler/capnp.c++'],
+                    dependencies: [build_machine_capnpc_dep,
+                                   build_machine_capnp_json_dep,
+                                   build_machine_capnp_dep,
+                                   build_machine_kj_dep],
+                    cpp_args: [f'-DCAPNP_INCLUDE_DIR="@capnp_include_dir@"',
+                               f'-DVERSION="@project_version@"'],
+                    native: true,
+                    install: not meson.is_cross_build())
+
+capnpc_cpp = executable('capnpc-c++', sources: [ 'compiler/capnpc-c++.c++'],
+                        include_directories: '..',
+                        implicit_include_directories: false,
+                        dependencies: [build_machine_capnp_dep, build_machine_kj_dep],
+                        native: true,
+                        install: not meson.is_cross_build())
+
+capnpc_capnp = executable('capnpc-capnp', sources: [ 'compiler/capnpc-capnp.c++'],
+                          include_directories: '..',
+                          implicit_include_directories: false,
+                          dependencies: [build_machine_capnp_dep, build_machine_kj_dep],
+                          native: true,
+                          install: not meson.is_cross_build())
+
+
+if get_option('build_testing')
+  test_capnp_files = [
+    'test.capnp',
+    'test-import.capnp',
+    'test-import2.capnp',
+    'compat/json-test.capnp'
+  ]
+
+
+  capnp_cpp_plugin_path = capnpc_cpp.full_path()
+  test_capnp_cpp_h_files = []
+  foreach test_capnp_file : test_capnp_files
+    test_capnp_file_parts = test_capnp_file.split('/')
+    src_prefix = '--src-prefix=@CURRENT_SOURCE_DIR@' + (test_capnp_file_parts.length() > 1 ? '/' + test_capnp_file_parts[0] : '')
+    test_capnp_cpp_h_files += custom_target(
+      depends: capnpc_cpp,
+      command: [capnpc, src_prefix,
+                '-I@CURRENT_SOURCE_DIR@/..',
+                f'-o@capnp_cpp_plugin_path@:' +  '@OUTDIR@',
+                '@INPUT@'],
+      input: test_capnp_file,
+      output: ['@BASENAME@.capnp.c++', '@BASENAME@.capnp.h'])
+  endforeach
+
+  test_dependencies =  [capnp_dep,
+                        kj_test_dep,
+                        kj_dep,
+                        capnp_json_dep,
+                        capnp_rpc_dep,
+                        capnp_websocket_dep,
+                        capnp_dep,
+                        capnpc_dep,
+                        kj_http_dep,
+                        kj_async_dep,
+                        kj_test_dep, kj_dep]
+
+  capnp_tests = executable(
+    'capnp-tests',
+    sources: ['common-test.c++',
+     'blob-test.c++',
+     'endian-test.c++',
+     'endian-fallback-test.c++',
+     'layout-test.c++',
+     'any-test.c++',
+     'message-test.c++',
+     'encoding-test.c++',
+     'orphan-test.c++',
+     'serialize-test.c++',
+     'serialize-packed-test.c++',
+     'canonicalize-test.c++',
+     'fuzz-test.c++',
+     'test-util.c++',
+     test_capnp_cpp_h_files],
+    dependencies: test_dependencies)
+
+  test('capnp-tests-run', capnp_tests)
+
+
+  capnp_heavy_tests = executable('capnp-heavy-tests',
+    sources: [
+      'endian-reverse-test.c++',
+     'capability-test.c++',
+     'membrane-test.c++',
+     'schema-test.c++',
+     'schema-loader-test.c++',
+     'schema-parser-test.c++',
+     'dynamic-test.c++',
+     'stringify-test.c++',
+     'serialize-async-test.c++',
+     'serialize-text-test.c++',
+     'rpc-test.c++',
+     'rpc-twoparty-test.c++',
+     'ez-rpc-test.c++',
+     'compiler/lexer-test.c++',
+     'compiler/type-id-test.c++',
+     'test-util.c++',
+     'compat/json-test.c++',
+     'compat/websocket-rpc-test.c++',
+     test_capnp_cpp_h_files],
+    include_directories: [],
+    dependencies: test_dependencies,
+    cpp_args: meson.get_compiler('cpp').get_supported_arguments('-Wno-deprecated-declarations'))
+
+   test('capnp-heavy-tests-run',
+        capnp_heavy_tests)
+  capnp_evolution_tests = executable('capnp-evolution-tests',
+                                     sources: 'compiler/evolution-test.c++',
+                                     dependencies: [capnpc_dep, capnp_dep, kj_dep])
+
+  test('capnp-evolution-tests-run',
+       capnp_evolution_tests)
+endif
+
+if meson.is_cross_build()
+  meson_prog = find_program('meson')
+  meson.add_install_script(meson_prog, 'setup','-D_meson_nested_invocation=true',
+                           '-Dprefix=@0@'.format(get_option('prefix')),
+                           '-Dbuild_testing=false', meson.project_source_root(), 'build-compilers')
+  meson.add_install_script(meson_prog, 'compile', '-C', '@0@/build-compilers'.format(meson.project_build_root()))
+  meson.add_install_script(meson_prog, 'install', '-C', '@0@/build-compilers'.format(meson.project_build_root()))
+endif

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -1051,7 +1051,7 @@ bool UnixEventPort::poll() {
         sigprocmask(SIG_SETMASK, &waitMask, &origMask);
         sigprocmask(SIG_SETMASK, &origMask, nullptr);
         break;
-#else
+#elif !defined(__EMSCRIPTEN__)
         sigsuspend(&waitMask);
         KJ_FAIL_ASSERT("sigsuspend() shouldn't return because the signal handler should "
                       "have siglongjmp()ed.");

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -388,18 +388,18 @@ public:
     // A fallocate() wrapper was only added to Android's Bionic C library as of API level 21,
     // but FALLOC_FL_PUNCH_HOLE is apparently defined in the headers before that, so we'll
     // have to explicitly test for that case.
-#if defined(FALLOC_FL_PUNCH_HOLE) && !(__ANDROID__ && __BIONIC__ && __ANDROID_API__ < 21)
-    KJ_SYSCALL_HANDLE_ERRORS(
-        fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, size)) {
-      case EOPNOTSUPP:
-        // fall back to below
-        break;
-      default:
-        KJ_FAIL_SYSCALL("fallocate(FALLOC_FL_PUNCH_HOLE)", error) { return; }
-    } else {
-      return;
-    }
-#endif
+// #if defined(FALLOC_FL_PUNCH_HOLE) && !(__ANDROID__ && __BIONIC__ && __ANDROID_API__ < 21)
+//     KJ_SYSCALL_HANDLE_ERRORS(
+//         fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, size)) {
+//       case EOPNOTSUPP:
+//         // fall back to below
+//         break;
+//         default:
+//         KJ_FAIL_SYSCALL("fallocate(FALLOC_FL_PUNCH_HOLE)", error) { return; }
+//     } else {
+//       return;
+//     }
+// #endif
 
     static const byte ZEROS[4096] = { 0 };
 

--- a/c++/src/kj/meson.build
+++ b/c++/src/kj/meson.build
@@ -1,0 +1,332 @@
+kj_sources_lite = [
+  'array.c++',
+  'list.c++',
+  'common.c++',
+  'debug.c++',
+  'exception.c++',
+  'io.c++',
+  'memory.c++',
+  'mutex.c++',
+  'string.c++',
+  'source-location.c++',
+  'hash.c++',
+  'table.c++',
+  'thread.c++',
+  'main.c++',
+  'arena.c++',
+  'test-helpers.c++',
+  'units.c++',
+  'encoding.c++']
+
+kj_sources_heavy = [
+  'refcount.c++',
+  'string-tree.c++',
+  'time.c++',
+  'filesystem.c++',
+  'filesystem-disk-unix.c++',
+  'filesystem-disk-win32.c++',
+  'parse/char.c++']
+
+kj_sources = kj_sources_heavy + kj_sources_lite
+
+kj_headers = [
+  'common.h',
+  'units.h',
+  'memory.h',
+  'refcount.h',
+  'array.h',
+  'list.h',
+  'vector.h',
+  'string.h',
+  'string-tree.h',
+  'source-location.h',
+  'hash.h',
+  'table.h',
+  'map.h',
+  'encoding.h',
+  'exception.h',
+  'debug.h',
+  'arena.h',
+  'io.h',
+  'tuple.h',
+  'one-of.h',
+  'function.h',
+  'mutex.h',
+  'thread.h',
+  'threadlocal.h',
+  'filesystem.h',
+  'time.h',
+  'main.h',
+  'win32-api-version.h',
+  'windows-sanity.h']
+
+
+
+kj_parse_headers = ['parse/common.h',
+                    'parse/char.h']
+
+kj_std_headers = ['std/iostream.h']
+
+install_lib = not get_option('_meson_nested_invocation')
+
+kj_lib = library('kj', kj_sources,
+                 dependencies: [threads_dep],
+                 implicit_include_directories: false,
+                 install: install_lib)
+
+build_machine_kj_lib = kj_lib
+if meson.is_cross_build()
+  build_machine_kj_lib = library('bm_kj', kj_sources,
+          dependencies: [threads_dep],
+          implicit_include_directories: false,
+          native: true)
+endif
+
+
+kj_dep = declare_dependency(link_with: [kj_lib],
+                            dependencies: [threads_dep],
+                            include_directories: '..')
+
+build_machine_kj_dep = kj_dep
+if meson.is_cross_build()
+  build_machine_kj_dep = declare_dependency(
+    link_with: [build_machine_kj_lib],
+    dependencies: [build_machine_threads_dep],
+    include_directories: '..')
+endif
+
+
+kj_async_sources = ['async.c++',
+  'async-unix.c++',
+  'async-win32.c++',
+  'async-io-win32.c++',
+  'async-io.c++',
+  'async-io-unix.c++',
+  'timer.c++']
+
+kj_async_headers = [
+  'async-prelude.h',
+  'async.h',
+  'async-inl.h',
+  'async-unix.h',
+  'async-win32.h',
+  'async-io.h',
+  'async-queue.h',
+  'timer.h']
+
+
+async_compile_args = []
+if with_fibers.allowed()
+  async_compile_args += '-DKJ_USE_FIBERS'
+else
+  async_compile_args += '-DKJ_USE_FIBERS=0'
+endif
+
+
+kj_async_lib = library('kj-async', kj_async_sources,
+                       cpp_args: async_compile_args,
+                       dependencies: [kj_dep,
+                                      libucontext_dep],
+                       implicit_include_directories: false,
+                       install: install_lib)
+
+build_machine_kj_async_lib = kj_async_lib
+if meson.is_cross_build()
+  build_machine_kj_async_lib = library('bm_kj-async', kj_async_sources,
+          cpp_args: async_compile_args,
+          dependencies: [build_machine_kj_dep,
+                         build_machine_libucontext_dep],
+          implicit_include_directories: false,
+          native: true)
+endif
+
+
+ws2_32_dep = dependency('ws2_32', required: false)
+kj_async_dep = declare_dependency(link_with: kj_async_lib,
+                                  include_directories: '..',
+                                  dependencies: [libucontext_dep,
+                                                 threads_dep,
+                                                 ws2_32_dep])
+
+build_machine_kj_async_dep = kj_async_dep
+if meson.is_cross_build()
+  build_machine_kj_async_dep = declare_dependency(link_with: build_machine_kj_async_lib,
+                                  include_directories: '..',
+                                  dependencies: [build_machine_libucontext_dep,
+                                                 build_machine_threads_dep,
+                                                 ws2_32_dep])
+endif
+
+kj_http_sources = ['compat/url.c++',
+  'compat/http.c++']
+
+kj_http_headers = [
+  'compat/url.h',
+  'compat/http.h']
+
+kj_http_lib = library('kj-http', kj_http_sources,
+                      dependencies: [kj_async_dep, kj_dep],
+                      implicit_include_directories: false,
+                      install: install_lib)
+if meson.is_cross_build()
+  build_machine_kj_http_lib = library(
+    'bm_kj-http', kj_http_sources,
+    dependencies: [build_machine_kj_async_dep, build_machine_kj_dep],
+    implicit_include_directories: false,
+    native: meson.is_cross_build())
+endif
+
+kj_http_dep = declare_dependency(link_with: kj_http_lib,
+                                include_directories: '..',
+                                dependencies: [kj_async_dep, kj_dep])
+
+build_machine_kj_http_dep = kj_http_dep
+if meson.is_cross_build()
+  build_machine_kj_http_dep = declare_dependency(
+    link_with: build_machine_kj_http_lib,
+    include_directories: '..',
+    dependencies: [build_machine_kj_async_dep,
+                   build_machine_kj_dep])
+endif
+
+
+kj_tls_sources = ['compat/readiness-io.c++',
+                  'compat/tls.c++']
+
+kj_tls_headers = ['compat/readiness-io.h',
+                  'compat/tls.h']
+
+
+openssl_dep = dependency('openssl',
+                         required: get_option('with_openssl'),
+                         disabler: true)
+
+
+tls_compile_args = openssl_dep.found() ? ['-DKJ_HAS_OPENSSL'] : []
+kj_tls_lib = library('kj-tls', kj_tls_sources,
+                     cpp_args: tls_compile_args,
+                     dependencies: [kj_async_dep, kj_dep, openssl_dep],
+                     implicit_include_directories: false,
+                     install: install_lib)
+
+
+kj_tls_dep = declare_dependency(link_with: kj_tls_lib,
+                                include_directories: '..',
+                                dependencies: [kj_async_dep])
+
+kj_gzip_sources = 'compat/gzip.c++'
+kj_gzip_headers = 'compat/gzip.h'
+
+zlib_dep = dependency('zlib',
+                      required: get_option('with_zlib'),
+                      native: false,
+                      disabler: true)
+
+gzip_compile_args = zlib_dep.found() ? ['-DKJ_HAS_ZLIB=1'] : []
+kj_gzip_lib = library('kj-gzip', kj_gzip_sources,
+                      cpp_args: gzip_compile_args,
+                      dependencies: [kj_dep, kj_async_dep, zlib_dep],
+                      implicit_include_directories: false,
+                      install: install_lib)
+
+
+kj_gzip_dep = declare_dependency(link_with: kj_gzip_lib,
+                                 include_directories: '..',
+                                 dependencies: [kj_async_dep,
+                                                kj_dep,
+                                                zlib_dep])
+kj_test_sources = 'test.c++'
+kj_test_headers = 'test.h'
+
+
+kj_test_compat_headers = 'compat/gtest.h'
+
+kj_test_lib = library('kj-test', kj_test_sources,
+                      dependencies: kj_dep,
+                      include_directories: '..',
+                      implicit_include_directories: false,
+                      install: install_lib)
+
+kj_test_dep = declare_dependency(link_with: kj_test_lib,
+                                 dependencies: kj_dep)
+
+if install_lib
+  install_headers(kj_headers +
+                kj_std_headers +
+                kj_parse_headers +
+                kj_async_headers +
+                kj_http_headers +
+                kj_tls_headers +
+                kj_gzip_headers +
+                kj_test_headers,
+                subdir: 'kj',
+                preserve_path: true)
+endif
+
+if get_option('build_testing')
+  kj_tests = executable('kj-tests',
+           ['common-test.c++',
+            'memory-test.c++',
+            'array-test.c++',
+            'list-test.c++',
+            'string-test.c++',
+            'table-test.c++',
+            'map-test.c++',
+            'exception-test.c++',
+            'debug-test.c++',
+            'io-test.c++',
+            'mutex-test.c++',
+            'time-test.c++',
+            'threadlocal-test.c++',
+            'test-test.c++',
+            'std/iostream-test.c++'],
+           dependencies: [kj_test_dep, kj_dep],
+           implicit_include_directories: false)
+
+  test('kj-tests-run', kj_tests)
+
+  extra_tests = []
+  if openssl_dep.found()
+    extra_tests += 'compat/tls-test.c++'
+  endif
+  if host_machine.system() != 'emscripten' and host_machine.system() != 'windows'
+    extra_tests += 'async-unix-test.c++'
+  endif
+  kj_heavy_tests = executable('kj-heavy-tests',
+      ['async-test.c++',
+      'async-xthread-test.c++',
+      'async-coroutine-test.c++',
+      'async-unix-xthread-test.c++',
+      'async-win32-test.c++',
+      'async-win32-xthread-test.c++',
+      'async-io-test.c++',
+      'async-queue-test.c++',
+      'refcount-test.c++',
+      'string-tree-test.c++',
+      'encoding-test.c++',
+      'arena-test.c++',
+      'units-test.c++',
+      'tuple-test.c++',
+      'one-of-test.c++',
+      'function-test.c++',
+      'filesystem-test.c++',
+      'filesystem-disk-test.c++',
+      'parse/common-test.c++',
+      'parse/char-test.c++',
+      'compat/url-test.c++',
+      'compat/http-test.c++',
+      'compat/gzip-test.c++',
+      extra_tests],
+      dependencies: [kj_http_dep,
+                     kj_gzip_dep,
+                     kj_tls_dep,
+                     kj_async_dep,
+                     kj_test_dep,
+                     openssl_dep,
+                     kj_dep],
+      cpp_args: openssl_dep.found()
+                ? '-DKJ_HAS_OPENSSL' : '',
+      implicit_include_directories: false)
+
+      test('kj-heavy-tests-run', kj_heavy_tests)
+endif

--- a/c++/src/meson.build
+++ b/c++/src/meson.build
@@ -1,0 +1,2 @@
+subdir('kj')
+subdir('capnp')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,8 @@
+project('Capnp\'n Proto', 'cpp',
+       meson_version: '>=1.1',
+       version: '0.10.3',
+       default_options: ['warning_level=3', 'cpp_std=gnu++14',
+                         'build.cpp_std=gnu++14',
+                         'default_library=static'])
+
+subdir('c++')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,20 @@
+option('external_capnp', type: 'boolean',
+       value: false,
+       description: 'Use the system capnp binary.')
+
+option('capnp_program', type: 'string', value: '',
+      description: 'Use this capnp program IF external_capnp is set to true')
+
+option('with_openssl', type: 'feature', value: 'auto',
+       description: '"Whether or not to build libkj-tls by linking against openssl')
+
+option('with_zlib', type: 'feature', value: 'auto',
+       description: '"Whether or not to build libkj-gzip by linking against zlib')
+
+option('with_fibers', type: 'feature', value: 'auto',
+      description: 'Whether or not to build libkj-async with fibers')
+
+option('build_testing', type: 'boolean', value: false,
+       description: 'Build tests')
+
+option('_meson_nested_invocation', type: 'boolean', value: false)

--- a/meson/cross/emscripten.ini
+++ b/meson/cross/emscripten.ini
@@ -1,0 +1,24 @@
+[built-in options]
+c_args = ['-pthread', '-fexceptions']
+c_link_args = ['-pthread', '-sEXPORT_ALL=1', '-s', 'SHARED_MEMORY=1', '-s', 'PTHREAD_POOL_SIZE=4', '-fexceptions']
+cpp_args = ['-pthread', '-fexceptions']
+cpp_link_args = ['-pthread', '-fexceptions', '-sEXPORT_ALL=1', '-s', 'SHARED_MEMORY=1', '-s', 'PTHREAD_POOL_SIZE=4']
+
+[binaries]
+c = emscripten_prefix + 'emcc'
+cpp = emscripten_prefix + 'em++'
+c_ld = wasm_bin_prefix + 'wasm-ld'
+cpp_ld = wasm_bin_prefix + 'wasm-ld'
+ar = emscripten_prefix + 'emar'
+pkgconfig = '/usr/local/bin/pkg-config'
+exe_wrapper = 'node'
+
+# Set here your pkg_config_path pointing to emscripten-compiled dependencies for host machine
+# pkg_config_path =
+
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'x86'
+cpu = 'x86'
+endian = 'little'

--- a/meson/cross/wasm.ini
+++ b/meson/cross/wasm.ini
@@ -1,0 +1,22 @@
+[constants]
+emsdk_prefix = '/Users/germandiago/emsdk/upstream/emscripten/'
+
+[built-in options]
+c_link_args = ['-sEXPORT_ALL=1']
+cpp_link_args = ['-sEXPORT_ALL=1']
+pkg_config_path = '/Users/germandiago/git/guinyote-project/build-emscripten/conan-meson'
+build.pkg_config_path = '/Users/germandiago/git/guinyote-project/build-all/conan-meson'
+
+
+[binaries]
+c = emsdk_prefix + 'emcc'
+cpp = emsdk_prefix + 'em++'
+ar = emsdk_prefix + 'emar'
+pkgconfig = '/usr/local/bin/pkg-config'
+exe_wrapper = 'node'
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'x86'
+cpu = 'x86'
+endian = 'little'


### PR DESCRIPTION
This PR adds emscripten support against version 0.10.3 of capnproto.

It has two commits, one with meson + emscripten support since it is what I have been working on and another with the C++-only changes.

Feel free to try it and especially to run the tests. Some tests still fail: some time-related tests and Capability/Basic (could be due to some missing emscripten flag when compiling since heap stuff is different and so on)  tests are failing. Many other tests pass.

I will try the library in the context of my game to see if failed tests are really relevant in my context. I expect to need more work to iron out a few details.

If a successful emscripten port can be added, I will port the build system to CMake. 

Meson support is not proposed, though you can read the commit to see what it does right.

## How to try this branch

If you do not have meson installed, assuming you have python, you can do:

```
python3 -m pip install meson
```


After meson ins installed, follow these instruction to test:


    1. use ./bootstrap-emscripten.sh. This will download the sdk and activate it and create a emscripten_constants.ini file in your meson/cross directory to point to your toolchain correctly.
   2. issue this command: meson setup -Dwith_openssl=disabled -Dwith_fibers=disabled -Dwith_zlib=disabled -Dbuild_testing=true --cross-file meson/cross/emscripten_constants.ini --cross-file meson/cross/emscripten.ini build-emscripten


You can run the tests by issuing from project root:

```
meson test -C build-emscripten --verbose
```


