### PR TITLE
Allow directory `openFile()` on Windows

### DIFF
--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -449,6 +449,12 @@ KJ_TEST("DiskDirectory") {
     auto stats = dir->lstat(Path("bar"));
     KJ_EXPECT(stats.type == FsNode::Type::DIRECTORY);
   }
+  
+  {
+    auto subdir = dir->openFile(Path("bar"));
+    auto stats = subdir->stat();
+    KJ_EXPECT(stats.type == FsNode::Type::DIRECTORY);
+  }
 
   {
     auto list = dir->listNames();

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -667,7 +667,7 @@ public:
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         NULL,
         OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL,
+        FILE_FLAG_BACKUP_SEMANTICS,  // required if path is a directory
         NULL)) {
       case ERROR_FILE_NOT_FOUND:
       case ERROR_PATH_NOT_FOUND:


### PR DESCRIPTION
Hey! 👋 This PR adds support for opening directories using `openFile()`. This is used by `workerd` to support directory listing in disk directory services: https://github.com/cloudflare/workerd/blob/cae438f99d3e070e5530dbf42f338ee3392e68ae/src/workerd/server/server.c%2B%2B#L796-L802. Without this change, you'll get an error that looks like `kj/filesystem-disk-win32.c++:676: failed: CreateFile(path, OPEN_EXISTING): #5 Access is denied.`.