### PR TITLE
Replace KJ_STACK_ARRAY with kj::SboArray and kj::SboArrayBuilder

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -302,7 +302,7 @@ void JsonCodec::encode(DynamicValue::Reader input, Type type, JsonValue::Builder
       auto structValue = input.as<capnp::DynamicStruct>();
       auto nonUnionFields = structValue.getSchema().getNonUnionFields();
 
-      KJ_STACK_ARRAY(bool, hasField, nonUnionFields.size(), 32, 128);
+      kj::SmallArray<bool, 32> hasField(nonUnionFields.size());
 
       uint fieldCount = 0;
       for (auto i: kj::indices(nonUnionFields)) {

--- a/c++/src/capnp/compiler/evolution-test.c++
+++ b/c++/src/capnp/compiler/evolution-test.c++
@@ -283,7 +283,7 @@ static ChangeInfo structPermuteFields(
   auto oldOrphan = decl.disownNestedDecls();
   auto old = oldOrphan.get();
 
-  KJ_STACK_ARRAY(uint, mapping, old.size(), 16, 64);
+  kj::SmallArray<uint, 16> mapping(old.size());
 
   for (uint i = 0; i < mapping.size(); i++) {
     mapping[i] = i;

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -185,7 +185,7 @@ InputStreamMessageReader::InputStreamMessageReader(
   }
 
   // Read sizes for all segments except the first.  Include padding if necessary.
-  KJ_STACK_ARRAY(_::WireValue<uint32_t>, moreSizes, segmentCount & ~1, 16, 64);
+  kj::SmallArray<_::WireValue<uint32_t>, 16> moreSizes(segmentCount & ~1);
   if (segmentCount > 1) {
     inputStream.read(moreSizes.begin(), moreSizes.size() * sizeof(moreSizes[0]));
     for (uint i = 0; i < segmentCount - 1; i++) {
@@ -276,7 +276,7 @@ void readMessageCopy(kj::InputStream& input, MessageBuilder& target,
 void writeMessage(kj::OutputStream& output, kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) {
   KJ_REQUIRE(segments.size() > 0, "Tried to serialize uninitialized message.");
 
-  KJ_STACK_ARRAY(_::WireValue<uint32_t>, table, (segments.size() + 2) & ~size_t(1), 16, 64);
+  kj::SmallArray<_::WireValue<uint32_t>, 16> table((segments.size() + 2) & ~size_t(1));
 
   // We write the segment count - 1 because this makes the first word zero for single-segment
   // messages, improving compression.  We don't bother doing this with segment sizes because
@@ -290,7 +290,7 @@ void writeMessage(kj::OutputStream& output, kj::ArrayPtr<const kj::ArrayPtr<cons
     table[segments.size() + 1].set(0);
   }
 
-  KJ_STACK_ARRAY(kj::ArrayPtr<const byte>, pieces, segments.size() + 1, 4, 32);
+  kj::SmallArray<kj::ArrayPtr<const byte>, 4> pieces(segments.size() + 1);
   pieces[0] = table.asBytes();
 
   for (uint i = 0; i < segments.size(); i++) {

--- a/c++/src/capnp/stringify.c++
+++ b/c++/src/capnp/stringify.c++
@@ -57,7 +57,7 @@ public:
     if (amount == 0 || canPrintAllInline(items, kind)) {
       return kj::StringTree(kj::mv(items), ", ");
     } else {
-      KJ_STACK_ARRAY(char, delimArrayPtr, amount * 2 + 3, 32, 256);
+      kj::SmallArray<char, 32> delimArrayPtr(amount * 2 + 3);
       auto delim = delimArrayPtr.begin();
       delim[0] = ',';
       delim[1] = '\n';

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -223,21 +223,19 @@ TEST(Array, ThrowingDestructor) {
   EXPECT_EQ(0, TestObject::count);
 }
 
-// TODO(now): Array's destructor is noexcept; the previous test passes because it uses nullptr
-//   assignment, but I'm not sure that makes sense to implement for SmallArray.
-// TEST(SmallArray, ThrowingDestructor) {
-//   TestObject::count = 0;
-//   TestObject::throwAt = -1;
+TEST(SmallArray, ThrowingDestructor) {
+  TestObject::count = 0;
+  TestObject::throwAt = -1;
 
-//   SpaceFor<SmallArray<TestObject, SBO_TEST_SIZE>> spaceForArray;
-//   auto array = spaceForArray.construct(SBO_TEST_SIZE);
-//   EXPECT_EQ(SBO_TEST_SIZE, TestObject::count);
+  SpaceFor<SmallArray<TestObject, SBO_TEST_SIZE>> spaceForArray;
+  auto array = spaceForArray.construct(SBO_TEST_SIZE);
+  EXPECT_EQ(SBO_TEST_SIZE, TestObject::count);
 
-//   // If a destructor throws, all elements should still be destroyed.
-//   TestObject::throwAt = 16;
-//   EXPECT_ANY_THROW(array = nullptr);
-//   EXPECT_EQ(0, TestObject::count);
-// }
+  // If a destructor throws, all elements should still be destroyed.
+  TestObject::throwAt = 16;
+  EXPECT_ANY_THROW(array = nullptr);
+  EXPECT_EQ(0, TestObject::count);
+}
 
 TEST(Array, ArrayBuilder) {
   TestObject::count = 0;

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -111,6 +111,39 @@ TEST(Array, TrivialConstructor) {
   }
 }
 
+// SmallArray and SmallArrayBuilder tests largely mirror the regular Array and ArrayBuilder tests, with
+// some minor modifications as required. Several of the SmallArray and SmallArrayBuilder tests have
+// ...OverLimit varieties, which test the SmallArray when it falls back to heapArray(). These are only
+// a few, since heapArray() is already well-tested by itself.
+
+constexpr auto SBO_TEST_SIZE = 32;
+
+TEST(SmallArray, TrivialConstructor) {
+  {
+    SmallArray<char, SBO_TEST_SIZE> chars(SBO_TEST_SIZE);
+    chars[0] = 12;
+    chars[1] = 34;
+  }
+
+  {
+    SmallArray<char, SBO_TEST_SIZE> chars(SBO_TEST_SIZE);
+    // TODO(test): See TEST(Array, TrivialConstructor) for why this ends abruptly.
+  }
+}
+
+TEST(SmallArray, TrivialConstructorOverLimit) {
+  {
+    SmallArray<char, SBO_TEST_SIZE> chars(SBO_TEST_SIZE * 2);
+    chars[0] = 12;
+    chars[1] = 34;
+  }
+
+  {
+    SmallArray<char, SBO_TEST_SIZE> chars(SBO_TEST_SIZE * 2);
+    // TODO(test): See TEST(Array, TrivialConstructor) for why this ends abruptly.
+  }
+}
+
 TEST(Array, ComplexConstructor) {
   TestObject::count = 0;
   TestObject::throwAt = -1;
@@ -122,12 +155,58 @@ TEST(Array, ComplexConstructor) {
   EXPECT_EQ(0, TestObject::count);
 }
 
+TEST(SmallArray, ComplexConstructor) {
+  TestObject::count = 0;
+  TestObject::throwAt = -1;
+
+  {
+    SmallArray<TestObject, SBO_TEST_SIZE> array(SBO_TEST_SIZE);
+    EXPECT_EQ(SBO_TEST_SIZE, TestObject::count);
+  }
+  EXPECT_EQ(0, TestObject::count);
+}
+
+TEST(SmallArray, ComplexConstructorOverLimit) {
+  TestObject::count = 0;
+  TestObject::throwAt = -1;
+
+  {
+    SmallArray<TestObject, SBO_TEST_SIZE> array(SBO_TEST_SIZE * 2);
+    EXPECT_EQ(SBO_TEST_SIZE * 2, TestObject::count);
+  }
+  EXPECT_EQ(0, TestObject::count);
+}
+
 TEST(Array, ThrowingConstructor) {
   TestObject::count = 0;
   TestObject::throwAt = 16;
 
   // If a constructor throws, the previous elements should still be destroyed.
   EXPECT_ANY_THROW(heapArray<TestObject>(32));
+  EXPECT_EQ(0, TestObject::count);
+}
+
+TEST(SmallArray, ThrowingConstructor) {
+  TestObject::count = 0;
+  TestObject::throwAt = 16;
+
+  // If a constructor throws, the previous elements should still be destroyed.
+  constexpr auto smallArray = []() {
+    SmallArray<TestObject, SBO_TEST_SIZE> arr(SBO_TEST_SIZE);
+  };
+  EXPECT_ANY_THROW(smallArray());
+  EXPECT_EQ(0, TestObject::count);
+}
+
+TEST(SmallArray, ThrowingConstructorOverLimit) {
+  TestObject::count = 0;
+  TestObject::throwAt = 16;
+
+  // If a constructor throws, the previous elements should still be destroyed.
+  constexpr auto smallArray = []() {
+    SmallArray<TestObject, SBO_TEST_SIZE> arr(SBO_TEST_SIZE * 2);
+  };
+  EXPECT_ANY_THROW(smallArray());
   EXPECT_EQ(0, TestObject::count);
 }
 
@@ -144,7 +223,23 @@ TEST(Array, ThrowingDestructor) {
   EXPECT_EQ(0, TestObject::count);
 }
 
-TEST(Array, AraryBuilder) {
+// TODO(now): Array's destructor is noexcept; the previous test passes because it uses nullptr
+//   assignment, but I'm not sure that makes sense to implement for SmallArray.
+// TEST(SmallArray, ThrowingDestructor) {
+//   TestObject::count = 0;
+//   TestObject::throwAt = -1;
+
+//   SpaceFor<SmallArray<TestObject, SBO_TEST_SIZE>> spaceForArray;
+//   auto array = spaceForArray.construct(SBO_TEST_SIZE);
+//   EXPECT_EQ(SBO_TEST_SIZE, TestObject::count);
+
+//   // If a destructor throws, all elements should still be destroyed.
+//   TestObject::throwAt = 16;
+//   EXPECT_ANY_THROW(array = nullptr);
+//   EXPECT_EQ(0, TestObject::count);
+// }
+
+TEST(Array, ArrayBuilder) {
   TestObject::count = 0;
   TestObject::throwAt = -1;
 
@@ -168,7 +263,43 @@ TEST(Array, AraryBuilder) {
   EXPECT_EQ(0, TestObject::count);
 }
 
-TEST(Array, AraryBuilderAddAll) {
+TEST(SmallArray, SmallArrayBuilder) {
+  TestObject::count = 0;
+  TestObject::throwAt = -1;
+
+  {
+    SmallArrayBuilder<TestObject, SBO_TEST_SIZE> builder(SBO_TEST_SIZE);
+
+    for (int i = 0; i < SBO_TEST_SIZE; i++) {
+      EXPECT_EQ(i, TestObject::count);
+      builder.add();
+    }
+
+    EXPECT_EQ(SBO_TEST_SIZE, TestObject::count);
+  }
+
+  EXPECT_EQ(0, TestObject::count);
+}
+
+TEST(SmallArray, SmallArrayBuilderOverLimit) {
+  TestObject::count = 0;
+  TestObject::throwAt = -1;
+
+  {
+    SmallArrayBuilder<TestObject, SBO_TEST_SIZE> builder(SBO_TEST_SIZE * 2);
+
+    for (int i = 0; i < SBO_TEST_SIZE * 2; i++) {
+      EXPECT_EQ(i, TestObject::count);
+      builder.add();
+    }
+
+    EXPECT_EQ(SBO_TEST_SIZE * 2, TestObject::count);
+  }
+
+  EXPECT_EQ(0, TestObject::count);
+}
+
+TEST(Array, ArrayBuilderAddAll) {
   {
     // Trivial case.
     char text[] = "foo";
@@ -270,6 +401,122 @@ TEST(Array, AraryBuilderAddAll) {
     TestObject::throwAt = 1;
 
     ArrayBuilder<TestObject> builder = heapArrayBuilder<TestObject>(3);
+    EXPECT_EQ(3, TestObject::count);
+    EXPECT_EQ(0, TestObject::copiedCount);
+
+    EXPECT_ANY_THROW(builder.addAll(objs, objs + 3));
+    TestObject::throwAt = -1;
+
+    EXPECT_EQ(3, TestObject::count);
+    EXPECT_EQ(0, TestObject::copiedCount);
+  }
+  EXPECT_EQ(0, TestObject::count);
+  EXPECT_EQ(0, TestObject::copiedCount);
+}
+
+TEST(SmallArray, SmallArrayBuilderAddAll) {
+  {
+    // Trivial case.
+    char text[] = "foo";
+    static_assert(5 <= SBO_TEST_SIZE);
+    SmallArrayBuilder<char, SBO_TEST_SIZE> builder(5);
+    builder.add('<');
+    builder.addAll(text, text + 3);
+    builder.add('>');
+    auto arrayPtr = builder.asPtr();
+    EXPECT_EQ("<foo>", std::string(arrayPtr.begin(), arrayPtr.end()));
+  }
+
+  {
+    // Trivial case, const.
+    const char* text = "foo";
+    static_assert(5 <= SBO_TEST_SIZE);
+    SmallArrayBuilder<char, SBO_TEST_SIZE> builder(5);
+    builder.add('<');
+    builder.addAll(text, text + 3);
+    builder.add('>');
+    auto arrayPtr = builder.asPtr();
+    EXPECT_EQ("<foo>", std::string(arrayPtr.begin(), arrayPtr.end()));
+  }
+
+  {
+    // Trivial case, non-pointer iterator.
+    std::list<char> text = {'f', 'o', 'o'};
+    static_assert(5 <= SBO_TEST_SIZE);
+    SmallArrayBuilder<char, SBO_TEST_SIZE> builder(5);
+    builder.add('<');
+    builder.addAll(text);
+    builder.add('>');
+    auto arrayPtr = builder.asPtr();
+    EXPECT_EQ("<foo>", std::string(arrayPtr.begin(), arrayPtr.end()));
+  }
+
+  {
+    // Complex case.
+    std::string strs[] = {"foo", "bar", "baz"};
+    static_assert(5 <= SBO_TEST_SIZE);
+    SmallArrayBuilder<std::string, SBO_TEST_SIZE> builder(5);
+    builder.add("qux");
+    builder.addAll(strs, strs + 3);
+    builder.add("quux");
+    auto arrayPtr = builder.asPtr();
+    EXPECT_EQ("qux", arrayPtr[0]);
+    EXPECT_EQ("foo", arrayPtr[1]);
+    EXPECT_EQ("bar", arrayPtr[2]);
+    EXPECT_EQ("baz", arrayPtr[3]);
+    EXPECT_EQ("quux", arrayPtr[4]);
+  }
+
+  {
+    // Complex case, noexcept.
+    TestNoexceptObject::count = 0;
+    TestNoexceptObject::copiedCount = 0;
+    TestNoexceptObject objs[3];
+    EXPECT_EQ(3, TestNoexceptObject::count);
+    EXPECT_EQ(0, TestNoexceptObject::copiedCount);
+    static_assert(3 <= SBO_TEST_SIZE);
+    SmallArrayBuilder<TestNoexceptObject, SBO_TEST_SIZE> builder(3);
+    EXPECT_EQ(3, TestNoexceptObject::count);
+    EXPECT_EQ(0, TestNoexceptObject::copiedCount);
+    builder.addAll(objs, objs + 3);
+    EXPECT_EQ(3, TestNoexceptObject::count);
+    EXPECT_EQ(3, TestNoexceptObject::copiedCount);
+  }
+  EXPECT_EQ(0, TestNoexceptObject::count);
+  EXPECT_EQ(0, TestNoexceptObject::copiedCount);
+
+  {
+    // Complex case, exceptions possible.
+    TestObject::count = 0;
+    TestObject::copiedCount = 0;
+    TestObject::throwAt = -1;
+    TestObject objs[3];
+    EXPECT_EQ(3, TestObject::count);
+    EXPECT_EQ(0, TestObject::copiedCount);
+    static_assert(3 <= SBO_TEST_SIZE);
+    SmallArrayBuilder<TestObject, SBO_TEST_SIZE> builder(3);
+    EXPECT_EQ(3, TestObject::count);
+    EXPECT_EQ(0, TestObject::copiedCount);
+    builder.addAll(objs, objs + 3);
+    EXPECT_EQ(3, TestObject::count);
+    EXPECT_EQ(3, TestObject::copiedCount);
+  }
+  EXPECT_EQ(0, TestObject::count);
+  EXPECT_EQ(0, TestObject::copiedCount);
+
+  {
+    // Complex case, exceptions occur.
+    TestObject::count = 0;
+    TestObject::copiedCount = 0;
+    TestObject::throwAt = -1;
+    TestObject objs[3];
+    EXPECT_EQ(3, TestObject::count);
+    EXPECT_EQ(0, TestObject::copiedCount);
+
+    TestObject::throwAt = 1;
+
+    static_assert(3 <= SBO_TEST_SIZE);
+    SmallArrayBuilder<TestObject, SBO_TEST_SIZE> builder(3);
     EXPECT_EQ(3, TestObject::count);
     EXPECT_EQ(0, TestObject::copiedCount);
 

--- a/c++/src/kj/array.c++
+++ b/c++/src/kj/array.c++
@@ -68,26 +68,36 @@ struct AutoDeleter {
   inline ~AutoDeleter() { operator delete(ptr); }
 };
 
-void* HeapArrayDisposer::allocateImpl(size_t elementSize, size_t elementCount, size_t capacity,
-                                      void (*constructElement)(void*),
-                                      void (*destroyElement)(void*)) {
-  AutoDeleter result(operator new(elementSize * capacity));
+namespace {
+
+void allocateImplImpl(void* firstElement, size_t elementSize, size_t elementCount,
+                       void (*constructElement)(void*),
+                       void (*destroyElement)(void*)) {
+  // Shared implementation between HeapArrayDisposer and SmallArrayDisposer.
 
   if (constructElement == nullptr) {
     // Nothing to do.
   } else if (destroyElement == nullptr) {
-    byte* pos = reinterpret_cast<byte*>(result.ptr);
+    byte* pos = reinterpret_cast<byte*>(firstElement);
     while (elementCount > 0) {
       constructElement(pos);
       pos += elementSize;
       --elementCount;
     }
   } else {
-    ExceptionSafeArrayUtil guard(result.ptr, elementSize, 0, destroyElement);
+    ExceptionSafeArrayUtil guard(firstElement, elementSize, 0, destroyElement);
     guard.construct(elementCount, constructElement);
     guard.release();
   }
+}
 
+}  // namespace
+
+void* HeapArrayDisposer::allocateImpl(size_t elementSize, size_t elementCount, size_t capacity,
+                                      void (*constructElement)(void*),
+                                      void (*destroyElement)(void*)) {
+  AutoDeleter result(operator new(elementSize * capacity));
+  allocateImplImpl(result.ptr, elementSize, elementCount, constructElement, destroyElement);
   return result.release();
 }
 

--- a/c++/src/kj/array.c++
+++ b/c++/src/kj/array.c++
@@ -115,5 +115,24 @@ void HeapArrayDisposer::disposeImpl(
 
 const HeapArrayDisposer HeapArrayDisposer::instance = HeapArrayDisposer();
 
+void* SmallArrayDisposer::allocateImpl(
+    void* firstElement, size_t elementSize, size_t elementCount, size_t capacity,
+    void (*constructElement)(void*),
+    void (*destroyElement)(void*)) {
+  allocateImplImpl(firstElement, elementSize, elementCount, constructElement, destroyElement);
+  return firstElement;
+}
+
+void SmallArrayDisposer::disposeImpl(
+    void* firstElement, size_t elementSize, size_t elementCount, size_t capacity,
+    void (*destroyElement)(void*)) const {
+  if (destroyElement != nullptr) {
+    ExceptionSafeArrayUtil guard(firstElement, elementSize, elementCount, destroyElement);
+    guard.destroyAll();
+  }
+}
+
+const SmallArrayDisposer SmallArrayDisposer::instance = SmallArrayDisposer();
+
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -144,7 +144,7 @@ public:
       : ptr(firstElement), size_(size), disposer(&disposer) {}
 
   KJ_DISALLOW_COPY(Array);
-  inline ~Array() noexcept { dispose(); }
+  inline ~Array() noexcept(false) { dispose(); }
 
   inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
     return ArrayPtr<T>(ptr, size_);
@@ -609,7 +609,6 @@ private:
 // 3. SmallArray/Builder have no specific constructor functions like `heapArray<T>()` or
 //    `heapArrayBuilder<T>()`. Instead, use their constructors directly, passing a single `size`
 //    parameter.
-
 
 template <typename T, size_t smallSize>
 class SmallArray final: private Array<T> {

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -285,9 +285,24 @@ private:
                    size_t capacity, void (*destroyElement)(void*)) const override;
 };
 
-  template <typename T, bool hasTrivialConstructor = KJ_HAS_TRIVIAL_CONSTRUCTOR(T),
-                        bool hasNothrowConstructor = KJ_HAS_NOTHROW_CONSTRUCTOR(T)>
-  struct Allocate_;
+class SmallArrayDisposer: public ArrayDisposer {
+public:
+  template <typename T>
+  static T* allocate(void* firstElement, size_t count);
+  template <typename T>
+  static T* allocateUninitialized(void* firstElement, size_t count);
+
+  static const SmallArrayDisposer instance;
+
+  static void* allocateImpl(void* firstElement, size_t elementSize, size_t elementCount,
+                     size_t capacity, void (*constructElement)(void*),
+                     void (*destroyElement)(void*));
+  // Allocates and constructs the array.  Both function pointers are null if the constructor is
+  // trivial, otherwise destroyElement is null if the constructor doesn't throw.
+
+private:
+  void disposeImpl(void* firstElement, size_t elementSize, size_t elementCount,
+                   size_t capacity, void (*destroyElement)(void*)) const override;
 };
 
 }  // namespace _ (private)
@@ -574,6 +589,103 @@ private:
 };
 
 // =======================================================================================
+// Small-buffer-optimized SmallArray and SmallArrayBuilder
+//
+// SmallArray and SmallArrayBuilder are useful when you need a temporary buffer, whose size you
+// cannot know until runtime but is likely to be small, and whose lifetime can be bounded by either
+// the stack or some immovable parent object.
+//
+// SmallArray and SmallArrayBuilder are not Arrays or ArrayBuilders. In particular, they have
+// following differences:
+//
+// 1. SmallArray/Builder have an inline buffer of `smallSize` elements, where `smallSize` is a
+//    size_t template parameter. If they are constructed with a size less than or equal to
+//    `smallSize`, the inline space is used, and no heap allocation is performed. Otherwise, a
+//    regular heap Array is allocated.
+//
+// 2. SmallArray/Builder are immovable. You must construct them in place wherever you want to use
+//    one. They cannot be "released", "finished", or assigned-to.
+//
+// 3. SmallArray/Builder have no specific constructor functions like `heapArray<T>()` or
+//    `heapArrayBuilder<T>()`. Instead, use their constructors directly, passing a single `size`
+//    parameter.
+
+
+template <typename T, size_t smallSize>
+class SmallArray final: private Array<T> {
+public:
+  explicit SmallArray(size_t size);
+
+  // We support the full Array<T> API except `releaseAsBytes()`, `releaseAsChars()`, `attach()`,
+  // `operator=()`, and move-construction.
+
+  KJ_DISALLOW_COPY_AND_MOVE(SmallArray);
+
+  using Array<T>::operator ArrayPtr<T>;
+  using Array<T>::operator ArrayPtr<const T>;
+  using Array<T>::asPtr;
+  using Array<T>::size;
+  using Array<T>::operator[];
+  using Array<T>::begin;
+  using Array<T>::end;
+  using Array<T>::front;
+  using Array<T>::back;
+  using Array<T>::operator==;
+  using Array<T>::slice;
+  using Array<T>::asBytes;
+  using Array<T>::asChars;
+
+  ~SmallArray() noexcept(false) {}
+  // We need an explicit destructor because we contain a union, and union member destructors are
+  // never implicitly invoked. However, there's actually nothing for this destructor to do: our
+  // private base class will deinitialize any objects in `space` using an SmallArrayDisposer.
+
+private:
+  union {
+    T space[smallSize];
+  };
+};
+
+template <typename T, size_t smallSize>
+class SmallArrayBuilder final: private ArrayBuilder<T> {
+public:
+  explicit SmallArrayBuilder(size_t size);
+
+  // We support the full ArrayBuilder<T> API except `finish()`, `operator=()`, and move-
+  // construction.
+
+  KJ_DISALLOW_COPY_AND_MOVE(SmallArrayBuilder);
+
+  using ArrayBuilder<T>::operator ArrayPtr<T>;
+  using ArrayBuilder<T>::operator ArrayPtr<const T>;
+  using ArrayBuilder<T>::asPtr;
+  using ArrayBuilder<T>::size;
+  using ArrayBuilder<T>::capacity;
+  using ArrayBuilder<T>::operator[];
+  using ArrayBuilder<T>::begin;
+  using ArrayBuilder<T>::end;
+  using ArrayBuilder<T>::front;
+  using ArrayBuilder<T>::back;
+  using ArrayBuilder<T>::add;
+  using ArrayBuilder<T>::addAll;
+  using ArrayBuilder<T>::removeLast;
+  using ArrayBuilder<T>::truncate;
+  using ArrayBuilder<T>::clear;
+  using ArrayBuilder<T>::resize;
+  using ArrayBuilder<T>::isFull;
+
+  ~SmallArrayBuilder() noexcept(false) {}
+  // We need an explicit destructor because we contain a union, and union member destructors are
+  // never implicitly invoked. However, there's actually nothing for this destructor to do: our
+  // private base class will deinitialize any objects in `space` using an SmallArrayDisposer.
+
+private:
+  union {
+    T space[smallSize];
+  };
+};
+
+// =======================================================================================
 // KJ_MAP
 
 #define KJ_MAP(elementName, array) \
@@ -649,6 +761,24 @@ void ArrayDisposer::dispose(T* firstElement, size_t elementCount, size_t capacit
   Dispose_<T>::dispose(firstElement, elementCount, capacity, *this);
 }
 
+template <typename T, size_t smallSize>
+SmallArray<T, smallSize>::SmallArray(size_t size)
+    : Array<T>(size <= smallSize
+        ? Array<T>(
+            _::SmallArrayDisposer::allocate<T>(space, size),
+            size,
+            _::SmallArrayDisposer::instance)
+        : heapArray<T>(size)) {}
+
+template <typename T, size_t smallSize>
+SmallArrayBuilder<T, smallSize>::SmallArrayBuilder(size_t size)
+    : ArrayBuilder<T>(size <= smallSize
+        ? ArrayBuilder<T>(
+            _::SmallArrayDisposer::allocateUninitialized<RemoveConst<T>>(space, size),
+            size,
+            _::SmallArrayDisposer::instance)
+        : heapArrayBuilder<T>(size)) {}
+
 namespace _ {  // private
 
 template <typename T, bool hasTrivialConstructor = KJ_HAS_TRIVIAL_CONSTRUCTOR(T),
@@ -697,6 +827,22 @@ T* HeapArrayDisposer::allocate(size_t count) {
 template <typename T>
 T* HeapArrayDisposer::allocateUninitialized(size_t count) {
   return Allocate_<T, true, true>::allocate(allocateImpl, 0, count);
+}
+
+template <typename T>
+T* SmallArrayDisposer::allocate(void* firstElement, size_t count) {
+  return Allocate_<T>::allocate([firstElement](auto&&... args) {
+    allocateImpl(firstElement, kj::fwd<decltype(args)>(args)...);
+    return firstElement;
+  }, count, count);
+}
+
+template <typename T>
+T* SmallArrayDisposer::allocateUninitialized(void* firstElement, size_t count) {
+  return Allocate_<T, true, true>::allocate([firstElement](auto&&... args) {
+    allocateImpl(firstElement, kj::fwd<decltype(args)>(args)...);
+    return firstElement;
+  }, 0, count);
 }
 
 template <typename Element, typename Iterator, bool move, bool = canMemcpy<Element>()>

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -624,7 +624,7 @@ private:
       // other platforms), so we want to allocate an array of words (we use void*). So... we use
       // CMSG_SPACE() and then additionally round up to deal with Mac.
       size_t msgWords = (msgBytes + sizeof(void*) - 1) / sizeof(void*);
-      KJ_STACK_ARRAY(void*, cmsgSpace, msgWords, 16, 256);
+      SmallArray<void*, 16> cmsgSpace(msgWords);
       auto cmsgBytes = cmsgSpace.asBytes();
       memset(cmsgBytes.begin(), 0, cmsgBytes.size());
       msg.msg_control = cmsgBytes.begin();
@@ -755,7 +755,7 @@ private:
     const size_t iovmax = kj::miniposix::iovMax();
     // If there are more than IOV_MAX pieces, we'll only write the first IOV_MAX for now, and
     // then we'll loop later.
-    KJ_STACK_ARRAY(struct iovec, iov, kj::min(1 + morePieces.size(), iovmax), 16, 128);
+    SmallArray<struct iovec, 16> iov(kj::min(1 + morePieces.size(), iovmax));
     size_t iovTotal = 0;
 
     // writev() interface is not const-correct.  :(
@@ -800,7 +800,7 @@ private:
       // other platforms), so we want to allocate an array of words (we use void*). So... we use
       // CMSG_SPACE() and then additionally round up to deal with Mac.
       size_t msgWords = (msgBytes + sizeof(void*) - 1) / sizeof(void*);
-      KJ_STACK_ARRAY(void*, cmsgSpace, msgWords, 16, 256);
+      SmallArray<void*, 16> cmsgSpace(msgWords);
       auto cmsgBytes = cmsgSpace.asBytes();
       memset(cmsgBytes.begin(), 0, cmsgBytes.size());
       msg.msg_control = cmsgBytes.begin();
@@ -1801,7 +1801,7 @@ Promise<size_t> DatagramPortImpl::send(
   msg.msg_namelen = addr.getRawSize();
 
   const size_t iovmax = kj::miniposix::iovMax();
-  KJ_STACK_ARRAY(struct iovec, iov, kj::min(pieces.size(), iovmax), 16, 64);
+  SmallArray<struct iovec, 16> iov(kj::min(pieces.size(), iovmax));
 
   for (size_t i: kj::indices(pieces)) {
     iov[i].iov_base = const_cast<void*>(implicitCast<const void*>(pieces[i].begin()));

--- a/c++/src/kj/cidr.c++
+++ b/c++/src/kj/cidr.c++
@@ -48,7 +48,7 @@ CidrRange::CidrRange(StringPtr pattern) {
 
   bitCount = pattern.slice(slashPos + 1).parseAs<uint>();
 
-  KJ_STACK_ARRAY(char, addr, slashPos + 1, 128, 128);
+  SmallArray<char, 128> addr(slashPos + 1);
   memcpy(addr.begin(), pattern.begin(), slashPos);
   addr[slashPos] = '\0';
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -372,32 +372,6 @@ KJ_NORETURN(void unreachable());
 #define KJ_FALLTHROUGH
 #endif
 
-// #define KJ_STACK_ARRAY(type, name, size, minStack, maxStack)
-//
-// Allocate an array, preferably on the stack, unless it is too big.  On GCC this will use
-// variable-sized arrays.  For other compilers we could just use a fixed-size array.  `minStack`
-// is the stack array size to use if variable-width arrays are not supported.  `maxStack` is the
-// maximum stack array size if variable-width arrays *are* supported.
-#if __GNUC__ && !__clang__
-#define KJ_STACK_ARRAY(type, name, size, minStack, maxStack) \
-  size_t name##_size = (size); \
-  bool name##_isOnStack = name##_size <= (maxStack); \
-  type name##_stack[kj::max(1, name##_isOnStack ? name##_size : 0)]; \
-  ::kj::Array<type> name##_heap = name##_isOnStack ? \
-      nullptr : kj::heapArray<type>(name##_size); \
-  ::kj::ArrayPtr<type> name = name##_isOnStack ? \
-      kj::arrayPtr(name##_stack, name##_size) : name##_heap
-#else
-#define KJ_STACK_ARRAY(type, name, size, minStack, maxStack) \
-  size_t name##_size = (size); \
-  bool name##_isOnStack = name##_size <= (minStack); \
-  type name##_stack[minStack]; \
-  ::kj::Array<type> name##_heap = name##_isOnStack ? \
-      nullptr : kj::heapArray<type>(name##_size); \
-  ::kj::ArrayPtr<type> name = name##_isOnStack ? \
-      kj::arrayPtr(name##_stack, name##_size) : name##_heap
-#endif
-
 #define KJ_CONCAT_(x, y) x##y
 #define KJ_CONCAT(x, y) KJ_CONCAT_(x, y)
 #define KJ_UNIQUE_NAME(prefix) KJ_CONCAT(prefix, __LINE__)

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -177,7 +177,7 @@ enum DescriptionStyle {
 static String makeDescriptionImpl(DescriptionStyle style, const char* code, int errorNumber,
                                   const char* sysErrorString, const char* macroArgs,
                                   ArrayPtr<String> argValues) {
-  KJ_STACK_ARRAY(ArrayPtr<const char>, argNames, argValues.size(), 8, 64);
+  SmallArray<ArrayPtr<const char>, 8> argNames(argValues.size());
 
   if (argValues.size() > 0) {
     size_t index = 0;

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -934,7 +934,7 @@ public:
     // No need to copy whatBuffer since it's just to hold the return value of what().
     insertIntoCurrentExceptions();
   }
-  ~ExceptionImpl() {
+  ~ExceptionImpl() noexcept {
     // Look for ourselves in the list.
     for (auto* ptr = &currentException; *ptr != nullptr; ptr = &(*ptr)->nextCurrentException) {
       if (*ptr == this) {

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -279,7 +279,7 @@ String stringifyStackTrace(ArrayPtr<void* const> trace) {
 
   HANDLE process = GetCurrentProcess();
 
-  KJ_STACK_ARRAY(String, lines, trace.size(), 32, 32);
+  SmallArray<String, 32> lines(trace.size());
 
   for (auto i: kj::indices(trace)) {
     IMAGEHLP_LINE64 lineInfo;
@@ -833,8 +833,8 @@ void Exception::extendTrace(uint ignoreCount, uint limit) {
     return;
   }
 
-  KJ_STACK_ARRAY(void*, newTraceSpace, kj::min(kj::size(trace), limit) + ignoreCount + 1,
-      sizeof(trace)/sizeof(trace[0]) + 8, 128);
+  SmallArray<void*, sizeof(trace)/sizeof(trace[0]) + 8> newTraceSpace(
+      kj::min(kj::size(trace), limit) + ignoreCount + 1);
 
   auto newTrace = kj::getStackTrace(newTraceSpace, ignoreCount + 1);
   if (newTrace.size() > ignoreCount + 2) {

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -428,7 +428,7 @@ public:
     // Use a 4k buffer of zeros amplified by iov to write zeros with as few syscalls as possible.
     size_t count = (size + sizeof(ZEROS) - 1) / sizeof(ZEROS);
     const size_t iovmax = miniposix::iovMax();
-    KJ_STACK_ARRAY(struct iovec, iov, kj::min(iovmax, count), 16, 256);
+    SmallArray<struct iovec, 16> iov(kj::min(iovmax, count));
 
     for (auto& item: iov) {
       item.iov_base = const_cast<byte*>(ZEROS);
@@ -812,7 +812,7 @@ public:
   Maybe<String> tryReadlink(PathPtr path) const {
     size_t trySize = 256;
     for (;;) {
-      KJ_STACK_ARRAY(char, buf, trySize, 256, 4096);
+      SmallArray<char, 256> buf(trySize);
       ssize_t n = readlinkat(fd, path.toString().cStr(), buf.begin(), buf.size());
       if (n < 0) {
         int error = errno;
@@ -1713,7 +1713,7 @@ private:
 
     size_t size = 256;
   retry:
-    KJ_STACK_ARRAY(char, buf, size, 256, 4096);
+    SmallArray<char, 256> buf(size);
     if (getcwd(buf.begin(), size) == nullptr) {
       int error = errno;
       if (error == ERANGE) {

--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -106,6 +106,9 @@ struct HashCoder {
   uint operator*(ArrayPtr<T> arr) const;
   template <typename T, typename = decltype(instance<const HashCoder&>() * instance<const T&>())>
   uint operator*(const Array<T>& arr) const;
+  template <typename T, size_t smallSize,
+      typename = decltype(instance<const HashCoder&>() * instance<const T&>())>
+  uint operator*(const SmallArray<T, smallSize>& arr) const;
   template <typename T, typename = EnableIf<__is_enum(T)>>
   inline uint operator*(T e) const;
 
@@ -182,6 +185,10 @@ inline uint HashCoder::operator*(ArrayPtr<T> arr) const {
 }
 template <typename T, typename>
 inline uint HashCoder::operator*(const Array<T>& arr) const {
+  return operator*(arr.asPtr());
+}
+template <typename T, size_t smallSize, typename>
+inline uint HashCoder::operator*(const SmallArray<T, smallSize>& arr) const {
   return operator*(arr.asPtr());
 }
 

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -383,7 +383,7 @@ void FdOutputStream::write(ArrayPtr<const ArrayPtr<const byte>> pieces) {
     pieces = pieces.slice(iovmax, pieces.size());
   }
 
-  KJ_STACK_ARRAY(struct iovec, iov, pieces.size(), 16, 128);
+  SmallArray<struct iovec, 16> iov(pieces.size());
 
   for (uint i = 0; i < pieces.size(); i++) {
     // writev() interface is not const-correct.  :(

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -91,7 +91,7 @@ static void writeLineToFd(int fd, StringPtr message) {
   }
 
 #if _WIN32
-  KJ_STACK_ARRAY(char, newlineExpansionBuffer, 2 * (message.size() + 1), 128, 512);
+  SmallArray<char, 128> newlineExpansionBuffer(2 * (message.size() + 1));
   char* p = newlineExpansionBuffer.begin();
   for(char ch : message) {
     if(ch == '\n') {
@@ -116,7 +116,7 @@ static void writeLineToFd(int fd, StringPtr message) {
   if(redirectedToFile) {
     WriteFile(handle, newlineExpansionBuffer.begin(), newlineExpandedSize, &writtenSize, nullptr);
   } else {
-    KJ_STACK_ARRAY(wchar_t, buffer, newlineExpandedSize, 128, 512);
+    SmallArray<wchar_t, 128> buffer(newlineExpandedSize);
 
     size_t finalSize = MultiByteToWideChar(
       CP_UTF8,
@@ -211,7 +211,7 @@ int runMainAndExit(ProcessContext& context, MainFunc&& func, int argc, char* arg
   try {
     KJ_ASSERT(argc > 0);
 
-    KJ_STACK_ARRAY(StringPtr, params, argc - 1, 8, 32);
+    SmallArray<StringPtr, 8> params(argc - 1);
     for (int i = 1; i < argc; i++) {
       params[i - 1] = argv[i];
     }

--- a/c++/src/kj/parse/char.c++
+++ b/c++/src/kj/parse/char.c++
@@ -39,7 +39,7 @@ double ParseFloat::operator()(const Array<char>& digits,
     bufSize += 1 + (get<0>(e) != kj::none) + get<1>(e).size();
   }
 
-  KJ_STACK_ARRAY(char, buf, bufSize + 1, 128, 128);
+  SmallArray<char, 128> buf(bufSize + 1);
 
   char* pos = buf.begin();
   memcpy(pos, digits.begin(), digits.size());

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -601,7 +601,7 @@ _::Delimited<T> delimited(T&& arr, kj::StringPtr delim);
 template <typename T>
 String strArray(T&& arr, const char* delim) {
   size_t delimLen = strlen(delim);
-  KJ_STACK_ARRAY(decltype(_::STR * arr[0]), pieces, kj::size(arr), 8, 32);
+  SmallArray<decltype(_::STR * arr[0]), 8> pieces(kj::size(arr));
   size_t size = 0;
   for (size_t i = 0; i < kj::size(arr); i++) {
     if (i > 0) size += delimLen;


### PR DESCRIPTION
We'd like to be able to use KJ_STACK_ARRAY in coroutines, but KJ_STACK_ARRAY uses variable-length arrays on compilers which support them (that is: GCC). ~~So, we're dropping support for VLAs from KJ_STACK_ARRAY.~~

It's worth noting that at present, we don't actually support GCC, so we have no target which even uses VLAs anymore. But, we'd like to support GCC again in the future, once its coroutine support is fixed.

Update: Instead of dropping support for VLAs from KJ_STACK_ARRAY, we're replacing the macro entirely with `kj::SboArray`.