### PR TITLE
Include JSON test in bazel build, support compiling it, add simple benchmark

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -212,6 +212,7 @@ cc_library(
         ":capnpc",
         "//src/kj:kj-test",
     ],
+    include_prefix = "capnp",
     visibility = [":__subpackages__" ]
 )
 

--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -24,6 +24,16 @@ cc_library(
 )
 
 cc_capnp_library(
+    name = "json-test_capnp",
+    srcs = [
+        "json-test.capnp",
+    ],
+    include_prefix = "capnp/compat",
+    src_prefix = "src",
+    visibility = ["//visibility:public"],
+)
+
+cc_capnp_library(
     name = "http-over-capnp_capnp",
     srcs = [
         "byte-stream.capnp",
@@ -82,6 +92,16 @@ cc_library(
     "http-over-capnp-perf-test.c++",
     "websocket-rpc-test.c++",
 ]]
+
+cc_test(
+    name = "json-test",
+    srcs = ["json-test.c++"],
+    deps = [
+        "//src/capnp:capnp-test",
+        ":json",
+        ":json-test_capnp"
+    ],
+)
 
 cc_library(
     name = "http-over-capnp-test-as-header",

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -23,11 +23,11 @@
 
 #include <capnp/test.capnp.h>
 #include <iostream>
-#include "blob.h"
+#include <capnp/blob.h>
 #include <kj/compat/gtest.h>
 
 #if !CAPNP_LITE
-#include "dynamic.h"
+#include <capnp/dynamic.h>
 #include <kj/io.h>
 #endif  // !CAPNP_LITE
 


### PR DESCRIPTION
Follow-up to #1763.

The JSON test was mistakenly not included in the bazel build, so compile issues with it were not being detected. I fixed this locally to verify that the changes in the previous PR are correct, but didn't have them cleaned up yet.

For the benchmark, this is largely similar to the workerd JSON benchmark, but uses a different test message for the parsing test.
Suggestions for how to structure the benchmark are welcome – not sure if adding more complex tests, removing KJ_EXPECT statements or moving this to a new file would be helpful.