### PR TITLE
Implement KJ_IF_SOME and kj::none

### DIFF
--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -33,4 +33,10 @@ build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-u
 build:windows --cxxopt='/Zc:__cplusplus' --host_cxxopt='/Zc:__cplusplus'
 
 # build with ssl, zlib and bazel by default
-build --//src/kj:openssl=True --//src/kj:zlib=True --//src/kj:brotli=True
+build --//src/kj:openssl=True
+build --//src/kj:zlib=True
+build --//src/kj:brotli=True
+
+# Disable deprecation warnings until we have more of the codebase converted.
+build --//src/kj:deprecate_kj_if_maybe=False
+build --//src/kj:deprecate_empty_maybe_from_nullptr=False

--- a/c++/build/configure.bzl
+++ b/c++/build/configure.bzl
@@ -37,6 +37,16 @@ def kj_configure():
         build_setting_default = False,
     )
 
+    bool_flag(
+        name = "deprecate_kj_if_maybe",
+        build_setting_default = True,
+    )
+
+    bool_flag(
+        name = "deprecate_empty_maybe_from_nullptr",
+        build_setting_default = True,
+    )
+
     # Settings to use in select() expressions
     native.config_setting(
         name = "use_openssl",
@@ -69,6 +79,16 @@ def kj_configure():
         flag_values = {"track_lock_blocking": "True"},
     )
 
+    native.config_setting(
+        name = "use_deprecate_kj_if_maybe",
+        flag_values = {"deprecate_kj_if_maybe": "True"},
+    )
+
+    native.config_setting(
+        name = "use_deprecate_empty_maybe_from_nullptr",
+        flag_values = {"deprecate_empty_maybe_from_nullptr": "True"},
+    )
+
     native.cc_library(
         name = "kj-defines",
         defines = select({
@@ -89,5 +109,11 @@ def kj_configure():
         }) + select({
             "//src/kj:use_track_lock_blocking": ["KJ_TRACK_LOCK_BLOCKING=1"],
             "//conditions:default": ["KJ_TRACK_LOCK_BLOCKING=0"],
+        }) + select({
+            "//src/kj:use_deprecate_kj_if_maybe": ["KJ_DEPRECATE_KJ_IF_MAYBE=1"],
+            "//conditions:default": ["KJ_DEPRECATE_KJ_IF_MAYBE=0"],
+        }) + select({
+            "//src/kj:use_deprecate_empty_maybe_from_nullptr": ["KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR=1"],
+            "//conditions:default": ["KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR=0"],
         }),
     )

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -195,15 +195,15 @@ TEST(AsyncIo, UnixSocket) {
     return promise.then([&,addr=kj::mv(addr)](AuthenticatedStream result) mutable {
       auto id = result.peerIdentity.downcast<LocalPeerIdentity>();
       auto creds = id->getCredentials();
-      KJ_IF_MAYBE(p, creds.pid) {
-        KJ_EXPECT(*p == getpid());
+      KJ_IF_SOME(p, creds.pid) {
+        KJ_EXPECT(p == getpid());
 #if __linux__ || __APPLE__
       } else {
         KJ_FAIL_EXPECT("LocalPeerIdentity for unix socket had null PID");
 #endif
       }
-      KJ_IF_MAYBE(u, creds.uid) {
-        KJ_EXPECT(*u == getuid());
+      KJ_IF_SOME(u, creds.uid) {
+        KJ_EXPECT(u == getuid());
       } else {
         KJ_FAIL_EXPECT("LocalPeerIdentity for unix socket had null UID");
       }
@@ -223,15 +223,15 @@ TEST(AsyncIo, UnixSocket) {
   }).then([&](AuthenticatedStream result) {
     auto id = result.peerIdentity.downcast<LocalPeerIdentity>();
     auto creds = id->getCredentials();
-    KJ_IF_MAYBE(p, creds.pid) {
-      KJ_EXPECT(*p == getpid());
+    KJ_IF_SOME(p, creds.pid) {
+      KJ_EXPECT(p == getpid());
 #if __linux__ || __APPLE__
     } else {
       KJ_FAIL_EXPECT("LocalPeerIdentity for unix socket had null PID");
 #endif
     }
-    KJ_IF_MAYBE(u, creds.uid) {
-      KJ_EXPECT(*u == getuid());
+    KJ_IF_SOME(u, creds.uid) {
+      KJ_EXPECT(u == getuid());
     } else {
       KJ_FAIL_EXPECT("LocalPeerIdentity for unix socket had null UID");
     }
@@ -2782,10 +2782,10 @@ KJ_TEST("Userland tee pump cancellation implies write cancellation") {
   leftPumpPromise = nullptr;
   // It should cancel its write operations, so it should now be safe to destroy the output stream to
   // which it was pumping.
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
     leftPipe.out = nullptr;
   })) {
-    KJ_FAIL_EXPECT("write promises were not canceled", *exception);
+    KJ_FAIL_EXPECT("write promises were not canceled", exception);
   }
 }
 
@@ -2993,8 +2993,8 @@ KJ_TEST("AggregateConnectionReceiver") {
 
   auto aggregate = newAggregateConnectionReceiver(receiversBuilder.finish());
 
-  CapabilityStreamNetworkAddress connector1(nullptr, *pipe1.ends[1]);
-  CapabilityStreamNetworkAddress connector2(nullptr, *pipe2.ends[1]);
+  CapabilityStreamNetworkAddress connector1(kj::none, *pipe1.ends[1]);
+  CapabilityStreamNetworkAddress connector2(kj::none, *pipe2.ends[1]);
 
   auto connectAndWrite = [&](NetworkAddress& addr, kj::StringPtr text) {
     return addr.connect()

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -947,7 +947,7 @@ TEST(Async, LargeTaskSetDestructionExceptions) {
       tasksRef.add(kj::Promise<void>(kj::NEVER_DONE).attach(kj::heap<ThrowingDestructor>()));
     }
 
-    KJ_EXPECT_THROW_MESSAGE("ThrowingDestructor_exception", { tasks = nullptr; });
+    KJ_EXPECT_THROW_MESSAGE("ThrowingDestructor_exception", { tasks = kj::none; });
   });
 }
 
@@ -1609,18 +1609,18 @@ KJ_TEST("run event loop on freelisted stacks") {
     bool wait() override {
       char c;
       waitStack = &c;
-      KJ_IF_MAYBE(f, fulfiller) {
-        f->get()->fulfill();
-        fulfiller = nullptr;
+      KJ_IF_SOME(f, fulfiller) {
+        f->fulfill();
+        fulfiller = kj::none;
       }
       return false;
     }
     bool poll() override {
       char c;
       pollStack = &c;
-      KJ_IF_MAYBE(f, fulfiller) {
-        f->get()->fulfill();
-        fulfiller = nullptr;
+      KJ_IF_SOME(f, fulfiller) {
+        f->fulfill();
+        fulfiller = kj::none;
       }
       return false;
     }

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -874,10 +874,10 @@ struct TestChild {
   }
 
   ~TestChild() noexcept(false) {
-    KJ_IF_MAYBE(p, pid) {
-      KJ_SYSCALL(::kill(*p, SIGKILL)) { return; }
+    KJ_IF_SOME(p, pid) {
+      KJ_SYSCALL(::kill(p, SIGKILL)) { return; }
       int status;
-      KJ_SYSCALL(waitpid(*p, &status, 0)) { return; }
+      KJ_SYSCALL(waitpid(p, &status, 0)) { return; }
     }
   }
 

--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -70,14 +70,14 @@ KJ_TEST("synchonous simple cross-thread events") {
     KJ_ASSERT(paf.promise.wait(waitScope) == 123);
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -95,7 +95,7 @@ KJ_TEST("synchonous simple cross-thread events") {
     });
     KJ_EXPECT(i == 456);
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -120,7 +120,7 @@ KJ_TEST("asynchronous simple cross-thread events") {
     KJ_ASSERT(paf.promise.wait(waitScope) == 123);
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
@@ -129,7 +129,7 @@ KJ_TEST("asynchronous simple cross-thread events") {
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -147,7 +147,7 @@ KJ_TEST("asynchronous simple cross-thread events") {
     });
     KJ_EXPECT(promise.wait(waitScope) == 456);
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -181,14 +181,14 @@ KJ_TEST("synchonous promise cross-thread events") {
     loop.run();
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -206,7 +206,7 @@ KJ_TEST("synchonous promise cross-thread events") {
     });
     KJ_EXPECT(i == 321);
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -240,7 +240,7 @@ KJ_TEST("asynchronous promise cross-thread events") {
     loop.run();
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
@@ -249,7 +249,7 @@ KJ_TEST("asynchronous promise cross-thread events") {
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -267,7 +267,7 @@ KJ_TEST("asynchronous promise cross-thread events") {
     });
     KJ_EXPECT(promise2.wait(waitScope) == 321);
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -285,7 +285,7 @@ KJ_TEST("cancel cross-thread event before it runs") {
     // We never run the loop here, so that when the event is canceled, it's still queued.
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
@@ -294,7 +294,7 @@ KJ_TEST("cancel cross-thread event before it runs") {
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -306,7 +306,7 @@ KJ_TEST("cancel cross-thread event before it runs") {
     }
     KJ_EXPECT(!called);
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -328,7 +328,7 @@ KJ_TEST("cancel cross-thread event while it runs") {
     paf.promise.wait(waitScope);
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
@@ -337,7 +337,7 @@ KJ_TEST("cancel cross-thread event while it runs") {
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -355,7 +355,7 @@ KJ_TEST("cancel cross-thread event while it runs") {
 
     exec->executeSync([&]() { fulfiller->fulfill(); });
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -381,7 +381,7 @@ KJ_TEST("cross-thread cancellation in both directions at once") {
     const Executor* exec;
     {
       auto lock = otherExecutor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -434,10 +434,10 @@ KJ_TEST("cross-thread cancellation in both directions at once") {
     }
 
     // OK, signal other that we're all done.
-    *otherExecutor.lockExclusive() = nullptr;
+    *otherExecutor.lockExclusive() = kj::none;
 
     // Wait until other thread sets executor to null, as a way to tell us to quit.
-    selfExecutor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    selfExecutor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   };
 
   {
@@ -490,7 +490,7 @@ KJ_TEST("cross-thread cancellation cycle") {
     paf.promise.wait(waitScope);
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   };
 
   Thread thread1([&]() noexcept { threadMain(child1Executor, fulfiller1); });
@@ -503,13 +503,13 @@ KJ_TEST("cross-thread cancellation cycle") {
     const Executor* exec1;
     {
       auto lock = child1Executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec1 = &KJ_ASSERT_NONNULL(*lock);
     }
     const Executor* exec2;
     {
       auto lock = child2Executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec2 = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -539,8 +539,8 @@ KJ_TEST("cross-thread cancellation cycle") {
     exec1->executeSync([&]() { fulfiller1->fulfill(); });
     exec2->executeSync([&]() { fulfiller2->fulfill(); });
 
-    *child1Executor.lockExclusive() = nullptr;
-    *child2Executor.lockExclusive() = nullptr;
+    *child1Executor.lockExclusive() = kj::none;
+    *child2Executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -590,14 +590,14 @@ KJ_TEST("synchronous cross-thread event disconnected") {
     }
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
     Own<const Executor> exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = KJ_ASSERT_NONNULL(*lock).addRef();
     }
 
@@ -618,7 +618,7 @@ KJ_TEST("synchronous cross-thread event disconnected") {
         "Executor's event loop has exited",
         exec->executeSync([&]() {}));
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -644,7 +644,7 @@ KJ_TEST("asynchronous cross-thread event disconnected") {
     }
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
@@ -653,7 +653,7 @@ KJ_TEST("asynchronous cross-thread event disconnected") {
     Own<const Executor> exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = KJ_ASSERT_NONNULL(*lock).addRef();
     }
 
@@ -674,7 +674,7 @@ KJ_TEST("asynchronous cross-thread event disconnected") {
         "Executor's event loop has exited",
         exec->executeAsync([&]() {}).wait(waitScope));
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -690,7 +690,7 @@ KJ_TEST("cross-thread event disconnected before it runs") {
     *executor.lockExclusive() = getCurrentThreadExecutor();
 
     // Don't actually run the event loop. Destroy it when the other thread signals us to.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
@@ -699,7 +699,7 @@ KJ_TEST("cross-thread event disconnected before it runs") {
     Own<const Executor> exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = KJ_ASSERT_NONNULL(*lock).addRef();
     }
 
@@ -712,7 +712,7 @@ KJ_TEST("cross-thread event disconnected before it runs") {
     });
     KJ_EXPECT(!promise.poll(waitScope));
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
 
     KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(
         "Executor's event loop exited before cross-thread event could complete",
@@ -744,14 +744,14 @@ KJ_TEST("cross-thread event disconnected without holding Executor ref") {
     }
 
     // Wait until parent thread sets executor to null, as a way to tell us to quit.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -768,7 +768,7 @@ KJ_TEST("cross-thread event disconnected without holding Executor ref") {
 
     // Can't check `exec->isLive()` because it's been destroyed by now.
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -790,7 +790,7 @@ KJ_TEST("detached cross-thread event doesn't cause crash") {
     // in other tests, for some reason? Oh well.
     waitScope.poll();
 
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
   });
 
   ([&]() noexcept {
@@ -800,7 +800,7 @@ KJ_TEST("detached cross-thread event doesn't cause crash") {
       const Executor* exec;
       {
         auto lock = executor.lockExclusive();
-        lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+        lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
         exec = &KJ_ASSERT_NONNULL(*lock);
       }
 
@@ -824,7 +824,7 @@ KJ_TEST("detached cross-thread event doesn't cause crash") {
       // led to an abort because the other thread had no way to reply back to this thread.
     }
 
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
   })();
 }
 
@@ -850,7 +850,7 @@ KJ_TEST("cross-thread event cancel requested while destination thread being dest
     // Let the other thread know, out-of-band, that the task is running, so that it can now request
     // cancellation. We do this by setting `executor` to null (but we could also use some separate
     // MutexGuarded conditional variable instead).
-    *executor.lockExclusive() = nullptr;
+    *executor.lockExclusive() = kj::none;
 
     // Give other thread a chance to request cancellation of the promise.
     delay();
@@ -864,7 +864,7 @@ KJ_TEST("cross-thread event cancel requested while destination thread being dest
     const Executor* exec;
     {
       auto lock = executor.lockExclusive();
-      lock.wait([&](kj::Maybe<const Executor&> value) { return value != nullptr; });
+      lock.wait([&](kj::Maybe<const Executor&> value) { return value != kj::none; });
       exec = &KJ_ASSERT_NONNULL(*lock);
     }
 
@@ -876,7 +876,7 @@ KJ_TEST("cross-thread event cancel requested while destination thread being dest
     });
 
     // Wait for the other thread to signal to us that it has indeed started executing our task.
-    executor.lockExclusive().wait([](auto& val) { return val == nullptr; });
+    executor.lockExclusive().wait([](auto& val) { return val == kj::none; });
 
     // Cancel the promise.
     promise = nullptr;
@@ -902,7 +902,7 @@ KJ_TEST("cross-thread fulfiller") {
     Own<PromiseFulfiller<int>> fulfiller;
     {
       auto lock = fulfillerMutex.lockExclusive();
-      lock.wait([&](auto& value) { return value != nullptr; });
+      lock.wait([&](auto& value) { return value != kj::none; });
       fulfiller = kj::mv(KJ_ASSERT_NONNULL(*lock));
     }
 
@@ -928,7 +928,7 @@ KJ_TEST("cross-thread fulfiller rejects") {
     Own<PromiseFulfiller<void>> fulfiller;
     {
       auto lock = fulfillerMutex.lockExclusive();
-      lock.wait([&](auto& value) { return value != nullptr; });
+      lock.wait([&](auto& value) { return value != kj::none; });
       fulfiller = kj::mv(KJ_ASSERT_NONNULL(*lock));
     }
 
@@ -956,7 +956,7 @@ KJ_TEST("cross-thread fulfiller destroyed") {
     Own<PromiseFulfiller<void>> fulfiller;
     {
       auto lock = fulfillerMutex.lockExclusive();
-      lock.wait([&](auto& value) { return value != nullptr; });
+      lock.wait([&](auto& value) { return value != kj::none; });
       fulfiller = kj::mv(KJ_ASSERT_NONNULL(*lock));
     }
 
@@ -975,7 +975,7 @@ KJ_TEST("cross-thread fulfiller canceled") {
     {
       auto lock = fulfillerMutex.lockExclusive();
       *lock = kj::mv(paf.fulfiller);
-      lock.wait([](auto& value) { return value == nullptr; });
+      lock.wait([](auto& value) { return value == kj::none; });
     }
 
     // cancel
@@ -993,10 +993,10 @@ KJ_TEST("cross-thread fulfiller canceled") {
     Own<PromiseFulfiller<void>> fulfiller;
     {
       auto lock = fulfillerMutex.lockExclusive();
-      lock.wait([&](auto& value) { return value != nullptr; });
+      lock.wait([&](auto& value) { return value != kj::none; });
       fulfiller = kj::mv(KJ_ASSERT_NONNULL(*lock));
       KJ_ASSERT(fulfiller->isWaiting());
-      *lock = nullptr;
+      *lock = kj::none;
     }
 
     // Should eventually show not waiting.
@@ -1027,7 +1027,7 @@ KJ_TEST("cross-thread fulfiller multiple fulfills") {
     PromiseFulfiller<int>* fulfiller;
     {
       auto lock = fulfillerMutex.lockExclusive();
-      lock.wait([&](auto& value) { return value != nullptr; });
+      lock.wait([&](auto& value) { return value != kj::none; });
       fulfiller = KJ_ASSERT_NONNULL(*lock).get();
     }
 

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -180,7 +180,7 @@ public:
 
   Maybe<Own<_::Event>> fire() override {
     fired = true;
-    return nullptr;
+    return kj::none;
   }
 
   void traceEvent(_::TraceBuilder& builder) override {
@@ -222,9 +222,9 @@ void Canceler::cancel(StringPtr cancelReason) {
 
 void Canceler::cancel(const Exception& exception) {
   for (;;) {
-    KJ_IF_MAYBE(a, list) {
-      a->unlink();
-      a->cancel(kj::cp(exception));
+    KJ_IF_SOME(a, list) {
+      a.unlink();
+      a.cancel(kj::cp(exception));
     } else {
       break;
     }
@@ -233,8 +233,8 @@ void Canceler::cancel(const Exception& exception) {
 
 void Canceler::release() {
   for (;;) {
-    KJ_IF_MAYBE(a, list) {
-      a->unlink();
+    KJ_IF_SOME(a, list) {
+      a.unlink();
     } else {
       break;
     }
@@ -245,8 +245,8 @@ Canceler::AdapterBase::AdapterBase(Canceler& canceler)
     : prev(canceler.list),
       next(canceler.list) {
   canceler.list = *this;
-  KJ_IF_MAYBE(n, next) {
-    n->prev = next;
+  KJ_IF_SOME(n, next) {
+    n.prev = next;
   }
 }
 
@@ -255,11 +255,11 @@ Canceler::AdapterBase::~AdapterBase() noexcept(false) {
 }
 
 void Canceler::AdapterBase::unlink() {
-  KJ_IF_MAYBE(p, prev) {
-    *p = next;
+  KJ_IF_SOME(p, prev) {
+    p = next;
   }
-  KJ_IF_MAYBE(n, next) {
-    n->prev = prev;
+  KJ_IF_SOME(n, next) {
+    n.prev = prev;
   }
   next = nullptr;
   prev = nullptr;
@@ -295,11 +295,11 @@ public:
   void destroy() override { freePromise(this); }
 
   OwnTask pop() {
-    KJ_IF_MAYBE(n, next) { n->get()->prev = prev; }
+    KJ_IF_SOME(n, next) { n->prev = prev; }
     OwnTask self = kj::mv(KJ_ASSERT_NONNULL(*prev));
     KJ_ASSERT(self.get() == this);
     *prev = kj::mv(next);
-    next = nullptr;
+    next = kj::none;
     prev = nullptr;
     return self;
   }
@@ -321,10 +321,10 @@ protected:
     node->get(result);
 
     // Delete the node, catching any exceptions.
-    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([this]() {
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
       node = nullptr;
     })) {
-      result.addException(kj::mv(*exception));
+      result.addException(kj::mv(exception));
     }
 
     // Remove from the task list. Do this before calling taskFailed(), so that taskFailed() can
@@ -333,16 +333,16 @@ protected:
 
     // We'll also process onEmpty() now, just in case `taskFailed()` actually destroys the whole
     // `TaskSet`.
-    KJ_IF_MAYBE(f, taskSet.emptyFulfiller) {
-      if (taskSet.tasks == nullptr) {
-        f->get()->fulfill();
-        taskSet.emptyFulfiller = nullptr;
+    KJ_IF_SOME(f, taskSet.emptyFulfiller) {
+      if (taskSet.tasks == kj::none) {
+        f->fulfill();
+        taskSet.emptyFulfiller = kj::none;
       }
     }
 
     // Call the error handler if there was an exception.
-    KJ_IF_MAYBE(e, result.exception) {
-      taskSet.errorHandler.taskFailed(kj::mv(*e));
+    KJ_IF_SOME(e, result.exception) {
+      taskSet.errorHandler.taskFailed(kj::mv(e));
     }
 
     return Own<Event>(mv(self));
@@ -365,8 +365,8 @@ TaskSet::~TaskSet() noexcept(false) {
 
 void TaskSet::add(Promise<void>&& promise) {
   auto task = _::appendPromise<Task>(_::PromiseNode::from(kj::mv(promise)), *this);
-  KJ_IF_MAYBE(head, tasks) {
-    head->get()->prev = &task->next;
+  KJ_IF_SOME(head, tasks) {
+    head->prev = &task->next;
     task->next = kj::mv(tasks);
   }
   task->prev = &tasks;
@@ -378,9 +378,9 @@ kj::String TaskSet::trace() {
 
   Maybe<OwnTask>* ptr = &tasks;
   for (;;) {
-    KJ_IF_MAYBE(task, *ptr) {
-      traces.add(task->get()->trace());
-      ptr = &task->get()->next;
+    KJ_IF_SOME(task, *ptr) {
+      traces.add(task->trace());
+      ptr = &task->next;
     } else {
       break;
     }
@@ -390,13 +390,13 @@ kj::String TaskSet::trace() {
 }
 
 Promise<void> TaskSet::onEmpty() {
-  KJ_IF_MAYBE(fulfiller, emptyFulfiller) {
-    if (fulfiller->get()->isWaiting()) {
+  KJ_IF_SOME(fulfiller, emptyFulfiller) {
+    if (fulfiller->isWaiting()) {
       KJ_FAIL_REQUIRE("onEmpty() can only be called once at a time");
     }
   }
 
-  if (tasks == nullptr) {
+  if (tasks == kj::none) {
     return READY_NOW;
   } else {
     auto paf = newPromiseAndFulfiller<void>();
@@ -408,8 +408,8 @@ Promise<void> TaskSet::onEmpty() {
 void TaskSet::clear() {
   destroyTasks();
 
-  KJ_IF_MAYBE(fulfiller, emptyFulfiller) {
-    fulfiller->get()->fulfill();
+  KJ_IF_SOME(fulfiller, emptyFulfiller) {
+    fulfiller->fulfill();
   }
 }
 
@@ -423,12 +423,12 @@ void TaskSet::destroyTasks() {
     // If an exception occurs, ensure the remaining tasks still get unlinked.  Here, we assume it
     // is not necessary to catch further exceptions, since we require destructors to guard against
     // exceptions when unwinding.
-    while (tasks != nullptr) {
+    while (tasks != kj::none) {
       auto removed = KJ_REQUIRE_NONNULL(tasks)->pop();
     }
   });
 
-  while (tasks != nullptr) {
+  while (tasks != kj::none) {
     auto removed = KJ_REQUIRE_NONNULL(tasks)->pop();
   }
 }
@@ -590,8 +590,8 @@ public:
     // a weird state.
 
 #if USE_CORE_LOCAL_FREELISTS
-    KJ_IF_MAYBE(core, lookupCoreLocalFreelist()) {
-      for (auto& stackPtr: core->stacks) {
+    KJ_IF_SOME(core, lookupCoreLocalFreelist()) {
+      for (auto& stackPtr: core.stacks) {
         _::FiberStack* result = __atomic_exchange_n(&stackPtr, nullptr, __ATOMIC_ACQUIRE);
         if (result != nullptr) {
           // Found a stack in this slot!
@@ -638,7 +638,7 @@ private:
 
   kj::Maybe<CoreLocalFreelist&> lookupCoreLocalFreelist() const {
     if (coreLocalFreelists == nullptr) {
-      return nullptr;
+      return kj::none;
     } else {
       int cpu = sched_getcpu();
       if (cpu >= 0) {
@@ -651,7 +651,7 @@ private:
           KJ_LOG(ERROR, "invalid cpu number from sched_getcpu()?", cpu, nproc);
           logged = true;
         }
-        return nullptr;
+        return kj::none;
       }
     }
   }
@@ -665,8 +665,8 @@ private:
     // where we don't want to reuse it.
     if (stack->isReset()) {
 #if USE_CORE_LOCAL_FREELISTS
-      KJ_IF_MAYBE(core, lookupCoreLocalFreelist()) {
-        for (auto& stackPtr: core->stacks) {
+      KJ_IF_SOME(core, lookupCoreLocalFreelist()) {
+        for (auto& stackPtr: core.stacks) {
           stack = __atomic_exchange_n(&stackPtr, stack, __ATOMIC_RELEASE);
           if (stack == nullptr) {
             // Cool, we inserted the stack into an unused slot. We're done.
@@ -709,7 +709,7 @@ void FiberPool::useCoreLocalFreelists() {
 void FiberPool::runSynchronously(kj::FunctionParam<void()> func) const {
   ensureThreadCanRunFibers();
 
-  _::FiberStack::SynchronousFunc syncFunc { func, nullptr };
+  _::FiberStack::SynchronousFunc syncFunc { func, kj::none };
 
   {
     auto stack = impl->takeStack();
@@ -718,8 +718,8 @@ void FiberPool::runSynchronously(kj::FunctionParam<void()> func) const {
     stack->reset();  // safe to reuse
   }
 
-  KJ_IF_MAYBE(e, syncFunc.exception) {
-    kj::throwRecoverableException(kj::mv(*e));
+  KJ_IF_SOME(e, syncFunc.exception) {
+    kj::throwRecoverableException(kj::mv(e));
   }
 }
 
@@ -798,7 +798,7 @@ struct Executor::Impl {
       for (auto& event: cancel) {
         cancel.remove(event);
 
-        if (event.promiseNode == nullptr) {
+        if (event.promiseNode == kj::none) {
           event.setDoneState();
         } else {
           // We can't destroy the promiseNode while the mutex is locked, because we don't know
@@ -821,7 +821,7 @@ struct Executor::Impl {
     // is released.
 
     for (auto& event: eventsToCancelOutsideLock) {
-      event->promiseNode = nullptr;
+      event->promiseNode = kj::none;
       event->disarm();
     }
 
@@ -857,7 +857,7 @@ struct Executor::Impl {
     for (auto& event: s.executing) {
       KJ_ASSERT(event.state == _::XThreadEvent::EXECUTING, event.state) { break; }
       s.executing.remove(event);
-      event.promiseNode = nullptr;
+      event.promiseNode = kj::none;
       event.setDisconnected();
       event.sendReply();
       event.setDoneState();
@@ -866,7 +866,7 @@ struct Executor::Impl {
     for (auto& event: s.cancel) {
       KJ_ASSERT(event.state == _::XThreadEvent::CANCELING, event.state) { break; }
       s.cancel.remove(event);
-      event.promiseNode = nullptr;
+      event.promiseNode = kj::none;
       event.setDoneState();
     }
 
@@ -907,8 +907,8 @@ void XThreadEvent::ensureDoneOrCanceled() {
     auto lock = targetExecutor->impl->state.lockExclusive();
 
     const EventLoop* loop;
-    KJ_IF_MAYBE(l, lock->loop) {
-      loop = l;
+    KJ_IF_SOME(l, lock->loop) {
+      loop = &l;
     } else {
       // Target event loop is already dead, so we know it's already working on transitioning all
       // events to the DONE state. We can just wait.
@@ -929,18 +929,18 @@ void XThreadEvent::ensureDoneOrCanceled() {
         lock->executing.remove(*this);
         lock->cancel.add(*this);
         state = CANCELING;
-        KJ_IF_MAYBE(p, loop->port) {
-          p->wake();
+        KJ_IF_SOME(p, loop->port) {
+          p.wake();
         }
 
-        Maybe<Executor&> maybeSelfExecutor = nullptr;
+        Maybe<Executor&> maybeSelfExecutor = kj::none;
         if (threadLocalEventLoop != nullptr) {
-          KJ_IF_MAYBE(e, threadLocalEventLoop->executor) {
-            maybeSelfExecutor = **e;
+          KJ_IF_SOME(e, threadLocalEventLoop->executor) {
+            maybeSelfExecutor = *e;
           }
         }
 
-        KJ_IF_MAYBE(selfExecutor, maybeSelfExecutor) {
+        KJ_IF_SOME(selfExecutor, maybeSelfExecutor) {
           // If, while waiting for other threads to process our cancellation request, we have
           // cancellation requests queued back to this thread, we must process them. Otherwise,
           // we could deadlock with two threads waiting on each other to process cancellations.
@@ -959,9 +959,9 @@ void XThreadEvent::ensureDoneOrCanceled() {
             lock = {};
 
             Vector<_::XThreadEvent*> eventsToCancelOutsideLock;
-            KJ_DEFER(selfExecutor->impl->processAsyncCancellations(eventsToCancelOutsideLock));
+            KJ_DEFER(selfExecutor.impl->processAsyncCancellations(eventsToCancelOutsideLock));
 
-            auto selfLock = selfExecutor->impl->state.lockExclusive();
+            auto selfLock = selfExecutor.impl->state.lockExclusive();
             selfLock->waitingForCancel = false;
             selfLock->dispatchCancels(eventsToCancelOutsideLock);
 
@@ -977,9 +977,9 @@ void XThreadEvent::ensureDoneOrCanceled() {
             lock = {};
             {
               Vector<_::XThreadEvent*> eventsToCancelOutsideLock;
-              KJ_DEFER(selfExecutor->impl->processAsyncCancellations(eventsToCancelOutsideLock));
+              KJ_DEFER(selfExecutor.impl->processAsyncCancellations(eventsToCancelOutsideLock));
 
-              auto selfLock = selfExecutor->impl->state.lockExclusive();
+              auto selfLock = selfExecutor.impl->state.lockExclusive();
               selfLock->waitingForCancel = true;
 
               // Note that we don't have to proactively delete the PromiseNodes extracted from
@@ -1030,26 +1030,26 @@ void XThreadEvent::ensureDoneOrCanceled() {
     }
   }
 
-  KJ_IF_MAYBE(e, replyExecutor) {
+  KJ_IF_SOME(e, replyExecutor) {
     // Since we know we reached the DONE state (or never left UNUSED), we know that the remote
     // thread is all done playing with our `replyPrev` pointer. Only the current thread could
     // possibly modify it after this point. So we can skip the lock if it's already null.
     if (replyLink.isLinked()) {
-      auto lock = e->impl->state.lockExclusive();
+      auto lock = e.impl->state.lockExclusive();
       lock->replies.remove(*this);
     }
   }
 }
 
 void XThreadEvent::sendReply() {
-  KJ_IF_MAYBE(e, replyExecutor) {
+  KJ_IF_SOME(e, replyExecutor) {
     // Queue the reply.
     const EventLoop* replyLoop;
     {
-      auto lock = e->impl->state.lockExclusive();
-      KJ_IF_MAYBE(l, lock->loop) {
+      auto lock = e.impl->state.lockExclusive();
+      KJ_IF_SOME(l, lock->loop) {
         lock->replies.add(*this);
-        replyLoop = l;
+        replyLoop = &l;
       } else {
         // Calling thread exited without cancelling the promise. This is UB. In fact,
         // `replyExecutor` is probably already destroyed and we are in use-after-free territory
@@ -1067,8 +1067,8 @@ void XThreadEvent::sendReply() {
     // EventLoop, and when it tries to destroy this promise, it will wait for `state` to become
     // `DONE`, which we don't set until later on. That's nice because wake() probably makes a
     // syscall and we'd rather not hold the lock through syscalls.
-    KJ_IF_MAYBE(p, replyLoop->port) {
-      p->wake();
+    KJ_IF_SOME(p, replyLoop->port) {
+      p.wake();
     }
   }
 }
@@ -1132,29 +1132,29 @@ protected:
 Maybe<Own<Event>> XThreadEvent::fire() {
   static constexpr DelayedDoneHack DISPOSER {};
 
-  KJ_IF_MAYBE(n, promiseNode) {
-    n->get()->get(result);
-    promiseNode = nullptr;  // make sure to destroy in the thread that created it
+  KJ_IF_SOME(n, promiseNode) {
+    n->get(result);
+    promiseNode = kj::none;  // make sure to destroy in the thread that created it
     return Own<Event>(this, DISPOSER);
   } else {
-    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
       promiseNode = execute();
     })) {
-      result.addException(kj::mv(*exception));
+      result.addException(kj::mv(exception));
     };
-    KJ_IF_MAYBE(n, promiseNode) {
-      n->get()->onReady(this);
+    KJ_IF_SOME(n, promiseNode) {
+      n->onReady(this);
     } else {
       return Own<Event>(this, DISPOSER);
     }
   }
 
-  return nullptr;
+  return kj::none;
 }
 
 void XThreadEvent::traceEvent(TraceBuilder& builder) {
-  KJ_IF_MAYBE(n, promiseNode) {
-    n->get()->tracePromise(builder, true);
+  KJ_IF_SOME(n, promiseNode) {
+    n->tracePromise(builder, true);
   }
 
   // We can't safely trace into another thread, so we'll stop here.
@@ -1229,13 +1229,13 @@ XThreadPaf::FulfillScope::FulfillScope(XThreadPaf** pointer) {
 XThreadPaf::FulfillScope::~FulfillScope() noexcept(false) {
   if (obj != nullptr) {
     auto lock = obj->executor.impl->state.lockExclusive();
-    KJ_IF_MAYBE(l, lock->loop) {
+    KJ_IF_SOME(l, lock->loop) {
       lock->fulfilled.add(*obj);
       __atomic_store_n(&obj->state, FULFILLED, __ATOMIC_RELEASE);
-      KJ_IF_MAYBE(p, l->port) {
+      KJ_IF_SOME(p, l.port) {
         // TODO(perf): It's annoying we have to call wake() with the lock held, but we have to
         //   prevent the destination EventLoop from being destroyed first.
-        p->wake();
+        p.wake();
       }
     } else {
       KJ_LOG(FATAL,
@@ -1268,7 +1268,7 @@ Executor::Executor(EventLoop& loop, Badge<EventLoop>): impl(kj::heap<Impl>(loop)
 Executor::~Executor() noexcept(false) {}
 
 bool Executor::isLive() const {
-  return impl->state.lockShared()->loop != nullptr;
+  return impl->state.lockShared()->loop != kj::none;
 }
 
 void Executor::send(_::XThreadEvent& event, bool sync) const {
@@ -1299,8 +1299,8 @@ void Executor::send(_::XThreadEvent& event, bool sync) const {
 
   auto lock = impl->state.lockExclusive();
   const EventLoop* loop;
-  KJ_IF_MAYBE(l, lock->loop) {
-    loop = l;
+  KJ_IF_SOME(l, lock->loop) {
+    loop = &l;
   } else {
     event.setDisconnected();
     return;
@@ -1309,8 +1309,8 @@ void Executor::send(_::XThreadEvent& event, bool sync) const {
   event.state = _::XThreadEvent::QUEUED;
   lock->start.add(event);
 
-  KJ_IF_MAYBE(p, loop->port) {
-    p->wake();
+  KJ_IF_SOME(p, loop->port) {
+    p.wake();
   } else {
     // Event loop will be waiting on executor.wait(), which will be woken when we unlock the mutex.
   }
@@ -1347,8 +1347,8 @@ bool Executor::poll() {
 }
 
 EventLoop& Executor::getLoop() const {
-  KJ_IF_MAYBE(l, impl->state.lockShared()->loop) {
-    return *l;
+  KJ_IF_SOME(l, impl->state.lockShared()->loop) {
+    return l;
   } else {
     kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "Executor's event loop has exited"));
   }
@@ -1503,8 +1503,8 @@ void FiberStack::run() {
         event->run();
       }
       KJ_CASE_ONEOF(func, SynchronousFunc*) {
-        KJ_IF_MAYBE(exception, kj::runCatchingExceptions(func->func)) {
-          func->exception.emplace(kj::mv(*exception));
+        KJ_IF_SOME(exception, kj::runCatchingExceptions(func->func)) {
+          func->exception.emplace(kj::mv(exception));
         }
       }
     }
@@ -1627,7 +1627,7 @@ Maybe<Own<Event>> FiberBase::fire() {
   KJ_ASSERT(state == WAITING);
   state = RUNNING;
   stack->switchToFiber();
-  return nullptr;
+  return kj::none;
 }
 
 void FiberStack::switchToFiber() {
@@ -1679,10 +1679,10 @@ void FiberBase::run() {
   WaitScope waitScope(currentEventLoop(), *this);
 
   try {
-    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
       runImpl(waitScope);
     })) {
-      result.addException(kj::mv(*exception));
+      result.addException(kj::mv(exception));
     }
   } catch (CanceledException) {
     if (state != CANCELED) {
@@ -1742,9 +1742,9 @@ EventLoop::~EventLoop() noexcept(false) {
   }
   daemons = nullptr;
 
-  KJ_IF_MAYBE(e, executor) {
+  KJ_IF_SOME(e, executor) {
     // Cancel all outstanding cross-thread events.
-    e->get()->impl->disconnect();
+    e->impl->disconnect();
   }
 
   // The application _should_ destroy everything using the EventLoop before destroying the
@@ -1824,8 +1824,8 @@ bool EventLoop::isRunnable() {
 }
 
 const Executor& EventLoop::getExecutor() {
-  KJ_IF_MAYBE(e, executor) {
-    return **e;
+  KJ_IF_SOME(e, executor) {
+    return *e;
   } else {
     return *executor.emplace(kj::atomicRefcounted<_::ExecutorImpl>(*this, Badge<EventLoop>()));
   }
@@ -1833,8 +1833,8 @@ const Executor& EventLoop::getExecutor() {
 
 void EventLoop::setRunnable(bool runnable) {
   if (runnable != lastRunnableState) {
-    KJ_IF_MAYBE(p, port) {
-      p->setRunnable(runnable);
+    KJ_IF_SOME(p, port) {
+      p.setRunnable(runnable);
     }
     lastRunnableState = runnable;
   }
@@ -1854,30 +1854,30 @@ void EventLoop::leaveScope() {
 }
 
 void EventLoop::wait() {
-  KJ_IF_MAYBE(p, port) {
-    if (p->wait()) {
+  KJ_IF_SOME(p, port) {
+    if (p.wait()) {
       // Another thread called wake(). Check for cross-thread events.
-      KJ_IF_MAYBE(e, executor) {
-        e->get()->poll();
+      KJ_IF_SOME(e, executor) {
+        e->poll();
       }
     }
-  } else KJ_IF_MAYBE(e, executor) {
-    e->get()->wait();
+  } else KJ_IF_SOME(e, executor) {
+    e->wait();
   } else {
     KJ_FAIL_REQUIRE("Nothing to wait for; this thread would hang forever.");
   }
 }
 
 void EventLoop::poll() {
-  KJ_IF_MAYBE(p, port) {
-    if (p->poll()) {
+  KJ_IF_SOME(p, port) {
+    if (p.poll()) {
       // Another thread called wake(). Check for cross-thread events.
-      KJ_IF_MAYBE(e, executor) {
-        e->get()->poll();
+      KJ_IF_SOME(e, executor) {
+        e->poll();
       }
     }
-  } else KJ_IF_MAYBE(e, executor) {
-    e->get()->poll();
+  } else KJ_IF_SOME(e, executor) {
+    e->poll();
   }
 }
 
@@ -1932,31 +1932,31 @@ void waitImpl(_::OwnPromiseNode&& node, _::ExceptionOrValue& result, WaitScope& 
   KJ_REQUIRE(&loop == threadLocalEventLoop, "WaitScope not valid for this thread.");
 
   // we don't support fibers when running without exceptions, so just remove the whole block
-  KJ_IF_MAYBE(fiber, waitScope.fiber) {
-    if (fiber->state == FiberBase::CANCELED) {
+  KJ_IF_SOME(fiber, waitScope.fiber) {
+    if (fiber.state == FiberBase::CANCELED) {
       throw fiberCanceledException();
     }
-    KJ_REQUIRE(fiber->state == FiberBase::RUNNING,
+    KJ_REQUIRE(fiber.state == FiberBase::RUNNING,
         "This WaitScope can only be used within the fiber that created it.");
 
     node->setSelfPointer(&node);
-    node->onReady(fiber);
+    node->onReady(&fiber);
 
-    fiber->currentInner = node;
-    KJ_DEFER(fiber->currentInner = nullptr);
+    fiber.currentInner = node;
+    KJ_DEFER(fiber.currentInner = nullptr);
 
     // Switch to the main stack to run the event loop.
-    fiber->state = FiberBase::WAITING;
-    fiber->stack->switchToMain();
+    fiber.state = FiberBase::WAITING;
+    fiber.stack->switchToMain();
 
     // The main stack switched back to us, meaning either the event we registered with
     // node->onReady() fired, or we are being canceled by FiberBase's destructor.
 
-    if (fiber->state == FiberBase::CANCELED) {
+    if (fiber.state == FiberBase::CANCELED) {
       throw fiberCanceledException();
     }
 
-    KJ_ASSERT(fiber->state == FiberBase::RUNNING);
+    KJ_ASSERT(fiber.state == FiberBase::RUNNING);
   } else {
     KJ_REQUIRE(!loop.running, "wait() is not allowed from within event callbacks.");
 
@@ -1994,10 +1994,10 @@ void waitImpl(_::OwnPromiseNode&& node, _::ExceptionOrValue& result, WaitScope& 
 
   waitScope.runOnStackPool([&]() {
     node->get(result);
-    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
       node = nullptr;
     })) {
-      result.addException(kj::mv(*exception));
+      result.addException(kj::mv(exception));
     }
   });
 }
@@ -2410,11 +2410,11 @@ void TransformPromiseNodeBase::onReady(Event* event) noexcept {
 }
 
 void TransformPromiseNodeBase::get(ExceptionOrValue& output) noexcept {
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
     getImpl(output);
     dropDependency();
   })) {
-    output.addException(kj::mv(*exception));
+    output.addException(kj::mv(exception));
   }
 }
 
@@ -2435,14 +2435,14 @@ void TransformPromiseNodeBase::dropDependency() {
 
 void TransformPromiseNodeBase::getDepResult(ExceptionOrValue& output) {
   dependency->get(output);
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
     dependency = nullptr;
   })) {
-    output.addException(kj::mv(*exception));
+    output.addException(kj::mv(exception));
   }
 
-  KJ_IF_MAYBE(e, output.exception) {
-    e->addTrace(continuationTracePtr);
+  KJ_IF_SOME(e, output.exception) {
+    e.addTrace(continuationTracePtr);
   }
 }
 
@@ -2473,10 +2473,10 @@ void ForkBranchBase::hubReady() noexcept {
 }
 
 void ForkBranchBase::releaseHub(ExceptionOrValue& output) {
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([this]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
     hub = nullptr;
   })) {
-    output.addException(kj::mv(*exception));
+    output.addException(kj::mv(exception));
   }
 }
 
@@ -2507,10 +2507,10 @@ ForkHubBase::ForkHubBase(OwnPromiseNode&& innerParam, ExceptionOrValue& resultRe
 Maybe<Own<Event>> ForkHubBase::fire() {
   // Dependency is ready.  Fetch its result and then delete the node.
   inner->get(resultRef);
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([this]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
     inner = nullptr;
   })) {
-    resultRef.addException(kj::mv(*exception));
+    resultRef.addException(kj::mv(exception));
   }
 
   for (auto branch = headBranch; branch != nullptr; branch = branch->next) {
@@ -2523,7 +2523,7 @@ Maybe<Own<Event>> ForkHubBase::fire() {
   // Indicate that the list is no longer active.
   tailBranch = nullptr;
 
-  return nullptr;
+  return kj::none;
 }
 
 void ForkHubBase::traceEvent(TraceBuilder& builder) {
@@ -2595,21 +2595,21 @@ Maybe<Own<Event>> ChainPromiseNode::fire() {
   ExceptionOr<PromiseBase> intermediate;
   inner->get(intermediate);
 
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([this]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
     inner = nullptr;
   })) {
-    intermediate.addException(kj::mv(*exception));
+    intermediate.addException(kj::mv(exception));
   }
 
-  KJ_IF_MAYBE(exception, intermediate.exception) {
+  KJ_IF_SOME(exception, intermediate.exception) {
     // There is an exception.  If there is also a value, delete it.
-    kj::runCatchingExceptions([&]() { intermediate.value = nullptr; });
+    kj::runCatchingExceptions([&]() { intermediate.value = kj::none; });
     // Now set step2 to a rejected promise.
-    inner = allocPromise<ImmediateBrokenPromiseNode>(kj::mv(*exception));
-  } else KJ_IF_MAYBE(value, intermediate.value) {
+    inner = allocPromise<ImmediateBrokenPromiseNode>(kj::mv(exception));
+  } else KJ_IF_SOME(value, intermediate.value) {
     // There is a value and no exception.  The value is itself a promise.  Adopt it as our
     // step2.
-    inner = _::PromiseNode::from(kj::mv(*value));
+    inner = _::PromiseNode::from(kj::mv(value));
   } else {
     // We can only get here if inner->get() returned neither an exception nor a
     // value, which never actually happens.
@@ -2634,7 +2634,7 @@ Maybe<Own<Event>> ChainPromiseNode::fire() {
       inner->onReady(onReadyEvent);
     }
 
-    return nullptr;
+    return kj::none;
   }
 }
 
@@ -2721,7 +2721,7 @@ Maybe<Own<Event>> ExclusiveJoinPromiseNode::Branch::fire() {
     // The other branch already fired, and this branch was canceled. It's possible for both
     // branches to fire if both were armed simultaneously.
   }
-  return nullptr;
+  return kj::none;
 }
 
 void ExclusiveJoinPromiseNode::Branch::traceEvent(TraceBuilder& builder) {
@@ -2764,15 +2764,15 @@ void ArrayJoinPromiseNodeBase::get(ExceptionOrValue& output) noexcept {
     }
 
     // If any of the elements threw exceptions, propagate them.
-    KJ_IF_MAYBE(exception, branch.output.exception) {
-      output.addException(kj::mv(*exception));
+    KJ_IF_SOME(exception, branch.output.exception) {
+      output.addException(kj::mv(exception));
     }
   }
 
   // We either failed fast, or waited for all promises.
-  KJ_DASSERT(countLeft == 0 || output.exception != nullptr);
+  KJ_DASSERT(countLeft == 0 || output.exception != kj::none);
 
-  if (output.exception == nullptr) {
+  if (output.exception == kj::none) {
     // No errors.  The template subclass will need to fill in the result.
     getNoError(output);
   }
@@ -2809,13 +2809,13 @@ Maybe<Own<Event>> ArrayJoinPromiseNodeBase::Branch::fire() {
   if (joinNode.joinBehavior == ArrayJoinBehavior::EAGER) {
     // This implements `joinPromisesFailFast()`'s eager-evaluation semantics.
     dependency->get(output);
-    if (output.exception != nullptr && !joinNode.armed) {
+    if (output.exception != kj::none && !joinNode.armed) {
       joinNode.onReadyEvent.arm();
       joinNode.armed = true;
     }
   }
 
-  return nullptr;
+  return kj::none;
 }
 
 void ArrayJoinPromiseNodeBase::Branch::traceEvent(TraceBuilder& builder) {
@@ -2889,14 +2889,14 @@ void EagerPromiseNodeBase::traceEvent(TraceBuilder& builder) {
 
 Maybe<Own<Event>> EagerPromiseNodeBase::fire() {
   dependency->get(resultRef);
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([this]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
     dependency = nullptr;
   })) {
-    resultRef.addException(kj::mv(*exception));
+    resultRef.addException(kj::mv(exception));
   }
 
   onReadyEvent.arm();
-  return nullptr;
+  return kj::none;
 }
 
 // -------------------------------------------------------------------
@@ -2962,10 +2962,10 @@ void CoroutineBase::unhandled_exception() {
 
   auto exception = getCaughtExceptionAsKj();
 
-  KJ_IF_MAYBE(disposalResults, maybeDisposalResults) {
+  KJ_IF_SOME(disposalResults, maybeDisposalResults) {
     // Exception during coroutine destruction. Only record the first one.
-    if (disposalResults->exception == nullptr) {
-      disposalResults->exception = kj::mv(exception);
+    if (disposalResults.exception == kj::none) {
+      disposalResults.exception = kj::mv(exception);
     }
   } else if (isWaiting()) {
     // Exception during coroutine execution.
@@ -3003,8 +3003,8 @@ void CoroutineBase::onReady(Event* event) noexcept {
 void CoroutineBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
   if (stopAtNextEvent) return;
 
-  KJ_IF_MAYBE(promise, promiseNodeForTrace) {
-    promise->tracePromise(builder, stopAtNextEvent);
+  KJ_IF_SOME(promise, promiseNodeForTrace) {
+    promise.tracePromise(builder, stopAtNextEvent);
   }
 
   // Maybe returning the address of coroutine() will give us a function name with meaningful type
@@ -3026,12 +3026,12 @@ Maybe<Own<Event>> CoroutineBase::fire() {
 
   coroutine.resume();
 
-  return nullptr;
+  return kj::none;
 }
 
 void CoroutineBase::traceEvent(TraceBuilder& builder) {
-  KJ_IF_MAYBE(promise, promiseNodeForTrace) {
-    promise->tracePromise(builder, true);
+  KJ_IF_SOME(promise, promiseNodeForTrace) {
+    promise.tracePromise(builder, true);
   }
 
   // Maybe returning the address of coroutine() will give us a function name with meaningful type
@@ -3063,7 +3063,7 @@ void CoroutineBase::destroy() {
     // the fact that it delivered the exception to _us_ via unhandled_exception(). Anyway, it
     // appears we can work around this by running coroutine.destroy() a second time.
     //
-    // On Clang, `disposalResults.exception != nullptr` implies `!disposalResults.destructorRan`.
+    // On Clang, `disposalResults.exception != kj::none` implies `!disposalResults.destructorRan`.
     // We could optimize out the separate `destructorRan` flag if we verify that other compilers
     // behave the same way.
     coroutine.destroy();
@@ -3071,9 +3071,9 @@ void CoroutineBase::destroy() {
 
   // WARNING: `this` is now a dangling pointer.
 
-  KJ_IF_MAYBE(exception, disposalResults.exception) {
+  KJ_IF_SOME(exception, disposalResults.exception) {
     if (shouldRethrow) {
-      kj::throwFatalException(kj::mv(*exception));
+      kj::throwFatalException(kj::mv(exception));
     } else {
       // An exception is already unwinding the stack, so throwing this secondary exception would
       // call std::terminate().
@@ -3086,8 +3086,8 @@ CoroutineBase::AwaiterBase::AwaiterBase(AwaiterBase&&) = default;
 CoroutineBase::AwaiterBase::~AwaiterBase() noexcept(false) {
   // Make sure it's safe to generate an async stack trace between now and when the Coroutine is
   // destroyed.
-  KJ_IF_MAYBE(coroutineEvent, maybeCoroutineEvent) {
-    coroutineEvent->promiseNodeForTrace = nullptr;
+  KJ_IF_SOME(coroutineEvent, maybeCoroutineEvent) {
+    coroutineEvent.promiseNodeForTrace = nullptr;
   }
 
   unwindDetector.catchExceptionsIfUnwinding([this]() {
@@ -3099,15 +3099,15 @@ CoroutineBase::AwaiterBase::~AwaiterBase() noexcept(false) {
 void CoroutineBase::AwaiterBase::getImpl(ExceptionOrValue& result, void* awaitedAt) {
   node->get(result);
 
-  KJ_IF_MAYBE(exception, result.exception) {
+  KJ_IF_SOME(exception, result.exception) {
     // Manually extend the stack trace with the instruction address where the co_await occurred.
-    exception->addTrace(awaitedAt);
+    exception.addTrace(awaitedAt);
 
     // Pass kj::maxValue for ignoreCount here so that `throwFatalException()` dosen't try to
     // extend the stack trace. There's no point in extending the trace beyond the single frame we
     // added above, as the rest of the trace will always be async framework stuff that no one wants
     // to see.
-    kj::throwFatalException(kj::mv(*exception), kj::maxValue);
+    kj::throwFatalException(kj::mv(exception), kj::maxValue);
   }
 }
 

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -588,11 +588,11 @@ struct CaptureForCoroutine {
 
   template<typename ...Args>
   auto operator()(Args&&... args) {
-    if (maybeFunctor == nullptr) {
+    if (maybeFunctor == kj::none) {
       throwMultipleCoCaptureInvocations();
     }
     auto localFunctor = kj::mv(*kj::_::readMaybe(maybeFunctor));
-    maybeFunctor = nullptr;
+    maybeFunctor = kj::none;
     return coInvoke(kj::mv(localFunctor), kj::fwd<Args>(args)...);
   }
 };
@@ -856,7 +856,7 @@ public:
   // Releases previously-wrapped promises, so that they will not be canceled regardless of what
   // happens to this Canceler.
 
-  bool isEmpty() const { return list == nullptr; }
+  bool isEmpty() const { return list == kj::none; }
   // Indicates if any previously-wrapped promises are still executing. (If this returns true, then
   // cancel() would be a no-op.)
 
@@ -946,7 +946,7 @@ public:
   kj::String trace();
   // Return debug info about all promises currently in the TaskSet.
 
-  bool isEmpty() { return tasks == nullptr; }
+  bool isEmpty() { return tasks == kj::none; }
   // Check if any tasks are running.
 
   Promise<void> onEmpty();
@@ -1257,7 +1257,7 @@ class WaitScope {
 
 public:
   inline explicit WaitScope(EventLoop& loop): loop(loop) { loop.enterScope(); }
-  inline ~WaitScope() { if (fiber == nullptr) loop.leaveScope(); }
+  inline ~WaitScope() { if (fiber == kj::none) loop.leaveScope(); }
   KJ_DISALLOW_COPY_AND_MOVE(WaitScope);
 
   uint poll(uint maxTurnCount = maxValue);
@@ -1290,7 +1290,7 @@ public:
   //
   // This has no effect if this WaitScope itself is for a fiber.
   //
-  // Pass `nullptr` as the parameter to go back to running events on the main stack.
+  // Pass `kj::none` as the parameter to go back to running events on the main stack.
 
   void cancelAllDetached();
   // HACK: Immediately cancel all detached promises.
@@ -1314,8 +1314,8 @@ private:
 
   template <typename Func>
   inline void runOnStackPool(Func&& func) {
-    KJ_IF_MAYBE(pool, runningStacksPool) {
-      pool->runSynchronously(kj::fwd<Func>(func));
+    KJ_IF_SOME(pool, runningStacksPool) {
+      pool.runSynchronously(kj::fwd<Func>(func));
     } else {
       func();
     }

--- a/c++/src/kj/cidr.c++
+++ b/c++/src/kj/cidr.c++
@@ -52,7 +52,7 @@ CidrRange::CidrRange(StringPtr pattern) {
   memcpy(addr.begin(), pattern.begin(), slashPos);
   addr[slashPos] = '\0';
 
-  if (pattern.findFirst(':') == nullptr) {
+  if (pattern.findFirst(':') == kj::none) {
     family = AF_INET;
     KJ_REQUIRE(bitCount <= 32, "invalid CIDR", pattern);
   } else {

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -62,15 +62,15 @@ struct CopyOrMove {
 TEST(Common, Maybe) {
   {
     Maybe<int> m = 123;
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(123, *v);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(123, v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(123, *v);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(123, v);
     } else {
       ADD_FAILURE();
     }
@@ -82,12 +82,12 @@ TEST(Common, Maybe) {
     }));
     EXPECT_FALSE(ranLazy);
 
-    KJ_IF_MAYBE(v, m) {
+    KJ_IF_SOME(v, m) {
       int notUsedForRef = 5;
       const int& ref = m.orDefault([&]() -> int& { return notUsedForRef; });
 
-      EXPECT_EQ(ref, *v);
-      EXPECT_EQ(&ref, v);
+      EXPECT_EQ(ref, v);
+      EXPECT_EQ(&ref, &v);
 
       const int& ref2 = m.orDefault([notUsed = 5]() -> int { return notUsed; });
       EXPECT_NE(&ref, &ref2);
@@ -99,15 +99,15 @@ TEST(Common, Maybe) {
 
   {
     Maybe<Own<CopyOrMove>> m = kj::heap<CopyOrMove>(123);
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(123, (*v)->i);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(123, v->i);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(123, (*v)->i);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(123, v->i);
     } else {
       ADD_FAILURE();
     }
@@ -148,15 +148,15 @@ TEST(Common, Maybe) {
 
   {
     Maybe<int> m = 0;
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(0, *v);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(0, v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(0, *v);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(0, v);
     } else {
       ADD_FAILURE();
     }
@@ -170,16 +170,16 @@ TEST(Common, Maybe) {
   }
 
   {
-    Maybe<int> m = nullptr;
-    EXPECT_TRUE(m == nullptr);
-    EXPECT_FALSE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
+    Maybe<int> m = kj::none;
+    EXPECT_TRUE(m == kj::none);
+    EXPECT_FALSE(m != kj::none);
+    KJ_IF_SOME(v, m) {
       ADD_FAILURE();
-      EXPECT_EQ(0, *v);  // avoid unused warning
+      EXPECT_EQ(0, v);  // avoid unused warning
     }
-    KJ_IF_MAYBE(v, mv(m)) {
+    KJ_IF_SOME(v, mv(m)) {
       ADD_FAILURE();
-      EXPECT_EQ(0, *v);  // avoid unused warning
+      EXPECT_EQ(0, v);  // avoid unused warning
     }
     EXPECT_EQ(456, m.orDefault(456));
     bool ranLazy = false;
@@ -193,15 +193,15 @@ TEST(Common, Maybe) {
   int i = 234;
   {
     Maybe<int&> m = i;
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&i, v);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(&i, &v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&i, v);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(&i, &v);
     } else {
       ADD_FAILURE();
     }
@@ -209,31 +209,31 @@ TEST(Common, Maybe) {
   }
 
   {
-    Maybe<int&> m = nullptr;
-    EXPECT_TRUE(m == nullptr);
-    EXPECT_FALSE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
+    Maybe<int&> m = kj::none;
+    EXPECT_TRUE(m == kj::none);
+    EXPECT_FALSE(m != kj::none);
+    KJ_IF_SOME(v, m) {
       ADD_FAILURE();
-      EXPECT_EQ(0, *v);  // avoid unused warning
+      EXPECT_EQ(0, v);  // avoid unused warning
     }
-    KJ_IF_MAYBE(v, mv(m)) {
+    KJ_IF_SOME(v, mv(m)) {
       ADD_FAILURE();
-      EXPECT_EQ(0, *v);  // avoid unused warning
+      EXPECT_EQ(0, v);  // avoid unused warning
     }
     EXPECT_EQ(456, m.orDefault(456));
   }
 
   {
     Maybe<int&> m = &i;
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&i, v);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(&i, &v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&i, v);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(&i, &v);
     } else {
       ADD_FAILURE();
     }
@@ -243,15 +243,15 @@ TEST(Common, Maybe) {
   {
     const Maybe<int&> m2 = &i;
     Maybe<const int&> m = m2;
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&i, v);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(&i, &v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&i, v);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(&i, &v);
     } else {
       ADD_FAILURE();
     }
@@ -260,15 +260,15 @@ TEST(Common, Maybe) {
 
   {
     Maybe<int&> m = implicitCast<int*>(nullptr);
-    EXPECT_TRUE(m == nullptr);
-    EXPECT_FALSE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
+    EXPECT_TRUE(m == kj::none);
+    EXPECT_FALSE(m != kj::none);
+    KJ_IF_SOME(v, m) {
       ADD_FAILURE();
-      EXPECT_EQ(0, *v);  // avoid unused warning
+      EXPECT_EQ(0, v);  // avoid unused warning
     }
-    KJ_IF_MAYBE(v, mv(m)) {
+    KJ_IF_SOME(v, mv(m)) {
       ADD_FAILURE();
-      EXPECT_EQ(0, *v);  // avoid unused warning
+      EXPECT_EQ(0, v);  // avoid unused warning
     }
     EXPECT_EQ(456, m.orDefault(456));
   }
@@ -276,15 +276,15 @@ TEST(Common, Maybe) {
   {
     Maybe<int> mi = i;
     Maybe<int&> m = mi;
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &v);
     } else {
       ADD_FAILURE();
     }
@@ -292,26 +292,26 @@ TEST(Common, Maybe) {
   }
 
   {
-    Maybe<int> mi = nullptr;
+    Maybe<int> mi = kj::none;
     Maybe<int&> m = mi;
-    EXPECT_TRUE(m == nullptr);
-    KJ_IF_MAYBE(v, m) {
-      KJ_FAIL_EXPECT(*v);
+    EXPECT_TRUE(m == kj::none);
+    KJ_IF_SOME(v, m) {
+      KJ_FAIL_EXPECT(v);
     }
   }
 
   {
     const Maybe<int> mi = i;
     Maybe<const int&> m = mi;
-    EXPECT_FALSE(m == nullptr);
-    EXPECT_TRUE(m != nullptr);
-    KJ_IF_MAYBE(v, m) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+    EXPECT_FALSE(m == kj::none);
+    EXPECT_TRUE(m != kj::none);
+    KJ_IF_SOME(v, m) {
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, mv(m)) {
-      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), v);
+    KJ_IF_SOME(v, mv(m)) {
+      EXPECT_EQ(&KJ_ASSERT_NONNULL(mi), &v);
     } else {
       ADD_FAILURE();
     }
@@ -319,17 +319,17 @@ TEST(Common, Maybe) {
   }
 
   {
-    const Maybe<int> mi = nullptr;
+    const Maybe<int> mi = kj::none;
     Maybe<const int&> m = mi;
-    EXPECT_TRUE(m == nullptr);
-    KJ_IF_MAYBE(v, m) {
-      KJ_FAIL_EXPECT(*v);
+    EXPECT_TRUE(m == kj::none);
+    KJ_IF_SOME(v, m) {
+      KJ_FAIL_EXPECT(v);
     }
   }
 
   {
     // Verify orDefault() works with move-only types.
-    Maybe<kj::String> m = nullptr;
+    Maybe<kj::String> m = kj::none;
     kj::String s = kj::mv(m).orDefault(kj::str("foo"));
     EXPECT_EQ("foo", s);
     EXPECT_EQ("foo", kj::mv(m).orDefault([] {
@@ -342,13 +342,13 @@ TEST(Common, Maybe) {
     Maybe<ImplicitToInt> m(ImplicitToInt { 123 });
     Maybe<uint> m2(m);
     Maybe<uint> m3(kj::mv(m));
-    KJ_IF_MAYBE(v, m2) {
-      EXPECT_EQ(123, *v);
+    KJ_IF_SOME(v, m2) {
+      EXPECT_EQ(123, v);
     } else {
       ADD_FAILURE();
     }
-    KJ_IF_MAYBE(v, m3) {
-      EXPECT_EQ(123, *v);
+    KJ_IF_SOME(v, m3) {
+      EXPECT_EQ(123, v);
     } else {
       ADD_FAILURE();
     }
@@ -357,11 +357,11 @@ TEST(Common, Maybe) {
   {
     // Test usage of immovable types.
     Maybe<Immovable> m;
-    KJ_EXPECT(m == nullptr);
+    KJ_EXPECT(m == kj::none);
     m.emplace();
-    KJ_EXPECT(m != nullptr);
-    m = nullptr;
-    KJ_EXPECT(m == nullptr);
+    KJ_EXPECT(m != kj::none);
+    m = kj::none;
+    KJ_EXPECT(m == kj::none);
   }
 
   {
@@ -369,7 +369,7 @@ TEST(Common, Maybe) {
     CopyOrMove x(123);
     Maybe<CopyOrMove&> m(x);
     Maybe<CopyOrMove> m2 = kj::mv(m);
-    KJ_EXPECT(m == nullptr);  // m is moved out of and cleared
+    KJ_EXPECT(m == kj::none);  // m is moved out of and cleared
     KJ_EXPECT(x.i == 123);  // but what m *referenced* was not moved out of
     KJ_EXPECT(KJ_ASSERT_NONNULL(m2).i == 123);  // m2 is a copy of what m referenced
   }
@@ -377,51 +377,51 @@ TEST(Common, Maybe) {
   {
     // Test that a moved-out-of Maybe<T> is left empty after move constructor.
     Maybe<int> m = 123;
-    KJ_EXPECT(m != nullptr);
+    KJ_EXPECT(m != kj::none);
 
     Maybe<int> n(kj::mv(m));
-    KJ_EXPECT(m == nullptr);
-    KJ_EXPECT(n != nullptr);
+    KJ_EXPECT(m == kj::none);
+    KJ_EXPECT(n != kj::none);
   }
 
   {
     // Test that a moved-out-of Maybe<T> is left empty after move constructor.
     Maybe<int> m = 123;
-    KJ_EXPECT(m != nullptr);
+    KJ_EXPECT(m != kj::none);
 
     Maybe<int> n = kj::mv(m);
-    KJ_EXPECT(m == nullptr);
-    KJ_EXPECT(n != nullptr);
+    KJ_EXPECT(m == kj::none);
+    KJ_EXPECT(n != kj::none);
   }
 
   {
     // Test that a moved-out-of Maybe<T&> is left empty when moved to a Maybe<T>.
     int x = 123;
     Maybe<int&> m = x;
-    KJ_EXPECT(m != nullptr);
+    KJ_EXPECT(m != kj::none);
 
     Maybe<int> n(kj::mv(m));
-    KJ_EXPECT(m == nullptr);
-    KJ_EXPECT(n != nullptr);
+    KJ_EXPECT(m == kj::none);
+    KJ_EXPECT(n != kj::none);
   }
 
   {
     // Test that a moved-out-of Maybe<T&> is left empty when moved to another Maybe<T&>.
     int x = 123;
     Maybe<int&> m = x;
-    KJ_EXPECT(m != nullptr);
+    KJ_EXPECT(m != kj::none);
 
     Maybe<int&> n(kj::mv(m));
-    KJ_EXPECT(m == nullptr);
-    KJ_EXPECT(n != nullptr);
+    KJ_EXPECT(m == kj::none);
+    KJ_EXPECT(n != kj::none);
   }
 
   {
     Maybe<int> m1 = 123;
     Maybe<int> m2 = 123;
     Maybe<int> m3 = 456;
-    Maybe<int> m4 = nullptr;
-    Maybe<int> m5 = nullptr;
+    Maybe<int> m4 = kj::none;
+    Maybe<int> m5 = kj::none;
 
     KJ_EXPECT(m1 == m2);
     KJ_EXPECT(m1 != m3);
@@ -438,8 +438,8 @@ TEST(Common, MaybeConstness) {
   const Maybe<int&> cmi = mi;
 //  const Maybe<int&> cmi2 = cmi;    // shouldn't compile!  Transitive const violation.
 
-  KJ_IF_MAYBE(i2, cmi) {
-    EXPECT_EQ(&i, i2);
+  KJ_IF_SOME(i2, cmi) {
+    EXPECT_EQ(&i, &i2);
   } else {
     ADD_FAILURE();
   }
@@ -448,8 +448,8 @@ TEST(Common, MaybeConstness) {
   const Maybe<const int&> cmci = mci;
   const Maybe<const int&> cmci2 = cmci;
 
-  KJ_IF_MAYBE(i2, cmci2) {
-    EXPECT_EQ(&i, i2);
+  KJ_IF_SOME(i2, cmci2) {
+    EXPECT_EQ(&i, &i2);
   } else {
     ADD_FAILURE();
   }
@@ -465,7 +465,7 @@ TEST(Common, MaybeUnwrapOrReturn) {
     };
 
     KJ_EXPECT(func(123) == 125);
-    KJ_EXPECT(func(nullptr) == -1);
+    KJ_EXPECT(func(kj::none) == -1);
   }
 
   {
@@ -475,7 +475,7 @@ TEST(Common, MaybeUnwrapOrReturn) {
     };
 
     KJ_EXPECT(func(kj::str("123")) == 123);
-    KJ_EXPECT(func(nullptr) == -1);
+    KJ_EXPECT(func(kj::none) == -1);
   }
 
   // Test void return.
@@ -488,7 +488,7 @@ TEST(Common, MaybeUnwrapOrReturn) {
     func(123);
     KJ_EXPECT(val == 123);
     val = 321;
-    func(nullptr);
+    func(kj::none);
     KJ_EXPECT(val == 321);
   }
 
@@ -506,7 +506,7 @@ TEST(Common, MaybeUnwrapOrReturn) {
 
     KJ_EXPECT(func(123) == 125);
     KJ_EXPECT(!wasNull);
-    KJ_EXPECT(func(nullptr) == -1);
+    KJ_EXPECT(func(kj::none) == -1);
     KJ_EXPECT(wasNull);
   }
 
@@ -522,7 +522,7 @@ TEST(Common, MaybeUnwrapOrReturn) {
 
     KJ_EXPECT(func(kj::str("123")) == 123);
     KJ_EXPECT(!wasNull);
-    KJ_EXPECT(func(nullptr) == -1);
+    KJ_EXPECT(func(kj::none) == -1);
     KJ_EXPECT(wasNull);
   }
 
@@ -538,7 +538,7 @@ TEST(Common, MaybeUnwrapOrReturn) {
     func(123);
     KJ_EXPECT(val == 123);
     val = 321;
-    func(nullptr);
+    func(kj::none);
     KJ_EXPECT(val == 321);
   }
 

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -577,15 +577,15 @@ TEST(Common, Downcast) {
 #endif
 
 #if KJ_NO_RTTI
-  EXPECT_TRUE(dynamicDowncastIfAvailable<Bar>(foo) == nullptr);
-  EXPECT_TRUE(dynamicDowncastIfAvailable<Baz>(foo) == nullptr);
+  EXPECT_TRUE(dynamicDowncastIfAvailable<Bar>(foo) == kj::none);
+  EXPECT_TRUE(dynamicDowncastIfAvailable<Baz>(foo) == kj::none);
 #else
-  KJ_IF_MAYBE(m, dynamicDowncastIfAvailable<Bar>(foo)) {
-    EXPECT_EQ(&bar, m);
+  KJ_IF_SOME(m, dynamicDowncastIfAvailable<Bar>(foo)) {
+    EXPECT_EQ(&bar, &m);
   } else {
     KJ_FAIL_ASSERT("Dynamic downcast returned null.");
   }
-  EXPECT_TRUE(dynamicDowncastIfAvailable<Baz>(foo) == nullptr);
+  EXPECT_TRUE(dynamicDowncastIfAvailable<Baz>(foo) == kj::none);
 #endif
 }
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2040,8 +2040,8 @@ public:
   void run() {
     // Move `maybeFunc` to the local scope so that even if we throw, we destroy the functor we had.
     auto maybeLocalFunc = kj::mv(maybeFunc);
-    KJ_IF_MAYBE(func, maybeLocalFunc) {
-      (*func)();
+    KJ_IF_SOME(func, maybeLocalFunc) {
+      func();
     }
   }
 

--- a/c++/src/kj/compat/brotli.h
+++ b/c++/src/kj/compat/brotli.h
@@ -55,7 +55,7 @@ constexpr size_t KJ_BROTLI_BUF_SIZE = 8192;
 
 class BrotliOutputContext final {
 public:
-  BrotliOutputContext(kj::Maybe<int> compressionLevel, kj::Maybe<int> windowBits = nullptr);
+  BrotliOutputContext(kj::Maybe<int> compressionLevel, kj::Maybe<int> windowBits = kj::none);
   ~BrotliOutputContext() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(BrotliOutputContext);
 
@@ -78,7 +78,7 @@ private:
 
 class BrotliInputStream final: public InputStream {
 public:
-  BrotliInputStream(InputStream& inner, kj::Maybe<int> windowBits = nullptr);
+  BrotliInputStream(InputStream& inner, kj::Maybe<int> windowBits = kj::none);
   ~BrotliInputStream() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(BrotliInputStream);
 
@@ -129,7 +129,7 @@ private:
 
 class BrotliAsyncInputStream final: public AsyncInputStream {
 public:
-  BrotliAsyncInputStream(AsyncInputStream& inner, kj::Maybe<int> windowBits = nullptr);
+  BrotliAsyncInputStream(AsyncInputStream& inner, kj::Maybe<int> windowBits = kj::none);
   ~BrotliAsyncInputStream() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(BrotliAsyncInputStream);
 

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -31,10 +31,10 @@ namespace _ {  // private
 GzipOutputContext::GzipOutputContext(kj::Maybe<int> compressionLevel) {
   int initResult;
 
-  KJ_IF_MAYBE(level, compressionLevel) {
+  KJ_IF_SOME(level, compressionLevel) {
     compressing = true;
     initResult =
-      deflateInit2(&ctx, *level, Z_DEFLATED,
+      deflateInit2(&ctx, level, Z_DEFLATED,
                    15 + 16,  // windowBits = 15 (maximum) + magic value 16 to ask for gzip.
                    8,        // memLevel = 8 (the default)
                    Z_DEFAULT_STRATEGY);
@@ -152,7 +152,7 @@ GzipOutputStream::GzipOutputStream(OutputStream& inner, int compressionLevel)
     : inner(inner), ctx(compressionLevel) {}
 
 GzipOutputStream::GzipOutputStream(OutputStream& inner, decltype(DECOMPRESS))
-    : inner(inner), ctx(nullptr) {}
+    : inner(inner), ctx(kj::none) {}
 
 GzipOutputStream::~GzipOutputStream() noexcept(false) {
   pump(Z_FINISH);
@@ -243,7 +243,7 @@ GzipAsyncOutputStream::GzipAsyncOutputStream(AsyncOutputStream& inner, int compr
     : inner(inner), ctx(compressionLevel) {}
 
 GzipAsyncOutputStream::GzipAsyncOutputStream(AsyncOutputStream& inner, decltype(DECOMPRESS))
-    : inner(inner), ctx(nullptr) {}
+    : inner(inner), ctx(kj::none) {}
 
 Promise<void> GzipAsyncOutputStream::write(const void* in, size_t size) {
   ctx.setInput(in, size);

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -59,8 +59,8 @@ namespace {
 KJ_TEST("HttpMethod parse / stringify") {
 #define TRY(name) \
   KJ_EXPECT(kj::str(HttpMethod::name) == #name); \
-  KJ_IF_MAYBE(parsed, tryParseHttpMethodAllowingConnect(#name)) { \
-    KJ_SWITCH_ONEOF(*parsed) { \
+  KJ_IF_SOME(parsed, tryParseHttpMethodAllowingConnect(#name)) { \
+    KJ_SWITCH_ONEOF(parsed) { \
       KJ_CASE_ONEOF(method, HttpMethod) { \
         KJ_EXPECT(method == HttpMethod::name); \
       } \
@@ -703,9 +703,9 @@ public:
     }
 
     auto size = requestBody.tryGetLength();
-    KJ_IF_MAYBE(expectedSize, expectedRequest.requestBodySize) {
-      KJ_IF_MAYBE(s, size) {
-        KJ_EXPECT(*s == *expectedSize, *s);
+    KJ_IF_SOME(expectedSize, expectedRequest.requestBodySize) {
+      KJ_IF_SOME(s, size) {
+        KJ_EXPECT(s == expectedSize, s);
       } else {
         KJ_FAIL_EXPECT("tryGetLength() returned nullptr; expected known size");
       }
@@ -823,7 +823,7 @@ kj::ArrayPtr<const HttpRequestTestCase> requestTestCases() {
         {HttpHeaderId::HOST, "example.com"},
         {HttpHeaderId::CONTENT_TYPE, "text/plain"},
       },
-      nullptr, { "foo", "barbaz" },
+      kj::none, { "foo", "barbaz" },
     },
 
     {
@@ -843,7 +843,7 @@ kj::ArrayPtr<const HttpRequestTestCase> requestTestCases() {
         {HttpHeaderId::HOST, "example.com"},
         {HttpHeaderId::CONTENT_TYPE, "text/plain"},
       },
-      nullptr, { "0123456789abcdef0123456789abc" },
+      kj::none, { "0123456789abcdef0123456789abc" },
     },
 
     {
@@ -884,7 +884,7 @@ kj::ArrayPtr<const HttpRequestTestCase> requestTestCases() {
       "/foo/bar",
       {{HttpHeaderId::HOST, "example.com"},
        {HttpHeaderId::TRANSFER_ENCODING, "chunked"}},
-      nullptr, { "foo", "bar" },
+      kj::none, { "foo", "bar" },
     }
   };
 
@@ -904,7 +904,7 @@ kj::ArrayPtr<const HttpResponseTestCase> responseTestCases() {
 
       200, "OK",
       {{HttpHeaderId::CONTENT_TYPE, "text/plain"}},
-      nullptr, {"baz qux"},
+      kj::none, {"baz qux"},
 
       HttpMethod::GET,
       CLIENT_ONLY,   // Server never sends connection: close
@@ -920,7 +920,7 @@ kj::ArrayPtr<const HttpResponseTestCase> responseTestCases() {
 
       200, "OK",
       {{HttpHeaderId::CONTENT_TYPE, "text/plain"}},
-      nullptr, {"baz qux"},
+      kj::none, {"baz qux"},
 
       HttpMethod::GET,
       CLIENT_ONLY,   // Server never sends transfer-encoding: identity
@@ -934,7 +934,7 @@ kj::ArrayPtr<const HttpResponseTestCase> responseTestCases() {
 
       200, "OK",
       {{HttpHeaderId::CONTENT_TYPE, "text/plain"}},
-      nullptr, {"baz qux"},
+      kj::none, {"baz qux"},
 
       HttpMethod::GET,
       CLIENT_ONLY,   // Server never sends non-delimited message
@@ -1033,7 +1033,7 @@ kj::ArrayPtr<const HttpResponseTestCase> responseTestCases() {
 
       200, "OK",
       {{HttpHeaderId::CONTENT_TYPE, "text/plain"}},
-      nullptr, { "qux", "corge" }
+      kj::none, { "qux", "corge" }
     },
   };
 
@@ -1319,7 +1319,7 @@ kj::ArrayPtr<const HttpTestCase> pipelineTestCases() {
         "0\r\n"
         "\r\n",
 
-        HttpMethod::POST, "/foo", {}, nullptr, {},
+        HttpMethod::POST, "/foo", {}, kj::none, {},
       },
       {
         "HTTP/1.1 200 OK\r\n"
@@ -1328,7 +1328,7 @@ kj::ArrayPtr<const HttpTestCase> pipelineTestCases() {
         "0\r\n"
         "\r\n",
 
-        200, "OK", {}, nullptr, {}
+        200, "OK", {}, kj::none, {}
       },
     },
 
@@ -1344,7 +1344,7 @@ kj::ArrayPtr<const HttpTestCase> pipelineTestCases() {
         "0\r\n"
         "\r\n",
 
-        HttpMethod::POST, "/bar", {}, nullptr, { "garply", "waldo" },
+        HttpMethod::POST, "/bar", {}, kj::none, { "garply", "waldo" },
       },
       {
         "HTTP/1.1 200 OK\r\n"
@@ -1357,7 +1357,7 @@ kj::ArrayPtr<const HttpTestCase> pipelineTestCases() {
         "0\r\n"
         "\r\n",
 
-        200, "OK", {}, nullptr, { "fred", "plugh" }
+        200, "OK", {}, kj::none, { "fred", "plugh" }
       },
     },
 
@@ -1710,8 +1710,8 @@ KJ_TEST("WebSocket core protocol") {
   KJ_HTTP_TEST_SETUP_IO;
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
 
-  auto client = newWebSocket(kj::mv(pipe.ends[0]), nullptr);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr);
+  auto client = newWebSocket(kj::mv(pipe.ends[0]), kj::none);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none);
 
   auto mediumString = kj::strArray(kj::repeat(kj::StringPtr("123456789"), 30), "");
   auto bigString = kj::strArray(kj::repeat(kj::StringPtr("123456789"), 10000), "");
@@ -1774,7 +1774,7 @@ KJ_TEST("WebSocket fragmented") {
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
 
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none);
 
   byte DATA[] = {
     0x01, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',
@@ -1801,7 +1801,7 @@ KJ_TEST("WebSocket compressed fragment") {
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
 
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, CompressionParameters{
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none, CompressionParameters{
       .outboundNoContextTakeover = false,
       .inboundNoContextTakeover = false,
       .outboundMaxWindowBits=15,
@@ -1882,7 +1882,7 @@ KJ_TEST("WebSocket unexpected RSV bits") {
 
   WebSocketErrorCatcher errorCatcher;
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none, kj::none, errorCatcher);
 
   byte DATA[] = {
     0x01, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',
@@ -1910,7 +1910,7 @@ KJ_TEST("WebSocket unexpected continuation frame") {
 
   WebSocketErrorCatcher errorCatcher;
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none, kj::none, errorCatcher);
 
   byte DATA[] = {
     0x80, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',  // Continuation frame with no start frame, plus FIN
@@ -1936,7 +1936,7 @@ KJ_TEST("WebSocket missing continuation frame") {
 
   WebSocketErrorCatcher errorCatcher;
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none, kj::none, errorCatcher);
 
   byte DATA[] = {
     0x01, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',  // Start frame
@@ -1962,7 +1962,7 @@ KJ_TEST("WebSocket fragmented control frame") {
 
   WebSocketErrorCatcher errorCatcher;
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none, kj::none, errorCatcher);
 
   byte DATA[] = {
     0x09, 0x04, 'd', 'a', 't', 'a'  // Fragmented ping frame
@@ -1988,7 +1988,7 @@ KJ_TEST("WebSocket unknown opcode") {
 
   WebSocketErrorCatcher errorCatcher;
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none, kj::none, errorCatcher);
 
   byte DATA[] = {
     0x85, 0x04, 'd', 'a', 't', 'a'  // 5 is a reserved opcode
@@ -2013,7 +2013,7 @@ KJ_TEST("WebSocket unsolicited pong") {
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
 
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none);
 
   byte DATA[] = {
     0x01, 0x06, 'h', 'e', 'l', 'l', 'o', ' ',
@@ -2039,7 +2039,7 @@ KJ_TEST("WebSocket ping") {
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
 
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none);
 
   // Be extra-annoying by having the ping arrive between fragments.
   byte DATA[] = {
@@ -2076,7 +2076,7 @@ KJ_TEST("WebSocket ping mid-send") {
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
 
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none);
 
   auto bigString = kj::strArray(kj::repeat(kj::StringPtr("12345678"), 65536), "");
   auto serverTask = server->send(bigString).eagerlyEvaluate(nullptr);
@@ -2160,7 +2160,7 @@ KJ_TEST("WebSocket double-ping mid-send") {
   auto downPipe = newOneWayPipe();
   InputOutputPair client(kj::mv(downPipe.in), kj::mv(upPipe.out));
   auto server = newWebSocket(kj::heap<InputOutputPair>(kj::mv(upPipe.in), kj::mv(downPipe.out)),
-                             nullptr);
+                             kj::none);
 
   auto bigString = kj::strArray(kj::repeat(kj::StringPtr("12345678"), 65536), "");
   auto serverTask = server->send(bigString).eagerlyEvaluate(nullptr);
@@ -2197,7 +2197,7 @@ KJ_TEST("WebSocket multiple ping outside of send") {
   auto downPipe = newOneWayPipe();
   InputOutputPair client(kj::mv(downPipe.in), kj::mv(upPipe.out));
   auto server = newWebSocket(kj::heap<InputOutputPair>(kj::mv(upPipe.in), kj::mv(downPipe.out)),
-                             nullptr);
+                             kj::none);
 
   byte DATA[] = {
     0x89, 0x05, 'p', 'i', 'n', 'g', '1',
@@ -2240,7 +2240,7 @@ KJ_TEST("WebSocket ping received during pong send") {
   auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
 
   auto client = kj::mv(pipe.ends[0]);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none);
 
   // Send a very large ping so that sending the pong takes a while. Then send a second ping
   // immediately after.
@@ -2276,9 +2276,9 @@ KJ_TEST("WebSocket pump byte counting") {
   auto pipe2 = KJ_HTTP_TEST_CREATE_2PIPE;
 
   FakeEntropySource maskGenerator;
-  auto server1 = newWebSocket(kj::mv(pipe1.ends[1]), nullptr);
+  auto server1 = newWebSocket(kj::mv(pipe1.ends[1]), kj::none);
   auto client2 = newWebSocket(kj::mv(pipe2.ends[0]), maskGenerator);
-  auto server2 = newWebSocket(kj::mv(pipe2.ends[1]), nullptr);
+  auto server2 = newWebSocket(kj::mv(pipe2.ends[1]), kj::none);
 
   auto pumpTask = server1->pumpTo(*client2);
   auto receiveTask = server2->receive();
@@ -2312,7 +2312,7 @@ KJ_TEST("WebSocket pump disconnect on send") {
 
   FakeEntropySource maskGenerator;
   auto client1 = newWebSocket(kj::mv(pipe1.ends[0]), maskGenerator);
-  auto server1 = newWebSocket(kj::mv(pipe1.ends[1]), nullptr);
+  auto server1 = newWebSocket(kj::mv(pipe1.ends[1]), kj::none);
   auto client2 = newWebSocket(kj::mv(pipe2.ends[0]), maskGenerator);
 
   auto pumpTask = server1->pumpTo(*client2);
@@ -2338,9 +2338,9 @@ KJ_TEST("WebSocket pump disconnect on receive") {
   auto pipe2 = KJ_HTTP_TEST_CREATE_2PIPE;
 
   FakeEntropySource maskGenerator;
-  auto server1 = newWebSocket(kj::mv(pipe1.ends[1]), nullptr);
+  auto server1 = newWebSocket(kj::mv(pipe1.ends[1]), kj::none);
   auto client2 = newWebSocket(kj::mv(pipe2.ends[0]), maskGenerator);
-  auto server2 = newWebSocket(kj::mv(pipe2.ends[1]), nullptr);
+  auto server2 = newWebSocket(kj::mv(pipe2.ends[1]), kj::none);
 
   auto pumpTask = server1->pumpTo(*client2);
   auto receiveTask = server2->receive();
@@ -2364,8 +2364,8 @@ KJ_TEST("WebSocket abort propagates through pipe") {
   KJ_HTTP_TEST_SETUP_IO;
   auto pipe1 = KJ_HTTP_TEST_CREATE_2PIPE;
 
-  auto server = newWebSocket(kj::mv(pipe1.ends[1]), nullptr);
-  auto client = newWebSocket(kj::mv(pipe1.ends[0]), nullptr);
+  auto server = newWebSocket(kj::mv(pipe1.ends[1]), kj::none);
+  auto client = newWebSocket(kj::mv(pipe1.ends[0]), kj::none);
 
   auto wsPipe = newWebSocketPipe();
 
@@ -2385,7 +2385,7 @@ KJ_TEST("WebSocket maximum message size") {
   WebSocketErrorCatcher errorCatcher;
   FakeEntropySource maskGenerator;
   auto client = newWebSocket(kj::mv(pipe.ends[0]), maskGenerator);
-  auto server = newWebSocket(kj::mv(pipe.ends[1]), nullptr, nullptr, errorCatcher);
+  auto server = newWebSocket(kj::mv(pipe.ends[1]), kj::none, kj::none, errorCatcher);
 
   size_t maxSize = 100;
   auto biggestAllowedString = kj::strArray(kj::repeat(kj::StringPtr("A"), maxSize), "");
@@ -2420,8 +2420,8 @@ public:
     KJ_ASSERT(headers.isWebSocket());
 
     HttpHeaders responseHeaders(headerTable);
-    KJ_IF_MAYBE(h, headers.get(hMyHeader)) {
-      responseHeaders.set(hMyHeader, kj::str("respond-", *h));
+    KJ_IF_SOME(h, headers.get(hMyHeader)) {
+      responseHeaders.set(hMyHeader, kj::str("respond-", h));
     }
 
     if (url == "/return-error") {
@@ -2712,9 +2712,9 @@ void testWebSocketOptimizePumpProxy(kj::WaitScope& waitScope, HttpHeaderTable& h
   auto ws = kj::mv(response.webSocketOrBody.get<kj::Own<WebSocket>>());
 
   auto maybeExt = ws->getPreferredExtensions(kj::WebSocket::ExtensionsContext::REQUEST);
-  // Should be nullptr since we are asking `ws` (a client) to give us extensions that we can give to
+  // Should be none since we are asking `ws` (a client) to give us extensions that we can give to
   // another client. Since clients cannot `optimizedPumpTo` each other, we must get null.
-  KJ_ASSERT(maybeExt == nullptr);
+  KJ_ASSERT(maybeExt == kj::none);
 
   maybeExt = ws->getPreferredExtensions(kj::WebSocket::ExtensionsContext::RESPONSE);
   kj::StringPtr extStr = KJ_ASSERT_NONNULL(maybeExt);
@@ -3259,7 +3259,7 @@ KJ_TEST("WebSocket Compression String Parsing (tryParseAllExtensionOffers)") {
       false,
       false,
       15, // server_max_window_bits = 15
-      nullptr
+      kj::none
   };
   maybeAccepted = _::tryParseAllExtensionOffers(serverOnly, allowServerBits);
   accepted = KJ_ASSERT_NONNULL(maybeAccepted);
@@ -3274,7 +3274,7 @@ KJ_TEST("WebSocket Compression String Parsing (tryParseAllExtensionOffers)") {
       true, // server_no_context_takeover = true
       false,
       13, // server_max_window_bits = 13
-      nullptr
+      kj::none
   };
 
   maybeAccepted = _::tryParseAllExtensionOffers(serverOnly, allowServerTakeoverAndBits);
@@ -3320,7 +3320,7 @@ KJ_TEST("WebSocket Compression String Parsing (tryParseExtensionAgreement)") {
       "client_max_window_bits; server_max_window_bits=10, "
       "permessage-deflate; client_no_context_takeover; client_max_window_bits;"_kj;
 
-  auto maybeAccepted = _::tryParseExtensionAgreement(nullptr, tooManyExtensions);
+  auto maybeAccepted = _::tryParseExtensionAgreement(kj::none, tooManyExtensions);
   KJ_ASSERT(
       KJ_ASSERT_NONNULL(maybeAccepted.tryGet<kj::Exception>()).getDescription() == didNotOffer);
 
@@ -3675,7 +3675,7 @@ void testBadWebSocketHandshake(
       // to our HttpServerErrorHandler (i.e., this function), because it assumes the exception is
       // related to the WebSocket error response. See `HttpServer::Connection::startLoop()` for
       // details.
-      bool responseWasSent = response == nullptr;
+      bool responseWasSent = response == kj::none;
       KJ_FAIL_EXPECT("Unexpected application error", responseWasSent, exception);
       return READY_NOW;
     }
@@ -3768,7 +3768,7 @@ KJ_TEST("HttpServer WebSocket with application error after accept") {
     Promise<void> handleApplicationError(Exception exception, Maybe<Response&> response) override {
       // We accepted the WebSocket, so the response was already sent. At one time, we _did_ expose a
       // useless Response reference here, so this is a regression test.
-      bool responseWasSent = response == nullptr;
+      bool responseWasSent = response == kj::none;
       KJ_EXPECT(responseWasSent);
       KJ_EXPECT(exception.getDescription() == "test exception"_kj);
       return READY_NOW;
@@ -3877,8 +3877,8 @@ public:
       HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& responseSender) override {
     return requestBody.readAllBytes().then([this](kj::Array<byte>&&) -> kj::Promise<void> {
-      KJ_IF_MAYBE(e, exception) {
-        return kj::cp(*e);
+      KJ_IF_SOME(e, exception) {
+        return kj::cp(e);
       } else {
         return kj::READY_NOW;
       }
@@ -4084,10 +4084,10 @@ public:
 private:
   kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText, String message,
       Maybe<HttpService::Response&> response) {
-    KJ_IF_MAYBE(r, response) {
+    KJ_IF_SOME(r, response) {
       HttpHeaderTable headerTable;
       HttpHeaders headers(headerTable);
-      auto body = r->send(statusCode, statusText, headers, message.size());
+      auto body = r.send(statusCode, statusText, headers, message.size());
       return body->write(message.begin(), message.size()).attach(kj::mv(body), kj::mv(message));
     } else {
       KJ_LOG(ERROR, "Saw an error but too late to report to client.");
@@ -4362,8 +4362,8 @@ public:
     ++inFlight;
     return result.attach(kj::defer([this]() {
       if (--inFlight == 0) {
-        KJ_IF_MAYBE(f, onCancelFulfiller) {
-          f->get()->fulfill();
+        KJ_IF_SOME(f, onCancelFulfiller) {
+          f->fulfill();
         }
       }
     }));
@@ -4419,14 +4419,14 @@ public:
   kj::Maybe<kj::Own<HttpService>> operator()(HttpServer::SuspendableRequest& sr) {
     if (countdown == 0) {
       suspendedRequest = sr.suspend();
-      return nullptr;
+      return kj::none;
     }
     --countdown;
     return kj::Own<HttpService>(static_cast<HttpService*>(this), kj::NullDisposer::instance);
   }
 
   kj::Maybe<HttpServer::SuspendedRequest> getSuspended() {
-    KJ_DEFER(suspendedRequest = nullptr);
+    KJ_DEFER(suspendedRequest = kj::none);
     return kj::mv(suspendedRequest);
   }
 
@@ -4978,7 +4978,7 @@ KJ_TEST("adapted client/server propagates request exceptions like non-adapted cl
   public:
     Request request(
         HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
-        kj::Maybe<uint64_t> expectedBodySize = nullptr) override {
+        kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
       KJ_FAIL_ASSERT("request_fail");
     }
 
@@ -5068,7 +5068,7 @@ KJ_TEST("adapted client waits for service to complete before returning EOF on re
 }
 
 KJ_TEST("adapted client waits for service to complete before returning EOF on chunked response") {
-  doDelayedCompletionTest(false, nullptr);
+  doDelayedCompletionTest(false, kj::none);
 }
 
 KJ_TEST("adapted client propagates throw from service after complete response body sent") {
@@ -5080,7 +5080,7 @@ KJ_TEST("adapted client propagates throw from service after incomplete response 
 }
 
 KJ_TEST("adapted client propagates throw from service after chunked response body sent") {
-  doDelayedCompletionTest(true, nullptr);
+  doDelayedCompletionTest(true, kj::none);
 }
 
 class DelayedCompletionWebSocketHttpService final: public HttpService {
@@ -5703,7 +5703,7 @@ KJ_TEST("NetworkHttpClient connect impl") {
   kj::TimerImpl clientTimer(kj::origin<kj::TimePoint>());
   HttpHeaderTable headerTable;
   auto client = newHttpClient(clientTimer, headerTable,
-      io.provider->getNetwork(), nullptr, clientSettings);
+      io.provider->getNetwork(), kj::none, clientSettings);
   auto request = client->connect(
       kj::str("localhost:", listener1->getPort()), HttpHeaders(headerTable), {});
 
@@ -5836,15 +5836,15 @@ KJ_TEST("HttpClient to capnproto.org") {
     return kj::mv(connection);
   }, [](kj::Exception&& e) -> kj::Maybe<kj::Own<kj::AsyncIoStream>> {
     KJ_LOG(WARNING, "skipping test because couldn't connect to capnproto.org");
-    return nullptr;
+    return kj::none;
   }).wait(io.waitScope);
 
-  KJ_IF_MAYBE(conn, maybeConn) {
+  KJ_IF_SOME(conn, maybeConn) {
     // Successfully connected to capnproto.org. Try doing GET /. We expect to get a redirect to
     // HTTPS, because what kind of horrible web site would serve in plaintext, really?
 
     HttpHeaderTable table;
-    auto client = newHttpClient(table, **conn);
+    auto client = newHttpClient(table, *conn);
 
     HttpHeaders headers(table);
     headers.set(HttpHeaderId::HOST, "capnproto.org");
@@ -7198,9 +7198,9 @@ struct HttpRangeTestCase {
   kj::OneOf<InitializeableArray<HttpByteRange>, HttpEverythingRange, HttpUnsatisfiableRange> expected;
 
   HttpRangeTestCase(kj::StringPtr value, uint64_t contentLength) :
-    value(value), contentLength(contentLength), expected(HttpUnsatisfiableRange {}) {} 
+    value(value), contentLength(contentLength), expected(HttpUnsatisfiableRange {}) {}
   HttpRangeTestCase(kj::StringPtr value, uint64_t contentLength, HttpEverythingRange expected) :
-    value(value), contentLength(contentLength), expected(expected) {}  
+    value(value), contentLength(contentLength), expected(expected) {}
   HttpRangeTestCase(kj::StringPtr value, uint64_t contentLength, InitializeableArray<HttpByteRange> expected) :
     value(value), contentLength(contentLength), expected(kj::mv(expected)) {}
 };
@@ -7215,7 +7215,7 @@ KJ_TEST("Range header parsing") {
     {"    Bytes        =0-1"_kjc,     2, HttpEverythingRange {}},
     // Check fails with other units
     {"nibbles=0-1"_kjc,               2},
-    
+
     // ===== Interval =====
     // Check valid ranges accepted
     {"bytes=0-1"_kjc,                 8, {{0,1}}},
@@ -7235,7 +7235,7 @@ KJ_TEST("Range header parsing") {
     {"bytes=0-2,1-3"_kjc,             5, {{0,2},{1,3}}},
     // Check unsatisfiable ranges ignored
     {"bytes=1-2,7-8"_kjc,             5, {{1,2}}},
-    
+
     // ===== Prefix =====
     // Check valid ranges accepted
     {"bytes=2-"_kjc,                  8, {{2,7}}},
@@ -7245,7 +7245,7 @@ KJ_TEST("Range header parsing") {
     {"bytes=5-"_kjc,                  2},
     // Check multiple valid ranges accepted
     {"bytes=  1-  ,6-, 10-11 "_kjc,  12, {{1,11},{6,11},{10,11}}},
-    
+
     // ===== Suffix =====
     // Check valid ranges accepted
     {"bytes=-2"_kjc,                  8, {{6,7}}},
@@ -7258,7 +7258,7 @@ KJ_TEST("Range header parsing") {
     // Check unsatisfiable empty range ignored
     {"bytes=-0"_kjc,                  2},
     {"bytes=0-1,-0,2-3"_kjc,          4, {{0,1},{2,3}}},
-    
+
     // ===== Invalid =====
     // Check range with no start or end rejected
     {"bytes=-"_kjc,                   2},
@@ -7270,7 +7270,7 @@ KJ_TEST("Range header parsing") {
     {"bytes="_kjc,                    2},
     {"bytes"_kjc,                     2},
   };
-  
+
   for (auto& testCase : RANGE_TEST_CASES) {
     auto ranges = tryParseHttpRangeHeader(testCase.value, testCase.contentLength);
     KJ_SWITCH_ONEOF(testCase.expected) {
@@ -7299,7 +7299,7 @@ KJ_TEST("Range header parsing") {
             KJ_FAIL_ASSERT("Expected ", testCase.value, testCase.contentLength, "to be unsatisfiable");
           }
         }
-      } 
+      }
     }
   }
 }

--- a/c++/src/kj/compat/readiness-io-test.c++
+++ b/c++/src/kj/compat/readiness-io-test.c++
@@ -49,9 +49,9 @@ KJ_TEST("readiness IO: write many odd") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_MAYBE(n, out.write(kj::StringPtr("bar").asBytes())) {
-      totalWritten += *n;
-      if (*n < 3) {
+    KJ_IF_SOME(n, out.write(kj::StringPtr("bar").asBytes())) {
+      totalWritten += n;
+      if (n < 3) {
         break;
       }
     } else {
@@ -75,9 +75,9 @@ KJ_TEST("readiness IO: write even") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_MAYBE(n, out.write(kj::StringPtr("ba").asBytes())) {
-      totalWritten += *n;
-      if (*n < 2) {
+    KJ_IF_SOME(n, out.write(kj::StringPtr("ba").asBytes())) {
+      totalWritten += n;
+      if (n < 2) {
         KJ_FAIL_ASSERT("pipe buffer is not divisible by 2? really?");
       }
     } else {
@@ -133,9 +133,9 @@ KJ_TEST("readiness IO: write many odd while corked") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_MAYBE(n, out.write(kj::StringPtr("bar").asBytes())) {
-      totalWritten += *n;
-      if (*n < 3) {
+    KJ_IF_SOME(n, out.write(kj::StringPtr("bar").asBytes())) {
+      totalWritten += n;
+      if (n < 3) {
         break;
       }
     } else {
@@ -165,9 +165,9 @@ KJ_TEST("readiness IO: write many even while corked") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_MAYBE(n, out.write(kj::StringPtr("ba").asBytes())) {
-      totalWritten += *n;
-      if (*n < 2) {
+    KJ_IF_SOME(n, out.write(kj::StringPtr("ba").asBytes())) {
+      totalWritten += n;
+      if (n < 2) {
         KJ_FAIL_ASSERT("pipe buffer is not divisible by 2? really?");
       }
     } else {
@@ -208,8 +208,8 @@ KJ_TEST("readiness IO: read small") {
   kj::Maybe<size_t> finalRead;
   for (;;) {
     finalRead = in.read(kj::ArrayPtr<char>(buf).asBytes());
-    KJ_IF_MAYBE(n, finalRead) {
-      KJ_ASSERT(*n == 0);
+    KJ_IF_SOME(n, finalRead) {
+      KJ_ASSERT(n == 0);
       break;
     } else {
       in.whenReady().wait(io.waitScope);
@@ -235,12 +235,12 @@ KJ_TEST("readiness IO: read many odd") {
 
   for (;;) {
     auto result = in.read(kj::ArrayPtr<char>(buf).asBytes());
-    KJ_IF_MAYBE(n, result) {
-      for (size_t i = 0; i < *n; i++) {
+    KJ_IF_SOME(n, result) {
+      for (size_t i = 0; i < n; i++) {
         KJ_ASSERT(buf[i] == "bar"[i]);
       }
-      KJ_ASSERT(*n != 0, "ended at wrong spot");
-      if (*n < 3) {
+      KJ_ASSERT(n != 0, "ended at wrong spot");
+      if (n < 3) {
         break;
       }
     } else {
@@ -251,8 +251,8 @@ KJ_TEST("readiness IO: read many odd") {
   kj::Maybe<size_t> finalRead;
   for (;;) {
     finalRead = in.read(kj::ArrayPtr<char>(buf).asBytes());
-    KJ_IF_MAYBE(n, finalRead) {
-      KJ_ASSERT(*n == 0);
+    KJ_IF_SOME(n, finalRead) {
+      KJ_ASSERT(n == 0);
       break;
     } else {
       in.whenReady().wait(io.waitScope);
@@ -278,14 +278,14 @@ KJ_TEST("readiness IO: read many even") {
 
   for (;;) {
     auto result = in.read(kj::ArrayPtr<char>(buf).asBytes());
-    KJ_IF_MAYBE(n, result) {
-      for (size_t i = 0; i < *n; i++) {
+    KJ_IF_SOME(n, result) {
+      for (size_t i = 0; i < n; i++) {
         KJ_ASSERT(buf[i] == "ba"[i]);
       }
-      if (*n == 0) {
+      if (n == 0) {
         break;
       }
-      KJ_ASSERT(*n == 2, "ended at wrong spot");
+      KJ_ASSERT(n == 2, "ended at wrong spot");
     } else {
       in.whenReady().wait(io.waitScope);
     }
@@ -294,8 +294,8 @@ KJ_TEST("readiness IO: read many even") {
   kj::Maybe<size_t> finalRead;
   for (;;) {
     finalRead = in.read(kj::ArrayPtr<char>(buf).asBytes());
-    KJ_IF_MAYBE(n, finalRead) {
-      KJ_ASSERT(*n == 0);
+    KJ_IF_SOME(n, finalRead) {
+      KJ_ASSERT(n == 0);
       break;
     } else {
       in.whenReady().wait(io.waitScope);

--- a/c++/src/kj/compat/readiness-io.c++
+++ b/c++/src/kj/compat/readiness-io.c++
@@ -54,7 +54,7 @@ kj::Maybe<size_t> ReadyInputStreamWrapper::read(kj::ArrayPtr<byte> dst) {
       }).fork();
     }
 
-    return nullptr;
+    return kj::none;
   }
 
   return copyInto(dst, content);
@@ -74,7 +74,7 @@ kj::Maybe<size_t> ReadyOutputStreamWrapper::write(kj::ArrayPtr<const byte> data)
 
   if (filled == sizeof(buffer)) {
     // No space.
-    return nullptr;
+    return kj::none;
   }
 
   uint end = start + filled;

--- a/c++/src/kj/compat/readiness-io.h
+++ b/c++/src/kj/compat/readiness-io.h
@@ -110,8 +110,8 @@ class ReadyOutputStreamWrapper::Cork {
   // An object that, when destructed, will uncork its parent stream.
 public:
   ~Cork() {
-    KJ_IF_MAYBE(p, parent) {
-      p->uncork();
+    KJ_IF_SOME(p, parent) {
+      p.uncork();
     }
   }
   Cork(Cork&& other) : parent(kj::mv(other.parent)) {

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -393,9 +393,9 @@ private:
 
   static int bioRead(BIO* b, char* out, int outl) {
     BIO_clear_retry_flags(b);
-    KJ_IF_MAYBE(n, reinterpret_cast<TlsConnection*>(BIO_get_data(b))->readBuffer
+    KJ_IF_SOME(n, reinterpret_cast<TlsConnection*>(BIO_get_data(b))->readBuffer
         .read(kj::arrayPtr(out, outl).asBytes())) {
-      return *n;
+      return n;
     } else {
       BIO_set_retry_read(b);
       return -1;
@@ -404,9 +404,9 @@ private:
 
   static int bioWrite(BIO* b, const char* in, int inl) {
     BIO_clear_retry_flags(b);
-    KJ_IF_MAYBE(n, reinterpret_cast<TlsConnection*>(BIO_get_data(b))->writeBuffer
+    KJ_IF_SOME(n, reinterpret_cast<TlsConnection*>(BIO_get_data(b))->writeBuffer
         .write(kj::arrayPtr(in, inl).asBytes())) {
-      return *n;
+      return n;
     } else {
       BIO_set_retry_write(b);
       return -1;
@@ -494,8 +494,8 @@ public:
         tasks(*this) {}
 
   void taskFailed(Exception&& e) override {
-    KJ_IF_MAYBE(handler, acceptErrorHandler){
-      handler->operator()(kj::mv(e));
+    KJ_IF_SOME(handler, acceptErrorHandler){
+      handler(kj::mv(e));
     } else if (e.getType() != Exception::Type::DISCONNECTED) {
       KJ_LOG(ERROR, "error accepting tls connection", kj::mv(e));
     }
@@ -508,9 +508,9 @@ public:
   }
 
   Promise<AuthenticatedStream> acceptAuthenticated() override {
-    KJ_IF_MAYBE(e, maybeInnerException) {
+    KJ_IF_SOME(e, maybeInnerException) {
       // We've experienced an exception from the inner receiver, we consider this unrecoverable.
-      return Exception(*e);
+      return Exception(e);
     }
 
     return queue.pop();
@@ -638,8 +638,8 @@ public:
 
     if (addr.startsWith("[")) {
       // IPv6, like "[1234:5678::abcd]:123". Take the part between the brackets.
-      KJ_IF_MAYBE(pos, addr.findFirst(']')) {
-        hostname = kj::str(addr.slice(1, *pos));
+      KJ_IF_SOME(pos, addr.findFirst(']')) {
+        hostname = kj::str(addr.slice(1, pos));
       } else {
         // Uhh??? Just take the whole thing, cert will fail later.
         hostname = kj::heapString(addr);
@@ -669,8 +669,8 @@ public:
         // us what the actual parser decided the hostname is. However, when I tried this it proved
         // rather cumbersome and actually broke code in the Workers Runtime that does complicated
         // stacking of kj::Network implementations.
-        KJ_IF_MAYBE(pos, addr.findFirst(':')) {
-          hostname = kj::heapString(addr.slice(0, *pos));
+        KJ_IF_SOME(pos, addr.findFirst(':')) {
+          hostname = kj::heapString(addr.slice(0, pos));
         } else {
           hostname = kj::heapString(addr);
         }
@@ -792,17 +792,17 @@ TlsContext::TlsContext(Options options) {
   }
 
   // honor options.defaultKeypair
-  KJ_IF_MAYBE(kp, options.defaultKeypair) {
-    if (!SSL_CTX_use_PrivateKey(ctx, reinterpret_cast<EVP_PKEY*>(kp->privateKey.pkey))) {
+  KJ_IF_SOME(kp, options.defaultKeypair) {
+    if (!SSL_CTX_use_PrivateKey(ctx, reinterpret_cast<EVP_PKEY*>(kp.privateKey.pkey))) {
       throwOpensslError();
     }
 
-    if (!SSL_CTX_use_certificate(ctx, reinterpret_cast<X509*>(kp->certificate.chain[0]))) {
+    if (!SSL_CTX_use_certificate(ctx, reinterpret_cast<X509*>(kp.certificate.chain[0]))) {
       throwOpensslError();
     }
 
-    for (size_t i = 1; i < kj::size(kp->certificate.chain); i++) {
-      X509* x509 = reinterpret_cast<X509*>(kp->certificate.chain[i]);
+    for (size_t i = 1; i < kj::size(kp.certificate.chain); i++) {
+      X509* x509 = reinterpret_cast<X509*>(kp.certificate.chain[i]);
       if (x509 == nullptr) break;  // end of chain
 
       if (!SSL_CTX_add_extra_chain_cert(ctx, x509)) {
@@ -815,15 +815,15 @@ TlsContext::TlsContext(Options options) {
   }
 
   // honor options.sniCallback
-  KJ_IF_MAYBE(sni, options.sniCallback) {
+  KJ_IF_SOME(sni, options.sniCallback) {
     SSL_CTX_set_tlsext_servername_callback(ctx, &SniCallback::callback);
-    SSL_CTX_set_tlsext_servername_arg(ctx, sni);
+    SSL_CTX_set_tlsext_servername_arg(ctx, &sni);
   }
 
-  KJ_IF_MAYBE(timeout, options.acceptTimeout) {
+  KJ_IF_SOME(timeout, options.acceptTimeout) {
     this->timer = KJ_REQUIRE_NONNULL(options.timer,
         "acceptTimeout option requires that a timer is also provided");
-    this->acceptTimeout = *timeout;
+    this->acceptTimeout = timeout;
   }
 
   this->acceptErrorHandler = kj::mv(options.acceptErrorHandler);
@@ -834,17 +834,17 @@ TlsContext::TlsContext(Options options) {
 int TlsContext::SniCallback::callback(SSL* ssl, int* ad, void* arg) {
   // The third parameter is actually type TlsSniCallback*.
 
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
     TlsSniCallback& sni = *reinterpret_cast<TlsSniCallback*>(arg);
 
     const char* name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
     if (name != nullptr) {
-      KJ_IF_MAYBE(kp, sni.getKey(name)) {
-        if (!SSL_use_PrivateKey(ssl, reinterpret_cast<EVP_PKEY*>(kp->privateKey.pkey))) {
+      KJ_IF_SOME(kp, sni.getKey(name)) {
+        if (!SSL_use_PrivateKey(ssl, reinterpret_cast<EVP_PKEY*>(kp.privateKey.pkey))) {
           throwOpensslError();
         }
 
-        if (!SSL_use_certificate(ssl, reinterpret_cast<X509*>(kp->certificate.chain[0]))) {
+        if (!SSL_use_certificate(ssl, reinterpret_cast<X509*>(kp.certificate.chain[0]))) {
           throwOpensslError();
         }
 
@@ -852,8 +852,8 @@ int TlsContext::SniCallback::callback(SSL* ssl, int* ad, void* arg) {
           throwOpensslError();
         }
 
-        for (size_t i = 1; i < kj::size(kp->certificate.chain); i++) {
-          X509* x509 = reinterpret_cast<X509*>(kp->certificate.chain[i]);
+        for (size_t i = 1; i < kj::size(kp.certificate.chain); i++) {
+          X509* x509 = reinterpret_cast<X509*>(kp.certificate.chain[i]);
           if (x509 == nullptr) break;  // end of chain
 
           if (!SSL_add0_chain_cert(ssl, x509)) {
@@ -866,7 +866,7 @@ int TlsContext::SniCallback::callback(SSL* ssl, int* ad, void* arg) {
       }
     }
   })) {
-    KJ_LOG(ERROR, "exception when invoking SNI callback", *exception);
+    KJ_LOG(ERROR, "exception when invoking SNI callback", exception);
     *ad = SSL_AD_INTERNAL_ERROR;
     return SSL_TLSEXT_ERR_ALERT_FATAL;
   }
@@ -891,8 +891,8 @@ kj::Promise<kj::Own<kj::AsyncIoStream>> TlsContext::wrapClient(
 kj::Promise<kj::Own<kj::AsyncIoStream>> TlsContext::wrapServer(kj::Own<kj::AsyncIoStream> stream) {
   auto conn = kj::heap<TlsConnection>(kj::mv(stream), reinterpret_cast<SSL_CTX*>(ctx));
   auto promise = conn->accept();
-  KJ_IF_MAYBE(timeout, acceptTimeout) {
-    promise = KJ_REQUIRE_NONNULL(timer).afterDelay(*timeout).then([]() -> kj::Promise<void> {
+  KJ_IF_SOME(timeout, acceptTimeout) {
+    promise = KJ_REQUIRE_NONNULL(timer).afterDelay(timeout).then([]() -> kj::Promise<void> {
       return KJ_EXCEPTION(DISCONNECTED, "timed out waiting for client during TLS handshake");
     }).exclusiveJoin(kj::mv(promise));
   }
@@ -915,8 +915,8 @@ kj::Promise<kj::AuthenticatedStream> TlsContext::wrapClient(
 kj::Promise<kj::AuthenticatedStream> TlsContext::wrapServer(kj::AuthenticatedStream stream) {
   auto conn = kj::heap<TlsConnection>(kj::mv(stream.stream), reinterpret_cast<SSL_CTX*>(ctx));
   auto promise = conn->accept();
-  KJ_IF_MAYBE(timeout, acceptTimeout) {
-    promise = KJ_REQUIRE_NONNULL(timer).afterDelay(*timeout).then([]() -> kj::Promise<void> {
+  KJ_IF_SOME(timeout, acceptTimeout) {
+    promise = KJ_REQUIRE_NONNULL(timer).afterDelay(timeout).then([]() -> kj::Promise<void> {
       return KJ_EXCEPTION(DISCONNECTED, "timed out waiting for client during TLS handshake");
     }).exclusiveJoin(kj::mv(promise));
   }
@@ -989,9 +989,9 @@ TlsPrivateKey::~TlsPrivateKey() noexcept(false) {
 int TlsPrivateKey::passwordCallback(char* buf, int size, int rwflag, void* u) {
   auto& password = *reinterpret_cast<kj::Maybe<kj::StringPtr>*>(u);
 
-  KJ_IF_MAYBE(p, password) {
-    int result = kj::min(p->size(), size);
-    memcpy(buf, p->begin(), result);
+  KJ_IF_SOME(p, password) {
+    int result = kj::min(p.size(), size);
+    memcpy(buf, p.begin(), result);
     return result;
   } else {
     return 0;

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -288,10 +288,10 @@ TEST(Debug, Catch) {
       line = __LINE__; KJ_FAIL_ASSERT("foo") { break; }
     });
 
-    KJ_IF_MAYBE(e, exception) {
-      String what = str(*e);
-      KJ_IF_MAYBE(eol, what.findFirst('\n')) {
-        what = kj::str(what.slice(0, *eol));
+    KJ_IF_SOME(e, exception) {
+      String what = str(e);
+      KJ_IF_SOME(eol, what.findFirst('\n')) {
+        what = kj::str(what.slice(0, eol));
       }
       std::string text(what.cStr());
       EXPECT_EQ(fileLine(__FILE__, line) + ": failed: foo", text);
@@ -306,10 +306,10 @@ TEST(Debug, Catch) {
       line = __LINE__; KJ_FAIL_ASSERT("foo");
     });
 
-    KJ_IF_MAYBE(e, exception) {
-      String what = str(*e);
-      KJ_IF_MAYBE(eol, what.findFirst('\n')) {
-        what = kj::str(what.slice(0, *eol));
+    KJ_IF_SOME(e, exception) {
+      String what = str(e);
+      KJ_IF_SOME(eol, what.findFirst('\n')) {
+        what = kj::str(what.slice(0, eol));
       }
       std::string text(what.cStr());
       EXPECT_EQ(fileLine(__FILE__, line) + ": failed: foo", text);
@@ -326,8 +326,8 @@ TEST(Debug, Catch) {
     } catch (const std::exception& e) {
       kj::StringPtr what = e.what();
       std::string text;
-      KJ_IF_MAYBE(eol, what.findFirst('\n')) {
-        text.assign(what.cStr(), *eol);
+      KJ_IF_SOME(eol, what.findFirst('\n')) {
+        text.assign(what.cStr(), eol);
       } else {
         text.assign(what.cStr());
       }

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -442,8 +442,8 @@ Debug::Context::Context(): logged(false) {}
 Debug::Context::~Context() noexcept(false) {}
 
 Debug::Context::Value Debug::Context::ensureInitialized() {
-  KJ_IF_MAYBE(v, value) {
-    return Value(v->file, v->line, heapString(v->description));
+  KJ_IF_SOME(v, value) {
+    return Value(v.file, v.line, heapString(v.description));
   } else {
     Value result = evaluate();
     value = Value(result.file, result.line, heapString(result.description));

--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -241,14 +241,26 @@ KJ_TEST("round-trip invalid UTF-16") {
 }
 
 KJ_TEST("EncodingResult as a Maybe") {
-  KJ_IF_MAYBE(result, encodeUtf16("\x80")) {
-    KJ_FAIL_EXPECT("expected failure");
+  {
+    auto result = encodeUtf16("\x80");
+    KJ_EXPECT(result != nullptr);  // It has bytes ...
+    KJ_EXPECT(result == kj::none); // But an error.
+    KJ_IF_SOME(unused, result) {
+      (void)unused;
+      KJ_FAIL_EXPECT("expected failure");
+    }
   }
 
-  KJ_IF_MAYBE(result, encodeUtf16("foo")) {
-    // good
-  } else {
+  {
+    auto result = encodeUtf16("foo");
+    KJ_EXPECT(result != nullptr);
+    KJ_EXPECT(result != kj::none);
+    KJ_IF_SOME(unused, result) {
+      (void)unused;
+      // good
+    } else {
     KJ_FAIL_EXPECT("expected success");
+    }
   }
 
   KJ_EXPECT(KJ_ASSERT_NONNULL(decodeUtf16(u"foo")) == "foo");

--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -356,7 +356,7 @@ static Maybe<uint> tryFromHexDigit(char c) {
   } else if ('A' <= c && c <= 'F') {
     return c - ('A' - 10);
   } else {
-    return nullptr;
+    return kj::none;
   }
 }
 
@@ -364,7 +364,7 @@ static Maybe<uint> tryFromOctDigit(char c) {
   if ('0' <= c && c <= '7') {
     return c - '0';
   } else {
-    return nullptr;
+    return kj::none;
   }
 }
 
@@ -382,13 +382,13 @@ EncodingResult<Array<byte>> decodeHex(ArrayPtr<const char> text) {
 
   for (auto i: kj::indices(result)) {
     byte b = 0;
-    KJ_IF_MAYBE(d1, tryFromHexDigit(text[i*2])) {
-      b = *d1 << 4;
+    KJ_IF_SOME(d1, tryFromHexDigit(text[i*2])) {
+      b = d1 << 4;
     } else {
       hadErrors = true;
     }
-    KJ_IF_MAYBE(d2, tryFromHexDigit(text[i*2+1])) {
-      b |= *d2;
+    KJ_IF_SOME(d2, tryFromHexDigit(text[i*2+1])) {
+      b |= d2;
     } else {
       hadErrors = true;
     }
@@ -507,13 +507,13 @@ EncodingResult<Array<byte>> decodeBinaryUriComponent(
 
       if (ptr == end) {
         hadErrors = true;
-      } else KJ_IF_MAYBE(d1, tryFromHexDigit(*ptr)) {
-        byte b = *d1;
+      } else KJ_IF_SOME(d1, tryFromHexDigit(*ptr)) {
+        byte b = d1;
         ++ptr;
         if (ptr == end) {
           hadErrors = true;
-        } else KJ_IF_MAYBE(d2, tryFromHexDigit(*ptr)) {
-          b = (b << 4) | *d2;
+        } else KJ_IF_SOME(d2, tryFromHexDigit(*ptr)) {
+          b = (b << 4) | d2;
           ++ptr;
         } else {
           hadErrors = true;
@@ -609,9 +609,9 @@ EncodingResult<Array<byte>> decodeBinaryCEscape(ArrayPtr<const char> text, bool 
         case '7': {
           uint value = c2 - '0';
           for (uint j = 0; j < 2 && i < text.size(); j++) {
-            KJ_IF_MAYBE(d, tryFromOctDigit(text[i])) {
+            KJ_IF_SOME(d, tryFromOctDigit(text[i])) {
               ++i;
-              value = (value << 3) | *d;
+              value = (value << 3) | d;
             } else {
               break;
             }
@@ -624,9 +624,9 @@ EncodingResult<Array<byte>> decodeBinaryCEscape(ArrayPtr<const char> text, bool 
         case 'x': {
           uint value = 0;
           while (i < text.size()) {
-            KJ_IF_MAYBE(d, tryFromHexDigit(text[i])) {
+            KJ_IF_SOME(d, tryFromHexDigit(text[i])) {
               ++i;
-              value = (value << 4) | *d;
+              value = (value << 4) | d;
             } else {
               break;
             }
@@ -642,9 +642,9 @@ EncodingResult<Array<byte>> decodeBinaryCEscape(ArrayPtr<const char> text, bool 
             if (i == text.size()) {
               hadErrors = true;
               break;
-            } else KJ_IF_MAYBE(d, tryFromHexDigit(text[i])) {
+            } else KJ_IF_SOME(d, tryFromHexDigit(text[i])) {
               ++i;
-              value = (value << 4) | *d;
+              value = (value << 4) | d;
             } else {
               hadErrors = true;
               break;
@@ -662,9 +662,9 @@ EncodingResult<Array<byte>> decodeBinaryCEscape(ArrayPtr<const char> text, bool 
             if (i == text.size()) {
               hadErrors = true;
               break;
-            } else KJ_IF_MAYBE(d, tryFromHexDigit(text[i])) {
+            } else KJ_IF_SOME(d, tryFromHexDigit(text[i])) {
               ++i;
-              value = (value << 4) | *d;
+              value = (value << 4) | d;
             } else {
               hadErrors = true;
               break;

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -40,11 +40,15 @@ struct EncodingResult: public ResultType {
   // so an application doesn't strictly have to check for errors. E.g. the Unicode functions
   // replace errors with U+FFFD in the output.
   //
-  // Through magic, KJ_IF_MAYBE() and KJ_{REQUIRE,ASSERT}_NONNULL() work on EncodingResult<T>
-  // exactly if it were a Maybe<T> that is null in case of errors.
+  // Through magic, KJ_IF_SOME() and KJ_{REQUIRE,ASSERT}_NONNULL() work on EncodingResult<T>
+  // exactly as if it were a Maybe<T> that is kj::none in case of errors. (Note that an
+  // EncodingResult<T> will compare false with `nullptr`, but true with `kj::none` in this case.)
 
   inline EncodingResult(ResultType&& result, bool hadErrors)
       : ResultType(kj::mv(result)), hadErrors(hadErrors) {}
+
+  using ResultType::operator==;
+  inline bool operator==(kj::None) const { return hadErrors; }
 
   const bool hadErrors;
 };

--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -49,8 +49,8 @@ TEST(Exception, RunCatchingExceptions) {
 
   EXPECT_FALSE(recovered);
 
-  KJ_IF_MAYBE(ex, e) {
-    EXPECT_EQ("foo", ex->getDescription());
+  KJ_IF_SOME(ex, e) {
+    EXPECT_EQ("foo", ex.getDescription());
   } else {
     ADD_FAILURE() << "Expected exception";
   }
@@ -61,8 +61,8 @@ TEST(Exception, RunCatchingExceptionsStdException) {
     throw std::logic_error("foo");
   });
 
-  KJ_IF_MAYBE(ex, e) {
-    EXPECT_EQ("std::exception: foo", ex->getDescription());
+  KJ_IF_SOME(ex, e) {
+    EXPECT_EQ("std::exception: foo", ex.getDescription());
   } else {
     ADD_FAILURE() << "Expected exception";
   }
@@ -73,11 +73,11 @@ TEST(Exception, RunCatchingExceptionsOtherException) {
     throw 123;
   });
 
-  KJ_IF_MAYBE(ex, e) {
+  KJ_IF_SOME(ex, e) {
 #if __GNUC__ && !KJ_NO_RTTI
-    EXPECT_EQ("unknown non-KJ exception of type: int", ex->getDescription());
+    EXPECT_EQ("unknown non-KJ exception of type: int", ex.getDescription());
 #else
-    EXPECT_EQ("unknown non-KJ exception", ex->getDescription());
+    EXPECT_EQ("unknown non-KJ exception", ex.getDescription());
 #endif
   } else {
     ADD_FAILURE() << "Expected exception";
@@ -99,8 +99,8 @@ TEST(Exception, UnwindDetector) {
     ThrowingDestructor t;
   });
 
-  KJ_IF_MAYBE(ex, e) {
-    EXPECT_EQ("this is a test, not a real bug", ex->getDescription());
+  KJ_IF_SOME(ex, e) {
+    EXPECT_EQ("this is a test, not a real bug", ex.getDescription());
   } else {
     ADD_FAILURE() << "Expected exception";
   }
@@ -113,8 +113,8 @@ TEST(Exception, UnwindDetector) {
     }
   });
 
-  KJ_IF_MAYBE(ex, e) {
-    EXPECT_EQ("baz", ex->getDescription());
+  KJ_IF_SOME(ex, e) {
+    EXPECT_EQ("baz", ex.getDescription());
   } else {
     ADD_FAILURE() << "Expected exception";
   }
@@ -208,14 +208,14 @@ KJ_TEST("InFlightExceptionIterator works") {
         KJ_FAIL_ASSERT("bar");
       } catch (const kj::Exception& e) {
         InFlightExceptionIterator iter;
-        KJ_IF_MAYBE(e2, iter.next()) {
-          KJ_EXPECT(e2 == &e, e2->getDescription());
+        KJ_IF_SOME(e2, iter.next()) {
+          KJ_EXPECT(&e2 == &e, e2.getDescription());
         } else {
           KJ_FAIL_EXPECT("missing first exception");
         }
 
-        KJ_IF_MAYBE(e2, iter.next()) {
-          KJ_EXPECT(e2->getDescription() == "foo", e2->getDescription());
+        KJ_IF_SOME(e2, iter.next()) {
+          KJ_EXPECT(e2.getDescription() == "foo", e2.getDescription());
         } else {
           KJ_FAIL_EXPECT("missing second exception");
         }

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -103,10 +103,10 @@ public:
   };
 
   inline Maybe<const Context&> getContext() const {
-    KJ_IF_MAYBE(c, context) {
-      return **c;
+    KJ_IF_SOME(c, context) {
+      return *c;
     } else {
-      return nullptr;
+      return kj::none;
     }
   }
 

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -67,8 +67,8 @@ static auto newTemp(Func&& create)
   static uint counter = 0;
   for (;;) {
     auto path = kj::str(tmpdir, "kj-filesystem-test.", GetCurrentProcessId(), ".", counter++);
-    KJ_IF_MAYBE(result, create(encodeWideString(path, true))) {
-      return kj::mv(*result);
+    KJ_IF_SOME(result, create(encodeWideString(path, true))) {
+      return kj::mv(result);
     }
   }
 }

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -1000,9 +1000,9 @@ public:
         // We must not be in MODIFY mode.
         return false;
       case ERROR_PATH_NOT_FOUND:
-        KJ_IF_MAYBE(p, pathForCreatingParents) {
+        KJ_IF_SOME(p, pathForCreatingParents) {
           if (has(mode, WriteMode::CREATE_PARENT) &&
-              p->size() > 0 && tryMkdir(p->parent(),
+              p.size() > 0 && tryMkdir(p.parent(),
                   WriteMode::CREATE | WriteMode::MODIFY | WriteMode::CREATE_PARENT, true)) {
             // Retry, but make sure we don't try to create the parent again.
             return tryCommitReplacement(toPath, fromPath, mode - WriteMode::CREATE_PARENT);
@@ -1239,10 +1239,10 @@ public:
       rawFromPath = dh->nativePath(fromPath);
     } else
 #endif
-    KJ_IF_MAYBE(h, fromDirectory.getWin32Handle()) {
+    KJ_IF_SOME(h, fromDirectory.getWin32Handle()) {
       // Can't downcast to DiskHandle, but getWin32Handle() returns a handle... maybe RTTI is
       // disabled? Or maybe this is some kind of wrapper?
-      rawFromPath = getPathFromHandle(*h).append(fromPath).forWin32Api(true);
+      rawFromPath = getPathFromHandle(h).append(fromPath).forWin32Api(true);
     } else {
       // Not a disk directory, so fall back to default implementation.
       return self.Directory::tryTransfer(toPath, toMode, fromDirectory, fromPath, mode);

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -302,7 +302,7 @@ String Path::stripNul(String input) {
 void Path::validatePart(StringPtr part) {
   KJ_REQUIRE(part != "" && part != "." && part != "..", "invalid path component", part);
   KJ_REQUIRE(strlen(part.begin()) == part.size(), "NUL character in path component", part);
-  KJ_REQUIRE(part.findFirst('/') == nullptr,
+  KJ_REQUIRE(part.findFirst('/') == kj::none,
       "'/' character in path component; did you mean to use Path::parse()?", part);
 }
 
@@ -348,7 +348,7 @@ Path Path::evalImpl(Vector<String>&& parts, StringPtr path) {
 Path Path::evalWin32Impl(Vector<String>&& parts, StringPtr path, bool fromApi) {
   // Convert all forward slashes to backslashes.
   String ownPath;
-  if (!fromApi && path.findFirst('/') != nullptr) {
+  if (!fromApi && path.findFirst('/') != kj::none) {
     ownPath = heapString(path);
     for (char& c: ownPath) {
       if (c == '/') c = '\\';
@@ -536,8 +536,8 @@ size_t File::copy(uint64_t offset, const ReadableFile& from,
 }
 
 FsNode::Metadata ReadableDirectory::lstat(PathPtr path) const {
-  KJ_IF_MAYBE(meta, tryLstat(path)) {
-    return *meta;
+  KJ_IF_SOME(meta, tryLstat(path)) {
+    return meta;
   } else {
     KJ_FAIL_REQUIRE("no such file or directory", path) { break; }
     return FsNode::Metadata();
@@ -545,8 +545,8 @@ FsNode::Metadata ReadableDirectory::lstat(PathPtr path) const {
 }
 
 Own<const ReadableFile> ReadableDirectory::openFile(PathPtr path) const {
-  KJ_IF_MAYBE(file, tryOpenFile(path)) {
-    return kj::mv(*file);
+  KJ_IF_SOME(file, tryOpenFile(path)) {
+    return kj::mv(file);
   } else {
     KJ_FAIL_REQUIRE("no such file", path) { break; }
     return newInMemoryFile(nullClock());
@@ -554,8 +554,8 @@ Own<const ReadableFile> ReadableDirectory::openFile(PathPtr path) const {
 }
 
 Own<const ReadableDirectory> ReadableDirectory::openSubdir(PathPtr path) const {
-  KJ_IF_MAYBE(dir, tryOpenSubdir(path)) {
-    return kj::mv(*dir);
+  KJ_IF_SOME(dir, tryOpenSubdir(path)) {
+    return kj::mv(dir);
   } else {
     KJ_FAIL_REQUIRE("no such directory", path) { break; }
     return newInMemoryDirectory(nullClock());
@@ -563,8 +563,8 @@ Own<const ReadableDirectory> ReadableDirectory::openSubdir(PathPtr path) const {
 }
 
 String ReadableDirectory::readlink(PathPtr path) const {
-  KJ_IF_MAYBE(p, tryReadlink(path)) {
-    return kj::mv(*p);
+  KJ_IF_SOME(p, tryReadlink(path)) {
+    return kj::mv(p);
   } else {
     KJ_FAIL_REQUIRE("not a symlink", path) { break; }
     return kj::str(".");
@@ -572,8 +572,8 @@ String ReadableDirectory::readlink(PathPtr path) const {
 }
 
 Own<const File> Directory::openFile(PathPtr path, WriteMode mode) const {
-  KJ_IF_MAYBE(f, tryOpenFile(path, mode)) {
-    return kj::mv(*f);
+  KJ_IF_SOME(f, tryOpenFile(path, mode)) {
+    return kj::mv(f);
   } else if (has(mode, WriteMode::CREATE) && !has(mode, WriteMode::MODIFY)) {
     KJ_FAIL_REQUIRE("file already exists", path) { break; }
   } else if (has(mode, WriteMode::MODIFY) && !has(mode, WriteMode::CREATE)) {
@@ -588,8 +588,8 @@ Own<const File> Directory::openFile(PathPtr path, WriteMode mode) const {
 }
 
 Own<AppendableFile> Directory::appendFile(PathPtr path, WriteMode mode) const {
-  KJ_IF_MAYBE(f, tryAppendFile(path, mode)) {
-    return kj::mv(*f);
+  KJ_IF_SOME(f, tryAppendFile(path, mode)) {
+    return kj::mv(f);
   } else if (has(mode, WriteMode::CREATE) && !has(mode, WriteMode::MODIFY)) {
     KJ_FAIL_REQUIRE("file already exists", path) { break; }
   } else if (has(mode, WriteMode::MODIFY) && !has(mode, WriteMode::CREATE)) {
@@ -604,8 +604,8 @@ Own<AppendableFile> Directory::appendFile(PathPtr path, WriteMode mode) const {
 }
 
 Own<const Directory> Directory::openSubdir(PathPtr path, WriteMode mode) const {
-  KJ_IF_MAYBE(f, tryOpenSubdir(path, mode)) {
-    return kj::mv(*f);
+  KJ_IF_SOME(f, tryOpenSubdir(path, mode)) {
+    return kj::mv(f);
   } else if (has(mode, WriteMode::CREATE) && !has(mode, WriteMode::MODIFY)) {
     KJ_FAIL_REQUIRE("directory already exists", path) { break; }
   } else if (has(mode, WriteMode::MODIFY) && !has(mode, WriteMode::CREATE)) {
@@ -653,13 +653,13 @@ static bool tryCopyDirectoryEntry(const Directory& to, PathPtr toPath, WriteMode
 
   switch (type) {
     case FsNode::Type::FILE: {
-      KJ_IF_MAYBE(fromFile, from.tryOpenFile(fromPath)) {
+      KJ_IF_SOME(fromFile, from.tryOpenFile(fromPath)) {
         if (atomic) {
           auto replacer = to.replaceFile(toPath, toMode);
-          replacer->get().copy(0, **fromFile, 0, kj::maxValue);
+          replacer->get().copy(0, *fromFile, 0, kj::maxValue);
           return replacer->tryCommit();
-        } else KJ_IF_MAYBE(toFile, to.tryOpenFile(toPath, toMode)) {
-          toFile->get()->copy(0, **fromFile, 0, kj::maxValue);
+        } else KJ_IF_SOME(toFile, to.tryOpenFile(toPath, toMode)) {
+          toFile->copy(0, *fromFile, 0, kj::maxValue);
           return true;
         } else {
           return false;
@@ -670,13 +670,13 @@ static bool tryCopyDirectoryEntry(const Directory& to, PathPtr toPath, WriteMode
       }
     }
     case FsNode::Type::DIRECTORY:
-      KJ_IF_MAYBE(fromSubdir, from.tryOpenSubdir(fromPath)) {
+      KJ_IF_SOME(fromSubdir, from.tryOpenSubdir(fromPath)) {
         if (atomic) {
           auto replacer = to.replaceSubdir(toPath, toMode);
-          copyContents(replacer->get(), **fromSubdir);
+          copyContents(replacer->get(), *fromSubdir);
           return replacer->tryCommit();
-        } else KJ_IF_MAYBE(toSubdir, to.tryOpenSubdir(toPath, toMode)) {
-          copyContents(**toSubdir, **fromSubdir);
+        } else KJ_IF_SOME(toSubdir, to.tryOpenSubdir(toPath, toMode)) {
+          copyContents(*toSubdir, *fromSubdir);
           return true;
         } else {
           return false;
@@ -686,8 +686,8 @@ static bool tryCopyDirectoryEntry(const Directory& to, PathPtr toPath, WriteMode
         return false;
       }
     case FsNode::Type::SYMLINK:
-      KJ_IF_MAYBE(content, from.tryReadlink(fromPath)) {
-        return to.trySymlink(toPath, *content, toMode);
+      KJ_IF_SOME(content, from.tryReadlink(fromPath)) {
+        return to.trySymlink(toPath, content, toMode);
       } else {
         // Apparently disappeared. Treat as source-doesn't-exist.
         return false;
@@ -716,15 +716,15 @@ bool Directory::tryTransfer(PathPtr toPath, WriteMode toMode,
   KJ_REQUIRE(toPath.size() > 0, "can't replace self") { return false; }
 
   // First try reversing.
-  KJ_IF_MAYBE(result, fromDirectory.tryTransferTo(*this, toPath, toMode, fromPath, mode)) {
-    return *result;
+  KJ_IF_SOME(result, fromDirectory.tryTransferTo(*this, toPath, toMode, fromPath, mode)) {
+    return result;
   }
 
   switch (mode) {
     case TransferMode::COPY:
-      KJ_IF_MAYBE(meta, fromDirectory.tryLstat(fromPath)) {
+      KJ_IF_SOME(meta, fromDirectory.tryLstat(fromPath)) {
         return tryCopyDirectoryEntry(*this, toPath, toMode, fromDirectory,
-                                     fromPath, meta->type, true);
+                                     fromPath, meta.type, true);
       } else {
         // Source doesn't exist.
         return false;
@@ -745,7 +745,7 @@ bool Directory::tryTransfer(PathPtr toPath, WriteMode toMode,
 
 Maybe<bool> Directory::tryTransferTo(const Directory& toDirectory, PathPtr toPath, WriteMode toMode,
                                      PathPtr fromPath, TransferMode mode) const {
-  return nullptr;
+  return kj::none;
 }
 
 void Directory::remove(PathPtr path) const {
@@ -779,7 +779,7 @@ public:
   }
 
   Maybe<int> getFd() const override {
-    return nullptr;
+    return kj::none;
   }
 
   Metadata stat() const override {
@@ -985,7 +985,7 @@ public:
   }
 
   Maybe<int> getFd() const override {
-    return nullptr;
+    return kj::none;
   }
 
   Metadata stat() const override {
@@ -1025,14 +1025,14 @@ public:
       return true;
     } else if (path.size() == 1) {
       auto lock = impl.lockShared();
-      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
-        return exists(lock, *entry);
+      KJ_IF_SOME(entry, lock->tryGetEntry(path[0])) {
+        return exists(lock, entry);
       } else {
         return false;
       }
     } else {
-      KJ_IF_MAYBE(subdir, tryGetParent(path[0])) {
-        return subdir->get()->exists(path.slice(1, path.size()));
+      KJ_IF_SOME(subdir, tryGetParent(path[0])) {
+        return subdir->exists(path.slice(1, path.size()));
       } else {
         return false;
       }
@@ -1044,45 +1044,45 @@ public:
       return stat();
     } else if (path.size() == 1) {
       auto lock = impl.lockShared();
-      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
-        if (entry->node.is<FileNode>()) {
-          return entry->node.get<FileNode>().file->stat();
-        } else if (entry->node.is<DirectoryNode>()) {
-          return entry->node.get<DirectoryNode>().directory->stat();
-        } else if (entry->node.is<SymlinkNode>()) {
-          auto& link = entry->node.get<SymlinkNode>();
+      KJ_IF_SOME(entry, lock->tryGetEntry(path[0])) {
+        if (entry.node.is<FileNode>()) {
+          return entry.node.get<FileNode>().file->stat();
+        } else if (entry.node.is<DirectoryNode>()) {
+          return entry.node.get<DirectoryNode>().directory->stat();
+        } else if (entry.node.is<SymlinkNode>()) {
+          auto& link = entry.node.get<SymlinkNode>();
           uint64_t hash = reinterpret_cast<uintptr_t>(link.content.begin());
           return FsNode::Metadata { FsNode::Type::SYMLINK, 0, 0, link.lastModified, 1, hash };
         } else {
-          KJ_FAIL_ASSERT("unknown node type") { return nullptr; }
+          KJ_FAIL_ASSERT("unknown node type") { return kj::none; }
         }
       } else {
-        return nullptr;
+        return kj::none;
       }
     } else {
-      KJ_IF_MAYBE(subdir, tryGetParent(path[0])) {
-        return subdir->get()->tryLstat(path.slice(1, path.size()));
+      KJ_IF_SOME(subdir, tryGetParent(path[0])) {
+        return subdir->tryLstat(path.slice(1, path.size()));
       } else {
-        return nullptr;
+        return kj::none;
       }
     }
   }
 
   Maybe<Own<const ReadableFile>> tryOpenFile(PathPtr path) const override {
     if (path.size() == 0) {
-      KJ_FAIL_REQUIRE("not a file") { return nullptr; }
+      KJ_FAIL_REQUIRE("not a file") { return kj::none; }
     } else if (path.size() == 1) {
       auto lock = impl.lockShared();
-      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
-        return asFile(lock, *entry);
+      KJ_IF_SOME(entry, lock->tryGetEntry(path[0])) {
+        return asFile(lock, entry);
       } else {
-        return nullptr;
+        return kj::none;
       }
     } else {
-      KJ_IF_MAYBE(subdir, tryGetParent(path[0])) {
-        return subdir->get()->tryOpenFile(path.slice(1, path.size()));
+      KJ_IF_SOME(subdir, tryGetParent(path[0])) {
+        return subdir->tryOpenFile(path.slice(1, path.size()));
       } else {
-        return nullptr;
+        return kj::none;
       }
     }
   }
@@ -1092,35 +1092,35 @@ public:
       return clone();
     } else if (path.size() == 1) {
       auto lock = impl.lockShared();
-      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
-        return asDirectory(lock, *entry);
+      KJ_IF_SOME(entry, lock->tryGetEntry(path[0])) {
+        return asDirectory(lock, entry);
       } else {
-        return nullptr;
+        return kj::none;
       }
     } else {
-      KJ_IF_MAYBE(subdir, tryGetParent(path[0])) {
-        return subdir->get()->tryOpenSubdir(path.slice(1, path.size()));
+      KJ_IF_SOME(subdir, tryGetParent(path[0])) {
+        return subdir->tryOpenSubdir(path.slice(1, path.size()));
       } else {
-        return nullptr;
+        return kj::none;
       }
     }
   }
 
   Maybe<String> tryReadlink(PathPtr path) const override {
     if (path.size() == 0) {
-      KJ_FAIL_REQUIRE("not a symlink") { return nullptr; }
+      KJ_FAIL_REQUIRE("not a symlink") { return kj::none; }
     } else if (path.size() == 1) {
       auto lock = impl.lockShared();
-      KJ_IF_MAYBE(entry, lock->tryGetEntry(path[0])) {
-        return asSymlink(lock, *entry);
+      KJ_IF_SOME(entry, lock->tryGetEntry(path[0])) {
+        return asSymlink(lock, entry);
       } else {
-        return nullptr;
+        return kj::none;
       }
     } else {
-      KJ_IF_MAYBE(subdir, tryGetParent(path[0])) {
-        return subdir->get()->tryReadlink(path.slice(1, path.size()));
+      KJ_IF_SOME(subdir, tryGetParent(path[0])) {
+        return subdir->tryReadlink(path.slice(1, path.size()));
       } else {
-        return nullptr;
+        return kj::none;
       }
     }
   }
@@ -1128,24 +1128,24 @@ public:
   Maybe<Own<const File>> tryOpenFile(PathPtr path, WriteMode mode) const override {
     if (path.size() == 0) {
       if (has(mode, WriteMode::MODIFY)) {
-        KJ_FAIL_REQUIRE("not a file") { return nullptr; }
+        KJ_FAIL_REQUIRE("not a file") { return kj::none; }
       } else if (has(mode, WriteMode::CREATE)) {
-        return nullptr;  // already exists (as a directory)
+        return kj::none;  // already exists (as a directory)
       } else {
-        KJ_FAIL_REQUIRE("can't replace self") { return nullptr; }
+        KJ_FAIL_REQUIRE("can't replace self") { return kj::none; }
       }
     } else if (path.size() == 1) {
       auto lock = impl.lockExclusive();
-      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
-        return asFile(lock, *entry, mode);
+      KJ_IF_SOME(entry, lock->openEntry(path[0], mode)) {
+        return asFile(lock, entry, mode);
       } else {
-        return nullptr;
+        return kj::none;
       }
     } else {
-      KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
-        return child->get()->tryOpenFile(path.slice(1, path.size()), mode);
+      KJ_IF_SOME(child, tryGetParent(path[0], mode)) {
+        return child->tryOpenFile(path.slice(1, path.size()), mode);
       } else {
-        return nullptr;
+        return kj::none;
       }
     }
   }
@@ -1158,8 +1158,8 @@ public:
       return heap<ReplacerImpl<File>>(*this, path[0],
           newInMemoryFile(impl.getWithoutLock().clock), mode);
     } else {
-      KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
-        return child->get()->replaceFile(path.slice(1, path.size()), mode);
+      KJ_IF_SOME(child, tryGetParent(path[0], mode)) {
+        return child->replaceFile(path.slice(1, path.size()), mode);
       }
     }
     return heap<BrokenReplacer<File>>(newInMemoryFile(impl.getWithoutLock().clock));
@@ -1170,22 +1170,22 @@ public:
       if (has(mode, WriteMode::MODIFY)) {
         return atomicAddRef(*this);
       } else if (has(mode, WriteMode::CREATE)) {
-        return nullptr;  // already exists
+        return kj::none;  // already exists
       } else {
-        KJ_FAIL_REQUIRE("can't replace self") { return nullptr; }
+        KJ_FAIL_REQUIRE("can't replace self") { return kj::none; }
       }
     } else if (path.size() == 1) {
       auto lock = impl.lockExclusive();
-      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
-        return asDirectory(lock, *entry, mode);
+      KJ_IF_SOME(entry, lock->openEntry(path[0], mode)) {
+        return asDirectory(lock, entry, mode);
       } else {
-        return nullptr;
+        return kj::none;
       }
     } else {
-      KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
-        return child->get()->tryOpenSubdir(path.slice(1, path.size()), mode);
+      KJ_IF_SOME(child, tryGetParent(path[0], mode)) {
+        return child->tryOpenSubdir(path.slice(1, path.size()), mode);
       } else {
-        return nullptr;
+        return kj::none;
       }
     }
   }
@@ -1198,8 +1198,8 @@ public:
       return heap<ReplacerImpl<Directory>>(*this, path[0],
           newInMemoryDirectory(impl.getWithoutLock().clock), mode);
     } else {
-      KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
-        return child->get()->replaceSubdir(path.slice(1, path.size()), mode);
+      KJ_IF_SOME(child, tryGetParent(path[0], mode)) {
+        return child->replaceSubdir(path.slice(1, path.size()), mode);
       }
     }
     return heap<BrokenReplacer<Directory>>(newInMemoryDirectory(impl.getWithoutLock().clock));
@@ -1208,24 +1208,24 @@ public:
   Maybe<Own<AppendableFile>> tryAppendFile(PathPtr path, WriteMode mode) const override {
     if (path.size() == 0) {
       if (has(mode, WriteMode::MODIFY)) {
-        KJ_FAIL_REQUIRE("not a file") { return nullptr; }
+        KJ_FAIL_REQUIRE("not a file") { return kj::none; }
       } else if (has(mode, WriteMode::CREATE)) {
-        return nullptr;  // already exists (as a directory)
+        return kj::none;  // already exists (as a directory)
       } else {
-        KJ_FAIL_REQUIRE("can't replace self") { return nullptr; }
+        KJ_FAIL_REQUIRE("can't replace self") { return kj::none; }
       }
     } else if (path.size() == 1) {
       auto lock = impl.lockExclusive();
-      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
-        return asFile(lock, *entry, mode).map(newFileAppender);
+      KJ_IF_SOME(entry, lock->openEntry(path[0], mode)) {
+        return asFile(lock, entry, mode).map(newFileAppender);
       } else {
-        return nullptr;
+        return kj::none;
       }
     } else {
-      KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
-        return child->get()->tryAppendFile(path.slice(1, path.size()), mode);
+      KJ_IF_SOME(child, tryGetParent(path[0], mode)) {
+        return child->tryAppendFile(path.slice(1, path.size()), mode);
       } else {
-        return nullptr;
+        return kj::none;
       }
     }
   }
@@ -1239,16 +1239,16 @@ public:
       }
     } else if (path.size() == 1) {
       auto lock = impl.lockExclusive();
-      KJ_IF_MAYBE(entry, lock->openEntry(path[0], mode)) {
-        entry->init(SymlinkNode { lock->clock.now(), heapString(content) });
+      KJ_IF_SOME(entry, lock->openEntry(path[0], mode)) {
+        entry.init(SymlinkNode { lock->clock.now(), heapString(content) });
         lock->modified();
         return true;
       } else {
         return false;
       }
     } else {
-      KJ_IF_MAYBE(child, tryGetParent(path[0], mode)) {
-        return child->get()->trySymlink(path.slice(1, path.size()), content, mode);
+      KJ_IF_SOME(child, tryGetParent(path[0], mode)) {
+        return child->trySymlink(path.slice(1, path.size()), content, mode);
       } else {
         KJ_FAIL_REQUIRE("couldn't create parent directory") { return false; }
       }
@@ -1271,15 +1271,15 @@ public:
       }
     } else if (toPath.size() == 1) {
       // tryTransferChild() needs to at least know the node type, so do an lstat.
-      KJ_IF_MAYBE(meta, fromDirectory.tryLstat(fromPath)) {
+      KJ_IF_SOME(meta, fromDirectory.tryLstat(fromPath)) {
         auto lock = impl.lockExclusive();
-        KJ_IF_MAYBE(entry, lock->openEntry(toPath[0], toMode)) {
+        KJ_IF_SOME(entry, lock->openEntry(toPath[0], toMode)) {
           // Make sure if we just cerated a new entry, and we don't successfully transfer to it, we
           // remove the entry before returning.
-          bool needRollback = entry->node == nullptr;
+          bool needRollback = entry.node == nullptr;
           KJ_DEFER(if (needRollback) { lock->entries.erase(toPath[0]); });
 
-          if (lock->tryTransferChild(*entry, meta->type, meta->lastModified, meta->size,
+          if (lock->tryTransferChild(entry, meta.type, meta.lastModified, meta.size,
                                      fromDirectory, fromPath, mode)) {
             lock->modified();
             needRollback = false;
@@ -1298,8 +1298,8 @@ public:
     } else {
       // TODO(someday): Ideally we wouldn't create parent directories if fromPath doesn't exist.
       //   This requires a different approach to the code here, though.
-      KJ_IF_MAYBE(child, tryGetParent(toPath[0], toMode)) {
-        return child->get()->tryTransfer(
+      KJ_IF_SOME(child, tryGetParent(toPath[0], toMode)) {
+        return child->tryTransfer(
             toPath.slice(1, toPath.size()), toMode, fromDirectory, fromPath, mode);
       } else {
         return false;
@@ -1312,20 +1312,20 @@ public:
     if (fromPath.size() <= 1) {
       // If `fromPath` is in this directory (or *is* this directory) then we don't have any
       // optimizations.
-      return nullptr;
+      return kj::none;
     }
 
     // `fromPath` is in a subdirectory. It could turn out that that subdirectory is not an
     // InMemoryDirectory and is instead something `toDirectory` is friendly with. So let's follow
     // the path.
 
-    KJ_IF_MAYBE(child, tryGetParent(fromPath[0], WriteMode::MODIFY)) {
+    KJ_IF_SOME(child, tryGetParent(fromPath[0], WriteMode::MODIFY)) {
       // OK, switch back to tryTransfer() but use the subdirectory.
       return toDirectory.tryTransfer(toPath, toMode,
-          **child, fromPath.slice(1, fromPath.size()), mode);
+          *child, fromPath.slice(1, fromPath.size()), mode);
     } else {
       // Hmm, doesn't exist. Fall back to standard path.
-      return nullptr;
+      return kj::none;
     }
   }
 
@@ -1343,8 +1343,8 @@ public:
         return true;
       }
     } else {
-      KJ_IF_MAYBE(child, tryGetParent(path[0], WriteMode::MODIFY)) {
-        return child->get()->tryRemove(path.slice(1, path.size()));
+      KJ_IF_SOME(child, tryGetParent(path[0], WriteMode::MODIFY)) {
+        return child->tryRemove(path.slice(1, path.size()));
       } else {
         return false;
       }
@@ -1410,8 +1410,8 @@ private:
       KJ_REQUIRE(!committed, "commit() already called") { return true; }
 
       auto lock = directory->impl.lockExclusive();
-      KJ_IF_MAYBE(entry, lock->openEntry(name, Replacer<T>::mode)) {
-        entry->set(inner->clone());
+      KJ_IF_SOME(entry, lock->openEntry(name, Replacer<T>::mode)) {
+        entry.set(inner->clone());
         lock->modified();
         return true;
       } else {
@@ -1467,7 +1467,7 @@ private:
 
         if (!insertResult.second && !has(mode, WriteMode::MODIFY)) {
           // Entry already existed and MODIFY not specified.
-          return nullptr;
+          return kj::none;
         }
 
         return insertResult.first->second;
@@ -1475,14 +1475,14 @@ private:
         return tryGetEntry(name);
       } else {
         // Neither CREATE nor MODIFY specified: precondition always fails.
-        return nullptr;
+        return kj::none;
       }
     }
 
     kj::Maybe<const EntryImpl&> tryGetEntry(kj::StringPtr name) const {
       auto iter = entries.find(name);
       if (iter == entries.end()) {
-        return nullptr;
+        return kj::none;
       } else {
         return iter->second;
       }
@@ -1491,7 +1491,7 @@ private:
     kj::Maybe<EntryImpl&> tryGetEntry(kj::StringPtr name) {
       auto iter = entries.find(name);
       if (iter == entries.end()) {
-        return nullptr;
+        return kj::none;
       } else {
         return iter->second;
       }
@@ -1506,10 +1506,10 @@ private:
                           PathPtr fromPath, TransferMode mode) {
       switch (type) {
         case FsNode::Type::FILE:
-          KJ_IF_MAYBE(file, fromDirectory.tryOpenFile(fromPath, WriteMode::MODIFY)) {
+          KJ_IF_SOME(file, fromDirectory.tryOpenFile(fromPath, WriteMode::MODIFY)) {
             if (mode == TransferMode::COPY) {
               auto copy = newInMemoryFile(clock);
-              copy->copy(0, **file, 0, size.orDefault(kj::maxValue));
+              copy->copy(0, *file, 0, size.orDefault(kj::maxValue));
               entry.set(kj::mv(copy));
             } else {
               if (mode == TransferMode::MOVE) {
@@ -1517,7 +1517,7 @@ private:
                   return false;
                 }
               }
-              entry.set(kj::mv(*file));
+              entry.set(kj::mv(file));
             }
             return true;
           } else {
@@ -1526,14 +1526,14 @@ private:
             }
           }
         case FsNode::Type::DIRECTORY:
-          KJ_IF_MAYBE(subdir, fromDirectory.tryOpenSubdir(fromPath, WriteMode::MODIFY)) {
+          KJ_IF_SOME(subdir, fromDirectory.tryOpenSubdir(fromPath, WriteMode::MODIFY)) {
             if (mode == TransferMode::COPY) {
               auto copy = atomicRefcounted<InMemoryDirectory>(clock);
               auto& cpim = copy->impl.getWithoutLock();  // safe because just-created
-              for (auto& subEntry: subdir->get()->listEntries()) {
+              for (auto& subEntry: subdir->listEntries()) {
                 EntryImpl newEntry(kj::mv(subEntry.name));
                 Path filename(newEntry.name);
-                if (!cpim.tryTransferChild(newEntry, subEntry.type, nullptr, nullptr, **subdir,
+                if (!cpim.tryTransferChild(newEntry, subEntry.type, kj::none, kj::none, *subdir,
                                            filename, TransferMode::COPY)) {
                   KJ_LOG(ERROR, "couldn't copy node of type not supported by InMemoryDirectory",
                          filename);
@@ -1549,7 +1549,7 @@ private:
                   return false;
                 }
               }
-              entry.set(kj::mv(*subdir));
+              entry.set(kj::mv(subdir));
             }
             return true;
           } else {
@@ -1558,9 +1558,9 @@ private:
             }
           }
         case FsNode::Type::SYMLINK:
-          KJ_IF_MAYBE(content, fromDirectory.tryReadlink(fromPath)) {
+          KJ_IF_SOME(content, fromDirectory.tryReadlink(fromPath)) {
             // Since symlinks are immutable, we can implement LINK the same as COPY.
-            entry.init(SymlinkNode { lastModified.orDefault(clock.now()), kj::mv(*content) });
+            entry.init(SymlinkNode { lastModified.orDefault(clock.now()), kj::mv(content) });
             if (mode == TransferMode::MOVE) {
               KJ_ASSERT(fromDirectory.tryRemove(fromPath), "couldn't move node", fromPath) {
                 return false;
@@ -1598,7 +1598,7 @@ private:
       lock.release();
       return tryOpenFile(newPath);
     } else {
-      KJ_FAIL_REQUIRE("not a file") { return nullptr; }
+      KJ_FAIL_REQUIRE("not a file") { return kj::none; }
     }
   }
   Maybe<Own<const ReadableDirectory>> asDirectory(
@@ -1610,14 +1610,14 @@ private:
       lock.release();
       return tryOpenSubdir(newPath);
     } else {
-      KJ_FAIL_REQUIRE("not a directory") { return nullptr; }
+      KJ_FAIL_REQUIRE("not a directory") { return kj::none; }
     }
   }
   Maybe<String> asSymlink(kj::Locked<const Impl>& lock, const EntryImpl& entry) const {
     if (entry.node.is<SymlinkNode>()) {
       return heapString(entry.node.get<SymlinkNode>().content);
     } else {
-      KJ_FAIL_REQUIRE("not a symlink") { return nullptr; }
+      KJ_FAIL_REQUIRE("not a symlink") { return kj::none; }
     }
   }
 
@@ -1635,7 +1635,7 @@ private:
       lock->modified();
       return entry.init(FileNode { newInMemoryFile(lock->clock) });
     } else {
-      KJ_FAIL_REQUIRE("not a file") { return nullptr; }
+      KJ_FAIL_REQUIRE("not a file") { return kj::none; }
     }
   }
   Maybe<Own<const Directory>> asDirectory(
@@ -1653,16 +1653,16 @@ private:
       lock->modified();
       return entry.init(DirectoryNode { newInMemoryDirectory(lock->clock) });
     } else {
-      KJ_FAIL_REQUIRE("not a directory") { return nullptr; }
+      KJ_FAIL_REQUIRE("not a directory") { return kj::none; }
     }
   }
 
   kj::Maybe<Own<const ReadableDirectory>> tryGetParent(kj::StringPtr name) const {
     auto lock = impl.lockShared();
-    KJ_IF_MAYBE(entry, impl.lockShared()->tryGetEntry(name)) {
-      return asDirectory(lock, *entry);
+    KJ_IF_SOME(entry, impl.lockShared()->tryGetEntry(name)) {
+      return asDirectory(lock, entry);
     } else {
-      return nullptr;
+      return kj::none;
     }
   }
 
@@ -1677,12 +1677,12 @@ private:
         : WriteMode::MODIFY;                      // don't create parent
 
     // Possibly create parent.
-    KJ_IF_MAYBE(entry, lock->openEntry(name, parentMode)) {
-      if (entry->node.is<DirectoryNode>()) {
-        return entry->node.get<DirectoryNode>().directory->clone();
-      } else if (entry->node == nullptr) {
+    KJ_IF_SOME(entry, lock->openEntry(name, parentMode)) {
+      if (entry.node.is<DirectoryNode>()) {
+        return entry.node.get<DirectoryNode>().directory->clone();
+      } else if (entry.node == nullptr) {
         lock->modified();
-        return entry->init(DirectoryNode { newInMemoryDirectory(lock->clock) });
+        return entry.init(DirectoryNode { newInMemoryDirectory(lock->clock) });
       }
       // Continue on.
     }
@@ -1690,9 +1690,9 @@ private:
     if (has(mode, WriteMode::CREATE)) {
       // CREATE is documented as returning null when the file already exists. In this case, the
       // file does NOT exist because the parent directory does not exist or is not a directory.
-      KJ_FAIL_REQUIRE("parent is not a directory") { return nullptr; }
+      KJ_FAIL_REQUIRE("parent is not a directory") { return kj::none; }
     } else {
-      return nullptr;
+      return kj::none;
     }
   }
 };
@@ -1708,7 +1708,7 @@ public:
   }
 
   Maybe<int> getFd() const override {
-    return nullptr;
+    return kj::none;
   }
 
   Metadata stat() const override {

--- a/c++/src/kj/list.h
+++ b/c++/src/kj/list.h
@@ -106,8 +106,8 @@ public:
     if ((element.*link).prev != nullptr) _::throwDoubleAdd();
     (element.*link).next = head;
     (element.*link).prev = &head;
-    KJ_IF_MAYBE(oldHead, head) {
-      (oldHead->*link).prev = &(element.*link).next;
+    KJ_IF_SOME(oldHead, head) {
+      (oldHead.*link).prev = &(element.*link).next;
     } else {
       tail = &(element.*link).next;
     }
@@ -118,8 +118,8 @@ public:
   void remove(T& element) {
     if ((element.*link).prev == nullptr) _::throwRemovedNotPresent();
     *((element.*link).prev) = (element.*link).next;
-    KJ_IF_MAYBE(n, (element.*link).next) {
-      (n->*link).prev = (element.*link).prev;
+    KJ_IF_SOME(n, (element.*link).next) {
+      (n.*link).prev = (element.*link).prev;
     } else {
       if (tail != &((element.*link).next)) _::throwRemovedWrongList();
       tail = (element.*link).prev;

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -216,10 +216,10 @@ int runMainAndExit(ProcessContext& context, MainFunc&& func, int argc, char* arg
       params[i - 1] = argv[i];
     }
 
-    KJ_IF_MAYBE(exception, runCatchingExceptions([&]() {
+    KJ_IF_SOME(exception, runCatchingExceptions([&]() {
       func(argv[0], params);
     })) {
-      context.error(str("*** Uncaught exception ***\n", *exception));
+      context.error(str("*** Uncaught exception ***\n", exception));
     }
     context.exit();
   } catch (const TopLevelProcessContext::CleanShutdownException& e) {
@@ -422,9 +422,9 @@ void MainBuilder::MainImpl::operator()(StringPtr programName, ArrayPtr<const Str
       // Long option.
       ArrayPtr<const char> name;
       Maybe<StringPtr> maybeArg;
-      KJ_IF_MAYBE(pos, param.findFirst('=')) {
-        name = param.slice(2, *pos);
-        maybeArg = param.slice(*pos + 1);
+      KJ_IF_SOME(pos, param.findFirst('=')) {
+        name = param.slice(2, pos);
+        maybeArg = param.slice(pos + 1);
       } else {
         name = param.slice(2);
       }
@@ -439,26 +439,26 @@ void MainBuilder::MainImpl::operator()(StringPtr programName, ArrayPtr<const Str
         const Impl::Option& option = *iter->second;
         if (option.hasArg) {
           // Argument expected.
-          KJ_IF_MAYBE(arg, maybeArg) {
+          KJ_IF_SOME(arg, maybeArg) {
             // "--foo=blah": "blah" is the argument.
-            KJ_IF_MAYBE(error, (*option.funcWithArg)(*arg).releaseError()) {
-              usageError(programName, str(param, ": ", *error));
+            KJ_IF_SOME(error, (*option.funcWithArg)(arg).releaseError()) {
+              usageError(programName, str(param, ": ", error));
             }
           } else if (i + 1 < params.size() &&
                      !(params[i + 1].startsWith("-") && params[i + 1].size() > 1)) {
             // "--foo blah": "blah" is the argument.
             ++i;
-            KJ_IF_MAYBE(error, (*option.funcWithArg)(params[i]).releaseError()) {
-              usageError(programName, str(param, "=", params[i], ": ", *error));
+            KJ_IF_SOME(error, (*option.funcWithArg)(params[i]).releaseError()) {
+              usageError(programName, str(param, "=", params[i], ": ", error));
             }
           } else {
             usageError(programName, str("--", name, ": missing argument"));
           }
         } else {
           // No argument expected.
-          if (maybeArg == nullptr) {
-            KJ_IF_MAYBE(error, (*option.func)().releaseError()) {
-              usageError(programName, str(param, ": ", *error));
+          if (maybeArg == kj::none) {
+            KJ_IF_SOME(error, (*option.func)().releaseError()) {
+              usageError(programName, str(param, ": ", error));
             }
           } else {
             usageError(programName, str("--", name, ": option does not accept an argument"));
@@ -479,16 +479,16 @@ void MainBuilder::MainImpl::operator()(StringPtr programName, ArrayPtr<const Str
             if (j + 1 < param.size()) {
               // Rest of flag is argument.
               StringPtr arg = param.slice(j + 1);
-              KJ_IF_MAYBE(error, (*option.funcWithArg)(arg).releaseError()) {
-                usageError(programName, str("-", c, " ", arg, ": ", *error));
+              KJ_IF_SOME(error, (*option.funcWithArg)(arg).releaseError()) {
+                usageError(programName, str("-", c, " ", arg, ": ", error));
               }
               break;
             } else if (i + 1 < params.size() &&
                        !(params[i + 1].startsWith("-") && params[i + 1].size() > 1)) {
               // Next parameter is argument.
               ++i;
-              KJ_IF_MAYBE(error, (*option.funcWithArg)(params[i]).releaseError()) {
-                usageError(programName, str("-", c, " ", params[i], ": ", *error));
+              KJ_IF_SOME(error, (*option.funcWithArg)(params[i]).releaseError()) {
+                usageError(programName, str("-", c, " ", params[i], ": ", error));
               }
               break;
             } else {
@@ -496,8 +496,8 @@ void MainBuilder::MainImpl::operator()(StringPtr programName, ArrayPtr<const Str
             }
           } else {
             // No argument expected.
-            KJ_IF_MAYBE(error, (*option.func)().releaseError()) {
-              usageError(programName, str("-", c, ": ", *error));
+            KJ_IF_SOME(error, (*option.func)().releaseError()) {
+              usageError(programName, str("-", c, ": ", error));
             }
           }
         }
@@ -584,8 +584,8 @@ void MainBuilder::MainImpl::operator()(StringPtr programName, ArrayPtr<const Str
       if (argPos == arguments.end()) {
         usageError(programName, str("missing argument ", argSpec.title));
       } else {
-        KJ_IF_MAYBE(error, argSpec.callback(*argPos).releaseError()) {
-          usageError(programName, str(*argPos, ": ", *error));
+        KJ_IF_SOME(error, argSpec.callback(*argPos).releaseError()) {
+          usageError(programName, str(*argPos, ": ", error));
         }
         ++argPos;
         --requiredArgCount;
@@ -595,8 +595,8 @@ void MainBuilder::MainImpl::operator()(StringPtr programName, ArrayPtr<const Str
     // If we have more arguments than we need, and this argument spec will accept extras, give
     // them to it.
     for (; i < argSpec.maxCount && arguments.end() - argPos > requiredArgCount; ++i) {
-      KJ_IF_MAYBE(error, argSpec.callback(*argPos).releaseError()) {
-        usageError(programName, str(*argPos, ": ", *error));
+      KJ_IF_SOME(error, argSpec.callback(*argPos).releaseError()) {
+        usageError(programName, str(*argPos, ": ", error));
       }
       ++argPos;
     }
@@ -608,9 +608,9 @@ void MainBuilder::MainImpl::operator()(StringPtr programName, ArrayPtr<const Str
   }
 
   // Run the final callback, if any.
-  KJ_IF_MAYBE(f, impl->finalCallback) {
-    KJ_IF_MAYBE(error, (*f)().releaseError()) {
-      usageError(programName, *error);
+  KJ_IF_SOME(f, impl->finalCallback) {
+    KJ_IF_SOME(error, f().releaseError()) {
+      usageError(programName, error);
     }
   }
 }
@@ -771,10 +771,10 @@ void MainBuilder::MainImpl::wrapText(Vector<char>& output, StringPtr indent, Str
   while (text.size() > 0) {
     output.addAll(indent);
 
-    KJ_IF_MAYBE(lineEnd, text.findFirst('\n')) {
-      if (*lineEnd <= width) {
-        output.addAll(text.slice(0, *lineEnd + 1));
-        text = text.slice(*lineEnd + 1);
+    KJ_IF_SOME(lineEnd, text.findFirst('\n')) {
+      if (lineEnd <= width) {
+        output.addAll(text.slice(0, lineEnd + 1));
+        text = text.slice(lineEnd + 1);
         continue;
       }
     }

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -300,8 +300,8 @@ TEST(Memory, OwnVoid) {
     Maybe<Own<void>> maybe;
     maybe = Own<void>(&maybe, NullDisposer::instance);
     KJ_EXPECT(KJ_ASSERT_NONNULL(maybe).get() == &maybe);
-    maybe = nullptr;
-    KJ_EXPECT(maybe == nullptr);
+    maybe = kj::none;
+    KJ_EXPECT(maybe == kj::none);
   }
 }
 
@@ -362,8 +362,8 @@ TEST(Memory, OwnConstVoid) {
     Maybe<Own<const void>> maybe;
     maybe = Own<const void>(&maybe, NullDisposer::instance);
     KJ_EXPECT(KJ_ASSERT_NONNULL(maybe).get() == &maybe);
-    maybe = nullptr;
-    KJ_EXPECT(maybe == nullptr);
+    maybe = kj::none;
+    KJ_EXPECT(maybe == kj::none);
   }
 }
 
@@ -453,7 +453,7 @@ KJ_TEST("Own with static disposer") {
 
 KJ_TEST("Maybe<Own<T>>") {
   Maybe<Own<int>> m = heap<int>(123);
-  KJ_EXPECT(m != nullptr);
+  KJ_EXPECT(m != kj::none);
   Maybe<int&> mRef = m;
   KJ_EXPECT(KJ_ASSERT_NONNULL(mRef) == 123);
   KJ_EXPECT(&KJ_ASSERT_NONNULL(mRef) == KJ_ASSERT_NONNULL(m).get());

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -450,7 +450,10 @@ public:
   template <typename U>
   inline Maybe(Own<U, D>&& other): ptr(mv(other)) {}
 
+  KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR_ATTR
   inline Maybe(decltype(nullptr)) noexcept: ptr(nullptr) {}
+
+  inline Maybe(kj::None) noexcept: ptr(nullptr) {}
 
   inline Own<T, D>& emplace(Own<T, D> value) {
     // Assign the Maybe to the given value and return the content. This avoids the need to do a
@@ -470,7 +473,10 @@ public:
 
   inline Maybe& operator=(Maybe&& other) { ptr = kj::mv(other.ptr); return *this; }
 
+  KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR_ATTR
   inline bool operator==(decltype(nullptr)) const { return ptr == nullptr; }
+
+  inline bool operator==(kj::None) const { return ptr == nullptr; }
 
   Own<T, D>& orDefault(Own<T, D>& defaultValue) {
     if (ptr == nullptr) {
@@ -500,7 +506,7 @@ public:
   template <typename Func>
   auto map(Func&& f) & -> Maybe<decltype(f(instance<Own<T, D>&>()))> {
     if (ptr == nullptr) {
-      return nullptr;
+      return kj::none;
     } else {
       return f(ptr);
     }
@@ -509,7 +515,7 @@ public:
   template <typename Func>
   auto map(Func&& f) const & -> Maybe<decltype(f(instance<const Own<T, D>&>()))> {
     if (ptr == nullptr) {
-      return nullptr;
+      return kj::none;
     } else {
       return f(ptr);
     }
@@ -518,7 +524,7 @@ public:
   template <typename Func>
   auto map(Func&& f) && -> Maybe<decltype(f(instance<Own<T, D>&&>()))> {
     if (ptr == nullptr) {
-      return nullptr;
+      return kj::none;
     } else {
       return f(kj::mv(ptr));
     }
@@ -527,7 +533,7 @@ public:
   template <typename Func>
   auto map(Func&& f) const && -> Maybe<decltype(f(instance<const Own<T, D>&&>()))> {
     if (ptr == nullptr) {
-      return nullptr;
+      return kj::none;
     } else {
       return f(kj::mv(ptr));
     }

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -654,8 +654,8 @@ KJ_TEST("tracking blocking on mutex acquisition") {
   memset(&handler, 0, sizeof(handler));
   handler.sa_sigaction = [](int, siginfo_t* info, void*) {
     auto& blockage = *reinterpret_cast<BlockDetected *>(info->si_value.sival_ptr);
-    KJ_IF_MAYBE(r, blockedReason()) {
-      KJ_SWITCH_ONEOF(*r) {
+    KJ_IF_SOME(r, blockedReason()) {
+      KJ_SWITCH_ONEOF(r) {
         KJ_CASE_ONEOF(b, BlockedOnMutexAcquisition) {
           blockage.blockedOnMutexAcquisition = true;
           blockage.blockLocation = b.origin;
@@ -711,8 +711,8 @@ KJ_TEST("tracking blocked on CondVar::wait") {
   memset(&handler, 0, sizeof(handler));
   handler.sa_sigaction = [](int, siginfo_t* info, void*) {
     auto& blockage = *reinterpret_cast<BlockDetected *>(info->si_value.sival_ptr);
-    KJ_IF_MAYBE(r, blockedReason()) {
-      KJ_SWITCH_ONEOF(*r) {
+    KJ_IF_SOME(r, blockedReason()) {
+      KJ_SWITCH_ONEOF(r) {
         KJ_CASE_ONEOF(b, BlockedOnCondVarWait) {
           blockage.blockedOnCondVar = true;
           blockage.blockLocation = b.origin;
@@ -768,8 +768,8 @@ KJ_TEST("tracking blocked on Once::init") {
   memset(&handler, 0, sizeof(handler));
   handler.sa_sigaction = [](int, siginfo_t* info, void*) {
     auto& blockage = *reinterpret_cast<BlockDetected *>(info->si_value.sival_ptr);
-    KJ_IF_MAYBE(r, blockedReason()) {
-      KJ_SWITCH_ONEOF(*r) {
+    KJ_IF_SOME(r, blockedReason()) {
+      KJ_SWITCH_ONEOF(r) {
         KJ_CASE_ONEOF(b, BlockedOnOnceInit) {
           blockage.blockedOnOnceInit = true;
           blockage.blockLocation = b.origin;

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -125,8 +125,8 @@ inline void Mutex::removeWaiter(Waiter& waiter) {
   assertLockedByCaller(EXCLUSIVE);
 #endif
   *waiter.prev = waiter.next;
-  KJ_IF_MAYBE(next, waiter.next) {
-    next->prev = waiter.prev;
+  KJ_IF_SOME(next, waiter.next) {
+    next.prev = waiter.prev;
   } else {
     KJ_DASSERT(waitersTail == &waiter.next);
     waitersTail = waiter.prev;
@@ -138,15 +138,15 @@ bool Mutex::checkPredicate(Waiter& waiter) {
   // signal the waiting thread. This is not only when the predicate passes, but also when it
   // throws, in which case we want to propagate the exception to the waiting thread.
 
-  if (waiter.exception != nullptr) return true;  // don't run again after an exception
+  if (waiter.exception != kj::none) return true;  // don't run again after an exception
 
   bool result = false;
-  KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
     result = waiter.predicate.check();
   })) {
     // Exception thrown.
     result = true;
-    waiter.exception = kj::heap(kj::mv(*exception));
+    waiter.exception = kj::heap(kj::mv(exception));
   };
   return result;
 }
@@ -219,8 +219,8 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
 
   auto spec = timeout.map([](Duration d) { return toRelativeTimespec(d); });
   struct timespec* specp = nullptr;
-  KJ_IF_MAYBE(s, spec) {
-    specp = s;
+  KJ_IF_SOME(s, spec) {
+    specp = &s;
   }
 
   switch (exclusivity) {
@@ -276,7 +276,7 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
         }
 
 #if KJ_CONTENTION_WARNING_THRESHOLD
-        if (contentionWaitStart == nullptr) {
+        if (contentionWaitStart == kj::none) {
           // We could have the exclusive mutex tell us how long it was holding the lock. That would
           // be the nicest. However, I'm hesitant to bloat the structure. I suspect having a reader
           // tell us how long it was waiting for is probably a good proxy.
@@ -312,11 +312,11 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
       }
 
 #ifdef KJ_CONTENTION_WARNING_THRESHOLD
-      KJ_IF_MAYBE(start, contentionWaitStart) {
+      KJ_IF_SOME(start, contentionWaitStart) {
         if (__atomic_load_n(&printContendedReader, __ATOMIC_RELAXED)) {
           // Double-checked lock avoids the CPU needing to acquire the lock in most cases.
           if (__atomic_exchange_n(&printContendedReader, false, __ATOMIC_RELAXED)) {
-            auto contentionDuration = kj::systemPreciseMonotonicClock().now() - *start;
+            auto contentionDuration = kj::systemPreciseMonotonicClock().now() - start;
             KJ_LOG(WARNING, "Acquired contended lock", location, contentionDuration,
                 kj::getStackTrace());
           }
@@ -355,16 +355,16 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
       // exclusive lock since under a shared lock the state couldn't have changed.
       auto nextWaiter = waitersHead;
       for (;;) {
-        KJ_IF_MAYBE(waiter, nextWaiter) {
-          nextWaiter = waiter->next;
+        KJ_IF_SOME(waiter, nextWaiter) {
+          nextWaiter = waiter.next;
 
-          if (waiter != waiterToSkip && checkPredicate(*waiter)) {
+          if (&waiter != waiterToSkip && checkPredicate(waiter)) {
             // This waiter's predicate now evaluates true, so wake it up.
-            if (waiter->hasTimeout) {
+            if (waiter.hasTimeout) {
               // In this case we need to be careful to make sure the target thread isn't already
               // processing a timeout, so we need to do an atomic CAS rather than just a store.
               uint expected = 0;
-              if (__atomic_compare_exchange_n(&waiter->futex, &expected, 1, false,
+              if (__atomic_compare_exchange_n(&waiter.futex, &expected, 1, false,
                                               __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {
                 // Good, we set it to 1, transferring ownership of the mutex. Continue on below.
               } else {
@@ -380,9 +380,9 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
                 continue;
               }
             } else {
-              __atomic_store_n(&waiter->futex, 1, __ATOMIC_RELEASE);
+              __atomic_store_n(&waiter.futex, 1, __ATOMIC_RELEASE);
             }
-            syscall(SYS_futex, &waiter->futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
+            syscall(SYS_futex, &waiter.futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
 
             // We transferred ownership of the lock to this waiter, so we're done now.
             return;
@@ -460,7 +460,7 @@ void Mutex::assertLockedByCaller(Exclusivity exclusivity) const {
 
 void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocationArg location) {
   // Add waiter to list.
-  Waiter waiter { nullptr, waitersTail, predicate, nullptr, 0, timeout != nullptr };
+  Waiter waiter { kj::none, waitersTail, predicate, kj::none, 0, timeout != kj::none };
   addWaiter(waiter);
 
   BlockedOnReason blockReason = BlockedOnCondVarWait{*this, &waiter, location};
@@ -473,7 +473,7 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocati
     // Infinite timeout for re-obtaining the lock is on purpose because the post-condition for this
     // function has to be that the lock state hasn't changed (& we have to be locked when we enter
     // since that's how condvars work).
-    if (!currentlyLocked) lock(EXCLUSIVE, nullptr, location);
+    if (!currentlyLocked) lock(EXCLUSIVE, kj::none, location);
     removeWaiter(waiter);
   });
 
@@ -483,8 +483,8 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocati
 
     struct timespec ts;
     struct timespec* tsp = nullptr;
-    KJ_IF_MAYBE(t, timeout) {
-      ts = toAbsoluteTimespec(now() + *t);
+    KJ_IF_SOME(t, timeout) {
+      ts = toAbsoluteTimespec(now() + t);
       tsp = &ts;
     }
 
@@ -514,7 +514,7 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocati
             // OK, we set our own futex to 1. That means no other thread will, and so we won't be
             // receiving a mutex ownership transfer. We have to lock the mutex ourselves.
             setCurrentThreadIsNoLongerWaiting();
-            lock(EXCLUSIVE, nullptr, location);
+            lock(EXCLUSIVE, kj::none, location);
             currentlyLocked = true;
             return;
           } else {
@@ -538,13 +538,13 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocati
         assertLockedByCaller(EXCLUSIVE);
 #endif
 
-        KJ_IF_MAYBE(exception, waiter.exception) {
+        KJ_IF_SOME(exception, waiter.exception) {
           // The predicate threw an exception, apparently. Propagate it.
           // TODO(someday): Could we somehow have this be a recoverable exception? Presumably we'd
           //   then want MutexGuarded::when() to skip calling the callback, but then what should it
           //   return, since it normally returns the callback's result? Or maybe people who disable
           //   exceptions just really should not write predicates that can throw.
-          kj::throwFatalException(kj::mv(**exception));
+          kj::throwFatalException(kj::mv(*exception));
         }
 
         return;
@@ -556,9 +556,9 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocati
 void Mutex::induceSpuriousWakeupForTest() {
   auto nextWaiter = waitersHead;
   for (;;) {
-    KJ_IF_MAYBE(waiter, nextWaiter) {
-      nextWaiter = waiter->next;
-      syscall(SYS_futex, &waiter->futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
+    KJ_IF_SOME(waiter, nextWaiter) {
+      nextWaiter = waiter.next;
+      syscall(SYS_futex, &waiter.futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
     } else {
       // No more waiters.
       break;
@@ -671,13 +671,13 @@ void Mutex::wakeReadyWaiter(Waiter* waiterToSkip) {
 
   auto nextWaiter = waitersHead;
   for (;;) {
-    KJ_IF_MAYBE(waiter, nextWaiter) {
-      nextWaiter = waiter->next;
+    KJ_IF_SOME(waiter, nextWaiter) {
+      nextWaiter = waiter.next;
 
-      if (waiter != waiterToSkip && checkPredicate(*waiter)) {
+      if (&waiter != waiterToSkip && checkPredicate(waiter)) {
         // This waiter's predicate now evaluates true, so wake it up. It doesn't matter if we
         // use Wake vs. WakeAll here since there's always only one thread waiting.
-        WakeConditionVariable(&coercedCondvar(waiter->condvar));
+        WakeConditionVariable(&coercedCondvar(waiter.condvar));
 
         // We only need to wake one waiter. Note that unlike the futex-based implementation, we
         // cannot "transfer ownership" of the lock to the waiter, therefore we cannot guarantee
@@ -734,22 +734,22 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
   const MonotonicClock* clock = nullptr;
   kj::Maybe<kj::TimePoint> endTime;
 
-  KJ_IF_MAYBE(t, timeout) {
+  KJ_IF_SOME(t, timeout) {
     // Windows sleeps are inaccurate -- they can be longer *or shorter* than the requested amount.
     // For many use cases of our API, a too-short sleep would be unacceptable. Experimentally, it
     // seems like sleeps can be up to half a millisecond short, so we'll add half a millisecond
     // (and then we round up, below).
-    *t += 500 * kj::MICROSECONDS;
+    t += 500 * kj::MICROSECONDS;
 
     // Compute initial sleep time.
-    sleepMs = *t / kj::MILLISECONDS;
-    if (*t % kj::MILLISECONDS > 0 * kj::SECONDS) {
+    sleepMs = t / kj::MILLISECONDS;
+    if (t % kj::MILLISECONDS > 0 * kj::SECONDS) {
       // We guarantee we won't wake up too early.
       ++sleepMs;
     }
 
     clock = &systemPreciseMonotonicClock();
-    endTime = clock->now() + *t;
+    endTime = clock->now() + t;
   } else {
     sleepMs = INFINITE;
   }
@@ -771,21 +771,21 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
       }
     }
 
-    KJ_IF_MAYBE(exception, waiter.exception) {
+    KJ_IF_SOME(exception, waiter.exception) {
       // The predicate threw an exception, apparently. Propagate it.
       // TODO(someday): Could we somehow have this be a recoverable exception? Presumably we'd
       //   then want MutexGuarded::when() to skip calling the callback, but then what should it
       //   return, since it normally returns the callback's result? Or maybe people who disable
       //   exceptions just really should not write predicates that can throw.
-      kj::throwFatalException(kj::mv(**exception));
+      kj::throwFatalException(kj::mv(*exception));
     }
 
     // Recompute sleep time.
-    KJ_IF_MAYBE(e, endTime) {
+    KJ_IF_SOME(e, endTime) {
       auto now = clock->now();
 
-      if (*e > now) {
-        auto sleepTime = *e - now;
+      if (e > now) {
+        auto sleepTime = e - now;
         sleepMs = sleepTime / kj::MILLISECONDS;
         if (sleepTime % kj::MILLISECONDS > 0 * kj::SECONDS) {
           // We guarantee we won't wake up too early.
@@ -802,9 +802,9 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
 void Mutex::induceSpuriousWakeupForTest() {
   auto nextWaiter = waitersHead;
   for (;;) {
-    KJ_IF_MAYBE(waiter, nextWaiter) {
-      nextWaiter = waiter->next;
-      WakeConditionVariable(&coercedCondvar(waiter->condvar));
+    KJ_IF_SOME(waiter, nextWaiter) {
+      nextWaiter = waiter.next;
+      WakeConditionVariable(&coercedCondvar(waiter.condvar));
     } else {
       // No more waiters.
       break;
@@ -904,15 +904,15 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
     // exclusive lock since under a shared lock the state couldn't have changed.
     auto nextWaiter = waitersHead;
     for (;;) {
-      KJ_IF_MAYBE(waiter, nextWaiter) {
-        nextWaiter = waiter->next;
+      KJ_IF_SOME(waiter, nextWaiter) {
+        nextWaiter = waiter.next;
 
-        if (waiter != waiterToSkip && checkPredicate(*waiter)) {
+        if (&waiter != waiterToSkip && checkPredicate(waiter)) {
           // This waiter's predicate now evaluates true, so wake it up. It doesn't matter if we
           // use _signal() vs. _broadcast() here since there's always only one thread waiting.
-          KJ_PTHREAD_CALL(pthread_mutex_lock(&waiter->stupidMutex));
-          KJ_PTHREAD_CALL(pthread_cond_signal(&waiter->condvar));
-          KJ_PTHREAD_CALL(pthread_mutex_unlock(&waiter->stupidMutex));
+          KJ_PTHREAD_CALL(pthread_mutex_lock(&waiter.stupidMutex));
+          KJ_PTHREAD_CALL(pthread_cond_signal(&waiter.condvar));
+          KJ_PTHREAD_CALL(pthread_mutex_unlock(&waiter.stupidMutex));
 
           // We only need to wake one waiter. Note that unlike the futex-based implementation, we
           // cannot "transfer ownership" of the lock to the waiter, therefore we cannot guarantee
@@ -1009,16 +1009,16 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
     bool timedOut = false;
 
     // Wait for someone to signal the condvar.
-    KJ_IF_MAYBE(t, endTime) {
+    KJ_IF_SOME(t, endTime) {
 #if __APPLE__
       // On macOS, the absolute timeout can only be specified in wall time, not monotonic time,
       // which means modifying the system clock will break the wait. However, macOS happens to
       // provide an alternative relative-time wait function, so I guess we'll use that. It does
       // require recomputing the time every iteration...
-      struct timespec ts = toRelativeTimespec(kj::max(toTimePoint(*t) - now(), 0 * kj::SECONDS));
+      struct timespec ts = toRelativeTimespec(kj::max(toTimePoint(t) - now(), 0 * kj::SECONDS));
       int error = pthread_cond_timedwait_relative_np(&waiter.condvar, &waiter.stupidMutex, &ts);
 #else
-      int error = pthread_cond_timedwait(&waiter.condvar, &waiter.stupidMutex, t);
+      int error = pthread_cond_timedwait(&waiter.condvar, &waiter.stupidMutex, &t);
 #endif
       if (error != 0) {
         if (error == ETIMEDOUT) {
@@ -1041,13 +1041,13 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
     lock(EXCLUSIVE, nullptr, NoopSourceLocation{});
     currentlyLocked = true;
 
-    KJ_IF_MAYBE(exception, waiter.exception) {
+    KJ_IF_SOME(exception, waiter.exception) {
       // The predicate threw an exception, apparently. Propagate it.
       // TODO(someday): Could we somehow have this be a recoverable exception? Presumably we'd
       //   then want MutexGuarded::when() to skip calling the callback, but then what should it
       //   return, since it normally returns the callback's result? Or maybe people who disable
       //   exceptions just really should not write predicates that can throw.
-      kj::throwFatalException(kj::mv(**exception));
+      kj::throwFatalException(kj::mv(*exception));
     }
 
     if (timedOut) {
@@ -1059,11 +1059,11 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, NoopSourceLocati
 void Mutex::induceSpuriousWakeupForTest() {
   auto nextWaiter = waitersHead;
   for (;;) {
-    KJ_IF_MAYBE(waiter, nextWaiter) {
-      nextWaiter = waiter->next;
-      KJ_PTHREAD_CALL(pthread_mutex_lock(&waiter->stupidMutex));
-      KJ_PTHREAD_CALL(pthread_cond_signal(&waiter->condvar));
-      KJ_PTHREAD_CALL(pthread_mutex_unlock(&waiter->stupidMutex));
+    KJ_IF_SOME(waiter, nextWaiter) {
+      nextWaiter = waiter.next;
+      KJ_PTHREAD_CALL(pthread_mutex_lock(&waiter.stupidMutex));
+      KJ_PTHREAD_CALL(pthread_cond_signal(&waiter.condvar));
+      KJ_PTHREAD_CALL(pthread_mutex_unlock(&waiter.stupidMutex));
     } else {
       // No more waiters.
       break;

--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -155,11 +155,11 @@ TEST(OneOf, Maybe) {
   Maybe<OneOf<int, float>> var;
   var = OneOf<int, float>(123);
 
-  KJ_IF_MAYBE(v, var) {
+  KJ_IF_SOME(v, var) {
     // At one time this failed to compile. Note that a Maybe<OneOf<...>> isn't necessarily great
     // style -- you might be better off with an explicit OneOf<Empty, ...>. Nevertheless, it should
     // compile.
-    KJ_SWITCH_ONEOF(*v) {
+    KJ_SWITCH_ONEOF(v) {
       KJ_CASE_ONEOF(i, int) {
         KJ_EXPECT(i == 123);
       }

--- a/c++/src/kj/parse/char-test.c++
+++ b/c++/src/kj/parse/char-test.c++
@@ -75,8 +75,8 @@ TEST(CharParsers, CharRange) {
     StringPtr text = "a";
     Input input(text.begin(), text.end());
     Maybe<char> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ('a', *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ('a', value);
     } else {
       ADD_FAILURE() << "Expected parse result, got null.";
     }
@@ -87,8 +87,8 @@ TEST(CharParsers, CharRange) {
     StringPtr text = "n";
     Input input(text.begin(), text.end());
     Maybe<char> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ('n', *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ('n', value);
     } else {
       ADD_FAILURE() << "Expected parse result, got null.";
     }
@@ -99,8 +99,8 @@ TEST(CharParsers, CharRange) {
     StringPtr text = "z";
     Input input(text.begin(), text.end());
     Maybe<char> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ('z', *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ('z', value);
     } else {
       ADD_FAILURE() << "Expected parse result, got null.";
     }
@@ -139,8 +139,8 @@ TEST(CharParsers, AnyOfChars) {
     StringPtr text = "a";
     Input input(text.begin(), text.end());
     Maybe<char> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ('a', *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ('a', value);
     } else {
       ADD_FAILURE() << "Expected parse result, got null.";
     }
@@ -151,8 +151,8 @@ TEST(CharParsers, AnyOfChars) {
     StringPtr text = "n";
     Input input(text.begin(), text.end());
     Maybe<char> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ('n', *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ('n', value);
     } else {
       ADD_FAILURE() << "Expected parse result, got null.";
     }
@@ -163,8 +163,8 @@ TEST(CharParsers, AnyOfChars) {
     StringPtr text = "B";
     Input input(text.begin(), text.end());
     Maybe<char> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ('B', *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ('B', value);
     } else {
       ADD_FAILURE() << "Expected parse result, got null.";
     }
@@ -204,8 +204,8 @@ TEST(CharParsers, CharGroupCombo) {
     StringPtr text = "foo1-bar2_baz3@qux";
     Input input(text.begin(), text.end());
     Maybe<Array<char>> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("foo1-bar2_baz3", str(*value));
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("foo1-bar2_baz3", str(value));
     } else {
       ADD_FAILURE() << "Expected parse result, got null.";
     }
@@ -220,8 +220,8 @@ TEST(CharParsers, Identifier) {
     StringPtr text = "helloWorld123 ";
     Input input(text.begin(), text.end());
     Maybe<String> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("helloWorld123", *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("helloWorld123", value);
     } else {
       ADD_FAILURE() << "Expected string, got null.";
     }
@@ -236,8 +236,8 @@ TEST(CharParsers, Integer) {
     StringPtr text = "12349";
     Input input(text.begin(), text.end());
     Maybe<uint64_t> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(12349u, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(12349u, value);
     } else {
       ADD_FAILURE() << "Expected integer, got null.";
     }
@@ -248,8 +248,8 @@ TEST(CharParsers, Integer) {
     StringPtr text = "0x1aF0";
     Input input(text.begin(), text.end());
     Maybe<uint64_t> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(0x1aF0u, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(0x1aF0u, value);
     } else {
       ADD_FAILURE() << "Expected integer, got null.";
     }
@@ -260,8 +260,8 @@ TEST(CharParsers, Integer) {
     StringPtr text = "064270";
     Input input(text.begin(), text.end());
     Maybe<uint64_t> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(064270u, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(064270u, value);
     } else {
       ADD_FAILURE() << "Expected integer, got null.";
     }
@@ -276,8 +276,8 @@ TEST(CharParsers, Number) {
     StringPtr text = "12345";
     Input input(text.begin(), text.end());
     Maybe<double> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(12345, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(12345, value);
     } else {
       ADD_FAILURE() << "Expected number, got null.";
     }
@@ -288,8 +288,8 @@ TEST(CharParsers, Number) {
     StringPtr text = "123.25";
     Input input(text.begin(), text.end());
     Maybe<double> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(123.25, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(123.25, value);
     } else {
       ADD_FAILURE() << "Expected number, got null.";
     }
@@ -300,8 +300,8 @@ TEST(CharParsers, Number) {
     StringPtr text = "123e10";
     Input input(text.begin(), text.end());
     Maybe<double> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(123e10, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(123e10, value);
     } else {
       ADD_FAILURE() << "Expected number, got null.";
     }
@@ -312,8 +312,8 @@ TEST(CharParsers, Number) {
     StringPtr text = "123.25E+10";
     Input input(text.begin(), text.end());
     Maybe<double> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(123.25E+10, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(123.25E+10, value);
     } else {
       ADD_FAILURE() << "Expected number, got null.";
     }
@@ -324,8 +324,8 @@ TEST(CharParsers, Number) {
     StringPtr text = "25e-2";
     Input input(text.begin(), text.end());
     Maybe<double> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(25e-2, *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(25e-2, value);
     } else {
       ADD_FAILURE() << "Expected number, got null.";
     }
@@ -340,8 +340,8 @@ TEST(CharParsers, DoubleQuotedString) {
     StringPtr text = "\"hello\"";
     Input input(text.begin(), text.end());
     Maybe<String> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("hello", *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("hello", value);
     } else {
       ADD_FAILURE() << "Expected \"hello\", got null.";
     }
@@ -352,8 +352,8 @@ TEST(CharParsers, DoubleQuotedString) {
     StringPtr text = "\"test\\a\\b\\f\\n\\r\\t\\v\\\'\\\"\\\?\\x01\\x20\\2\\34\\156\"";
     Input input(text.begin(), text.end());
     Maybe<String> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("test\a\b\f\n\r\t\v\'\"\?\x01\x20\2\34\156", *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("test\a\b\f\n\r\t\v\'\"\?\x01\x20\2\34\156", value);
     } else {
       ADD_FAILURE() << "Expected string, got null.";
     }
@@ -364,8 +364,8 @@ TEST(CharParsers, DoubleQuotedString) {
     StringPtr text = "\"foo'bar\"";
     Input input(text.begin(), text.end());
     Maybe<String> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("foo'bar", *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("foo'bar", value);
     } else {
       ADD_FAILURE() << "Expected string, got null.";
     }
@@ -380,8 +380,8 @@ TEST(CharParsers, SingleQuotedString) {
     StringPtr text = "\'hello\'";
     Input input(text.begin(), text.end());
     Maybe<String> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("hello", *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("hello", value);
     } else {
       ADD_FAILURE() << "Expected \"hello\", got null.";
     }
@@ -392,8 +392,8 @@ TEST(CharParsers, SingleQuotedString) {
     StringPtr text = "\'test\\a\\b\\f\\n\\r\\t\\v\\\'\\\"\\\?\x01\2\34\156\'";
     Input input(text.begin(), text.end());
     Maybe<String> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("test\a\b\f\n\r\t\v\'\"\?\x01\2\34\156", *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("test\a\b\f\n\r\t\v\'\"\?\x01\2\34\156", value);
     } else {
       ADD_FAILURE() << "Expected string, got null.";
     }
@@ -404,8 +404,8 @@ TEST(CharParsers, SingleQuotedString) {
     StringPtr text = "\'foo\"bar\'";
     Input input(text.begin(), text.end());
     Maybe<String> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ("foo\"bar", *value);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ("foo\"bar", value);
     } else {
       ADD_FAILURE() << "Expected string, got null.";
     }

--- a/c++/src/kj/parse/char.c++
+++ b/c++/src/kj/parse/char.c++
@@ -32,11 +32,11 @@ double ParseFloat::operator()(const Array<char>& digits,
                               const Maybe<Array<char>>& fraction,
                               const Maybe<Tuple<Maybe<char>, Array<char>>>& exponent) const {
   size_t bufSize = digits.size();
-  KJ_IF_MAYBE(f, fraction) {
-    bufSize += 1 + f->size();
+  KJ_IF_SOME(f, fraction) {
+    bufSize += 1 + f.size();
   }
-  KJ_IF_MAYBE(e, exponent) {
-    bufSize += 1 + (get<0>(*e) != nullptr) + get<1>(*e).size();
+  KJ_IF_SOME(e, exponent) {
+    bufSize += 1 + (get<0>(e) != kj::none) + get<1>(e).size();
   }
 
   KJ_STACK_ARRAY(char, buf, bufSize + 1, 128, 128);
@@ -44,18 +44,18 @@ double ParseFloat::operator()(const Array<char>& digits,
   char* pos = buf.begin();
   memcpy(pos, digits.begin(), digits.size());
   pos += digits.size();
-  KJ_IF_MAYBE(f, fraction) {
+  KJ_IF_SOME(f, fraction) {
     *pos++ = '.';
-    memcpy(pos, f->begin(), f->size());
-    pos += f->size();
+    memcpy(pos, f.begin(), f.size());
+    pos += f.size();
   }
-  KJ_IF_MAYBE(e, exponent) {
+  KJ_IF_SOME(e, exponent) {
     *pos++ = 'e';
-    KJ_IF_MAYBE(sign, get<0>(*e)) {
-      *pos++ = *sign;
+    KJ_IF_SOME(sign, get<0>(e)) {
+      *pos++ = sign;
     }
-    memcpy(pos, get<1>(*e).begin(), get<1>(*e).size());
-    pos += get<1>(*e).size();
+    memcpy(pos, get<1>(e).begin(), get<1>(e).size());
+    pos += get<1>(e).size();
   }
 
   *pos++ = '\0';

--- a/c++/src/kj/parse/char.h
+++ b/c++/src/kj/parse/char.h
@@ -320,10 +320,10 @@ struct ParseHexByte {
 struct ParseOctEscape {
   inline char operator()(char first, Maybe<char> second, Maybe<char> third) const {
     char result = first - '0';
-    KJ_IF_MAYBE(digit1, second) {
-      result = (result << 3) | (*digit1 - '0');
-      KJ_IF_MAYBE(digit2, third) {
-        result = (result << 3) | (*digit2 - '0');
+    KJ_IF_SOME(digit1, second) {
+      result = (result << 3) | (digit1 - '0');
+      KJ_IF_SOME(digit2, third) {
+        result = (result << 3) | (digit2 - '0');
       }
     }
     return result;

--- a/c++/src/kj/parse/common-test.c++
+++ b/c++/src/kj/parse/common-test.c++
@@ -35,24 +35,24 @@ TEST(CommonParsers, AnyParser) {
   constexpr auto parser = any;
 
   Maybe<char> result = parser(input);
-  KJ_IF_MAYBE(c, result) {
-    EXPECT_EQ('f', *c);
+  KJ_IF_SOME(c, result) {
+    EXPECT_EQ('f', c);
   } else {
     ADD_FAILURE() << "Expected 'c', got null.";
   }
   EXPECT_FALSE(input.atEnd());
 
   result = parser(input);
-  KJ_IF_MAYBE(c, result) {
-    EXPECT_EQ('o', *c);
+  KJ_IF_SOME(c, result) {
+    EXPECT_EQ('o', c);
   } else {
     ADD_FAILURE() << "Expected 'o', got null.";
   }
   EXPECT_FALSE(input.atEnd());
 
   result = parser(input);
-  KJ_IF_MAYBE(c, result) {
-    EXPECT_EQ('o', *c);
+  KJ_IF_SOME(c, result) {
+    EXPECT_EQ('o', c);
   } else {
     ADD_FAILURE() << "Expected 'o', got null.";
   }
@@ -115,8 +115,8 @@ TEST(CommonParsers, ConstResultParser) {
   StringPtr text = "o";
   Input input(text.begin(), text.end());
   Maybe<int> result = parser(input);
-  KJ_IF_MAYBE(i, result) {
-    EXPECT_EQ(123, *i);
+  KJ_IF_SOME(i, result) {
+    EXPECT_EQ(123, i);
   } else {
     ADD_FAILURE() << "Expected 123, got null.";
   }
@@ -177,8 +177,8 @@ TEST(CommonParsers, SequenceParser) {
     Input input(text.begin(), text.end());
     Maybe<int> result = sequence(transform(exactly('f'), [](){return 123;}),
                                  exactly('o'), exactly('o'))(input);
-    KJ_IF_MAYBE(i, result) {
-      EXPECT_EQ(123, *i);
+    KJ_IF_SOME(i, result) {
+      EXPECT_EQ(123, i);
     } else {
       ADD_FAILURE() << "Expected 123, got null.";
     }
@@ -194,8 +194,8 @@ TEST(CommonParsers, ManyParserCountOnly) {
   {
     Input input(text.begin(), text.begin() + 3);
     Maybe<int> result = parser(input);
-    KJ_IF_MAYBE(i, result) {
-      EXPECT_EQ(2, *i);
+    KJ_IF_SOME(i, result) {
+      EXPECT_EQ(2, i);
     } else {
       ADD_FAILURE() << "Expected 2, got null.";
     }
@@ -205,8 +205,8 @@ TEST(CommonParsers, ManyParserCountOnly) {
   {
     Input input(text.begin(), text.begin() + 5);
     Maybe<int> result = parser(input);
-    KJ_IF_MAYBE(i, result) {
-      EXPECT_EQ(4, *i);
+    KJ_IF_SOME(i, result) {
+      EXPECT_EQ(4, i);
     } else {
       ADD_FAILURE() << "Expected 4, got null.";
     }
@@ -216,8 +216,8 @@ TEST(CommonParsers, ManyParserCountOnly) {
   {
     Input input(text.begin(), text.end());
     Maybe<int> result = parser(input);
-    KJ_IF_MAYBE(i, result) {
-      EXPECT_EQ(4, *i);
+    KJ_IF_SOME(i, result) {
+      EXPECT_EQ(4, i);
     } else {
       ADD_FAILURE() << "Expected 4, got null.";
     }
@@ -240,8 +240,8 @@ TEST(CommonParsers, TimesParser) {
   {
     Input input(text.begin(), text.begin() + 5);
     Maybe<Array<char>> result = parser(input);
-    KJ_IF_MAYBE(s, result) {
-      EXPECT_EQ("ooba", heapString(*s));
+    KJ_IF_SOME(s, result) {
+      EXPECT_EQ("ooba", heapString(s));
     } else {
       ADD_FAILURE() << "Expected string, got null.";
     }
@@ -251,8 +251,8 @@ TEST(CommonParsers, TimesParser) {
   {
     Input input(text.begin(), text.end());
     Maybe<Array<char>> result = parser(input);
-    KJ_IF_MAYBE(s, result) {
-      EXPECT_EQ("ooba", heapString(*s));
+    KJ_IF_SOME(s, result) {
+      EXPECT_EQ("ooba", heapString(s));
     } else {
       ADD_FAILURE() << "Expected string, got null.";
     }
@@ -304,8 +304,8 @@ TEST(CommonParsers, ManyParserSubResult) {
   {
     Input input(text.begin(), text.end());
     Maybe<Array<char>> result = parser(input);
-    KJ_IF_MAYBE(chars, result) {
-      EXPECT_EQ(text, heapString(*chars));
+    KJ_IF_SOME(chars, result) {
+      EXPECT_EQ(text, heapString(chars));
     } else {
       ADD_FAILURE() << "Expected char array, got null.";
     }
@@ -323,14 +323,14 @@ TEST(CommonParsers, OptionalParser) {
     StringPtr text = "bar";
     Input input(text.begin(), text.end());
     Maybe<Tuple<uint, Maybe<uint>, uint>> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(123u, get<0>(*value));
-      KJ_IF_MAYBE(value2, get<1>(*value)) {
-        EXPECT_EQ(456u, *value2);
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(123u, get<0>(value));
+      KJ_IF_SOME(value2, get<1>(value)) {
+        EXPECT_EQ(456u, value2);
       } else {
         ADD_FAILURE() << "Expected 456, got null.";
       }
-      EXPECT_EQ(789u, get<2>(*value));
+      EXPECT_EQ(789u, get<2>(value));
     } else {
       ADD_FAILURE() << "Expected result tuple, got null.";
     }
@@ -341,10 +341,10 @@ TEST(CommonParsers, OptionalParser) {
     StringPtr text = "br";
     Input input(text.begin(), text.end());
     Maybe<Tuple<uint, Maybe<uint>, uint>> result = parser(input);
-    KJ_IF_MAYBE(value, result) {
-      EXPECT_EQ(123u, get<0>(*value));
-      EXPECT_TRUE(get<1>(*value) == nullptr);
-      EXPECT_EQ(789u, get<2>(*value));
+    KJ_IF_SOME(value, result) {
+      EXPECT_EQ(123u, get<0>(value));
+      EXPECT_TRUE(get<1>(value) == kj::none);
+      EXPECT_EQ(789u, get<2>(value));
     } else {
       ADD_FAILURE() << "Expected result tuple, got null.";
     }
@@ -370,8 +370,8 @@ TEST(CommonParsers, OneOfParser) {
     StringPtr text = "foo";
     Input input(text.begin(), text.end());
     Maybe<StringPtr> result = parser(input);
-    KJ_IF_MAYBE(s, result) {
-      EXPECT_EQ("foo", *s);
+    KJ_IF_SOME(s, result) {
+      EXPECT_EQ("foo", s);
     } else {
       ADD_FAILURE() << "Expected 'foo', got null.";
     }
@@ -382,8 +382,8 @@ TEST(CommonParsers, OneOfParser) {
     StringPtr text = "bar";
     Input input(text.begin(), text.end());
     Maybe<StringPtr> result = parser(input);
-    KJ_IF_MAYBE(s, result) {
-      EXPECT_EQ("bar", *s);
+    KJ_IF_SOME(s, result) {
+      EXPECT_EQ("bar", s);
     } else {
       ADD_FAILURE() << "Expected 'bar', got null.";
     }
@@ -404,8 +404,8 @@ TEST(CommonParsers, TransformParser) {
   {
     Input input(text.begin(), text.end());
     Maybe<int> result = parser(input);
-    KJ_IF_MAYBE(i, result) {
-      EXPECT_EQ(123, *i);
+    KJ_IF_SOME(i, result) {
+      EXPECT_EQ(123, i);
     } else {
       ADD_FAILURE() << "Expected 123, got null.";
     }
@@ -427,8 +427,8 @@ TEST(CommonParsers, TransformOrRejectParser) {
     StringPtr text = "foo";
     Input input(text.begin(), text.end());
     Maybe<int> result = parser(input);
-    KJ_IF_MAYBE(i, result) {
-      EXPECT_EQ(123, *i);
+    KJ_IF_SOME(i, result) {
+      EXPECT_EQ(123, i);
     } else {
       ADD_FAILURE() << "Expected 123, got null.";
     }
@@ -475,8 +475,8 @@ TEST(CommonParsers, References) {
   {
     Input input(text.begin(), text.end());
     Maybe<int> result = parser(input);
-    KJ_IF_MAYBE(i, result) {
-      EXPECT_EQ(12 + 34 + 56, *i);
+    KJ_IF_SOME(i, result) {
+      EXPECT_EQ(12 + 34 + 56, i);
     } else {
       ADD_FAILURE() << "Expected 12 + 34 + 56, got null.";
     }

--- a/c++/src/kj/std/iostream-test.c++
+++ b/c++/src/kj/std/iostream-test.c++
@@ -92,7 +92,7 @@ TEST(StdIoStream, ReadToEndOfFile) {
   });
   buf[6] = '\0';
 
-  ASSERT_FALSE(e == nullptr);
+  ASSERT_FALSE(e == kj::none);
 
   // Ensure that the value is still read up to the EOF.
   EXPECT_STREQ("foobar", buf);

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -47,12 +47,12 @@ long long parseSigned(const StringPtr& s, long long min, long long max) {
 }
 
 Maybe<long long> tryParseSigned(const StringPtr& s, long long min, long long max) {
-  if (s == nullptr) { return nullptr; } // String does not contain valid number.
+  if (s == nullptr) { return kj::none; } // String does not contain valid number.
   char *endPtr;
   errno = 0;
   auto value = strtoll(s.begin(), &endPtr, isHex(s.cStr()) ? 16 : 10);
   if (endPtr != s.end() || errno == ERANGE || value < min || max < value) {
-    return nullptr;
+    return kj::none;
   }
   return value;
 }
@@ -71,11 +71,11 @@ unsigned long long parseUnsigned(const StringPtr& s, unsigned long long max) {
 }
 
 Maybe<unsigned long long> tryParseUnsigned(const StringPtr& s, unsigned long long max) {
-  if (s == nullptr) { return nullptr; } // String does not contain valid number.
+  if (s == nullptr) { return kj::none; } // String does not contain valid number.
   char *endPtr;
   errno = 0;
   auto value = strtoull(s.begin(), &endPtr, isHex(s.cStr()) ? 16 : 10);
-  if (endPtr != s.end() || errno == ERANGE || max < value || s[0] == '-') { return nullptr; }
+  if (endPtr != s.end() || errno == ERANGE || max < value || s[0] == '-') { return kj::none; }
   return value;
 }
 
@@ -614,11 +614,11 @@ double parseDouble(const StringPtr& s) {
 }
 
 Maybe<double> tryParseDouble(const StringPtr& s) {
-  if(s == nullptr) { return nullptr; }
+  if(s == nullptr) { return kj::none; }
   char *endPtr;
   errno = 0;
   auto value = _::NoLocaleStrtod(s.begin(), &endPtr);
-  if (endPtr != s.end()) { return nullptr; }
+  if (endPtr != s.end()) { return kj::none; }
 #if _WIN32 || __CYGWIN__ || __BIONIC__
   if (isNaN(value)) {
     return kj::nan();

--- a/c++/src/kj/table.c++
+++ b/c++/src/kj/table.c++
@@ -933,7 +933,7 @@ kj::Maybe<size_t> InsertionOrderIndex::insertImpl(size_t pos) {
   links[links[0].prev].next = pos + 1;
   links[0].prev = pos + 1;
 
-  return nullptr;
+  return kj::none;
 }
 
 void InsertionOrderIndex::eraseImpl(size_t pos) {

--- a/c++/src/kj/test-test.c++
+++ b/c++/src/kj/test-test.c++
@@ -87,7 +87,7 @@ KJ_TEST("GlobFilter") {
 
 KJ_TEST("expect exit from exit") {
   KJ_EXPECT_EXIT(42, _exit(42));
-  KJ_EXPECT_EXIT(nullptr, _exit(42));
+  KJ_EXPECT_EXIT(kj::none, _exit(42));
 }
 
 KJ_TEST("expect exit from thrown exception") {
@@ -100,7 +100,7 @@ KJ_TEST("expect signal from abort") {
 
 KJ_TEST("expect signal from sigint") {
   KJ_EXPECT_SIGNAL(SIGINT, raise(SIGINT));
-  KJ_EXPECT_SIGNAL(nullptr, raise(SIGINT));
+  KJ_EXPECT_SIGNAL(kj::none, raise(SIGINT));
 }
 
 }  // namespace

--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -224,9 +224,9 @@ public:
     uint minLine = kj::minValue;
     uint maxLine = kj::maxValue;
 
-    KJ_IF_MAYBE(colonPos, pattern.findLast(':')) {
+    KJ_IF_SOME(colonPos, pattern.findLast(':')) {
       char* end;
-      StringPtr lineStr = pattern.slice(*colonPos + 1);
+      StringPtr lineStr = pattern.slice(colonPos + 1);
 
       bool parsedRange = false;
       minLine = strtoul(lineStr.cStr(), &end, 0);
@@ -246,7 +246,7 @@ public:
 
       if (parsedRange) {
         // We have an exact line number.
-        filePattern = pattern.slice(0, *colonPos);
+        filePattern = pattern.slice(0, colonPos);
       } else {
         // Can't parse as a number. Maybe the colon is part of a Windows path name or something.
         // Let's just keep it as part of the file pattern.
@@ -273,8 +273,8 @@ public:
   }
 
   MainBuilder::Validity setBenchmarkIters(StringPtr param) {
-    KJ_IF_MAYBE(i, param.tryParseAs<size_t>()) {
-      benchmarkIterCount = *i;
+    KJ_IF_SOME(i, param.tryParseAs<size_t>()) {
+      benchmarkIterCount = i;
       return true;
     } else {
       return "expected an integer";
@@ -315,12 +315,12 @@ public:
         if (!listOnly) {
           bool currentFailed = true;
           auto start = readClock();
-          KJ_IF_MAYBE(exception, runCatchingExceptions([&]() {
+          KJ_IF_SOME(exception, runCatchingExceptions([&]() {
             TestExceptionCallback exceptionCallback(context);
             testCase->run();
             currentFailed = exceptionCallback.failed();
           })) {
-            context.error(kj::str(*exception));
+            context.error(kj::str(exception));
           }
           auto end = readClock();
 

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -95,9 +95,9 @@ private:
 #if _MSC_VER && !defined(__clang__)
 #define KJ_EXPECT_THROW_RECOVERABLE(type, code, ...) \
   do { \
-    KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
-      KJ_INDIRECT_EXPAND(KJ_EXPECT, (e->getType() == ::kj::Exception::Type::type, \
-          "code threw wrong exception type: " #code, *e, __VA_ARGS__)); \
+    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+      KJ_INDIRECT_EXPAND(KJ_EXPECT, (e.getType() == ::kj::Exception::Type::type, \
+          "code threw wrong exception type: " #code, e, __VA_ARGS__)); \
     } else { \
       KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("code did not throw: " #code, __VA_ARGS__)); \
     } \
@@ -105,9 +105,9 @@ private:
 
 #define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code, ...) \
   do { \
-    KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
-      KJ_INDIRECT_EXPAND(KJ_EXPECT, (::kj::_::hasSubstring(e->getDescription(), message), \
-          "exception description didn't contain expected substring", *e, __VA_ARGS__)); \
+    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+      KJ_INDIRECT_EXPAND(KJ_EXPECT, (::kj::_::hasSubstring(e.getDescription(), message), \
+          "exception description didn't contain expected substring", e, __VA_ARGS__)); \
     } else { \
       KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("code did not throw: " #code, __VA_ARGS__)); \
     } \
@@ -115,9 +115,9 @@ private:
 #else
 #define KJ_EXPECT_THROW_RECOVERABLE(type, code, ...) \
   do { \
-    KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
-      KJ_EXPECT(e->getType() == ::kj::Exception::Type::type, \
-          "code threw wrong exception type: " #code, *e, ##__VA_ARGS__); \
+    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+      KJ_EXPECT(e.getType() == ::kj::Exception::Type::type, \
+          "code threw wrong exception type: " #code, e, ##__VA_ARGS__); \
     } else { \
       KJ_FAIL_EXPECT("code did not throw: " #code, ##__VA_ARGS__); \
     } \
@@ -125,9 +125,9 @@ private:
 
 #define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code, ...) \
   do { \
-    KJ_IF_MAYBE(e, ::kj::runCatchingExceptions([&]() { code; })) { \
-      KJ_EXPECT(::kj::_::hasSubstring(e->getDescription(), message), \
-          "exception description didn't contain expected substring", *e, ##__VA_ARGS__); \
+    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+      KJ_EXPECT(::kj::_::hasSubstring(e.getDescription(), message), \
+          "exception description didn't contain expected substring", e, ##__VA_ARGS__); \
     } else { \
       KJ_FAIL_EXPECT("code did not throw: " #code, ##__VA_ARGS__); \
     } \

--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -86,7 +86,7 @@ TimerImpl::~TimerImpl() noexcept(false) {}
 Maybe<TimePoint> TimerImpl::nextEvent() {
   auto iter = impl->timers.begin();
   if (iter == impl->timers.end()) {
-    return nullptr;
+    return kj::none;
   } else {
     return (*iter)->time;
   }
@@ -110,7 +110,7 @@ Maybe<uint64_t> TimerImpl::timeoutToNextEvent(TimePoint start, Duration unit, ui
 }
 
 void TimerImpl::advanceTo(TimePoint newTime) {
-  // On Macs running an Intel processor, it has been observed that clock_gettime 
+  // On Macs running an Intel processor, it has been observed that clock_gettime
   // may return non monotonic time, even when CLOCK_MONOTONIC is used.
   // This workaround is to avoid the assert triggering on these machines.
   // See also https://github.com/capnproto/capnproto/issues/1693


### PR DESCRIPTION
The KJ_IF_MAYBE macro has a footgun in that it defines a pointer, rather than a reference, meaning it is easy to accidentally use pointers when you mean to use references. Now that we require C++20, we can use modern syntax (technically, from C++17) to implement a new macro which defines a reference instead of a pointer.

This PR:
- Defines a new KJ_IF_SOME macro to replace KJ_IF_MAYBE.
- Defines a new `kj::none` constant to be used instead of `nullptr` in Maybe comparisons/initializations.
- Deprecates all existing usage of KJ_IF_MAYBE and `nullptr`-meaning-empty-Maybe.
- Adds Bazel build flags to control the deprecation warnings, since otherwise they are very spammy.
- Updates the entire src/kj directory to use the new tools.

For now, I have converted libkj to prove out the approach. Conversion of the rest of the codebase (i.e., src/capnp) will come later.