### PR TITLE
http: Call getInner() after every co_await in HttpChunkedEntityWriter

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2555,20 +2555,18 @@ public:
 
   Promise<uint64_t> pumpImpl(AsyncInputStream& input, uint64_t length) {
     // Hey, we know exactly how large the input is, so we can write just one chunk.
-    auto& inner = getInner();
-
-    co_await inner.writeBodyData(kj::str(kj::hex(length), "\r\n"));
-    auto actual = co_await inner.pumpBodyFrom(input, length);
+    co_await getInner().writeBodyData(kj::str(kj::hex(length), "\r\n"));
+    auto actual = co_await getInner().pumpBodyFrom(input, length);
 
     if (actual < length) {
-      inner.abortBody();
+      getInner().abortBody();
       KJ_FAIL_REQUIRE(
           "value returned by input.tryGetLength() was greater than actual bytes transferred") {
         break;
       }
     }
 
-    co_await inner.writeBodyData(kj::str("\r\n"));
+    co_await getInner().writeBodyData(kj::str("\r\n"));
     co_return actual;
   }
 


### PR DESCRIPTION
The reference to the inner output stream provided by HttpChunkedEntityWriter's base class's getInner() can be invalidated before the HttpChunkedEntityWriter. To put it another way, body streams which we provide to user code (the HttpChunkedEntityWriter) can be prolonged by the user beyond the lifetime of the underlying connection. getInner() is written in such a way to catch the issue, by checking for validity before returning a reference, and I think the tryPumpFrom() implementation probably should call it after every resumption.