### PR TITLE
ignore .vscode/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 .dist-buildwrapper
 /c++/gen/
 
+# VS Code config
+.vscode/
+
 # Code you may want to map in from elsewhere.
 /c++/src/base
 /c++/src/capnp/compilerbin


### PR DESCRIPTION
one day we might want to provide our configuration, but ignore this folder for now.