### PR TITLE
mark fuzz_test as manual

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -276,4 +276,5 @@ cc_test(
     size = "large",
     srcs = ["fuzz-test.c++"],
     deps = [":capnp-test"],
+    tags = ["manual"],
 )


### PR DESCRIPTION
this way we won't need to exclude it everywhere