### PR TITLE
iterator_traits<IndexingIterator>::reference should not be a reference

### DIFF
--- a/c++/src/capnp/compat/std-iterator.h
+++ b/c++/src/capnp/compat/std-iterator.h
@@ -39,7 +39,7 @@ struct iterator_traits<capnp::_::IndexingIterator<Container, Element>> {
   using value_type = Element;
   using difference_type	= int;
   using pointer = Element*;
-  using reference = Element&;
+  using reference = Element;
 };
 
 }  // namespace std


### PR DESCRIPTION
Per [\[input.iterators\]](http://eel.is/c++draft/tab:inputiterator), `*a` should return `reference`. `IndexingIterator::operator*` returns `Element`, not `Element&`, so `reference` should be `Element`, not `Element&`.

This is usually not a problem; we only noticed it because the following code started breaking when using libstdc++ debug iterators `_GLIBCXX_DEBUG` https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html:
```c++
#include <vector>
#include <capnp/compat/std-iterator.h>
void f(capnp::List<int>::Reader l) {
    std::vector<int> v;
    v.insert(v.end(), l.begin(), l.end());
}
```

```
$ g++ -std=c++20 -D_GLIBCXX_DEBUG a.cpp -I c++/src
In file included from /opt/gcc-13.1.0/include/c++/13.1.0/debug/debug.h:141,
                 from /opt/gcc-13.1.0/include/c++/13.1.0/bits/stl_algobase.h:69,
                 from /opt/gcc-13.1.0/include/c++/13.1.0/vector:62,
                 from a.cpp:1:
/opt/gcc-13.1.0/include/c++/13.1.0/debug/functions.h: In instantiation of 'bool __gnu_debug::__foreign_iterator_aux3(const _Safe_iterator<_Iterator, _Sequence, _Category>&, const _InputIterator&, const _InputIterator&, std::__true_type) [with _Iterator = __gnu_cxx::__normal_iterator<const int*, std::__cxx1998::vector<int, std::allocator<int> > >; _Sequence = std::__debug::vector<int>; _Category = std::random_access_iterator_tag; _InputIterator = capnp::_::IndexingIterator<const capnp::List<int>::Reader, int>]':
/opt/gcc-13.1.0/include/c++/13.1.0/debug/functions.h:164:37:   required from 'bool __gnu_debug::__foreign_iterator_aux2(const _Safe_iterator<_Iterator, _Sequence, _Category>&, const _InputIterator&, const _InputIterator&) [with _Iterator = __gnu_cxx::__normal_iterator<const int*, std::__cxx1998::vector<int, std::allocator<int> > >; _Sequence = std::__debug::vector<int>; _Category = std::random_access_iterator_tag; _InputIterator = capnp::_::IndexingIterator<const capnp::List<int>::Reader, int>]'
/opt/gcc-13.1.0/include/c++/13.1.0/debug/functions.h:186:28:   required from 'bool __gnu_debug::__foreign_iterator_aux(const _Safe_iterator<_Iterator, _Sequence, _Category>&, _InputIterator, _InputIterator, std::__false_type) [with _Iterator = __gnu_cxx::__normal_iterator<const int*, std::__cxx1998::vector<int, std::allocator<int> > >; _Sequence = std::__debug::vector<int>; _Category = std::random_access_iterator_tag; _InputIterator = capnp::_::IndexingIterator<const capnp::List<int>::Reader, int>]'
/opt/gcc-13.1.0/include/c++/13.1.0/debug/functions.h:198:36:   required from 'bool __gnu_debug::__foreign_iterator(const _Safe_iterator<_Iterator, _Sequence, _Category>&, _InputIterator, _InputIterator) [with _Iterator = __gnu_cxx::__normal_iterator<const int*, std::__cxx1998::vector<int, std::allocator<int> > >; _Sequence = std::__debug::vector<int>; _Category = std::random_access_iterator_tag; _InputIterator = capnp::_::IndexingIterator<const capnp::List<int>::Reader, int>]'
/opt/gcc-13.1.0/include/c++/13.1.0/debug/vector:626:4:   required from 'std::__debug::vector<_Tp, _Allocator>::iterator std::__debug::vector<_Tp, _Allocator>::insert(const_iterator, _InputIterator, _InputIterator) [with _InputIterator = capnp::_::IndexingIterator<const capnp::List<int>::Reader, int>; <template-parameter-2-2> = void; _Tp = int; _Allocator = std::allocator<int>; iterator = std::__debug::vector<int>::iterator; const_iterator = std::__debug::vector<int>::const_iterator]'
a.cpp:5:13:   required from here
/opt/gcc-13.1.0/include/c++/13.1.0/debug/functions.h:110:61: error: cannot bind non-const lvalue reference of type 'int&' to an rvalue of type 'int'
  110 |       return __foreign_iterator_aux4(__it, std::__addressof(*__other));
      |                                                             ^~~~~~~~
In file included from /opt/gcc-13.1.0/include/c++/13.1.0/bits/stl_pair.h:61,
                 from /opt/gcc-13.1.0/include/c++/13.1.0/bits/stl_algobase.h:64:
/opt/gcc-13.1.0/include/c++/13.1.0/bits/move.h:49:22: note:   initializing argument 1 of 'constexpr _Tp* std::__addressof(_Tp&) [with _Tp = int]'
   49 |     __addressof(_Tp& __r) _GLIBCXX_NOEXCEPT
      |                 ~~~~~^~~
```