### PR TITLE
Treat List(T) with generic parameter as AnyList

### DIFF
--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -172,7 +172,7 @@ inline constexpr Kind kind() {
   return k;
 }
 
-#if _MSC_VER && !defined(__clang__)
+#if (_MSC_VER < 1900) && !defined(__clang__)
 
 #define CAPNP_KIND(T) ::capnp::_::Kind_<T>::kind
 // Avoid constexpr methods in MSVC (it remains buggy in many situations).

--- a/c++/src/capnp/compiler/generics.c++
+++ b/c++/src/capnp/compiler/generics.c++
@@ -130,19 +130,31 @@ bool BrandedDecl::compileAsType(
           return false;
         }
 
+        KJ_CONTEXT(elementType);
         if (elementType.isAnyPointer()) {
-          auto unconstrained = elementType.getAnyPointer().getUnconstrained();
+          auto anyPointer = elementType.getAnyPointer();
+          switch (anyPointer.which()) {
+            case schema::Type::AnyPointer::PARAMETER:
+              return true;
 
-          if (unconstrained.isAnyKind()) {
-            addError(errorReporter, "'List(AnyPointer)' is not supported.");
-            // Seeing List(AnyPointer) later can mess things up, so change the type to Void.
-            elementType.setVoid();
-            return false;
-          } else if (unconstrained.isStruct()) {
-            addError(errorReporter, "'List(AnyStruct)' is not supported.");
-            // Seeing List(AnyStruct) later can mess things up, so change the type to Void.
-            elementType.setVoid();
-            return false;
+            case schema::Type::AnyPointer::UNCONSTRAINED:
+            default: {
+              auto unconstrained = anyPointer.getUnconstrained();
+
+              if (unconstrained.isAnyKind()) {
+                addError(errorReporter, "'List(AnyPointer)' is not supported.");
+                // Seeing List(AnyPointer) later can mess things up, so change the type to Void.
+                elementType.setVoid();
+                return false;
+              }
+              else if (unconstrained.isStruct()) {
+                addError(errorReporter, "'List(AnyStruct)' is not supported.");
+                // Seeing List(AnyStruct) later can mess things up, so change the type to Void.
+                elementType.setVoid();
+                return false;
+              }
+              break;
+            }
           }
         }
 

--- a/c++/src/capnp/encoding-test.c++
+++ b/c++/src/capnp/encoding-test.c++
@@ -1202,6 +1202,10 @@ TEST(Encoding, UpgradeListInBuilder) {
     EXPECT_NONFATAL_FAILURE(root.getAnyPointerField().getAs<List<uint64_t>>());
     checkList(root.getAnyPointerField().getAs<List<Text>>(), {"foo", "bar", "baz"});
 
+    auto ptrlist = root.getAnyPointerField().getAs<AnyList>();
+    ASSERT_EQ(3, ptrlist.size());
+    checkList(ptrlist.as<List<Text>>(), { "foo", "bar", "baz" });
+
     checkList(orig, {"foo", "bar", "baz"});
     checkUpgradedList(root, {0, 0, 0}, {"foo", "bar", "baz"});
     checkList(orig, {"", "", ""});  // old location zero'd during upgrade
@@ -1951,7 +1955,7 @@ TEST(Encoding, GenericDefaults) {
 
 TEST(Encoding, UnionInGenerics) {
   MallocMessageBuilder message;
-  auto builder = message.initRoot<test::TestGenerics<>>();
+  auto builder = message.initRoot<test::TestGenerics<test::TestAnyPointer, test::TestAnyPointer>>();
   auto reader = builder.asReader();
 
   //just call the methods to verify that generated code compiles
@@ -1971,6 +1975,82 @@ TEST(Encoding, UnionInGenerics) {
   reader.getUg();
   builder.getUg();
   builder.initUg();
+
+  reader.getListFoo();
+  builder.getListFoo();
+  reader.hasListFoo();
+  builder.hasListFoo();
+
+  auto list = builder.initListFoo(3);
+}
+
+KJ_TEST("Test generic passthrough doesn't corrupt list contents") {
+  MallocMessageBuilder message;
+  auto builder = message.initRoot<test::TestGenerics<TestAllTypes, TestAllTypes>>();
+  auto reader = builder.asReader();
+
+  //just call the methods to verify that generated code compiles
+  reader.getListFoo();
+  builder.getListFoo();
+  reader.hasListFoo();
+  builder.hasListFoo();
+
+  // Ensure the encoding of List<T> doesn't break
+  auto list = builder.initListFoo(2);
+  initTestMessage(list[0]);
+  list.setWithCaveats(0, list[0]);
+  checkTestMessage(list[0]);
+  checkTestMessageAllZero(list[1]);
+  list.setWithCaveats(1, list[0]);
+  checkTestMessage(list[0]);
+  checkTestMessage(list[1]);
+}
+
+KJ_TEST("Test generic passthrough anypointer representation") {
+  MallocMessageBuilder message;
+  auto builder = message.initRoot<test::TestGenerics<test::TestAnyPointer, test::TestAnyPointer>>();
+  auto reader = builder.asReader();
+
+  auto list = builder.initListFoo(3);
+
+  for (int i = 0; i < 3; ++i) {
+    initTestMessage(list[i].getAnyPointerField().initAs<TestAllTypes>());
+    checkTestMessage(list[i].getAnyPointerField().getAs<TestAllTypes>());
+    checkTestMessage(list[i].asReader().getAnyPointerField().getAs<TestAllTypes>());
+
+    list[i].getAnyPointerField().setAs<Text>("foo");
+    EXPECT_EQ("foo", list[i].getAnyPointerField().getAs<Text>());
+    EXPECT_EQ("foo", list[i].asReader().getAnyPointerField().getAs<Text>());
+
+    list[i].getAnyPointerField().setAs<Data>(data("foo"));
+    EXPECT_EQ(data("foo"), list[i].getAnyPointerField().getAs<Data>());
+    EXPECT_EQ(data("foo"), list[i].asReader().getAnyPointerField().getAs<Data>());
+  }
+}
+
+KJ_TEST("Test generic passthrough interface") {
+  MallocMessageBuilder message;
+  auto builder = message.initRoot<test::TestGenerics<TestAllTypes, TestAllTypes>>();
+  const int COUNT = 3;
+  auto list = builder.initListFoo(COUNT);
+  
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+  
+  test::TestGenericParameterPassThroughInterface<TestAllTypes>::Client client(kj::heap<TestGenericParameterPassThroughInterfaceImpl<TestAllTypes>>());
+
+  auto request1 = client.setGenericListRequest();
+  request1.setListResult(builder.getListFoo());
+  auto promise1 = request1.send();
+
+  auto request2 = client.getGenericListRequest();
+  auto promise2 = request2.send();
+
+  auto response1 = promise1.wait(waitScope);
+
+  auto response2 = promise2.wait(waitScope);
+
+  EXPECT_EQ(COUNT, response2.getListResult().size());
 }
 
 TEST(Encoding, DefaultListBuilder) {

--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -32,6 +32,7 @@
 #include <kj/string.h>
 #include <kj/string-tree.h>
 #include <kj/hash.h>
+#include <type_traits>
 
 CAPNP_BEGIN_HEADER
 
@@ -312,6 +313,12 @@ inline constexpr uint sizeInWords() {
   return unbound((upgradeBound<uint>(_::structSize<T>().data) +
       _::structSize<T>().pointers * WORDS_PER_POINTER) / WORDS);
 }
+
+template<class, class = void>
+struct EnableIfReader : std::false_type {};
+
+template<class T>
+struct EnableIfReader<T, std::void_t<typename T::Reader>> : std::true_type { };
 
 }  // namespace capnp
 

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -358,6 +358,27 @@ public:
   }
 };
 
+template<typename T>
+class TestGenericParameterPassThroughInterfaceImpl final : public test::TestGenericParameterPassThroughInterface<T>::Server {
+public:
+  kj::Promise<void> setGenericList(typename test::TestGenericParameterPassThroughInterface<T>::Server::SetGenericListContext context) override {
+    auto params = context.getParams();
+    if (params.hasListResult()) {
+      auto list = params.getListResult();
+      count = list.size();
+    }
+    return kj::READY_NOW;
+  }
+  kj::Promise<void> getGenericList(typename test::TestGenericParameterPassThroughInterface<T>::Server::GetGenericListContext context) override {
+    auto results = context.getResults();
+    results.initListResult(count);
+    return kj::READY_NOW;
+  }
+
+private:
+  int count;
+};
+
 #endif  // !CAPNP_LITE
 
 }  // namespace _ (private)

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -546,6 +546,8 @@ struct TestGenerics(Foo, Bar) {
     bar @1 :Bar;
   }
 
+  listFoo @5 :List(Foo);
+
   struct Inner2(Baz) {
     bar @0 :Bar;
     baz @1 :Baz;
@@ -811,6 +813,9 @@ interface TestPipeline {
   struct Box {
     cap @0 :TestInterface;
   }
+  struct ListBox {
+    cap @0 :List(TestInterface);
+  }
   struct AnyBox {
     cap @0 :Capability;
   }
@@ -1039,4 +1044,9 @@ struct TestCycleAWithCaps {
 struct TestCycleBWithCaps {
   foo @0 :List(TestCycleAWithCaps);
   bar @1 :TestInterface;
+}
+
+interface TestGenericParameterPassThroughInterface(T) {
+  getGenericList @0 () -> (listResult :List(T));
+  setGenericList @1 (listResult :List(T)) -> ();
 }


### PR DESCRIPTION
This is a new iteration of the previous pull request #1608 (recreated due to v2 branch shenanigans), which generates code that transparently converts a typed `List(T)` with a generic parameter `T` into `AnyList`. The schema is still modified to allow describing a list with a generic parameter, which ensures that the type information can be used by the codegen, but a `List(AnyPointer)` is never actually encoded anywhere, which avoids accidentally creating two simultaneous possible encodings of a list of structs.

For the C++ codegen, this is accomplished via a `TypedAnyList` class, which pretends to be a normal `List(T)` interface, but actually initializes and encodes an `AnyList` under the hood.

However, the existence of truly generic parameters breaks some assumptions the C++ codegen was making. In particular, the ArrayInitializer codepath assumes that it knows if a type is an interface or not at codegen time, which is no longer true for a true generic parameter. This means the C++ code must be able to determine whether a type as `::Reader` or `::Client` at compile-time, which is done using old-fashioned C++17 SFINAE in `EnableIfReader` instead of C++20 `requires`, in case these changes need to be backported.

In addition, because it didn't seem like any code path was testing the `::Client` array initializer, it simply deletes the array initializer function if the type doesn't have `::Reader` - this PR can be modified to instead replace it with a `::Client` version instead, if that is more appropriate. I have tried to keep the changes as minimal as possible here, so let me know if any additional cleanup is needed before this PR is accepted.