### PR TITLE
Make Promises [[nodiscard]]

### DIFF
--- a/c++/WORKSPACE
+++ b/c++/WORKSPACE
@@ -31,6 +31,7 @@ cc_library(
     name = "zlib",
     srcs = glob(["*.c"]),
     hdrs = glob(["*.h"]),
+    includes = ["."],
     # Temporary workaround for zlib warnings and mac compilation, should no longer be needed with next release https://github.com/madler/zlib/issues/633
     copts = [
         "-w",
@@ -46,9 +47,9 @@ cc_library(
 http_archive(
     name = "zlib",
     build_file_content = _zlib_build,
-    sha256 = "d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98",
-    strip_prefix = "zlib-1.2.13",
-    urls = ["https://zlib.net/zlib-1.2.13.tar.xz"],
+    sha256 = "8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7",
+    strip_prefix = "zlib-1.3",
+    urls = ["https://zlib.net/zlib-1.3.tar.xz"],
 )
 
 load_brotli()

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -780,7 +780,7 @@ struct CopyConstructArray_<T, Iterator, true, false> {
 
   static T* apply(T* __restrict__ pos, Iterator start, Iterator end) {
     // Verify that T can be *implicitly* constructed from the source values.
-    if (false) { auto ignored = implicitCast<T>(kj::mv(*start)); ignored; }
+    if (false) { [[maybe_unused]] auto ignored = implicitCast<T>(kj::mv(*start)); }
 
     if (noexcept(T(kj::mv(*start)))) {
       while (start != end) {

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -780,7 +780,7 @@ struct CopyConstructArray_<T, Iterator, true, false> {
 
   static T* apply(T* __restrict__ pos, Iterator start, Iterator end) {
     // Verify that T can be *implicitly* constructed from the source values.
-    if (false) { auto ignored = implicitCast<T>(kj::mv(*start)) }
+    if (false) { auto ignored = implicitCast<T>(kj::mv(*start)); }
 
     if (noexcept(T(kj::mv(*start)))) {
       while (start != end) {

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -780,7 +780,7 @@ struct CopyConstructArray_<T, Iterator, true, false> {
 
   static T* apply(T* __restrict__ pos, Iterator start, Iterator end) {
     // Verify that T can be *implicitly* constructed from the source values.
-    if (false) implicitCast<T>(kj::mv(*start));
+    if (false) { auto ignored = implicitCast<T>(kj::mv(*start)) }
 
     if (noexcept(T(kj::mv(*start)))) {
       while (start != end) {

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -780,7 +780,7 @@ struct CopyConstructArray_<T, Iterator, true, false> {
 
   static T* apply(T* __restrict__ pos, Iterator start, Iterator end) {
     // Verify that T can be *implicitly* constructed from the source values.
-    if (false) { auto ignored = implicitCast<T>(kj::mv(*start)); }
+    if (false) { auto ignored = implicitCast<T>(kj::mv(*start)); ignored; }
 
     if (noexcept(T(kj::mv(*start)))) {
       while (start != end) {

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -288,7 +288,7 @@ KJ_TEST("Exceptions during suspended coroutine frame-unwind propagate via destru
   WaitScope waitScope(loop);
 
   auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
-    deferredThrowCoroutine(kj::NEVER_DONE);
+    auto promise = deferredThrowCoroutine(kj::NEVER_DONE);
   }));
 
   KJ_EXPECT(exception.getDescription() == "thrown during unwind");

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1577,7 +1577,7 @@ KJ_TEST("Userland pipe pump into zero-limited pipe, no data to pump") {
   auto pipe2 = newOneWayPipe(uint64_t(0));
   auto pumpPromise = KJ_ASSERT_NONNULL(pipe2.out->tryPumpFrom(*pipe.in));
 
-  expectRead(*pipe2.in, "");
+  expectRead(*pipe2.in, "").wait(ws);
   pipe.out = nullptr;
   KJ_EXPECT(pumpPromise.wait(ws) == 0);
 }
@@ -1590,7 +1590,7 @@ KJ_TEST("Userland pipe pump into zero-limited pipe, data is pumped") {
   auto pipe2 = newOneWayPipe(uint64_t(0));
   auto pumpPromise = KJ_ASSERT_NONNULL(pipe2.out->tryPumpFrom(*pipe.in));
 
-  expectRead(*pipe2.in, "");
+  expectRead(*pipe2.in, "").wait(ws);
   auto writePromise = pipe.out->write("foo", 3);
   KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("abortRead() has been called", pumpPromise.wait(ws));
 }

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -118,7 +118,7 @@ private:
 // Promises
 
 template <typename T>
-class Promise: protected _::PromiseBase {
+class [[nodiscard]] Promise: protected _::PromiseBase {
   // The basic primitive of asynchronous computation in KJ.  Similar to "futures", but designed
   // specifically for event loop concurrency.  Similar to E promises and JavaScript Promises/A.
   //

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -6553,7 +6553,7 @@ KJ_TEST("Simple CONNECT Server works") {
              "\r\n"
              "hello"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 
@@ -6628,7 +6628,7 @@ KJ_TEST("CONNECT Server (201 status)") {
              "\r\n"
              "hello"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 
@@ -6706,7 +6706,7 @@ KJ_TEST("CONNECT Server rejected") {
              "\r\n"
              "boom"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 
@@ -6774,7 +6774,7 @@ KJ_TEST("CONNECT Server cancels read") {
              "HTTP/1.1 200 OK\r\n"
              "\r\n"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }
@@ -6840,7 +6840,7 @@ KJ_TEST("CONNECT Server cancels write") {
              "HTTP/1.1 200 OK\r\n"
              "\r\n"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }
@@ -6913,7 +6913,7 @@ KJ_TEST("CONNECT rejects Transfer-Encoding") {
              "\r\n"
              "ERROR: Bad Request"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }
@@ -6947,7 +6947,7 @@ KJ_TEST("CONNECT rejects Content-Length") {
              "\r\n"
              "ERROR: Bad Request"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -1037,15 +1037,15 @@ KJ_TEST("TLS receiver experiences pre-TLS error") {
   TlsReceiverTest test;
 
   KJ_LOG(INFO, "Accepting before a bad connect");
-  auto promise = test.receiver->accept();
+  auto acceptPromise = test.receiver->accept();
 
   KJ_LOG(INFO, "Disappointing our server");
-  test.baseReceiver->badConnect();
+  auto connectPromise = test.baseReceiver->badConnect();
 
   // Can't use KJ_EXPECT_THROW_RECOVERABLE_MESSAGE because wait() that returns a value can't throw
   // recoverable exceptions. Can't use KJ_EXPECT_THROW_MESSAGE because non-recoverable exceptions
   // will fork() in -fno-exception which screws up our state.
-  promise.then([](auto) {
+  acceptPromise.then([](auto) {
     KJ_FAIL_EXPECT("expected exception");
   }, [](kj::Exception&& e) {
     KJ_EXPECT(e.getDescription() == "Pipes are leaky");


### PR DESCRIPTION
Bonus (malus?) update to zlib 1.3 to get the project to build again.

This emits a warning, not an error, when dropping a Promise on the floor. Since it's only a warning, I believe it's safe to apply to the 1.0 branch. If you'd rather have it on `v2` only, that's fine too.