### PR TITLE
Warn when ignoring a Promise.

### DIFF
--- a/c++/WORKSPACE
+++ b/c++/WORKSPACE
@@ -31,6 +31,7 @@ cc_library(
     name = "zlib",
     srcs = glob(["*.c"]),
     hdrs = glob(["*.h"]),
+    includes = ["."],
     # Workaround for zlib warnings and mac compilation. Some issues were resolved in v1.3, but there are still implicit function declarations.
     copts = [
         "-w",

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -777,7 +777,7 @@ struct CopyConstructArray_<T, Iterator, true, false> {
 
   static T* apply(T* __restrict__ pos, Iterator start, Iterator end) {
     // Verify that T can be *implicitly* constructed from the source values.
-    if (false) implicitCast<T>(kj::mv(*start));
+    if (false) (void)implicitCast<T>(kj::mv(*start));
 
     if (noexcept(T(kj::mv(*start)))) {
       while (start != end) {

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -286,7 +286,7 @@ KJ_TEST("Exceptions during suspended coroutine frame-unwind propagate via destru
   WaitScope waitScope(loop);
 
   auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
-    deferredThrowCoroutine(kj::NEVER_DONE);
+    (void)deferredThrowCoroutine(kj::NEVER_DONE);
   }));
 
   KJ_EXPECT(exception.getDescription() == "thrown during unwind");

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1577,7 +1577,7 @@ KJ_TEST("Userland pipe pump into zero-limited pipe, no data to pump") {
   auto pipe2 = newOneWayPipe(uint64_t(0));
   auto pumpPromise = KJ_ASSERT_NONNULL(pipe2.out->tryPumpFrom(*pipe.in));
 
-  expectRead(*pipe2.in, "");
+  expectRead(*pipe2.in, "").wait(ws);
   pipe.out = nullptr;
   KJ_EXPECT(pumpPromise.wait(ws) == 0);
 }
@@ -1590,7 +1590,7 @@ KJ_TEST("Userland pipe pump into zero-limited pipe, data is pumped") {
   auto pipe2 = newOneWayPipe(uint64_t(0));
   auto pumpPromise = KJ_ASSERT_NONNULL(pipe2.out->tryPumpFrom(*pipe.in));
 
-  expectRead(*pipe2.in, "");
+  expectRead(*pipe2.in, "").wait(ws);
   auto writePromise = pipe.out->write("foo", 3);
   KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("abortRead() has been called", pumpPromise.wait(ws));
 }

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -114,7 +114,7 @@ private:
 // Promises
 
 template <typename T>
-class Promise: protected _::PromiseBase {
+class [[nodiscard]] Promise: protected _::PromiseBase {
   // The basic primitive of asynchronous computation in KJ.  Similar to "futures", but designed
   // specifically for event loop concurrency.  Similar to E promises and JavaScript Promises/A.
   //

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -573,7 +573,7 @@ TEST(Common, Downcast) {
 
   EXPECT_EQ(&bar, &downcast<Bar>(foo));
 #if defined(KJ_DEBUG) && !KJ_NO_RTTI
-  KJ_EXPECT_THROW_MESSAGE("Value cannot be downcast", downcast<Baz>(foo));
+  KJ_EXPECT_THROW_MESSAGE("Value cannot be downcast", (void)downcast<Baz>(foo));
 #endif
 
 #if KJ_NO_RTTI

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -6573,7 +6573,7 @@ KJ_TEST("Simple CONNECT Server works") {
              "\r\n"
              "hello"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 
@@ -6648,7 +6648,7 @@ KJ_TEST("CONNECT Server (201 status)") {
              "\r\n"
              "hello"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 
@@ -6726,7 +6726,7 @@ KJ_TEST("CONNECT Server rejected") {
              "\r\n"
              "boom"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 
@@ -6794,7 +6794,7 @@ KJ_TEST("CONNECT Server cancels read") {
              "HTTP/1.1 200 OK\r\n"
              "\r\n"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }
@@ -6860,7 +6860,7 @@ KJ_TEST("CONNECT Server cancels write") {
              "HTTP/1.1 200 OK\r\n"
              "\r\n"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }
@@ -6933,7 +6933,7 @@ KJ_TEST("CONNECT rejects Transfer-Encoding") {
              "\r\n"
              "ERROR: Bad Request"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }
@@ -6967,7 +6967,7 @@ KJ_TEST("CONNECT rejects Content-Length") {
              "\r\n"
              "ERROR: Bad Request"_kj).wait(waitScope);
 
-  expectEnd(*pipe.ends[1]);
+  expectEnd(*pipe.ends[1]).wait(waitScope);
 
   listenTask.wait(waitScope);
 }

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -1037,15 +1037,15 @@ KJ_TEST("TLS receiver experiences pre-TLS error") {
   TlsReceiverTest test;
 
   KJ_LOG(INFO, "Accepting before a bad connect");
-  auto promise = test.receiver->accept();
+  auto acceptPromise = test.receiver->accept();
 
   KJ_LOG(INFO, "Disappointing our server");
-  test.baseReceiver->badConnect();
+  auto connectPromise = test.baseReceiver->badConnect();
 
   // Can't use KJ_EXPECT_THROW_RECOVERABLE_MESSAGE because wait() that returns a value can't throw
   // recoverable exceptions. Can't use KJ_EXPECT_THROW_MESSAGE because non-recoverable exceptions
   // will fork() in -fno-exception which screws up our state.
-  promise.then([](auto) {
+  acceptPromise.then([](auto) {
     KJ_FAIL_EXPECT("expected exception");
   }, [](kj::Exception&& e) {
     KJ_EXPECT(e.getDescription() == "Pipes are leaky");

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -92,6 +92,7 @@ private:
   else KJ_FAIL_EXPECT("failed: expected " #cond, _kjCondition, ##__VA_ARGS__)
 #endif
 
+// TODO(msvc): cast results to void like non-MSVC versions do
 #if _MSC_VER && !defined(__clang__)
 #define KJ_EXPECT_THROW_RECOVERABLE(type, code, ...) \
   do { \
@@ -115,7 +116,7 @@ private:
 #else
 #define KJ_EXPECT_THROW_RECOVERABLE(type, code, ...) \
   do { \
-    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { (void)({code;}); })) { \
       KJ_EXPECT(e.getType() == ::kj::Exception::Type::type, \
           "code threw wrong exception type: " #code, e, ##__VA_ARGS__); \
     } else { \
@@ -125,7 +126,7 @@ private:
 
 #define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code, ...) \
   do { \
-    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { code; })) { \
+    KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { (void)({code;}); })) { \
       KJ_EXPECT(::kj::_::hasSubstring(e.getDescription(), message), \
           "exception description didn't contain expected substring", e, ##__VA_ARGS__); \
     } else { \


### PR DESCRIPTION
Ignoring a promise is almost never intentional. Now it generates a compiler warning.

If you do want to ignore a promise, call `Promise::ignore()`. It does nothing but appease the compiler.