### PR TITLE
Allow TLS users to configure preferred curves

### DIFF
--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -791,6 +791,12 @@ TlsContext::TlsContext(Options options) {
     throwOpensslError();
   }
 
+  KJ_IF_SOME(curves, options.curveList) {
+    if (!SSL_CTX_set1_curves_list(ctx, curves.cStr())){
+      throwOpensslError();
+    }
+  }
+
   // honor options.defaultKeypair
   KJ_IF_SOME(kp, options.defaultKeypair) {
     if (!SSL_CTX_use_PrivateKey(ctx, reinterpret_cast<EVP_PKEY*>(kp.privateKey.pkey))) {

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -97,6 +97,11 @@ public:
     //   algorithms.
     // - You need quickly to disable an algorithm recently discovered to be broken.
 
+    kj::Maybe<kj::StringPtr> curveList;
+    // Sets the preferred curves (Groups in TLS 1.3), by default this is not set. Similar to the
+    // cipher list, this is a colon separated list of human readable names or NIDs.
+    // https://boringssl.googlesource.com/boringssl/+/refs/heads/master/include/openssl/nid.h
+
     kj::Maybe<const TlsKeypair&> defaultKeypair;
     // Default keypair to use for all connections. Required for servers; optional for clients.
 


### PR DESCRIPTION
Note, in TLS 1.3 curves are called groups. SSL libs have decided to use the legacy api that mentions curves.