### PR TITLE
Fix MSVC with C++20 on 1.x branch.

### DIFF
--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -335,7 +335,7 @@ inline constexpr uint sizeInWords() {
 #endif
 
 // TODO(msvc): MSVC does not even expect constexprs to have definitions below C++17.
-#if (__cplusplus < 201703L) && !(defined(_MSC_VER) && !defined(__clang__))
+#if (KJ_CPP_STD < 201703L) && !(defined(_MSC_VER) && !defined(__clang__))
 #define CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL 1
 #else
 #define CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL 0

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -378,7 +378,7 @@ TEST(Array, ReleaseAsBytesOrChars) {
   }
 }
 
-#if __cplusplus > 201402L
+#if __cplusplus > 201402L || _MSVC_LANG > 201402L
 KJ_TEST("kj::arr()") {
   kj::Array<kj::String> array = kj::arr(kj::str("foo"), kj::str(123));
   KJ_EXPECT(array == kj::ArrayPtr<const kj::StringPtr>({"foo", "123"}));

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -378,7 +378,7 @@ TEST(Array, ReleaseAsBytesOrChars) {
   }
 }
 
-#if __cplusplus > 201402L || _MSVC_LANG > 201402L
+#if KJ_CPP_STD > 201402L
 KJ_TEST("kj::arr()") {
   kj::Array<kj::String> array = kj::arr(kj::str("foo"), kj::str(123));
   KJ_EXPECT(array == kj::ArrayPtr<const kj::StringPtr>({"foo", "123"}));

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -848,7 +848,7 @@ inline Array<T> heapArray(std::initializer_list<T> init) {
   return heapArray<T>(init.begin(), init.end());
 }
 
-#if __cplusplus > 201402L || _MSVC_LANG > 201402L
+#if KJ_CPP_STD > 201402L
 template <typename T, typename... Params>
 inline Array<Decay<T>> arr(T&& param1, Params&&... params) {
   ArrayBuilder<Decay<T>> builder = heapArrayBuilder<Decay<T>>(sizeof...(params) + 1);

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -848,7 +848,7 @@ inline Array<T> heapArray(std::initializer_list<T> init) {
   return heapArray<T>(init.begin(), init.end());
 }
 
-#if __cplusplus > 201402L
+#if __cplusplus > 201402L || _MSVC_LANG > 201402L
 template <typename T, typename... Params>
 inline Array<Decay<T>> arr(T&& param1, Params&&... params) {
   ArrayBuilder<Decay<T>> builder = heapArrayBuilder<Decay<T>>(sizeof...(params) + 1);

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -378,7 +378,7 @@ KJ_TEST("co_await only sees coroutine destruction exceptions if promise was not 
       awaitPromise(kj::mv(rejectedThrowyDtorPromise)).wait(waitScope));
 }
 
-#if (!_MSC_VER || defined(__clang__)) && !__aarch64__
+#if !_MSC_VER  && !__aarch64__
 uint countLines(StringPtr s) {
   uint lines = 0;
   for (char c: s) {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2983,7 +2983,12 @@ void CoroutineBase::unhandled_exception() {
     // the event loop.
 
     // final_suspend() has not been called.
+#if _MSC_VER && !defined(__clang__)
+    // See comment at `finalSuspendCalled`'s definition.
+    KJ_IASSERT(!finalSuspendCalled);
+#else
     KJ_IASSERT(!coroutine.done());
+#endif
 
     // Since final_suspend() hasn't been called, whatever Event is waiting on us has not fired,
     // and will see this exception.

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -60,12 +60,18 @@
 #define KJ_HAS_COMPILER_FEATURE(x) 0
 #endif
 
+#if defined(_MSVC_LANG) && !defined(__clang__)
+#define KJ_CPP_STD _MSVC_LANG
+#else
+#define KJ_CPP_STD __cplusplus
+#endif
+
 KJ_BEGIN_HEADER
 
 #ifndef KJ_NO_COMPILER_CHECK
 // Technically, __cplusplus should be 201402L for C++14, but GCC 4.9 -- which is supported -- still
 // had it defined to 201300L even with -std=c++14.
-#if __cplusplus < 201300L && !__CDT_PARSER__ && !_MSC_VER
+#if KJ_CPP_STD < 201300L && !__CDT_PARSER__
   #error "This code requires C++14. Either your compiler does not support it or it is not enabled."
   #ifdef __GNUC__
     // Compiler claims compatibility with GCC, so presumably supports -std.
@@ -77,7 +83,7 @@ KJ_BEGIN_HEADER
   #if __clang__
     #if __clang_major__ < 5
       #warning "This library requires at least Clang 5.0."
-    #elif __cplusplus >= 201402L && !__has_include(<initializer_list>)
+    #elif KJ_CPP_STD >= 201402L && !__has_include(<initializer_list>)
       #warning "Your compiler supports C++14 but your C++ standard library does not.  If your "\
                "system has libc++ installed (as should be the case on e.g. Mac OSX), try adding "\
                "-stdlib=libc++ to your CXXFLAGS."
@@ -103,7 +109,7 @@ KJ_BEGIN_HEADER
 #include <initializer_list>
 #include <string.h>
 
-#if __linux__ && __cplusplus > 201200L
+#if __linux__ && KJ_CPP_STD > 201200L
 // Hack around stdlib bug with C++14 that exists on some Linux systems.
 // Apparently in this mode the C library decides not to define gets() but the C++ library still
 // tries to import it into the std namespace. This bug has been fixed at the source but is still
@@ -275,7 +281,7 @@ typedef unsigned char byte;
 #define KJ_UNUSED_MEMBER
 #endif
 
-#if __cplusplus > 201703L || (__clang__  && __clang_major__ >= 9 && __cplusplus >= 201103L) || _MSVC_LANG > 201703L
+#if KJ_CPP_STD > 201703L || (__clang__  && __clang_major__ >= 9 && KJ_CPP_STD >= 201103L)
 // Technically this was only added to C++20 but Clang allows it for >= C++11 and spelunking the
 // attributes manual indicates it first came in with Clang 9.
 #define KJ_NO_UNIQUE_ADDRESS [[no_unique_address]]

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -275,7 +275,7 @@ typedef unsigned char byte;
 #define KJ_UNUSED_MEMBER
 #endif
 
-#if __cplusplus > 201703L || (__clang__  && __clang_major__ >= 9 && __cplusplus >= 201103L)
+#if __cplusplus > 201703L || (__clang__  && __clang_major__ >= 9 && __cplusplus >= 201103L) || _MSVC_LANG > 201703L
 // Technically this was only added to C++20 but Clang allows it for >= C++11 and spelunking the
 // attributes manual indicates it first came in with Clang 9.
 #define KJ_NO_UNIQUE_ADDRESS [[no_unique_address]]

--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -28,6 +28,10 @@ namespace {
 
 CappedArray<char, sizeof(char    ) * 2 + 1> hex(byte     i) { return kj::hex((uint8_t )i); }
 CappedArray<char, sizeof(char    ) * 2 + 1> hex(char     i) { return kj::hex((uint8_t )i); }
+#if __cpp_char8_t
+[[maybe_unused]]
+CappedArray<char, sizeof(char8_t ) * 2 + 1> hex(char8_t  i) { return kj::hex((uint8_t )i); }
+#endif
 CappedArray<char, sizeof(char16_t) * 2 + 1> hex(char16_t i) { return kj::hex((uint16_t)i); }
 CappedArray<char, sizeof(char32_t) * 2 + 1> hex(char32_t i) { return kj::hex((uint32_t)i); }
 CappedArray<char, sizeof(uint32_t) * 2 + 1> hex(wchar_t  i) { return kj::hex((uint32_t)i); }
@@ -58,7 +62,7 @@ void expectRes(EncodingResult<T> result,
   expectResImpl(kj::mv(result), arrayPtr(expected, s - 1), errors);
 }
 
-#if __cplusplus >= 202000L
+#if __cpp_char8_t
 template <typename T, size_t s>
 void expectRes(EncodingResult<T> result,
                const char8_t (&expected)[s],

--- a/c++/src/kj/encoding.h
+++ b/c++/src/kj/encoding.h
@@ -372,7 +372,7 @@ EncodingResult<Array<byte>> decodeBase64(const char (&text)[s]) {
   return decodeBase64(arrayPtr(text, s - 1));
 }
 
-#if __cplusplus >= 202000L
+#if __cpp_char8_t
 template <size_t s>
 inline EncodingResult<Array<char16_t>> encodeUtf16(const char8_t (&text)[s], bool nulTerminate=false) {
   return encodeUtf16(arrayPtr(reinterpret_cast<const char*>(text), s - 1), nulTerminate);

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -1204,7 +1204,7 @@ void throwRecoverableException(kj::Exception&& exception, uint ignoreCount) {
 
 namespace _ {  // private
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 
 uint uncaughtExceptionCount() {
   return std::uncaught_exceptions();

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -1204,7 +1204,7 @@ void throwRecoverableException(kj::Exception&& exception, uint ignoreCount) {
 
 namespace _ {  // private
 
-#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+#if KJ_CPP_STD >= 201703L
 
 uint uncaughtExceptionCount() {
   return std::uncaught_exceptions();

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -459,7 +459,7 @@ KJ_TEST("Maybe<Own<T>>") {
   KJ_EXPECT(&KJ_ASSERT_NONNULL(mRef) == KJ_ASSERT_NONNULL(m).get());
 }
 
-#if __cplusplus > 201402L || _MSVC_LANG > 201402L
+#if KJ_CPP_STD > 201402L
 int* sawIntPtr = nullptr;
 
 void freeInt(int* ptr) {

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -459,7 +459,7 @@ KJ_TEST("Maybe<Own<T>>") {
   KJ_EXPECT(&KJ_ASSERT_NONNULL(mRef) == KJ_ASSERT_NONNULL(m).get());
 }
 
-#if __cplusplus > 201402L
+#if __cplusplus > 201402L || _MSVC_LANG > 201402L
 int* sawIntPtr = nullptr;
 
 void freeInt(int* ptr) {

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -571,6 +571,18 @@ template <typename T>
 const HeapDisposer<T> HeapDisposer<T>::instance = HeapDisposer<T>();
 #endif
 
+#if (__cplusplus >= 202002L)
+template <typename T, void(*F)(T*)>
+class CustomDisposer: public Disposer {
+public:
+  void disposeImpl(void* pointer) const override {
+    (*F)(reinterpret_cast<T*>(pointer));
+  }
+};
+
+template <typename T, void(*F)(T*)>
+static constexpr CustomDisposer<T, F> CUSTOM_DISPOSER_INSTANCE {};
+#else
 template <typename T, void(*F)(T*)>
 class CustomDisposer: public Disposer {
 public:
@@ -583,6 +595,7 @@ public:
 
 template <typename T, void(*F)(T*)>
 const CustomDisposer<T, F> CustomDisposer<T, F>::instance = CustomDisposer<T, F>();
+#endif
 
 }  // namespace _ (private)
 
@@ -608,6 +621,7 @@ Own<Decay<T>> heap(T&& orig) {
 }
 
 #if __cplusplus > 201402L
+#if __cplusplus < 202002L
 template <auto F, typename T>
 Own<T> disposeWith(T* ptr) {
   // Associate a pre-allocated raw pointer with a corresponding disposal function.
@@ -615,6 +629,15 @@ Own<T> disposeWith(T* ptr) {
 
   return Own<T>(ptr, _::CustomDisposer<T, F>::instance);
 }
+#else
+template <auto F, typename T>
+Own<T> disposeWith(T* ptr) {
+  // Associate a pre-allocated raw pointer with a corresponding disposal function.
+  // The first template parameter should be a function pointer e.g. disposeWith<freeInt>(new int(0)).
+
+  return Own<T>(ptr, _::CUSTOM_DISPOSER_INSTANCE<T, F>);
+}
+#endif
 #endif
 
 template <typename T, typename... Attachments>

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -571,7 +571,7 @@ template <typename T>
 const HeapDisposer<T> HeapDisposer<T>::instance = HeapDisposer<T>();
 #endif
 
-#if (__cplusplus >= 202002L)
+#if __cplusplus >= 202002L || _MSVC_LANG >= 202002L
 template <typename T, void(*F)(T*)>
 class CustomDisposer: public Disposer {
 public:
@@ -620,8 +620,8 @@ Own<Decay<T>> heap(T&& orig) {
   return Own<T2>(new T2(kj::fwd<T>(orig)), _::HeapDisposer<T2>::instance);
 }
 
-#if __cplusplus > 201402L
-#if __cplusplus < 202002L
+#if __cplusplus > 201402L || _MSVC_LANG > 201402L
+#if (!defined(_MSVC_LANG) && __cplusplus < 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG < 202002L)
 template <auto F, typename T>
 Own<T> disposeWith(T* ptr) {
   // Associate a pre-allocated raw pointer with a corresponding disposal function.

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -571,7 +571,7 @@ template <typename T>
 const HeapDisposer<T> HeapDisposer<T>::instance = HeapDisposer<T>();
 #endif
 
-#if __cplusplus >= 202002L || _MSVC_LANG >= 202002L
+#if KJ_CPP_STD >= 202002L
 template <typename T, void(*F)(T*)>
 class CustomDisposer: public Disposer {
 public:
@@ -620,8 +620,8 @@ Own<Decay<T>> heap(T&& orig) {
   return Own<T2>(new T2(kj::fwd<T>(orig)), _::HeapDisposer<T2>::instance);
 }
 
-#if __cplusplus > 201402L || _MSVC_LANG > 201402L
-#if (!defined(_MSVC_LANG) && __cplusplus < 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG < 202002L)
+#if KJ_CPP_STD > 201402L
+#if KJ_CPP_STD < 202002L
 template <auto F, typename T>
 Own<T> disposeWith(T* ptr) {
   // Associate a pre-allocated raw pointer with a corresponding disposal function.

--- a/c++/src/kj/one-of.h
+++ b/c++/src/kj/one-of.h
@@ -604,7 +604,7 @@ void OneOf<Variants...>::allHandled() {
   KJ_UNREACHABLE;
 }
 
-#if __cplusplus > 201402L || _MSVC_LANG > 201402L
+#if KJ_CPP_STD > 201402L
 #define KJ_SWITCH_ONEOF(value) \
   switch (auto _kj_switch_subject = (value)._switchSubject(); _kj_switch_subject->which())
 #else

--- a/c++/src/kj/one-of.h
+++ b/c++/src/kj/one-of.h
@@ -604,7 +604,7 @@ void OneOf<Variants...>::allHandled() {
   KJ_UNREACHABLE;
 }
 
-#if __cplusplus > 201402L
+#if __cplusplus > 201402L || _MSVC_LANG > 201402L
 #define KJ_SWITCH_ONEOF(value) \
   switch (auto _kj_switch_subject = (value)._switchSubject(); _kj_switch_subject->which())
 #else

--- a/c++/src/kj/source-location.h
+++ b/c++/src/kj/source-location.h
@@ -41,7 +41,7 @@ KJ_BEGIN_HEADER
 #define KJ_CALLER_COLUMN() 0
 #endif
 
-#if __cplusplus > 201703L || _MSVC_LANG > 201703L
+#if KJ_CPP_STD > 201703L
 #define KJ_COMPILER_SUPPORTS_SOURCE_LOCATION 1
 #elif defined(__has_builtin)
 // Clang 9 added these builtins: https://releases.llvm.org/9.0.0/tools/clang/docs/LanguageExtensions.html

--- a/c++/src/kj/source-location.h
+++ b/c++/src/kj/source-location.h
@@ -41,7 +41,7 @@ KJ_BEGIN_HEADER
 #define KJ_CALLER_COLUMN() 0
 #endif
 
-#if __cplusplus > 201703L
+#if __cplusplus > 201703L || _MSVC_LANG > 201703L
 #define KJ_COMPILER_SUPPORTS_SOURCE_LOCATION 1
 #elif defined(__has_builtin)
 // Clang 9 added these builtins: https://releases.llvm.org/9.0.0/tools/clang/docs/LanguageExtensions.html

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -332,7 +332,7 @@ KJ_TEST("ArrayPtr == StringPtr") {
   ArrayPtr<const char> a = s;
 
   KJ_EXPECT(a == s);
-#if __cplusplus >= 202000L || _MSVC_LANG >= 202000L
+#if KJ_CPP_STD >= 202000L
   KJ_EXPECT(s == a);
 #endif
 }

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -332,7 +332,7 @@ KJ_TEST("ArrayPtr == StringPtr") {
   ArrayPtr<const char> a = s;
 
   KJ_EXPECT(a == s);
-#if __cplusplus >= 202000L
+#if __cplusplus >= 202000L || _MSVC_LANG >= 202000L
   KJ_EXPECT(s == a);
 #endif
 }


### PR DESCRIPTION
@kentonv 
This is continuation of the effort from #1814. Following your recommendations, I cherry-picked the few commits from `v2` branch which were addressing the issues I saw when building `release-1.0.1` with MSVC with C++20 standard.
I had to put one fix from @harrishancock (aa4d3699fc7c7a1524d377f55494fb2b7134592f) into a conditional compiled block as the fix only worked with higher C++ standard than C++14 which `v1` targets.

I tested this on MSVC v193 (VS2022) compiling with C++14, C++17, C++20 and it works - sort of.

The problem I found is that the `Release` build crashes in `kj-heavy-tests.exe` in particular in `async-test.c++` and `fiber pool limit`. What makes it a bit hard to debug is the fact that it only crashes in the release build (the `Debug` runs fine and even `RelWithDebInfo` runs fine). The trigger seems to be `/Ob2` compiler option which is only set in `Release` (as defined by `CMake`), while `RelWithDebInfo` is compiled for some reason with stepped down `/Ob1`.

This option controls inline expansion (https://learn.microsoft.com/en-us/cpp/build/reference/ob-inline-function-expansion?view=msvc-170).

It is possible to build the code with debug info even with `/O2` and `/Ob2` (which is the default for `Release`), but debugging is a bit limited and I, not being familiar with both the fibers capnproto implementation and the test, was not able to determine the reason. The behavior is same with `clang-cl`, so it kind of rules out that the culprit is the compiler alone. I suspect that it might be MSVC STL implementation (which `clang-cl` uses as well), or even a bug in the test.

This behavior is reproducible on any of `v1` commits, the one in this PR, the original `release-1.0.1` and even on `release-0.10.4`, regardless which C++ standard is targeted. So I am not sure what to do about it.

There is another thing I noticed during the tests. I use `clang-cl` as a tool to "cross check" the validity of the code and noticed a regular pattern in `capnproto` code which goes like this:
```c++
#if !_MSC_VER || defined(__clang__)
// do something here
#endif
```
which seems to be used to exclude a code for MSVC toolchain.
With `clang-cl` however this condition is met as the compiler defines both defines: `_MSC_VER` *and* `__clang__`. For example the version of `clang-cl` I am using defines it this way:
```
_MSC_VER=1937
__clang__=1
```
Now, depending on whether you are trying to target the particular compiler, or rather the STL behavior it may or may not work. For example this code https://github.com/capnproto/capnproto/blob/e7a7f2d6f9c4efc7d81cb2aac4fd13c561c47b63/c%2B%2B/src/kj/async-test.c%2B%2B#L40-L45 does not work on `clang-cl` either (and is thus correctly commented out) so my assumption would be this is rather the STL implementation than the toolchain problem.
On the other hand, this test gets compiled in (with `clang-cl`) and fails: https://github.com/capnproto/capnproto/blob/e7a7f2d6f9c4efc7d81cb2aac4fd13c561c47b63/c%2B%2B/src/kj/async-coroutine-test.c%2B%2B#L381-L437