### PR TITLE
less ambigous STL string interop SFINAE

### DIFF
--- a/c++/WORKSPACE
+++ b/c++/WORKSPACE
@@ -31,12 +31,12 @@ cc_library(
     name = "zlib",
     srcs = glob(["*.c"]),
     hdrs = glob(["*.h"]),
-    # Temporary workaround for zlib warnings and mac compilation, should no longer be needed with next release https://github.com/madler/zlib/issues/633
+    # Workaround for zlib warnings and mac compilation. Some issues were resolved in v1.3, but there are still implicit function declarations.
     copts = [
         "-w",
         "-Dverbose=-1",
     ] + select({
-        "@platforms//os:macos": [ "-std=c90" ],
+        "@platforms//os:macos": [ "-Wno-implicit-function-declaration" ],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
@@ -46,9 +46,9 @@ cc_library(
 http_archive(
     name = "zlib",
     build_file_content = _zlib_build,
-    sha256 = "d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98",
-    strip_prefix = "zlib-1.2.13",
-    urls = ["https://zlib.net/zlib-1.2.13.tar.xz"],
+    sha256 = "8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7",
+    strip_prefix = "zlib-1.3",
+    urls = ["https://zlib.net/zlib-1.3.tar.xz"],
 )
 
 load_brotli()

--- a/c++/src/capnp/blob.h
+++ b/c++/src/capnp/blob.h
@@ -79,7 +79,9 @@ public:
   inline Reader(const StringPtr& value): StringPtr(value) {}
 
 #if KJ_COMPILER_SUPPORTS_STL_STRING_INTEROP
-  template <typename T, typename = decltype(kj::instance<T>().c_str())>
+  template <
+    typename T,
+    typename = kj::EnableIf<kj::canConvert<decltype(kj::instance<T>().c_str()), const char*>()>>
   inline Reader(const T& t): StringPtr(t) {}
   // Allow implicit conversion from any class that has a c_str() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -100,7 +100,7 @@ public:
 #if KJ_COMPILER_SUPPORTS_STL_STRING_INTEROP
   template <
     typename T,
-    typename = decltype(instance<T>().c_str()),
+    typename = EnableIf<canConvert<decltype(instance<T>().c_str()), const char*>()>,
     typename = decltype(instance<T>().size())>
   inline StringPtr(const T& t KJ_LIFETIMEBOUND): StringPtr(t.c_str(), t.size()) {}
   // Allow implicit conversion from any class that has a c_str() and a size() method (namely, std::string).
@@ -108,7 +108,7 @@ public:
   // those who don't want it.
   template <
     typename T,
-    typename = decltype(instance<T>().c_str()),
+    typename = EnableIf<canConvert<decltype(instance<T>().c_str()), const char*>()>,
     typename = decltype(instance<T>().size())>
   inline operator T() const { return {cStr(), size()}; }
   // Allow implicit conversion to any class that has a c_str() method and a size() method (namely, std::string).


### PR DESCRIPTION
Hello,

Here is a fix I would be interested to have in the v1 branch (I guess it applies to v2 too) to fix some build issues.

The issue is on a "legacy" codebase with `using namespace boost::filesystem in header files and combined with a recent boost version (1.82).
I considered multiple fixes but I feel like the proper one would be if KJ was stricter in its std::string interop.