### PR TITLE
Revert "Make Array destructor noexcept(false)"

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -144,7 +144,7 @@ public:
       : ptr(firstElement), size_(size), disposer(&disposer) {}
 
   KJ_DISALLOW_COPY(Array);
-  inline ~Array() noexcept(false) { dispose(); }
+  inline ~Array() noexcept { dispose(); }
 
   inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
     return ArrayPtr<T>(ptr, size_);

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -934,7 +934,7 @@ public:
     // No need to copy whatBuffer since it's just to hold the return value of what().
     insertIntoCurrentExceptions();
   }
-  ~ExceptionImpl() noexcept {
+  ~ExceptionImpl() {
     // Look for ourselves in the list.
     for (auto* ptr = &currentException; *ptr != nullptr; ptr = &(*ptr)->nextCurrentException) {
       if (*ptr == this) {


### PR DESCRIPTION
This reverts commit 14c4469ee4b89ee89eb5ec11ef28ca5f9d03d3dc.

This seems to expose a bug downstream in the Workers runtime, reverting for now.