### PR TITLE
Prevent attach(...) functions from taking functors

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -234,8 +234,13 @@ public:
   }
 
   template <typename... Attachments>
+  requires (Attachable<Attachments...>)
   Array<T> attach(Attachments&&... attachments) KJ_WARN_UNUSED_RESULT;
   // Like Own<T>::attach(), but attaches to an Array.
+
+  template <typename... Attachments>
+  requires (!Attachable<Attachments...>)
+  Array<T> attach(Attachments&&... attachments) = delete;
 
 private:
   T* ptr;
@@ -870,6 +875,7 @@ struct ArrayDisposableOwnedBundle final: public ArrayDisposer, public OwnedBundl
 
 template <typename T>
 template <typename... Attachments>
+requires (Attachable<Attachments...>)
 Array<T> Array<T>::attach(Attachments&&... attachments) {
   T* ptrCopy = ptr;
   auto sizeCopy = size_;
@@ -888,6 +894,7 @@ Array<T> Array<T>::attach(Attachments&&... attachments) {
 
 template <typename T>
 template <typename... Attachments>
+requires (Attachable<Attachments...>)
 Array<T> ArrayPtr<T>::attach(Attachments&&... attachments) const {
   T* ptrCopy = ptr;
 

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1395,6 +1395,7 @@ Promise<T> Promise<T>::exclusiveJoin(Promise<T>&& other, SourceLocation location
 
 template <typename T>
 template <typename... Attachments>
+requires (Attachable<Attachments...>)
 Promise<T> Promise<T>::attach(Attachments&&... attachments) {
   return Promise(false, _::appendPromise<_::AttachmentPromiseNode<Tuple<Attachments...>>>(
       kj::mv(node), kj::tuple(kj::fwd<Attachments>(attachments)...)));

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -333,11 +333,17 @@ public:
   //   and produces a tuple?
 
   template <typename... Attachments>
+  requires (Attachable<Attachments...>)
   Promise<T> attach(Attachments&&... attachments) KJ_WARN_UNUSED_RESULT;
   // "Attaches" one or more movable objects (often, Own<T>s) to the promise, such that they will
   // be destroyed when the promise resolves.  This is useful when a promise's callback contains
   // pointers into some object and you want to make sure the object still exists when the callback
   // runs -- after calling then(), use attach() to add necessary objects to the result.
+
+  template <typename... Attachments>
+  requires (!Attachable<Attachments...>)
+  Promise<T> attach(Attachments&&... attachments) = delete;
+  // Let's give a clean failure when something isn't attachable!
 
   template <typename ErrorFunc>
   Promise<T> eagerlyEvaluate(ErrorFunc&& errorHandler, SourceLocation location = {})

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -231,6 +231,7 @@ public:
   }
 
   template <typename... Attachments>
+  requires (Attachable<Attachments...>)
   Own<T> attach(Attachments&&... attachments) KJ_WARN_UNUSED_RESULT;
   // Returns an Own<T> which points to the same object but which also ensures that all values
   // passed to `attachments` remain alive until after this object is destroyed. Normally
@@ -238,6 +239,12 @@ public:
   //
   // Note that attachments will eventually be destroyed in the order they are listed. Hence,
   // foo.attach(bar, baz) is equivalent to (but more efficient than) foo.attach(bar).attach(baz).
+
+
+  template <typename... Attachments>
+  requires (!Attachable<Attachments...>)
+  Own<T> attach(Attachments&&... attachments) = delete;
+  // Let's give a clean failure when something isn't attachable!
 
   template <typename U>
   Own<U> downcast() {
@@ -724,6 +731,7 @@ const StaticDisposerAdapter<T, D> StaticDisposerAdapter<T, D>::instance =
 
 template <typename T>
 template <typename... Attachments>
+requires (Attachable<Attachments...>)
 Own<T> Own<T>::attach(Attachments&&... attachments) {
   T* ptrCopy = ptr;
 

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -163,10 +163,16 @@ public:
   // Same as parseAs, but rather than throwing an exception we return NULL.
 
   template <typename... Attachments>
+  requires (Attachable<Attachments...>)
   ConstString attach(Attachments&&... attachments) const KJ_WARN_UNUSED_RESULT;
   ConstString attach() const KJ_WARN_UNUSED_RESULT;
   // Like ArrayPtr<T>::attach(), but instead promotes a StringPtr into a ConstString. Generally the
   // attachment should be an object that somehow owns the String that the StringPtr is pointing at.
+
+  template <typename... Attachments>
+  requires (!Attachable<Attachments...>)
+  ConstString attach(Attachments&&... attachments) const = delete;
+  // Let's give a clean failure when something isn't attachable!
 
 private:
   inline explicit constexpr StringPtr(ArrayPtr<const char> content): content(content) {}
@@ -711,6 +717,7 @@ inline ConstString StringPtr::attach() const {
 }
 
 template <typename... Attachments>
+requires (Attachable<Attachments...>)
 inline ConstString StringPtr::attach(Attachments&&... attachments) const {
   return ConstString { .content = content.attach(kj::fwd<Attachments>(attachments)...) };
 }


### PR DESCRIPTION
This has been a source of bugs where someone intends to attach a _::Deferred but just attaches a functor.