### PR TITLE
Fix stat overflow on x86_32bit

### DIFF
--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -25,8 +25,7 @@
 
 #ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
-// Request 64-bit off_t. (The code will still work if we get 32-bit off_t as long as actual files
-// are under 4GB.)
+// Request 64-bit off_t and ino_t, otherwise this code will break when either value exceeds 2^32.
 #endif
 
 #if _WIN32

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -23,6 +23,12 @@
 #define _GNU_SOURCE
 #endif
 
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+// Request 64-bit off_t. (The code will still work if we get 32-bit off_t as long as actual files
+// are under 4GB.)
+#endif
+
 #if _WIN32
 #include <kj/win32-api-version.h>
 #endif

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -21,8 +21,7 @@
 
 #ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
-// Request 64-bit off_t. (The code will still work if we get 32-bit off_t as long as actual files
-// are under 4GB.)
+// Request 64-bit off_t and ino_t, otherwise this code will break when either value exceeds 2^32.
 #endif
 
 #include "debug.h"

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -19,6 +19,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+// Request 64-bit off_t. (The code will still work if we get 32-bit off_t as long as actual files
+// are under 4GB.)
+#endif
+
 #include "debug.h"
 #include "filesystem.h"
 #include "string.h"


### PR DESCRIPTION
Those issues are found on a machine that have i-node(file or directory) number exceeding 2^32:
https://github.com/capnproto/capnproto/blob/c3b4b54f22f11b57e057e1aacd937d83fc9ba5c0/c%2B%2B/src/capnp/compiler/capnp.c%2B%2B#L444-L445
coming from `capnproto.c++`
```
libtool: link: g++ -I./src -I./src -DKJ_HEADER_WARNINGS -DCAPNP_HEADER_WARNINGS -DCAPNP_INCLUDE_DIR=\"/usr/local/include\" -O2 -DNDEBUG -DKJ_USE_FIBERS -o .libs/capnp src/capnp/compiler/module-loader.o src/capnp/compiler/capnp.o  ./.libs/libcapnpc.so ./.libs/libcapnp-json.so ./.libs/libcapnp.so ./.libs/libkj.so
./capnp compile --src-prefix=./src -o./capnpc-c++:src -I./src $(for FILE in src/capnp/test.capnp src/capnp/test-import.capnp src/capnp/test-import2.capnp src/capnp/compat/json-test.capnp; do echo ./$FILE; done)
/src/capnproto/c++/.libs/capnp compile: -o ./capnpc-c++:src: output location is inaccessible or is not a directory
Try '/src/capnproto/c++/.libs/capnp compile --help' for more information.
make: *** [Makefile:4465: test_capnpc_middleman] Error 1
"/usr/bin/linux32" "/bin/sh" "-c" "cd capnproto/c++ && autoupdate && autoreconf -i && ./configure && make -j6 && sudo make install" failed with exit status 2
```
coming from `filesystem-disk-test.c++`:
```
kj/filesystem-disk-test.c++:274: failed: rmdir(path.cStr()): Directory not empty
stack: 56750df1 56750ebd 56761ad6
kj/filesystem-disk-test.c++:274: failed: rmdir(path.cStr()): Directory not empty
stack: 56750df1 56750ebd 5675de63
[ FAIL ] kj/filesystem-disk-test.c++:546: DiskDirectory symlinks (539 μs)
[ TEST ] kj/filesystem-disk-test.c++:602: DiskDirectory link
*** Fatal uncaught kj::Exception: kj/filesystem-disk-test.c++:274: failed: rmdir(path.cStr()): Directory not empty
stack: 56750df1 56750ebd 565e37a0 f7a7e706 f7a7f107 f7a7f830 f7a4ee35 f7a509ac f7a7d55a f759e2c4 f759e387 5668a3c6
FAIL: capnp-test
Randomly testing backwards-compatibility scenarios with seed: 1698136498
PASS: capnp-evolution-test
PASS: src/capnp/compiler/capnp-test.sh
===========================================
1 of 3 tests failed
Please report to capnproto@googlegroups.com
===========================================
make[2]: *** [Makefile:3640: check-TESTS] Error 1
make[2]: Leaving directory '/src/capnproto/c++'
make[1]: *** [Makefile:3906: check-am] Error 2
make[1]: Leaving directory '/src/capnproto/c++'
make: *** [Makefile:3908: check] Error 2
"/usr/bin/linux32" "/bin/sh" "-c" "cd capnproto/c++ && autoupdate && autoreconf -i && ./configure && make -j6 check && sudo make install" failed with exit status 2
```
