### PR TITLE
Implement find and contains for kj's String, ConstString, and StringPtr classes

### DIFF
--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -410,6 +410,31 @@ KJ_TEST("StringPtr find") {
   KJ_EXPECT(foobar.slice(2).find(foobar.slice(1)) == kj::none);
 }
 
+KJ_TEST("StringPtr contains") {
+  // Empty string doesn't find anything
+  StringPtr empty("");
+  KJ_EXPECT(empty.contains("") == true);
+  KJ_EXPECT(empty.contains("foo") == false);
+
+  StringPtr foobar("foobar"_kj);
+  KJ_EXPECT(foobar.contains("") == true);
+  KJ_EXPECT(foobar.contains("baz") == false);
+  KJ_EXPECT(foobar.contains("foobar") == true);
+  KJ_EXPECT(foobar.contains("f") == true);
+  KJ_EXPECT(foobar.contains("oobar") == true);
+  KJ_EXPECT(foobar.contains("ar") == true);
+  KJ_EXPECT(foobar.contains("o") == true);
+  KJ_EXPECT(foobar.contains("oo") == true);
+  KJ_EXPECT(foobar.contains("r") == true);
+  KJ_EXPECT(foobar.contains("foobar!") == false);
+
+  // Self pointers shouldn't cause issues, but it's worth testing.
+  KJ_EXPECT(foobar.contains(foobar) == true);
+  KJ_EXPECT(foobar.contains(foobar.slice(1)) == true);
+  KJ_EXPECT(foobar.slice(1).contains(foobar.slice(1)) == true);
+  KJ_EXPECT(foobar.slice(2).contains(foobar.slice(1)) == false);
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -385,6 +385,31 @@ KJ_TEST("ConstString") {
   KJ_EXPECT(theString == "it's a const string!");
 }
 
+KJ_TEST("StringPtr find") {
+  // Empty string doesn't find anything
+  StringPtr empty("");
+  KJ_EXPECT(empty.find("") == 0);
+  KJ_EXPECT(empty.find("foo") == kj::none);
+
+  StringPtr foobar("foobar"_kj);
+  KJ_EXPECT(foobar.find("") == 0);
+  KJ_EXPECT(foobar.find("baz") == kj::none);
+  KJ_EXPECT(foobar.find("foobar") == 0);
+  KJ_EXPECT(foobar.find("f") == 0);
+  KJ_EXPECT(foobar.find("oobar") == 1);
+  KJ_EXPECT(foobar.find("ar") == 4);
+  KJ_EXPECT(foobar.find("o") == 1);
+  KJ_EXPECT(foobar.find("oo") == 1);
+  KJ_EXPECT(foobar.find("r") == 5);
+  KJ_EXPECT(foobar.find("foobar!") == kj::none);
+
+  // Self pointers shouldn't cause issues, but it's worth testing.
+  KJ_EXPECT(foobar.find(foobar) == 0);
+  KJ_EXPECT(foobar.find(foobar.slice(1)) == 1);
+  KJ_EXPECT(foobar.slice(1).find(foobar.slice(1)) == 0);
+  KJ_EXPECT(foobar.slice(2).find(foobar.slice(1)) == kj::none);
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -26,6 +26,9 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <stdint.h>
+#if !defined(_WIN32)
+#include <string.h>
+#endif
 
 namespace kj {
 
@@ -647,10 +650,15 @@ Maybe<size_t> StringPtr::find(const StringPtr& other) const {
     return kj::none;
   }
 
+#if !defined(_WIN32)
+  void* found = memmem(begin(), size(), other.begin(), other.size());
+  if (found == nullptr) {
+    return kj::none;
+  } else {
+    return static_cast<char*>(found)-begin();
+  }
+#else
   // TODO(perf) This is O(len(this)*len(other)), which is very slow on big strings.
-  //
-  // On platforms that support memmem, we should use memmem since memmem has all kinds of
-  // performance hacks in addition to linear runtime.
   //
   // On platforms that don't support memem, we should implement the Two-Way String-Matching
   // algorithm with linear performance.  The Two-Way String-Matching algorithm is described in
@@ -672,6 +680,7 @@ Maybe<size_t> StringPtr::find(const StringPtr& other) const {
   }
 
   return kj::none;
+#endif
 }
 
 }  // namespace kj

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -635,4 +635,43 @@ template <> float StringPtr::parseAs<float>() const { return _::parseDouble(*thi
 template <> Maybe<double> StringPtr::tryParseAs<double>() const { return _::tryParseDouble(*this); }
 template <> Maybe<float> StringPtr::tryParseAs<float>() const { return _::tryParseDouble(*this); }
 
+Maybe<size_t> StringPtr::find(const StringPtr& other) const {
+  if (other.size() == 0) {
+    return size_t(0);
+  }
+  if (size() == 0) {
+    return kj::none;
+  }
+  if (other.size() > size()) {
+    // We won't find the entirety of other if other is longer than this.
+    return kj::none;
+  }
+
+  // TODO(perf) This is O(len(this)*len(other)), which is very slow on big strings.
+  //
+  // On platforms that support memmem, we should use memmem since memmem has all kinds of
+  // performance hacks in addition to linear runtime.
+  //
+  // On platforms that don't support memem, we should implement the Two-Way String-Matching
+  // algorithm with linear performance.  The Two-Way String-Matching algorithm is described in
+  // Crochemore and Perrin's CACM paper (Crochemore M., Perrin D., 1991, Two-way
+  // string-matching, Journal of the ACM 38(3):651-675).
+  //
+  // * A scan of the original paper can be found at
+  //   https://monge.univ-mlv.fr/~mac/Articles-PDF/CP-1991-jacm.pdf.
+  //
+  // * I find Python's implementation notes much easier to understand than the original paoer.
+  //   https://github.com/python/cpython/blob/main/Objects/stringlib/stringlib_find_two_way_notes.txt
+  //
+  // * https://www-igm.univ-mlv.fr/~lecroq/string/node26.html#SECTION00260 has a description of
+  //   the algorithm with some C code.
+  for (size_t i = 0; i + other.size() <= size(); ++i) {
+    if (slice(i).startsWith(other)) {
+      return i;
+    }
+  }
+
+  return kj::none;
+}
+
 }  // namespace kj

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -151,6 +151,12 @@ public:
   inline Maybe<size_t> findFirst(char c) const { return asArray().findFirst(c); }
   inline Maybe<size_t> findLast(char c) const { return asArray().findLast(c); }
 
+  Maybe<size_t> find(const StringPtr& other) const;
+  // Return the index at which other appears in this string.
+  //
+  // In keeping with std::string::find, if other is the empty string, return 0 since the empty
+  // string is a substring of any string.
+
   template <typename T>
   T parseAs() const;
   // Parse string as template number type.

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -297,6 +297,14 @@ public:
   inline bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
   inline bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
 
+  Maybe<size_t> find(const StringPtr& other) const { return asPtr().find(other); }
+  // Return the index at which other appears in this string.
+  //
+  // In keeping with std::string::find, if other is the empty string, return 0 since the empty
+  // string is a substring of any string.
+
+  bool contains(const StringPtr& other) const { return asPtr().contains(other); }
+
   inline StringPtr slice(size_t start) const KJ_LIFETIMEBOUND {
     return StringPtr(*this).slice(start);
   }
@@ -386,6 +394,14 @@ public:
 
   inline bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
   inline bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
+
+  Maybe<size_t> find(const StringPtr& other) const { return asPtr().find(other); }
+  // Return the index at which other appears in this string.
+  //
+  // In keeping with std::string::find, if other is the empty string, return 0 since the empty
+  // string is a substring of any string.
+
+  bool contains(const StringPtr& other) const { return asPtr().contains(other); }
 
   inline StringPtr slice(size_t start) const KJ_LIFETIMEBOUND {
     return StringPtr(*this).slice(start);

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -157,6 +157,8 @@ public:
   // In keeping with std::string::find, if other is the empty string, return 0 since the empty
   // string is a substring of any string.
 
+  bool contains(const StringPtr& other) const { return find(other) != kj::none; }
+
   template <typename T>
   T parseAs() const;
   // Parse string as template number type.


### PR DESCRIPTION
While it's possible to implement `find` (and therefore, `contains`) with a few lines of code, I'd rather implement them in `kj` so we can share the implementation more widely.  See issue #868.

This is a simple implementation that uses memmem on platforms that provide that function and a naive algorithm on other platforms.

