### PR TITLE
Remove hasSubstring in favor of StringPtr::contains

### DIFF
--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -738,12 +738,12 @@ void expectInvalidCert(kj::StringPtr hostname, TlsCertificate cert,
   clientPromise.then([](kj::Own<kj::AsyncOutputStream>) {
     KJ_FAIL_EXPECT("expected exception");
   }, [message, altMessage](kj::Exception&& e) {
-    if (kj::_::hasSubstring(e.getDescription(), message)) {
+    if (e.getDescription().contains(message)) {
       return;
     }
 
     KJ_IF_SOME(a, altMessage) {
-      if (kj::_::hasSubstring(e.getDescription(), a)) {
+      if (e.getDescription().contains(a)) {
         return;
       }
     }

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -862,7 +862,7 @@ KJ_TEST("make sure contended mutex warns") {
     void logMessage(LogSeverity severity, const char* file, int line, int contextDepth,
                     String&& text) override {
       if (!seen && severity == this->severity) {
-        if (_::hasSubstring(text, substring)) {
+        if (text.contains(substring)) {
           // Match. Ignore it.
           seen = true;
           return;

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -107,7 +107,7 @@ private:
 #define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code, ...) \
   do { \
     KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { code; })) { \
-      KJ_INDIRECT_EXPAND(KJ_EXPECT, (::kj::_::hasSubstring(e.getDescription(), message), \
+      KJ_INDIRECT_EXPAND(KJ_EXPECT, (e.getDescription().contains(message), \
           "exception description didn't contain expected substring", e, __VA_ARGS__)); \
     } else { \
       KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("code did not throw: " #code, __VA_ARGS__)); \
@@ -127,7 +127,7 @@ private:
 #define KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(message, code, ...) \
   do { \
     KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { (void)({code;}); })) { \
-      KJ_EXPECT(::kj::_::hasSubstring(e.getDescription(), message), \
+      KJ_EXPECT(e.getDescription().contains(message), \
           "exception description didn't contain expected substring", e, ##__VA_ARGS__); \
     } else { \
       KJ_FAIL_EXPECT("code did not throw: " #code, ##__VA_ARGS__); \
@@ -159,8 +159,6 @@ private:
 // =======================================================================================
 
 namespace _ {  // private
-
-bool hasSubstring(kj::StringPtr haystack, kj::StringPtr needle);
 
 bool expectExit(Maybe<int> statusCode, FunctionParam<void()> code) noexcept;
 // Expects that the given code will exit with a given statusCode.


### PR DESCRIPTION
Now that we have StringPtr::contains, hasSubstring is redundant.

Inspired by issue #868.