### PR TITLE
Revert "gracefully handling http 431 error"

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1453,9 +1453,7 @@ public:
   }
 
   kj::Promise<Message> readMessage() override {
-    auto textOrError = co_await readMessageHeaders();
-    KJ_REQUIRE(textOrError.is<kj::ArrayPtr<char>>(), "bad message");
-    auto text = textOrError.get<kj::ArrayPtr<char>>();
+    auto text = co_await readMessageHeaders();
     headers.clear();
     KJ_REQUIRE(headers.tryParse(text), "bad message");
     auto body = getEntityBody(HttpInputStreamImpl::RESPONSE, HttpMethod::GET, 0, headers);
@@ -1530,7 +1528,7 @@ public:
     return !lineBreakBeforeNextHeader && leftover == nullptr;
   }
 
-  kj::Promise<kj::OneOf<kj::ArrayPtr<char>, HttpHeaders::ProtocolError>> readMessageHeaders() {
+  kj::Promise<kj::ArrayPtr<char>> readMessageHeaders() {
     ++pendingMessageCount;
     auto paf = kj::newPromiseAndFulfiller<void>();
 
@@ -1543,38 +1541,28 @@ public:
     co_return co_await readHeader(HeaderType::MESSAGE, 0, 0);
   }
 
-  kj::Promise<kj::OneOf<uint64_t, HttpHeaders::ProtocolError>> readChunkHeader() {
+  kj::Promise<uint64_t> readChunkHeader() {
     KJ_REQUIRE(onMessageDone != kj::none);
 
     // We use the portion of the header after the end of message headers.
-    auto textOrError = co_await readHeader(HeaderType::CHUNK, messageHeaderEnd, messageHeaderEnd);
+    auto text = co_await readHeader(HeaderType::CHUNK, messageHeaderEnd, messageHeaderEnd);
+    KJ_REQUIRE(text.size() > 0) { break; }
 
-    KJ_SWITCH_ONEOF(textOrError) {
-      KJ_CASE_ONEOF(protocolError, HttpHeaders::ProtocolError) {
-        co_return protocolError;
-      }
-      KJ_CASE_ONEOF(text, kj::ArrayPtr<char>) {
-        KJ_REQUIRE(text.size() > 0) { break; }
-
-        uint64_t value = 0;
-        for (char c: text) {
-          if ('0' <= c && c <= '9') {
-            value = value * 16 + (c - '0');
-          } else if ('a' <= c && c <= 'f') {
-            value = value * 16 + (c - 'a' + 10);
-          } else if ('A' <= c && c <= 'F') {
-            value = value * 16 + (c - 'A' + 10);
-          } else {
-            KJ_FAIL_REQUIRE("invalid HTTP chunk size", text, text.asBytes()) { break; }
-            co_return value;
-          }
-        }
-
+    uint64_t value = 0;
+    for (char c: text) {
+      if ('0' <= c && c <= '9') {
+        value = value * 16 + (c - '0');
+      } else if ('a' <= c && c <= 'f') {
+        value = value * 16 + (c - 'a' + 10);
+      } else if ('A' <= c && c <= 'F') {
+        value = value * 16 + (c - 'A' + 10);
+      } else {
+        KJ_FAIL_REQUIRE("invalid HTTP chunk size", text, text.asBytes()) { break; }
         co_return value;
       }
     }
 
-    KJ_UNREACHABLE;
+    co_return value;
   }
 
   inline kj::Promise<HttpHeaders::RequestConnectOrProtocolError> readRequestHeaders() {
@@ -1583,36 +1571,18 @@ public:
       co_return HttpHeaders::RequestConnectOrProtocolError(resuming);
     }
 
-    auto textOrError = co_await readMessageHeaders();
-    KJ_SWITCH_ONEOF(textOrError) {
-      KJ_CASE_ONEOF(protocolError, HttpHeaders::ProtocolError) {
-        co_return protocolError;
-      }
-      KJ_CASE_ONEOF(text, kj::ArrayPtr<char>) {
-        headers.clear();
-        co_return headers.tryParseRequestOrConnect(text);
-      }
-    }
-
-    KJ_UNREACHABLE;
+    auto text = co_await readMessageHeaders();
+    headers.clear();
+    co_return headers.tryParseRequestOrConnect(text);
   }
 
   inline kj::Promise<HttpHeaders::ResponseOrProtocolError> readResponseHeaders() {
     // Note: readResponseHeaders() could be called multiple times concurrently when pipelining
     //   requests. readMessageHeaders() will serialize these, but it's important not to mess with
     //   state (like calling headers.clear()) before said serialization has taken place.
-    auto headersOrError = co_await readMessageHeaders();
-    KJ_SWITCH_ONEOF(headersOrError) {
-      KJ_CASE_ONEOF(protocolError, HttpHeaders::ProtocolError) {
-        co_return protocolError;
-      }
-      KJ_CASE_ONEOF(text, kj::ArrayPtr<char>) {
-        headers.clear();
-        co_return headers.tryParseResponse(text);
-      }
-    }
-
-    KJ_UNREACHABLE;
+    auto text = co_await readMessageHeaders();
+    headers.clear();
+    co_return headers.tryParseResponse(text);
   }
 
   inline const HttpHeaders& getHeaders() const { return headers; }
@@ -1667,11 +1637,6 @@ public:
     return { headerBuffer.releaseAsBytes(), leftover.asBytes() };
   }
 
-  kj::Promise<void> discard(AsyncOutputStream &output, size_t maxBytes) {
-    // Used to read and discard the input during error handling.
-    return inner.pumpTo(output, maxBytes).ignoreResult();
-  }
-
 private:
   AsyncInputStream& inner;
   kj::Array<char> headerBuffer;
@@ -1711,7 +1676,7 @@ private:
     CHUNK
   };
 
-  kj::Promise<kj::OneOf<kj::ArrayPtr<char>, HttpHeaders::ProtocolError>> readHeader(
+  kj::Promise<kj::ArrayPtr<char>> readHeader(
       HeaderType type, size_t bufferStart, size_t bufferEnd) {
     // Reads the HTTP message header or a chunk header (as in transfer-encoding chunked) and
     // returns the buffer slice containing it.
@@ -1757,12 +1722,7 @@ private:
               // Can't grow because we'd invalidate the HTTP headers.
               kj::throwFatalException(KJ_EXCEPTION(FAILED, "invalid HTTP chunk size"));
             }
-            if (headerBuffer.size() >= MAX_BUFFER) {
-              co_return HttpHeaders::ProtocolError {
-                  .statusCode = 431,
-                  .statusMessage = "Request Header Fields Too Large",
-                  .description = "header too large." };
-            }
+            KJ_REQUIRE(headerBuffer.size() < MAX_BUFFER, "request headers too large");
             auto newBuffer = kj::heapArray<char>(headerBuffer.size() * 2);
             memcpy(newBuffer.begin(), headerBuffer.begin(), headerBuffer.size());
             headerBuffer = kj::mv(newBuffer);
@@ -2044,9 +2004,7 @@ public:
         co_return alreadyRead;
       } else if (chunkSize == 0) {
         // Read next chunk header.
-        auto nextChunkSizeOrError = co_await getInner().readChunkHeader();
-        KJ_REQUIRE(nextChunkSizeOrError.is<uint64_t>(), "bad header");
-        auto nextChunkSize = nextChunkSizeOrError.get<uint64_t>();
+        auto nextChunkSize = co_await getInner().readChunkHeader();
         if (nextChunkSize == 0) {
           doneReading();
         }
@@ -7485,21 +7443,6 @@ private:
       }
       KJ_CASE_ONEOF(protocolError, HttpHeaders::ProtocolError) {
         // Bad request.
-
-        auto needClientGrace = protocolError.statusCode == 431;
-        if (needClientGrace) {
-          // We're going to reply with an error and close the connection.
-          // The client might not be able to read the error back. Read some data and wait
-          // a bit to give client a chance to finish writing.
-
-          auto dummy = kj::heap<HttpDiscardingEntityWriter>();
-          auto lengthGrace = kj::evalNow([&]() {
-            return httpInput.discard(*dummy, server.settings.canceledUploadGraceBytes);
-          }).catch_([](kj::Exception&& e) -> void { })
-            .attach(kj::mv(dummy));
-          auto timeGrace = server.timer.afterDelay(server.settings.canceledUploadGracePeriod);
-          co_await lengthGrace.exclusiveJoin(kj::mv(timeGrace));
-        }
 
         // sendError() uses Response::send(), which requires that we have a currentMethod, but we
         // never read one. GET seems like the correct choice here.


### PR DESCRIPTION
Reverts capnproto/capnproto#1828

reverting to stabilize the downstream. the intent is to re-land this after.