### PR TITLE
Clean up uses of strstr in tests

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -114,7 +114,7 @@ TEST(AsyncIo, SimpleNetworkAuthentication) {
       // `addr` was resolved from `localhost` and may contain multiple addresses, but
       // result.peerIdentity tells us the specific address that was used. So it should be one
       // of the ones on the list, but only one.
-      KJ_EXPECT(strstr(addr->toString().cStr(), id->getAddress().toString().cStr()) != nullptr);
+      KJ_EXPECT(addr->toString().contains(id->getAddress().toString()));
       KJ_EXPECT(id->getAddress().toString().findFirst(',') == nullptr);
 
       client = kj::mv(result.stream);

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -131,11 +131,10 @@ public:
     text += "recoverable exception: ";
     auto what = str(exception);
     // Discard the stack trace.
-    const char* end = strstr(what.cStr(), "\nstack: ");
-    if (end == nullptr) {
-      text += what.cStr();
+    KJ_IF_SOME(end, what.find("\nstack: ")) {
+      text.append(what.cStr(), what.cStr()+end);
     } else {
-      text.append(what.cStr(), end);
+      text += what.cStr();
     }
     text += '\n';
     flush();
@@ -145,11 +144,10 @@ public:
     text += "fatal exception: ";
     auto what = str(exception);
     // Discard the stack trace.
-    const char* end = strstr(what.cStr(), "\nstack: ");
-    if (end == nullptr) {
-      text += what.cStr();
+    KJ_IF_SOME(end, what.find("\nstack: ")) {
+      text.append(what.cStr(), what.cStr()+end);
     } else {
-      text.append(what.cStr(), end);
+      text += what.cStr();
     }
     text += '\n';
     flush();

--- a/c++/src/kj/exception-override-symbolizer-test.c++
+++ b/c++/src/kj/exception-override-symbolizer-test.c++
@@ -40,7 +40,7 @@ namespace {
 
 KJ_TEST("getStackTrace() uses symbolizer override") {
   auto trace = getStackTrace();
-  KJ_ASSERT(strstr(trace.cStr(), "TEST_SYMBOLIZER") != nullptr, trace);
+  KJ_ASSERT(trace.contains("TEST_SYMBOLIZER"), trace);
 }
 
 }  // namespace

--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -197,7 +197,7 @@ KJ_TEST("getStackTrace() returns correct line number, not line + 1") {
   auto trace = testStackTrace();
   auto wrong = kj::str("exception-test.c++:", __LINE__);
 
-  KJ_ASSERT(strstr(trace.cStr(), wrong.cStr()) == nullptr, trace, wrong);
+  KJ_ASSERT(!trace.contains(wrong), trace, wrong);
 }
 
 KJ_TEST("InFlightExceptionIterator works") {


### PR DESCRIPTION
We can replace uses of strstr with StringPtr::contains and StringPtr::contains

Inspired by issue #868.