### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/c++/src/kj/cidr.c++
+++ b/c++/src/kj/cidr.c++
@@ -41,6 +41,10 @@
 #include <arpa/inet.h>
 #endif
 
+#if __FreeBSD__
+#include <netinet/in.h>
+#endif
+
 namespace kj {
 
 CidrRange::CidrRange(StringPtr pattern) {


### PR DESCRIPTION
Without this, the following build error occurs:

```
➜  build git:(v2) ✗ ninja
[1/48] Building CXX object c++/src/kj/CMakeFiles/kj.dir/cidr.c++.o
FAILED: c++/src/kj/CMakeFiles/kj.dir/cidr.c++.o
/usr/local/bin/clang++17  -I/home/alex/software/capnproto/c++/src -g -std=gnu++20 -Wall -Wextra -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -pthread -MD -MT c++/src/kj/CMakeFiles/kj.dir/cidr.c++.o -MF c++/src/kj/CMakeFiles/kj.dir/cidr.c++.o.d -o c++/src/kj/CMakeFiles/kj.dir/cidr.c++.o -c /home/alex/software/capnproto/c++/src/kj/cidr.c++
/home/alex/software/capnproto/c++/src/kj/cidr.c++:116:71: error: member access into incomplete type 'const struct sockaddr_in6'
  116 |         otherBits = reinterpret_cast<const struct sockaddr_in6*>(addr)->sin6_addr.s6_addr;
      |                                                                       ^
/home/alex/software/capnproto/c++/src/kj/cidr.c++:116:51: note: forward declaration of 'sockaddr_in6'
  116 |         otherBits = reinterpret_cast<const struct sockaddr_in6*>(addr)->sin6_addr.s6_addr;
      |                                                   ^
/home/alex/software/capnproto/c++/src/kj/cidr.c++:127:63: error: member access into incomplete type 'const struct sockaddr_in'
  127 |             &reinterpret_cast<const struct sockaddr_in*>(addr)->sin_addr.s_addr);
      |                                                               ^
/home/alex/software/capnproto/c++/src/kj/cidr.c++:127:44: note: forward declaration of 'sockaddr_in'
  127 |             &reinterpret_cast<const struct sockaddr_in*>(addr)->sin_addr.s_addr);
      |                                            ^
/home/alex/software/capnproto/c++/src/kj/cidr.c++:137:69: error: member access into incomplete type 'const struct sockaddr_in6'
  137 |       otherBits = reinterpret_cast<const struct sockaddr_in6*>(addr)->sin6_addr.s6_addr;
      |                                                                     ^
/home/alex/software/capnproto/c++/src/kj/cidr.c++:137:49: note: forward declaration of 'sockaddr_in6'
  137 |       otherBits = reinterpret_cast<const struct sockaddr_in6*>(addr)->sin6_addr.s6_addr;
      |                                                 ^
3 errors generated.
ninja: build stopped: subcommand failed.
➜  build git:(v2) ✗
```