### PR TITLE
Fix problems with stack traces through coroutines

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3115,7 +3115,9 @@ void CoroutineBase::AwaiterBase::getImpl(ExceptionOrValue& result, void* awaited
 
   KJ_IF_SOME(exception, result.exception) {
     // Manually extend the stack trace with the instruction address where the co_await occurred.
-    exception.addTrace(awaitedAt);
+    // Subtract 1 from the address to be consistent with `getStackTrace()` in `exception.c++` (see
+    // comment there).
+    exception.addTrace(reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(awaitedAt) - 1));
 
     // Pass kj::maxValue for ignoreCount here so that `throwFatalException()` dosen't try to
     // extend the stack trace. There's no point in extending the trace beyond the single frame we

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -885,10 +885,8 @@ void Exception::truncateCommonTrace() {
             // If we matched more than half of the reference trace, guess that this is in fact
             // the prefix we're looking for.
             if (j > refTrace.size() / 2) {
-              // Delete the matching suffix. Also delete one non-matched entry on the assumption
-              // that both traces contain that stack frame but are simply at different points in
-              // the function.
-              traceCount -= j + 1;
+              // Delete the matching suffix.
+              traceCount -= j;
               return;
             }
           }


### PR DESCRIPTION
These issues confused me while debugging today. The stack trace looked like garbage, but it was actually just slightly wrong...