### PR TITLE
Fix compiler warning when zlib not available.

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -2530,8 +2530,10 @@ const byte WEBSOCKET_SEND_MESSAGE[] =
     { 0x81, 0x83, 12, 34, 56, 78, 'b'^12, 'a'^34, 'r'^56 };
 const byte WEBSOCKET_REPLY_MESSAGE[] =
     { 0x81, 0x09, 'r','e','p','l','y',':','b','a','r' };
+#if KJ_HAS_ZLIB
 const byte WEBSOCKET_SEND_HI[] =
     { 0x81, 0x82, 12, 34, 56, 78, 'H'^12, 'i'^34 };
+#endif  // KJ_HAS_ZLIB
 const byte WEBSOCKET_SEND_CLOSE[] =
     { 0x88, 0x85, 12, 34, 56, 78, 0x12^12, 0x34^34, 'q'^56, 'u'^78, 'x'^12 };
 const byte WEBSOCKET_REPLY_CLOSE[] =

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2802,6 +2802,15 @@ public:
         return receive(newMax);
       }
 
+      // Provide a reasonable error if a compressed frame is received without compression enabled.
+      if (isCompressed && compressionConfig == kj::none) {
+        return errorHandler.handleWebSocketProtocolError({
+          1002, kj::str(
+              "Received a WebSocket frame whose compression bit was set, but the compression "
+              "extension was not negotiated for this connection.")
+        });
+      }
+
       switch (opcode) {
         case OPCODE_CONTINUATION:
           // Shouldn't get here; handled above.


### PR DESCRIPTION
The `isCompressed` bit is captured but not used in this case. Instead of #ifdefing it out, I went ahead and used it to provide a nice error message.

This should fix the musl build.