### PR TITLE
Fix leftover handling in HTTP CONNECT implementation.

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -4337,6 +4337,7 @@ public:
 
       if (bytesToCopy > 0) {
         memcpy(destination, leftover.begin(), bytesToCopy);
+        leftover = nullptr;
         leftoverBackingBuffer = nullptr;
         minBytes -= bytesToCopy;
         maxBytes -= bytesToCopy;


### PR DESCRIPTION
A buffer was read after being freed when two unusual things happened together: 1) Some of the initial connection content arrived immediately with the HTTP response headers, causing there to be a `leftover` buffer. This is rare because the response headers would normally be returned when the connection was opened, but the nature of TCP doesn't allow the server to return any bytes until an additional network round trip has occurred. 2) The application tried to read with a `minBytes` greater than the size of this leftover. (This is unusual because most use cases set `minBytes` to 1, which can't possibly be larger than a non-empty leftover size.)

In this case, the leftover's backing buffer was destroyed, but the ArrayPtr pointing into it was not reset, so the next read would try to read it again.

I have not observed this problem happening in practice. I just noticed the bug while reading the code.