### PR TITLE
Add "lifetimebound" annotation to aggregate field accessors of Readers

### DIFF
--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1674,7 +1674,7 @@ private:
             kj::mv(unionDiscrim.readerIsDecl),
             "  inline bool has", titleCase, "() const;\n",
             COND(shouldExcludeInLiteMode, "#if !CAPNP_LITE\n"),
-            "  inline ", readerType, " get", titleCase, "() const;\n",
+            "  inline ", readerType, " get", titleCase, "() const KJ_LIFETIMEBOUND;\n",
             COND(shouldExcludeInLiteMode, "#endif  // !CAPNP_LITE\n"),
             "\n"),
 
@@ -1723,7 +1723,7 @@ private:
             "}\n",
             COND(shouldExcludeInLiteMode, "#if !CAPNP_LITE\n"),
             templateContext.allDecls(),
-            "inline ", readerType, " ", scope, "Reader::get", titleCase, "() const {\n",
+            "inline ", readerType, " ", scope, "Reader::get", titleCase, "() const KJ_LIFETIMEBOUND {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_reader.getPointerField(\n"
             "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"


### PR DESCRIPTION
Hello,

Recently there was an [article posted to Lobsters](https://blog.dureuill.net/articles/recurring-lifetime/) by @dureuill that described a lifetime "footgun" that exists in capnproto: 

Essentially, when a response is returned from a send() promise, we must store the response in a variable for as long as we access the values that live inside it. If the response contains a list and we leave the response as a temporary while we retrieve the list handle, accesses to the list handle later on will be a UAF, e.g.: `auto list = request.send().wait(wait_scope).getList();`.

@davidchisnall in that Lobsters thread [suggested](https://lobste.rs/s/zzuirh/curiously_recurring_lifetime_issue#c_ymfkof) using `[[clang::lifetimebound]]` to fix this issue and indeed it would have caused the compiler to issue a warning here. All that needs to be done is to add the `[[clang::lifetimebound]]` attribute to all accessor methods in the `Reader` helper classes generated by `capnpc-c++`.

When that is done I get the following error when compiling his original code:

```
./test.cc:18:7: warning: temporary whose address is used as value of local variable 'list' will be destroyed at the end
      of the full-expression [-Wdangling]
      request.send().wait(wait_scope).getList();
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This simple change should improve the experience using capnproto and save lots of time debugging.

To get the ball rolling, I've created a minimal patch the fixes the specific problem in question. You may want to expand the patch to apply the same strategy in other cases. I'm not very familiar with capnproto internals so I didn't want to modify too many things.

Thanks,
Rian Hunter