### PR TITLE
as<T>() syntax sugar methods for primitive types

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -24,6 +24,7 @@
 #include <string>
 #include <list>
 #include <kj/compat/gtest.h>
+#include <span>
 
 namespace kj {
 namespace {
@@ -507,6 +508,19 @@ TEST(Array, AttachFromArrayPtr) {
   arr = nullptr;
 
   KJ_EXPECT(destroyed1 == 3, destroyed1);
+}
+
+struct Std {
+  template<typename T>
+  static std::span<T> from(Array<T>* arr) {
+    return std::span<T>(arr->begin(), arr->size());
+  }
+};
+
+KJ_TEST("Array::as<Std>") {
+  kj::Array<int> arr = kj::arr(1, 2, 4);
+  std::span<int> stdArr = arr.as<Std>();
+  KJ_EXPECT(stdArr.size() == 3);
 }
 
 }  // namespace

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -237,6 +237,11 @@ public:
   Array<T> attach(Attachments&&... attachments) KJ_WARN_UNUSED_RESULT;
   // Like Own<T>::attach(), but attaches to an Array.
 
+  template <typename U>
+  inline auto as() { return U::from(this); }
+  // Syntax sugar for invoking U::from.
+  // Used to chain conversion calls rather than wrap with function.
+
 private:
   T* ptr;
   size_t size_;

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -23,6 +23,7 @@
 #include "test.h"
 #include <inttypes.h>
 #include <kj/compat/gtest.h>
+#include <span>
 
 namespace kj {
 namespace {
@@ -923,6 +924,20 @@ KJ_TEST("kj::ArrayPtr startsWith / endsWith / findFirst / findLast") {
   KJ_EXPECT(arr.findLast(34).orDefault(100) == 3);
   KJ_EXPECT(arr.findLast(56).orDefault(100) == 2);
   KJ_EXPECT(arr.findLast(78).orDefault(100) == 100);
+}
+
+struct Std {
+  template<typename T>
+  static std::span<T> from(ArrayPtr<T>* arr) {
+    return std::span<T>(arr->begin(), arr->size());
+  }
+};
+
+KJ_TEST("ArrayPtr::as<Std>") {
+  int rawArray[] = {12, 34, 56, 34, 12};
+  ArrayPtr<int> arr(rawArray);
+  std::span<int> stdPtr = arr.as<Std>();
+  KJ_EXPECT(stdPtr.size() == 5);
 }
 
 }  // namespace

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1927,6 +1927,11 @@ public:
   //
   // You must include kj/array.h to call this.
 
+  template <typename U>
+  inline auto as() { return U::from(this); }
+  // Syntax sugar for invoking U::from.
+  // Used to chain conversion calls rather than wrap with function.
+
 private:
   T* ptr;
   size_t size_;

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -435,6 +435,26 @@ KJ_TEST("StringPtr contains") {
   KJ_EXPECT(foobar.slice(2).contains(foobar.slice(1)) == false);
 }
 
+struct Std {
+  static std::string from(const String* str) {
+    return std::string(str->cStr());
+  }
+
+  static std::string from(const StringPtr* str) {
+    return std::string(str->cStr());
+  }
+};
+
+KJ_TEST("as<Std>") {
+  String str = kj::str("foo"_kj);
+  std::string stdStr = str.as<Std>();
+  KJ_EXPECT(stdStr == "foo");
+
+  StringPtr ptr = "bar"_kj; 
+  std::string stdPtr = ptr.as<Std>();
+  KJ_EXPECT(stdPtr == "bar");
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -176,6 +176,11 @@ public:
   // Like ArrayPtr<T>::attach(), but instead promotes a StringPtr into a ConstString. Generally the
   // attachment should be an object that somehow owns the String that the StringPtr is pointing at.
 
+  template <typename T>
+  inline auto as() { return T::from(this); }
+  // Syntax sugar for invoking T::from.
+  // Used to chain conversion calls rather than wrap with function.
+
 private:
   inline explicit constexpr StringPtr(ArrayPtr<const char> content): content(content) {}
   friend constexpr StringPtr (::operator "" _kj)(const char* str, size_t n);
@@ -321,6 +326,11 @@ public:
 
   template <typename T>
   Maybe<T> tryParseAs() const { return StringPtr(*this).tryParseAs<T>(); }
+
+  template <typename T>
+  inline auto as() { return T::from(this); }
+  // Syntax sugar for invoking T::from.
+  // Used to chain conversion calls rather than wrap with function.
 
 private:
   Array<char> content;


### PR DESCRIPTION
String, StringPtr, Array, ArrayPtr gain as<T>() method which is a syntax sugar for T::from(this).

This enables defining conversion domains (such as Std in tests) and use `.as<Std>()` chained calls for more fluid expressions.