### PR TITLE
Allow InMemoryDirectory to be backed by memfds

### DIFF
--- a/c++/src/kj/filesystem-test.c++
+++ b/c++/src/kj/filesystem-test.c++
@@ -752,6 +752,23 @@ KJ_TEST("InMemoryDirectory move") {
   KJ_EXPECT(dst->openFile(Path({"link", "baz", "qux"}))->readAllText() == "bazqux");
 }
 
+KJ_TEST("InMemoryDirectory transfer from self") {
+  TestClock clock;
+
+  auto dir = newInMemoryDirectory(clock);
+
+  auto file = dir->openFile(Path({"foo"}), WriteMode::CREATE);
+
+  dir->transfer(Path({"bar"}), WriteMode::CREATE, Path({"foo"}), TransferMode::MOVE);
+
+  auto list = dir->listNames();
+  KJ_EXPECT(list.size() == 1);
+  KJ_EXPECT(list[0] == "bar");
+
+  auto file2 = dir->openFile(Path({"bar"}));
+  KJ_EXPECT(file.get() == file2.get());
+}
+
 KJ_TEST("InMemoryDirectory createTemporary") {
   TestClock clock;
 


### PR DESCRIPTION
In this mode, InMemoryDirectory works as normal, but when it creates a File, instead of using InMemoryFile, it uses DiskFile wrapping a memfd.

This creates a nice compromise for writing tests of code that depends on files being backed by real file descriptors, but does not need the same for directories.

(If we wanted similar functionality on other operating systems, we could create an InMemoryFileFactory that backs files with anonymous temporary files on disk...)

**Also in this PR:** Fix InMemoryDirectory deadlock bug.

(Some SRS tests I'm writing require both of these changes.)