### PR TITLE
Extend UnixEventPort on Linux to allow external polling.

### DIFF
--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -919,10 +919,7 @@ public:
 
 class LowLevelAsyncIoProviderImpl final: public LowLevelAsyncIoProvider {
 public:
-  LowLevelAsyncIoProviderImpl()
-      : eventLoop(eventPort), waitScope(eventLoop) {}
-
-  inline WaitScope& getWaitScope() { return waitScope; }
+  LowLevelAsyncIoProviderImpl(Win32EventPort& eventPort): eventPort(eventPort) {}
 
   Own<AsyncInputStream> wrapInputFd(SOCKET fd, uint flags = 0) override {
     return heap<AsyncStreamFd>(eventPort, fd, flags);
@@ -952,12 +949,8 @@ public:
 
   Timer& getTimer() override { return eventPort.getTimer(); }
 
-  Win32EventPort& getEventPort() { return eventPort; }
-
 private:
-  Win32IocpEventPort eventPort;
-  EventLoop eventLoop;
-  WaitScope waitScope;
+  Win32EventPort& eventPort;
 };
 
 // =======================================================================================
@@ -1153,10 +1146,13 @@ public:
     auto pipe = lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS);
 
     auto thread = heap<Thread>([threadFd,startFunc=kj::mv(startFunc)]() mutable {
-      LowLevelAsyncIoProviderImpl lowLevel;
+      Win32IocpEventPort eventPort;
+      EventLoop eventLoop(eventPort);
+      WaitScope waitScope(eventLoop);
+      LowLevelAsyncIoProviderImpl lowLevel(eventPort);
       auto stream = lowLevel.wrapSocketFd(threadFd, NEW_FD_FLAGS);
       AsyncIoProviderImpl ioProvider(lowLevel);
-      startFunc(ioProvider, *stream, lowLevel.getWaitScope());
+      startFunc(ioProvider, *stream, waitScope);
     });
 
     return { kj::mv(thread), kj::mv(pipe) };
@@ -1175,13 +1171,34 @@ Own<AsyncIoProvider> newAsyncIoProvider(LowLevelAsyncIoProvider& lowLevel) {
   return kj::heap<AsyncIoProviderImpl>(lowLevel);
 }
 
+Own<LowLevelAsyncIoProvider> newLowLevelAsyncIoProvider(Win32EventPort& eventPort) {
+  return kj::heap<LowLevelAsyncIoProviderImpl>(eventPort);
+}
+
 AsyncIoContext setupAsyncIo() {
   _::initWinsockOnce();
 
-  auto lowLevel = heap<LowLevelAsyncIoProviderImpl>();
+  struct BasicContext {
+    Win32IocpEventPort eventPort;
+    EventLoop eventLoop;
+    WaitScope waitScope;
+
+    BasicContext(): eventLoop(eventPort), waitScope(eventLoop) {}
+  };
+
+  auto basicContext = heap<BasicContext>();
+  auto lowLevel = heap<LowLevelAsyncIoProviderImpl>(basicContext->eventPort);
   auto ioProvider = kj::heap<AsyncIoProviderImpl>(*lowLevel);
-  auto& waitScope = lowLevel->getWaitScope();
-  auto& eventPort = lowLevel->getEventPort();
+  auto& waitScope = basicContext->waitScope;
+  auto& eventPort = basicContext->eventPort;
+
+  // Historically, `LowLevelAsyncIoProviderImpl` contained the stuff that `BasicContext` now
+  // contains. However, this made it impossible to create more elaborate EventLoop arrangements
+  // while still using the default LLAIOP implementation. For backwards-compatibility,
+  // `setupAsyncIo()` still attaches this context to the LLAIOP, but it's now possible to construct
+  // these objects directly and LLAIOP on top.
+  lowLevel = lowLevel.attach(kj::mv(basicContext));
+
   return { kj::mv(lowLevel), kj::mv(ioProvider), waitScope, eventPort };
 }
 

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -903,6 +903,14 @@ public:
 Own<AsyncIoProvider> newAsyncIoProvider(LowLevelAsyncIoProvider& lowLevel);
 // Make a new AsyncIoProvider wrapping a `LowLevelAsyncIoProvider`.
 
+#if _WIN32
+Own<LowLevelAsyncIoProvider> newLowLevelAsyncIoProvider(Win32EventPort& eventPort);
+// Make a new `LowLevelAsyncIoProvider` backed by a `Win32EventPort`.
+#else
+Own<LowLevelAsyncIoProvider> newLowLevelAsyncIoProvider(UnixEventPort& eventPort);
+// Make a new `LowLevelAsyncIoProvider` backed by a `UnixEventPort`.
+#endif
+
 struct AsyncIoContext {
   Own<LowLevelAsyncIoProvider> lowLevelProvider;
   Own<AsyncIoProvider> provider;

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <atomic>
 #include "mutex.h"
+#include <poll.h>
 
 #if KJ_USE_EPOLL
 #include <sys/epoll.h>
@@ -1115,6 +1116,132 @@ KJ_TEST("UnixEventPort thread-specific signals") {
     threads[i] = nullptr;  // wait for that one thread to exit
     usleep(1000);
     KJ_ASSERT(doneCount.load(std::memory_order_relaxed) == ++count);
+  }
+}
+#endif
+
+#if KJ_USE_EPOLL
+KJ_TEST("UnixEventPoll::getFd() for external waiting") {
+  kj::UnixEventPort port;
+  kj::EventLoop loop(port);
+  kj::WaitScope ws(loop);
+
+  auto portIsReady = [&port](int timout = 0) {
+    struct pollfd pfd;
+    memset(&pfd, 0, sizeof(pfd));
+    pfd.events = POLLIN;
+    pfd.fd = port.getPollableFd();
+
+    int n;
+    KJ_SYSCALL(n = poll(&pfd, 1, timout));
+    return n > 0;
+  };
+
+  // Test wakeup on observed FD.
+  {
+    int pair[2];
+    KJ_SYSCALL(pipe(pair));
+    kj::AutoCloseFd in(pair[0]);
+    kj::AutoCloseFd out(pair[1]);
+
+    kj::UnixEventPort::FdObserver observer(port, in, kj::UnixEventPort::FdObserver::OBSERVE_READ);
+    auto promise = observer.whenBecomesReadable();
+
+    KJ_EXPECT(!promise.poll(ws));
+    ws.poll();
+    port.preparePollableFdForSleep();
+
+    KJ_EXPECT(!portIsReady());
+
+    KJ_SYSCALL(write(out, "a", 1));
+
+    KJ_EXPECT(portIsReady());
+
+    KJ_ASSERT(promise.poll(ws));
+    promise.wait(ws);
+  }
+
+  // Test wakeup due to queuing work to the event loop in-process.
+  {
+    ws.poll();
+    port.preparePollableFdForSleep();
+
+    KJ_EXPECT(!portIsReady());
+
+    auto promise = kj::evalLater([]() {}).eagerlyEvaluate(nullptr);
+
+    KJ_EXPECT(portIsReady());
+    KJ_ASSERT(promise.poll(ws));
+    promise.wait(ws);
+  }
+
+  // Test wakeup on timeout.
+  {
+    auto promise = port.getTimer().afterDelay(50 * kj::MILLISECONDS);
+
+    KJ_EXPECT(!promise.poll(ws));
+    ws.poll();
+    port.preparePollableFdForSleep();
+
+    KJ_EXPECT(!portIsReady());
+
+    usleep(50'000);
+
+    KJ_EXPECT(portIsReady());
+
+    KJ_ASSERT(promise.poll(ws));
+    promise.wait(ws);
+  }
+
+  // Test wakeup on time in past. This verifies timerfd_settime() won't just silently fail if the
+  // time is already past.
+  {
+    ws.poll();
+
+    // Schedule time event in the past.
+    auto promise = port.getTimer().atTime(kj::origin<TimePoint>() + 1 * SECONDS);
+
+    // As of this writing, atTime() doesn't do any special handling of times in the past, e.g. to
+    // immediately resolve the promise. It goes ahead and schedules them like any other I/O. So
+    // scheduling such a promise will not immediately schedule work on the event loop, and
+    // preparePollableFdForSleep() will in fact go and timerfd_settime() to a time in the past. (If
+    // this changes, we'll need to structure this test differently I guess.)
+    KJ_EXPECT(!loop.isRunnable());
+
+    port.preparePollableFdForSleep();
+
+    // Uhhhh... Apparently when timerfd_settime() sets a time in the past, the timerfd does NOT
+    // immediately become readable. The kernel still needs to process the timer in the background
+    // before it raises the event. So we will need to give it some time... we give it 10ms here.
+    KJ_EXPECT(portIsReady(10));
+
+    KJ_ASSERT(promise.poll(ws));
+    promise.wait(ws);
+  }
+
+  // Test wakeup when a timer event is created during sleep.
+  {
+    ws.poll();
+    auto startTime = port.getTimer().now();
+    port.preparePollableFdForSleep();
+
+    KJ_EXPECT(!portIsReady());
+
+    // When sleeping, passage of real time updates `timer.now()`.
+    usleep(50'000);
+    KJ_EXPECT(port.getTimer().now() - startTime >= 50 * MILLISECONDS);
+
+    // We can set a timer now, and the epoll FD will wake up when it expires, even though no timer
+    // was set when `preparePollableFdForSleep()` was called.
+    auto promise = port.getTimer().afterDelay(50 * MILLISECONDS);
+
+    // It won't expire too early: the delay was added to the real time, not the last time the
+    // timer was advanced to.
+    KJ_EXPECT(!portIsReady(10));
+    KJ_EXPECT(portIsReady(40));
+
+    KJ_ASSERT(promise.poll(ws));
+    promise.wait(ws);
   }
 }
 #endif

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -1121,7 +1121,7 @@ KJ_TEST("UnixEventPort thread-specific signals") {
 #endif
 
 #if KJ_USE_EPOLL
-KJ_TEST("UnixEventPoll::getFd() for external waiting") {
+KJ_TEST("UnixEventPoll::getPollableFd() for external waiting") {
   kj::UnixEventPort port;
   kj::EventLoop loop(port);
   kj::WaitScope ws(loop);

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -661,7 +661,7 @@ bool UnixEventPort::processEpollEvents(struct epoll_event events[], int n) {
       timerfdIsArmed = false;
 
       // The purpose of this event is just to wake up the event loop when needed. We'll check the
-      // timer queue separately, so we don't need to do anything special it response to this event
+      // timer queue separately, so we don't need to do anything special in response to this event
       // here.
     } else {
       FdObserver* observer = reinterpret_cast<FdObserver*>(events[i].data.ptr);

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -203,7 +203,7 @@ public:
   //   it should be possible to implement for kqueue as well.
 
   void preparePollableFdForSleep();
-  // If you plan to monitor the FD return by getFd() for notifications that this queue is ready,
+  // If you plan to monitor the FD return by getPollableFd() for notifications that this queue is ready,
   // you must call preparePollableFdForSleep() after each run of this port's event loop in order to
   // ensure that all event types will in fact wake up the queue.
   //

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -64,7 +64,7 @@ struct timespec;
 
 namespace kj {
 
-class UnixEventPort: public EventPort {
+class UnixEventPort: public EventPort, private TimerImpl::SleepHooks {
   // An EventPort implementation which can wait for events on file descriptors as well as signals.
   // This API only makes sense on Unix.
   //
@@ -178,10 +178,69 @@ public:
   // This method may capture the `SIGCHLD` signal. You must not use `captureSignal(SIGCHLD)` nor
   // `onSignal(SIGCHLD)` in your own code if you use `captureChildExit()`.
 
+#if KJ_USE_EPOLL
+  int getPollableFd();
+  // Get a file descriptor which represents the EventPort's backing OS event queue, and becomes
+  // readable when there are events to process. This may be an epoll FD or a kqueue FD depending on
+  // the OS.
+  //
+  // You MUST use preparePollableFdForSleep() before waiting on this FD.
+  //
+  // The caller should not perform operations on this FD. It should only be used for polling in
+  // some other event loop. This can be useful for allowing UnixEventPort to operate embedded in
+  // an application that uses some other event loop as its main loop. Whenever this FD becomes
+  // readable, call waitScope.poll() to handle all available events, then
+  // `preparePollableFdForSleep()`.
+  //
+  // It's also possible to use this to drive multiple event loops from the same thread, or even
+  // multiple threads in an m:n mapping. When an event loop becomes ready, create a temporary
+  // WaitScope on the thread where you want to run it, pump the loop, and then destroy the
+  // WaitScope. A WaitScope binds a loop to a thread while it exists, but an event loop is allowed
+  // to change threads and a thread is allowed to change event loops as long as no WaitScope is
+  // currently binding them.
+  //
+  // TODO(someday): Currently this is only implemented for epoll, NOT for kqueue. But in principle
+  //   it should be possible to implement for kqueue as well.
+
+  void preparePollableFdForSleep();
+  // If you plan to monitor the FD return by getFd() for notifications that this queue is ready,
+  // you must call preparePollableFdForSleep() after each run of this port's event loop in order to
+  // ensure that all event types will in fact wake up the queue.
+  //
+  // This call is needed in particular to arrange for timer events. Normally, timer events are not
+  // implemented via the epoll/kqueue at all, but instead the call to epoll_wait() / kevent() is
+  // given a timeout that causes it to return early when the next timer event is scheduled. This
+  // doesn't work when the wait is being performed on an external event loop, so instead the
+  // implementation must arrange to use timerfd (for epoll) of EVFILT_TIMER (for kqueue) so that
+  // the queue FD actually becomes ready when the next timer event is ready to run. This requires
+  // some extra syscalls, unfortunately.
+  //
+  // A second reason this call is needed is to wake up the event queue if any work is queued
+  // directly to the event loop via function calls rather than OS events. For example, if anyone
+  // calls `fulfill()` on a `PromiseFulfiller`, thus queuing work to this event loop, it needs
+  // to wake up. The EventPort achieves this by implicitly calling `wake()` if any work is queued
+  // while sleeping -- similar to a cross-thread wakup. NOTE: Queuing work like this while the
+  // event loop is asleep is only safe if the EventLoop is still bound to the thread by the
+  // existence of a WaitScope. If you are destroying the WaitScope while sleeping, then you cannot
+  // manipulate promises attached to this loop at all while it is asleep. (Cross-thread events,
+  // e.g. queued via newPromiseAndCrossThreadFulfiller(), or via kj::Executor, are always safe.
+  // These will cause the queue fd to become ready so that the loop can wake up and respond to the
+  // events.)
+  //
+  // This method will throw an exception if the port is currently waiting on any signals via
+  // onSignal() or onChildExit(). Although it might theoretically be possible to support signals in
+  // this mode, deep flaws in the relevant APIs across multiple OSs make it likely not worth
+  // attempting.
+#endif
+
   // implements EventPort ------------------------------------------------------
   bool wait() override;
   bool poll() override;
   void wake() const override;
+
+#if KJ_USE_EPOLL
+  void setRunnable(bool runnable) override;
+#endif
 
 private:
   class SignalPromiseAdapter;
@@ -203,6 +262,11 @@ private:
   sigset_t originalMask;
   AutoCloseFd epollFd;
   AutoCloseFd eventFd;   // Used for cross-thread wakeups.
+  kj::Maybe<AutoCloseFd> timerFd;   // Used if preparePollableFdForSleep() is ever called.
+
+  bool sleeping = false;  // Was preparePollableFdForSleep() called?
+  bool runnable = false;  // Last value passed to setRunnable().
+  bool timerfdIsArmed = false;
 
   bool processEpollEvents(struct epoll_event events[], int n);
 #elif KJ_USE_KQUEUE
@@ -234,6 +298,10 @@ private:
   static void registerReservedSignal();
 #endif
   static void ignoreSigpipe();
+
+  // Implements TimerImpl::SleepHooks.
+  void updateNextTimerEvent(kj::Maybe<TimePoint> time) override;
+  kj::TimePoint getTimeWhileSleeping() override;
 };
 
 class UnixEventPort::FdObserver: private AsyncObject {

--- a/c++/src/kj/timer.h
+++ b/c++/src/kj/timer.h
@@ -115,7 +115,7 @@ public:
 
     virtual kj::TimePoint getTimeWhileSleeping() = 0;
     // Get the current time. While sleeping, we can't lock time in place and advance it on each
-    // poll of the event queue, because aribtrary time might have passed outside the control of
+    // poll of the event queue, because arbitrary time might have passed outside the control of
     // the KJ event loop.
   };
 

--- a/c++/src/kj/timer.h
+++ b/c++/src/kj/timer.h
@@ -108,6 +108,25 @@ public:
   void advanceTo(TimePoint newTime);
   // Set the time to `time` and fire any at() events that have been passed.
 
+  class SleepHooks {
+  public:
+    virtual void updateNextTimerEvent(kj::Maybe<TimePoint> time) = 0;
+    // Called whenever the value returned by `nextEvent()` changes.
+
+    virtual kj::TimePoint getTimeWhileSleeping() = 0;
+    // Get the current time. While sleeping, we can't lock time in place and advance it on each
+    // poll of the event queue, because aribtrary time might have passed outside the control of
+    // the KJ event loop.
+  };
+
+  void setSleeping(SleepHooks& hooks) { sleepHooks = hooks; }
+  // Hooks needed by UnixEventPort::preparePollableFdForSleep(). When the loop is sleeping, we
+  // would like for the application to be able to invoke the kj::Timer and for it to basically work
+  // correctly. This requires that we make some callbacks to the UnixEventPort to keep things
+  // consistent, since we can't assume the UnixEventPort will be actively polling the TimerImpl.
+  //
+  // The sleep hooks are automatically cleared when advanceTo() is next called.
+
   // implements Timer ----------------------------------------------------------
   TimePoint now() const override;
   Promise<void> atTime(TimePoint time) override;
@@ -118,6 +137,7 @@ private:
   class TimerPromiseAdapter;
   TimePoint time;
   Own<Impl> impl;
+  kj::Maybe<SleepHooks&> sleepHooks;
 };
 
 // =======================================================================================
@@ -136,8 +156,6 @@ Promise<T> Timer::timeoutAfter(Duration delay, Promise<T>&& promise) {
     return makeTimeoutException();
   }));
 }
-
-inline TimePoint TimerImpl::now() const { return time; }
 
 }  // namespace kj
 


### PR DESCRIPTION
This makes it possible to use UnixEventPort inside a thread running some other event loop, by arranging for that other event loop to listen for the UnixEventPort's epoll FD becoming ready. Whenever it does, the application must pump the KJ event loop.

This also could allow multiple event loops to run in the same thread, or even across some thread pool, as long as only one event loop is active in a thread a time, and each event loop is active in no more than one thread at a time. A scheduler could schedule event loops to threads when their epoll FD becomes ready. 

**Reviewer:** Be sure to read the headers first, they explain a lot of what's going on.