### PR TITLE
Fix compilation issue for standards prior to C++ 20

### DIFF
--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -748,7 +748,7 @@ inline ConstString StringPtr::attach() const {
 
 template <typename... Attachments>
 inline ConstString StringPtr::attach(Attachments&&... attachments) const {
-  return ConstString { .content = content.attach(kj::fwd<Attachments>(attachments)...) };
+  return ConstString { content = content.attach(kj::fwd<Attachments>(attachments)...) };
 }
 
 inline String::operator ArrayPtr<char>() {


### PR DESCRIPTION
Remove usage of designated member assignment in kj string header for const string attachments.
Related to discussion: https://github.com/capnproto/capnproto/commit/2e69f54eb8fcaa0d2c4c96a82005b5842e633392#r135989017

I am unsure of your branch integration direction, so I guessed it would be master to v2. So I PR'd on master.