### PR TITLE
Add new KJ_DISALLOW_IN_COROUTINE mechanism

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2062,6 +2062,7 @@ template <typename T>
 concept NoWaitScope = !isSameType<Decay<T>, WaitScope>();
 // Define a Concept to use in our `coroutine_traits` specialization to validate allowable coroutine
 // parameter types.
+// TODO(cleanup): This can be removed by adding KJ_DISALLOW_AS_COROUTINE_PARAM to WaitScope.
 
 }  // namespace kj::_
 
@@ -2072,6 +2073,9 @@ namespace KJ_COROUTINE_STD_NAMESPACE {
 template <class T, class... Args>
 struct coroutine_traits<kj::Promise<T>, Args...> {
   // `Args...` are the coroutine's parameter types.
+
+  static_assert((!kj::_::isDisallowedInCoroutine<Args>() && ...),
+      "Disallowed type in coroutine");
 
   static_assert((::kj::_::NoWaitScope<Args> && ...),
       "Coroutines are not allowed to accept `WaitScope` parameters.");

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -940,5 +940,33 @@ KJ_TEST("ArrayPtr::as<Std>") {
   KJ_EXPECT(stdPtr.size() == 5);
 }
 
+// Verifies the expected values of kj::isDisallowedInCoroutine<T>
+
+struct DisallowedInCoroutineStruct {
+  KJ_DISALLOW_AS_COROUTINE_PARAM;
+};
+class DisallowedInCoroutinePublic {
+public:
+  KJ_DISALLOW_AS_COROUTINE_PARAM;
+};
+class DisallowedInCoroutinePrivate {
+private:
+  KJ_DISALLOW_AS_COROUTINE_PARAM;
+};
+struct AllowedInCoroutine {};
+
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutineStruct>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutineStruct&>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutineStruct*>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutinePublic>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutinePublic&>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutinePublic*>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutinePrivate>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutinePrivate&>());
+static_assert(_::isDisallowedInCoroutine<DisallowedInCoroutinePrivate*>());
+static_assert(!_::isDisallowedInCoroutine<AllowedInCoroutine>());
+static_assert(!_::isDisallowedInCoroutine<AllowedInCoroutine&>());
+static_assert(!_::isDisallowedInCoroutine<AllowedInCoroutine*>());
+
 }  // namespace
 }  // namespace kj


### PR DESCRIPTION
Allows a type to be explicitly marked in a way that prevent it from being passed into a kj promise coroutine as an arg.

```
class Foo {
private:
  KJ_DISALLOW_IN_COROUTINE();
};

kj::Promise<void> simpleCoroutine(Foo foo) { // Compile Error!
  co_return;
}

kj::Promise<void> simpleCoroutine2(Foo& foo) { // Compile Error!
  co_return;
}

kj::Promise<void> simpleCoroutine3(Foo* foo) { // Compile Error!
  co_return;
}
```