### PR TITLE
Fix OpenBSD issues related to lack of full dual-stack IPv6 and EVFILT_USER

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -66,7 +66,7 @@
 #include <sys/ucred.h>
 #endif
 
-#if !defined(SOL_LOCAL) && (__FreeBSD__ || __DragonflyBSD__ || __APPLE__)
+#if !defined(SOL_LOCAL) && (__FreeBSD__ || __OpenBSD__ || __DragonflyBSD__ || __APPLE__)
 // On DragonFly, FreeBSD < 12.2 and older Darwin you're supposed to use 0 for SOL_LOCAL.
 #define SOL_LOCAL 0
 #endif

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -40,6 +40,11 @@ KJ_BEGIN_HEADER
   #endif
 #endif
 
+#if __OpenBSD__
+// OpenBSD doesn't have full dual-stack IPv6.
+#define AI_V4MAPPED 0
+#endif
+
 namespace kj {
 
 class EventLoop;

--- a/c++/src/kj/cidr.c++
+++ b/c++/src/kj/cidr.c++
@@ -41,7 +41,7 @@
 #include <arpa/inet.h>
 #endif
 
-#if __FreeBSD__
+#if __FreeBSD__ || __OpenBSD__
 #include <netinet/in.h>
 #endif
 


### PR DESCRIPTION
This is a fix against the `master` / `1.1-dev` branch.

It fixes build issues on OpenBSD related to the lack of full dual-stack IPv6 [1] and EVFILT_USER [2].

Everything builds fine. There are a few test failures on OpenBSD but they seem unrelated to the changes introduced here.

[1]: https://man.openbsd.org/inet6
[2]: https://marc.info/?l=openbsd-tech&m=165132673502937