### PR TITLE
[nfc] Assorted build system cleanup

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -42,7 +42,6 @@ jobs:
             libunwind: libunwind-12-dev
     steps:
       - uses: actions/checkout@v2
-      - uses: bazelbuild/setup-bazelisk@v2
       - name: install dependencies
         # I observed 404s for some packages and added an `apt-get update`. Then, I observed package
         # conflicts between LLVM 14 and 15, and added the line which removes LLVM 14, the default on

--- a/c++/build/configure.bzl
+++ b/c++/build/configure.bzl
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 def kj_configure():
     """Generates set of flag, settings for kj configuration.

--- a/c++/src/capnp/cc_capnp_library.bzl
+++ b/c++/src/capnp/cc_capnp_library.bzl
@@ -87,6 +87,7 @@ def cc_capnp_library(
         data = [],
         deps = [],
         src_prefix = "",
+        tags = ["off-by-default"],
         visibility = None,
         target_compatible_with = None,
         **kwargs):
@@ -122,6 +123,8 @@ def cc_capnp_library(
         srcs = srcs_cpp,
         hdrs = hdrs,
         deps = deps + ["@capnp-cpp//src/capnp:capnp_runtime"],
+        # Allows us to avoid building the library archive when using start_end_lib
+        tags = tags,
         visibility = visibility,
         target_compatible_with = target_compatible_with,
         **kwargs

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -39,7 +39,6 @@
 #include <kj/miniposix.h>
 #include <kj/debug.h>
 #include "../message.h"
-#include <iostream>
 #include <kj/main.h>
 #include <kj/parse/char.h>
 #include <sys/stat.h>

--- a/c++/src/capnp/compiler/compiler.c++
+++ b/c++/src/capnp/compiler/compiler.c++
@@ -256,7 +256,7 @@ private:
   Node rootNode;
 };
 
-class Compiler::Impl: public SchemaLoader::LazyLoadCallback {
+class Compiler::Impl final : public SchemaLoader::LazyLoadCallback {
 public:
   explicit Impl(AnnotationFlag annotationFlag);
   virtual ~Impl() noexcept(false);

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -557,7 +557,7 @@ kj::Promise<MessageReaderAndFds> MessageStream::readMessage(
 
 // =======================================================================================
 
-class BufferedMessageStream::MessageReaderImpl: public FlatArrayMessageReader {
+class BufferedMessageStream::MessageReaderImpl final : public FlatArrayMessageReader {
 public:
   MessageReaderImpl(BufferedMessageStream& parent, kj::ArrayPtr<const word> data,
                     ReaderOptions options)


### PR DESCRIPTION
This mirrors the cc_library off-by-default changes in workerd and edgeworker, also includes some minor cleanup. Also see the workerd and downstream branches felix/refactor-012624 and felix/lib-off-by-default.