### PR TITLE
[bazel] Avoid linker errors by aligning source/header dependency sets

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -7,7 +7,9 @@ cc_library(
         "arena.c++",
         "blob.c++",
         "c++.capnp.c++",
+        "capability.c++",
         "dynamic.c++",
+        "dynamic-capability.c++",
         "layout.c++",
         "list.c++",
         "message.c++",
@@ -31,7 +33,6 @@ cc_library(
         "generated-header-support.h",
         "layout.h",
         "list.h",
-        "membrane.h",
         "message.h",
         "orphan.h",
         "pointer-helpers.h",
@@ -41,11 +42,8 @@ cc_library(
         "schema.h",
         "schema-lite.h",
         "schema-loader.h",
-        "schema-parser.h",
         "serialize.h",
-        "serialize-async.h",
         "serialize-packed.h",
-        "serialize-text.h",
         "stream.capnp.h",
     ],
     include_prefix = "capnp",
@@ -58,8 +56,6 @@ cc_library(
 cc_library(
     name = "capnp-rpc",
     srcs = [
-        "capability.c++",
-        "dynamic-capability.c++",
         "membrane.c++",
         "persistent.capnp.c++",
         "reconnect.c++",
@@ -70,6 +66,7 @@ cc_library(
         "serialize-async.c++",
     ],
     hdrs = [
+        "membrane.h",
         "persistent.capnp.h",
         "reconnect.h",
         "rpc.capnp.h",
@@ -77,6 +74,7 @@ cc_library(
         "rpc-prelude.h",
         "rpc-twoparty.capnp.h",
         "rpc-twoparty.h",
+        "serialize-async.h",
     ],
     include_prefix = "capnp",
     visibility = ["//visibility:public"],
@@ -107,11 +105,12 @@ cc_library(
         "compiler/grammar.capnp.h",
         "compiler/lexer.capnp.h",
         "compiler/lexer.h",
-        "compiler/module-loader.h",
         "compiler/node-translator.h",
         "compiler/parser.h",
         "compiler/resolver.h",
         "compiler/type-id.h",
+        "schema-parser.h",
+        "serialize-text.h",
     ],
     include_prefix = "capnp",
     visibility = ["//visibility:public"],
@@ -125,6 +124,7 @@ cc_binary(
     srcs = [
         "compiler/capnp.c++",
         "compiler/module-loader.c++",
+        "compiler/module-loader.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -204,14 +204,12 @@ cc_library(
     name = "capnp-test",
     srcs = ["test-util.c++"],
     hdrs = ["test-util.h"],
+    include_prefix = "capnp",
+    visibility = [":__subpackages__"],
     deps = [
-        ":capnp-rpc",
         ":capnp_test",
-        ":capnpc",
         "//src/kj:kj-test",
     ],
-    include_prefix = "capnp",
-    visibility = [":__subpackages__" ]
 )
 
 [cc_test(
@@ -224,36 +222,57 @@ cc_library(
     "canonicalize-test.c++",
     "common-test.c++",
     "capability-test.c++",
-    "compiler/lexer-test.c++",
-    "compiler/type-id-test.c++",
     "dynamic-test.c++",
     "encoding-test.c++",
     "endian-test.c++",
     "layout-test.c++",
-    "membrane-test.c++",
     "message-test.c++",
     "orphan-test.c++",
+    "schema-test.c++",
+    "schema-loader-test.c++",
+    "serialize-packed-test.c++",
+    "serialize-test.c++",
+    "stringify-test.c++",
+]]
+
+# test targets requiring capnp-rpc or capnpc
+[cc_test(
+    name = f.removesuffix(".c++"),
+    srcs = [f],
+    deps = [
+        ":capnp-rpc",
+        ":capnp-test",
+    ],
+) for f in [
+    "membrane-test.c++",
     "reconnect-test.c++",
     "rpc-test.c++",
     "rpc-twoparty-test.c++",
-    "schema-test.c++",
-    "schema-loader-test.c++",
-    "schema-parser-test.c++",
     "serialize-async-test.c++",
-    "serialize-packed-test.c++",
-    "serialize-test.c++",
+]]
+
+[cc_test(
+    name = f.removesuffix(".c++"),
+    srcs = [f],
+    deps = [
+        ":capnp-test",
+        ":capnpc",
+    ],
+) for f in [
+    "compiler/lexer-test.c++",
+    "compiler/type-id-test.c++",
+    "schema-parser-test.c++",
     "serialize-text-test.c++",
-    "stringify-test.c++",
 ]]
 
 cc_test(
     name = "endian-reverse-test",
     srcs = ["endian-reverse-test.c++"],
-    deps = [":capnp-test"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    deps = [":capnp-test"],
 )
 
 cc_library(
@@ -272,6 +291,6 @@ cc_test(
     name = "fuzz-test",
     size = "large",
     srcs = ["fuzz-test.c++"],
-    deps = [":capnp-test"],
     tags = ["manual"],
+    deps = [":capnp-test"],
 )

--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -100,6 +100,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/capnp",
+        "//src/capnp:capnp-rpc",
         "//src/kj/compat:kj-http",
     ],
 )
@@ -108,9 +109,9 @@ cc_library(
     name = f.removesuffix(".c++"),
     srcs = [f],
     deps = [
-        ":websocket-rpc",
         ":http-over-capnp",
-        "//src/capnp:capnp-test"
+        ":websocket-rpc",
+        "//src/capnp:capnp-test",
     ],
 ) for f in [
     "byte-stream-test.c++",

--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -47,7 +47,7 @@
 //
 // Mark Miller on membranes: http://www.eros-os.org/pipermail/e-lang/2003-January/008434.html
 
-#include "capability.h"
+#include <capnp/capability.h>
 #include <kj/map.h>
 
 CAPNP_BEGIN_HEADER

--- a/c++/src/capnp/schema-parser.h
+++ b/c++/src/capnp/schema-parser.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "schema-loader.h"
+#include <capnp/schema-loader.h>
 #include <kj/string.h>
 #include <kj/filesystem.h>
 

--- a/c++/src/capnp/serialize-async.h
+++ b/c++/src/capnp/serialize-async.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
+#include <capnp/message.h>
 #include <kj/async-io.h>
 #include <kj/io.h>
-#include "message.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/serialize-text.h
+++ b/c++/src/capnp/serialize-text.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
+#include <capnp/dynamic.h>
+#include <capnp/orphan.h>
+#include <capnp/schema.h>
 #include <kj/string.h>
-#include "dynamic.h"
-#include "orphan.h"
-#include "schema.h"
 
 CAPNP_BEGIN_HEADER
 


### PR DESCRIPTION
`cc_library()` targets containing a header file without the corresponding source file could lead to puzzling linker errors due to missing symbols. The source files being moved to different targets have been carefully chosen to keep the main capnp target small while minimizing the need for dependency changes in upstream targets, in some cases dependencies on capnp-rpc and capnpc have been resolved.
This also enables some minor dependency cleanup and linting.

Note that this may still require small changes in upstream repos – PRs for that to follow.