### PR TITLE
check for empty AggregateConnectionReceiver

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -3087,13 +3087,7 @@ KJ_TEST("AggregateConnectionReceiver empty") {
   int value;
   uint length = sizeof(value);
 
-  KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
-    aggregate->getsockopt(0, 0, &value, &length);
-  })) {
-    (void)exception;
-  } else {
-    KJ_FAIL_EXPECT("Expected an exception");
-  }
+  KJ_EXPECT_THROW_MESSAGE("receivers.size() > 0", aggregate->getsockopt(0, 0, &value, &length));
 }
 
 // =======================================================================================

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -3080,6 +3080,22 @@ KJ_TEST("AggregateConnectionReceiver") {
   acceptPromise3.wait(ws);
 }
 
+KJ_TEST("AggregateConnectionReceiver empty") {
+  auto aggregate = newAggregateConnectionReceiver({});
+  KJ_EXPECT(aggregate->getPort() == 0);
+
+  int value;
+  uint length = sizeof(value);
+
+  KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
+    aggregate->getsockopt(0, 0, &value, &length);
+  })) {
+    (void)exception;
+  } else {
+    KJ_FAIL_EXPECT("Expected an exception");
+  }
+}
+
 // =======================================================================================
 // Tests for optimized pumpTo() between OS handles. Note that this is only even optimized on
 // some OSes (only Linux as of this writing), but the behavior should still be the same on all

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -2893,9 +2893,10 @@ public:
   }
 
   uint getPort() override {
-    return receivers[0]->getPort();
+    return receivers.size() > 0 ? receivers[0]->getPort() : 0u;
   }
   void getsockopt(int level, int option, void* value, uint* length) override {
+    KJ_REQUIRE(receivers.size() > 0);
     return receivers[0]->getsockopt(level, option, value, length);
   }
   void setsockopt(int level, int option, const void* value, uint length) override {
@@ -2905,6 +2906,7 @@ public:
     }
   }
   void getsockname(struct sockaddr* addr, uint* length) override {
+    KJ_REQUIRE(receivers.size() > 0);
     return receivers[0]->getsockname(addr, length);
   }
 


### PR DESCRIPTION
Empty AggregateConnectionReceivers work fine, except those methods which access the first entry.