### PR TITLE
kj/table: fix the initialization of BTreeImpl::MaybeUnit with uint.

### DIFF
--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -1164,7 +1164,7 @@ class BTreeImpl::MaybeUint {
   // A nullable uint, using the value zero to mean null and shifting all other values up by 1.
 public:
   MaybeUint() = default;
-  inline MaybeUint(uint i): i(i - 1) {}
+  inline MaybeUint(uint i): i(i + 1) {}
   inline MaybeUint(decltype(nullptr)): i(0) {}
 
   inline bool operator==(decltype(nullptr)) const { return i == 0; }


### PR DESCRIPTION
This constructor is currently unused, so the current issue has no immediate impact.

Signed-off-by: Jianyong Chen <baluschch@gmail.com>
