### PR TITLE
nitpick: fix a few typos in the comments

### DIFF
--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -330,7 +330,7 @@ public:
 
   SegmentBuilder* addExternalSegment(kj::ArrayPtr<const word> content);
   // Add a new segment to the arena which points to some existing memory region.  The segment is
-  // assumed to be completley full; the arena will never allocate from it.  In fact, the segment
+  // assumed to be completely full; the arena will never allocate from it.  In fact, the segment
   // is considered read-only.  Any attempt to get a Builder pointing into this segment will throw
   // an exception.  Readers are allowed, however.
   //

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -133,7 +133,7 @@ public:
   //   to complete (and possibly other things, if that RPC itself returned a promise capability),
   //   but when using `sendPipelineOnly()`, `whenResolved()` may complete immediately, or never, or
   //   at an arbitrary time. Do not rely on it.
-  // - Normal path shortening may not work with these capabilities. For exmaple, if the caller
+  // - Normal path shortening may not work with these capabilities. For example, if the caller
   //   forwards a pipelined capability back to the callee's vat, calls made by the callee to that
   //   capability may continue to proxy through the caller. Conversely, if the callee ends up
   //   returning a capability that points back to the caller's vat, calls on the pipelined

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -714,7 +714,7 @@ private:
   bool gotReturnForHighQuestionId = false;
   // Becomes true if we ever get a `Return` message for a high question ID (with top bit set),
   // which we use in cases where we've hinted to the peer that we don't want a `Return`. If the
-  // peer sends us one anyway then it seemingly doesn't not implement our hints. We need to stop
+  // peer sends us one anyway then it seemingly does not implement our hints. We need to stop
   // using the hints in this case before the high question ID space wraps around since otherwise
   // we might reuse an ID that the peer thinks is still in use.
 
@@ -1933,7 +1933,7 @@ private:
       question.paramExports = kj::mv(exports);
       question.isTailCall = isTailCall;
 
-      // Make the QuentionRef and result promise.
+      // Make the QuestionRef and result promise.
       SendInternalResult result;
       auto paf = kj::newPromiseAndFulfiller<kj::Promise<kj::Own<RpcResponse>>>();
       result.questionRef = kj::refcounted<QuestionRef>(
@@ -2024,7 +2024,7 @@ private:
       question.paramExports = kj::mv(exports);
       question.isTailCall = false;
 
-      // Make the QuentionRef and result promise.
+      // Make the QuestionRef and result promise.
       auto questionRef = kj::refcounted<QuestionRef>(*connectionState, questionId, kj::none);
       question.selfRef = *questionRef;
 
@@ -2249,7 +2249,7 @@ private:
 
     struct Resolution {
       kj::Own<ClientHook> returnedCap;
-      // The capabiilty that appeared in the response message in this slot.
+      // The capability that appeared in the response message in this slot.
 
       kj::Own<ClientHook> unwrapped;
       // Exactly what `getInnermostClient(returnedCap)` produced at the time that the return
@@ -2463,7 +2463,7 @@ private:
         if (!responseImpl.hasCapabilities()) {
           returnMessage.setNoFinishNeeded(true);
 
-          // Tell ourselves that a finsih was already received, so that `cleanupAnswerTable()`
+          // Tell ourselves that a finish was already received, so that `cleanupAnswerTable()`
           // removes the answer table entry.
           receivedFinish = true;
 
@@ -2696,7 +2696,7 @@ private:
     // Cancellation state ----------------------------------
 
     bool receivedFinish = false;
-    // True if a `Finish` message has been recevied OR we sent a `Return` with `noFinishNedeed`.
+    // True if a `Finish` message has been received OR we sent a `Return` with `noFinishNeeded`.
     // In either case, it is our responsibility to clean up the answer table.
 
     kj::UnwindDetector unwindDetector;
@@ -3451,7 +3451,7 @@ private:
         // Carol returns a capability from this call that points all the way back though Bob to
         // Alice. When this return capability passes through Bob, Bob will resolve the previous
         // promise-pipeline capability to it. However, Bob has to send a Disembargo to Carol before
-        // completing this resolution. In the meantime, though, Bob returns the final repsonse to
+        // completing this resolution. In the meantime, though, Bob returns the final response to
         // Alice. Alice then *also* sends a Disembargo to Bob. The Alice -> Bob Disembargo might
         // arrive at Bob before the Bob -> Carol Disembargo has resolved, in which case the
         // Disembargo is delivered to a promise capability.

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -125,7 +125,7 @@ class [[nodiscard]] Promise: protected _::PromiseBase {
   // `kj::READY_NOW` to an already-fulfilled Promise<void>.  You may also implicitly convert a
   // `kj::Exception` to an already-broken promise of any type.
   //
-  // Promises are linear types -- they are moveable but not copyable.  If a Promise is destroyed
+  // Promises are linear types -- they are movable but not copyable.  If a Promise is destroyed
   // or goes out of scope (without being moved elsewhere), any ongoing asynchronous operations
   // meant to fulfill the promise will be canceled if possible.  All methods of `Promise` (unless
   // otherwise noted) actually consume the promise in the sense of move semantics.  (Arguably they
@@ -476,7 +476,7 @@ PromiseForResult<Func, void> retryOnDisconnect(Func&& func) KJ_WARN_UNUSED_RESUL
 template <typename Func>
 PromiseForResult<Func, WaitScope&> startFiber(
     size_t stackSize, Func&& func, SourceLocation location = {}) KJ_WARN_UNUSED_RESULT;
-// Executes `func()` in a fiber, returning a promise for the eventual reseult. `func()` will be
+// Executes `func()` in a fiber, returning a promise for the eventual result. `func()` will be
 // passed a `WaitScope&` as its parameter, allowing it to call `.wait()` on promises. Thus, `func()`
 // can be written in a synchronous, blocking style, instead of using `.then()`. This is often much
 // easier to write and read, and may even be significantly faster if it allows the use of stack

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -290,7 +290,7 @@ typedef unsigned char byte;
 #define KJ_DEPRECATED(reason) \
     __attribute__((deprecated))
 #define KJ_UNAVAILABLE(reason) = delete
-// If the `unavailable` attribute is not supproted, just mark the method deleted, which at least
+// If the `unavailable` attribute is not supported, just mark the method deleted, which at least
 // makes it a compile-time error to try to call it. Note that on Clang, marking a method deleted
 // *and* unavailable unfortunately defeats the purpose of the unavailable annotation, as the
 // generic "deleted" error is reported instead.
@@ -1771,7 +1771,7 @@ public:
 //     ArrayPtr<const int> ptr = { 1, 2, 3 };
 //     foo(ptr[1]); // undefined behavior!
 // Any KJ programmer should be able to recognize that this is UB, because an ArrayPtr does not own
-// its content. That's not what this constructor is for, tohugh. This constructor is meant to allow
+// its content. That's not what this constructor is for, though. This constructor is meant to allow
 // code like this:
 //     int foo(ArrayPtr<const int> p);
 //     // ... later ...

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -255,7 +255,7 @@ ArrayPtr<void* const> getStackTrace(ArrayPtr<void*> space, uint ignoreCount) {
 
 #if (__GNUC__ && !_WIN32) || __clang__
 // Allow dependents to override the implementation of stack symbolication by making it a weak
-// symbol. We prefer weak symbols over some sort of callback registration mechanism becasue this
+// symbol. We prefer weak symbols over some sort of callback registration mechanism because this
 // allows an alternate symbolication library to be easily linked into tests without changing the
 // code of the test.
 __attribute__((weak))


### PR DESCRIPTION
I came across a few typos while working on https://github.com/capnproto/capnproto/pull/1460, and I thought it wouldn't hurt to share them :blush:.

Feel free to just close if it is irrelevant.