### PR TITLE
byte-stream: Allow ExplicitEndOutputStream in other direction.

### DIFF
--- a/c++/src/capnp/compat/byte-stream.h
+++ b/c++/src/capnp/compat/byte-stream.h
@@ -45,6 +45,9 @@ class ExplicitEndOutputStream: public kj::AsyncOutputStream {
   //   capnpToKjExplicitEnd() returns an ExplicitEndOutputStream, which expect to receive an
   //   `end()` call on clean EOF, and treats destruction without `end()` as an abort. This is used
   //   in particular within http-over-capnp to improve behavior somewhat.
+  //
+  //   Additionally, if `kjToCapnp()` is given an `ExplicitEndOutputStream`, and the application
+  //   is built with RTTI enabled, then its `end()` method will be used when appropriate.
 public:
   virtual kj::Promise<void> end() = 0;
 };


### PR DESCRIPTION
This makes it so the application can choose to implement ExplicitEndOutputStream in order to get explicit end() calls from the byte-stream implementation.

We already supported the other direction: having the application request an ExplicitEndOutputStream when converting from a ByteStream capability.