### PR TITLE
kj::Pin<T>, kj::Ptr<T> smart pointers

### DIFF
--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -19,7 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include "kj/common.h"
+#include "kj/string.h"
+#include "kj/test.h"
 #include "memory.h"
+#include <signal.h>
 #include <kj/compat/gtest.h>
 #include "debug.h"
 
@@ -500,5 +504,125 @@ KJ_TEST("disposeWith") {
 
 // TODO(test):  More tests.
 
-}  // namespace
+struct Obj {
+  Obj(kj::StringPtr name) : name(kj::str(name)) { }
+  Obj(Obj&&) = default;
+
+  kj::String name;
+
+  KJ_DISALLOW_COPY(Obj);
+};
+
+struct PtrHolder {
+  kj::Ptr<Obj> ptr;
+};
+
+KJ_TEST("kj::Pin<T> basic properties") {
+  // kj::Pin<T> guarantees that T won't move or disappear while there are active pointers.
+  
+  // pin constructor is a simple argument pass through
+  kj::Pin<Obj> pin("a");
+
+  // pin is a smart pointer and can be used so
+  KJ_EXPECT(pin->name == "a"_kj);
+
+  // pin can be auto converted to Ptr<T>
+  kj::Ptr<Obj> ptr1 = pin;
+  KJ_EXPECT(ptr1 == pin);
+  KJ_EXPECT(pin == ptr1);
+
+  // Ptr<T> is a smart pointer too
+  KJ_EXPECT(ptr1->name == "a"_kj);
+
+  // you can have more than one Ptr<T> pointing to the same object
+  kj::Ptr<Obj> ptr2 = pin;
+  KJ_EXPECT(ptr1 == ptr2);
+  KJ_EXPECT(ptr2->name == "a"_kj);
+
+  // when leaving the scope ptrs will be destroyed first,
+  // so pin will be destroyed without problems
+}
+
+KJ_TEST("moving kj::Pin<T>") {
+  kj::Pin<Obj> pin("a");
+
+  // you can move pin around as long as there are no pointers to it
+  kj::Pin<Obj> pin2(kj::mv(pin));
+  
+  // data belongs to a new pin now
+  KJ_EXPECT(pin2->name == "a"_kj);
+
+  // it is C++ and old pin still points to a valid object
+  KJ_EXPECT(pin->name == ""_kj);
+
+  // you can add new pointers to the pin with asPtr() method as well
+  kj::Ptr<Obj> ptr1 = pin2.asPtr();
+  KJ_EXPECT(ptr1 == pin2);
+  KJ_EXPECT(ptr1->name == "a"_kj);
+
+  {
+    // you can copy pointers
+    kj::Ptr<Obj> ptr2 = ptr1;
+    KJ_EXPECT(ptr2 == ptr1);
+    KJ_EXPECT(ptr2->name == "a"_kj);
+
+    // ptr2 will be auto-destroyed
+  }
+
+  // you can move the pin again if all pointers are destroyed
+  ptr1 = nullptr;
+  kj::Pin<Obj> pin3(kj::mv(pin2));
+  KJ_EXPECT(pin3->name == "a"_kj);
+}
+
+struct Obj2 : public Obj {
+  Obj2(kj::StringPtr name, int size) : Obj(name), size(size) {}
+  int size;
+};
+
+KJ_TEST("kj::Ptr<T> subtyping") {
+  // pin the child
+  kj::Pin<Obj2> pin("obj2", 42);
+
+  // pointer to the child
+  kj::Ptr<Obj2> ptr1 = pin;
+  KJ_EXPECT(ptr1->name == "obj2"_kj);
+  KJ_EXPECT(ptr1->size == 42);
+
+  // pointer to the base
+  kj::Ptr<Obj> ptr2 = pin;
+  KJ_EXPECT(ptr2->name == "obj2"_kj);
+  KJ_EXPECT(ptr2 == pin);
+  KJ_EXPECT(ptr1 == ptr2);
+
+  // pointers can be converted to the base type too
+  kj::Ptr<Obj> ptr3 = kj::mv(ptr1);
+  KJ_EXPECT(ptr3->name == "obj2"_kj);
+  KJ_EXPECT(ptr3 == pin);
+}
+
+#ifdef KJ_ASSERT_PTR_COUNTERS  
+KJ_TEST("kj::Pin<T> destroyed with active ptrs crashed") {
+  PtrHolder* holder = nullptr;
+  
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    kj::Pin<Obj> obj("b");
+    // create a pointer and leak it
+    holder = new PtrHolder { obj };
+    // destroying a pin when exiting scope crashes
+  });
+}
+
+KJ_TEST("kj::Pin<T> moved with active ptrs crashes") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    kj::Pin<Obj> obj("b");
+    auto ptr = obj.asPtr();
+    // moving a pin with active reference crashes
+    kj::Pin<Obj> obj2(kj::mv(obj));
+  });
+}
+#endif  
+
+} // namespace 
+
 }  // namespace kj

--- a/c++/src/kj/memory.c++
+++ b/c++/src/kj/memory.c++
@@ -20,9 +20,24 @@
 // THE SOFTWARE.
 
 #include "memory.h"
+#include "debug.h"
+#include <stdlib.h>
 
 namespace kj {
 
 const NullDisposer NullDisposer::instance = NullDisposer();
+
+#ifdef KJ_ASSERT_PTR_COUNTERS
+namespace _ {
+
+void atomicPtrCounterAssertionFailed(char const* reason) {
+  KJ_FAIL_ASSERT("ptr counter contract violated", reason);
+
+  // Really make sure we abort.
+  KJ_KNOWN_UNREACHABLE(abort());
+}
+
+}
+#endif
 
 }  // namespace kj

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "common.h"
+#include <atomic>
 
 KJ_BEGIN_HEADER
 
@@ -167,6 +168,53 @@ public:
 
   void disposeImpl(void* pointer) const override {}
 };
+
+
+// =======================================================================================
+// Ptr Counters
+
+#ifdef KJ_DEBUG
+#define KJ_ASSERT_PTR_COUNTERS
+// When defined, keeps track of active Ptr<T> instances and asserts validity of their ownership
+#endif
+
+namespace _ {
+#ifdef KJ_ASSERT_PTR_COUNTERS
+
+void atomicPtrCounterAssertionFailed(const char* const);
+
+class AtomicPtrCounter {
+  // AtomicPtrCounter uses atomic operations to keep track of active pointers.
+  // Since no other memory location is observed, memory_order_relaxed is used.
+
+public:
+  inline void dec() {
+    size_t prevCount = count.fetch_sub(1, std::memory_order_relaxed);
+    if (KJ_UNLIKELY(prevCount == 0)) {
+      atomicPtrCounterAssertionFailed("unbalanced inc/dec");
+    }
+  }
+
+  inline void inc() {
+    count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  inline void assertEmpty() {
+    size_t c = count.load(std::memory_order_relaxed);
+    if (KJ_UNLIKELY(c != 0)) {
+      atomicPtrCounterAssertionFailed("active pointers exist");
+    }
+  }
+
+private:
+  std::atomic<size_t> count = 0;
+};
+
+using PtrCounter = AtomicPtrCounter;
+// Default counter type to use
+
+#endif
+}
 
 // =======================================================================================
 // Own<T> -- An owned pointer.
@@ -654,6 +702,186 @@ private:
   union {
     T value;
   };
+};
+
+// =======================================================================================
+// Pin<T>
+
+template <typename T>
+class Ptr;
+
+template <typename T>
+class Pin {
+  // Pin<T> is a smart, in-place storage for T. 
+  //
+  // Pin<T> should be created on the stack or used as a data member. It should not be 
+  // allocated on the heap.
+  // Pin<T> is integrated with Ptr<T>, and is legal to move/destroy only when there are no active
+  // pointers. 
+  // When KJ_ASSERT_PTR_COUNTERS is defined, pointers are tracked and validity of these 
+  // operations are asserted.
+  // Zero-overhead replacement for T if KJ_ASSERT_PTR_COUNTERS is not defined.
+
+public:
+  template <typename... Params>
+  inline Pin(Params&&... params) : t(kj::fwd<Params>(params)...) {  }
+  // Create new Pin<T> using corresponding T constructor.
+
+  inline Pin(Pin<T>&& other): t(kj::mv(other.t)) {
+    // Move T's ownership.
+    // Undefined behavior when live pointers exist, asserted when KJ_ASSERT_PTR_COUNTERS is defined.
+#ifdef KJ_ASSERT_PTR_COUNTERS
+    other.ptrCounter.assertEmpty();
+#endif
+  }
+
+  inline ~Pin() {
+    // Destroy a Pin with underlying object. 
+    // Undefined behavior when live pointers exist, asserted when KJ_ASSERT_PTR_COUNTERS is defined.
+#ifdef KJ_ASSERT_PTR_COUNTERS
+    ptrCounter.assertEmpty();
+#endif
+  }
+
+  inline T* operator->() { return get(); }
+  inline const T* operator->() const { return get(); }
+
+  inline operator Ptr<T>() { return Ptr<T>(this); }
+  // Pin<T> can be implicitly converted to Ptr<T> to obtain new pointers.
+
+  inline Ptr<T> asPtr() { return Ptr<T>(this); }
+  // Explicit convenience method to create new pointers.
+
+  template <typename U, typename = EnableIf<canConvert<T*, U*>()>>
+  inline operator Ptr<U>() { return Ptr<U>(this); }
+  // Pin<T> can be implicitly converted to pointers of compatible types.
+
+  template <typename U, typename = EnableIf<canConvert<T*, U*>()>>
+  inline Ptr<U> asPtr() { return Ptr<U>(this); }
+  // Explicit convenience method to create new pointers of compatible types.
+
+  void* operator new(size_t count) = delete;
+  void* operator new[](size_t count) = delete;
+  // Pin<T> can't be heap allocated, only local or data field usage is ok.
+
+private:
+  KJ_DISALLOW_COPY(Pin);
+
+  inline Pin(T&& t): t(kj::mv(t)) {}
+
+  T t;
+#ifdef KJ_ASSERT_PTR_COUNTERS
+  _::PtrCounter ptrCounter;
+#endif
+
+  inline T* get() { return &t; }
+  inline const T* get() const { return &t; }
+
+  template <typename>
+  friend class Ptr;
+};
+
+// =======================================================================================
+// Ptr<T>
+
+template <typename T>
+class Ptr {
+  // Ptr<T> is a smart alternative to T&.
+  // 
+  // When used together with Pin<T> it keeps track of active pointers.
+  // Asserts lifetime constraints when KJ_ASSERT_PTR_COUNTERS is defined.
+  // Zero-overhead alternative for T& if KJ_ASSERT_PTR_COUNTERS is not defined.
+
+public:
+  inline ~Ptr() {
+    if (ptr == nullptr) {
+      // the value was moved out
+      return;
+    }
+#ifdef KJ_ASSERT_PTR_COUNTERS
+    counter->dec();
+#endif
+  }
+
+#ifdef KJ_ASSERT_PTR_COUNTERS
+  Ptr(Ptr&& other) : ptr(other.ptr), counter(other.counter) { other.ptr = nullptr; }
+#else
+  Ptr(Ptr&& other) : ptr(other.ptr) { other.ptr = nullptr; }
+#endif
+
+#ifdef KJ_ASSERT_PTR_COUNTERS
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  Ptr(Ptr<U>&& other) : ptr(other.ptr), counter(other.counter) { other.ptr = nullptr; }
+#else
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  Ptr(Ptr<U>&& other) : ptr(other.ptr) { other.ptr = nullptr; }
+#endif
+
+// Ptr<T> can be freely copied.
+#ifdef KJ_ASSERT_PTR_COUNTERS
+  Ptr(const Ptr& other) : ptr(other.ptr), counter(other.counter) { counter->inc(); }
+#else
+  Ptr(const Ptr& other) : ptr(other.ptr) {}
+#endif
+
+  inline void operator=(std::nullptr_t other) { 
+    if (ptr != nullptr) {
+#ifdef KJ_ASSERT_PTR_COUNTERS
+      counter->dec();
+      counter = nullptr;
+#endif
+      ptr = nullptr;
+    }
+  }
+
+  inline T* operator->() { return get(); }
+  inline const T* operator->() const { return get(); }
+
+  inline bool operator==(const Pin<T>& other) const { return get() == other.get(); }
+  inline bool operator==(const Ptr<T>& other) const { return get() == other.get(); }
+  inline bool operator==(const T* const other) const { return get() == other; }
+
+  template <typename U>
+  inline bool operator==(const Pin<U>& other) const { return get() == other.get(); }
+
+  template <typename U>
+  inline bool operator==(const Ptr<U>& other) const { return get() == other.get(); }
+
+  inline T& asRef() { return *get(); }
+  // Obtain a `T&` reference.
+  // This is an unsafe operation and should be avoided unless absolutely necessary.
+  // It is undefined behavior to use the reference after the object managed by this Ptr<T>
+  // ceased to exist.
+
+private:
+
+#ifdef KJ_ASSERT_PTR_COUNTERS
+  inline Ptr(Pin<T>* pin) : ptr(pin->get()), counter(&pin->ptrCounter) { counter->inc(); }
+#else
+  inline Ptr(Pin<T>* pin) : ptr(pin->get()) {}
+#endif
+
+
+#ifdef KJ_ASSERT_PTR_COUNTERS
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  inline Ptr(Pin<U>* pin) : ptr(pin->get()), counter(&pin->ptrCounter) { counter->inc(); }
+#else
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  inline Ptr(Pin<U>* pin) : ptr(pin->get()) {}
+#endif
+
+  T *ptr;
+#ifdef KJ_ASSERT_PTR_COUNTERS
+  _::PtrCounter* counter;
+#endif
+
+  inline T* get() { return ptr; }
+  inline const T* get() const { return ptr; }
+
+  template <typename>
+  friend class Ptr;
+  template <typename>
+  friend class Pin;
 };
 
 // =======================================================================================


### PR DESCRIPTION
`Pin<T>/Ptr<T>` pair is designed to replace `T/T&` usage with additional runtime checks for T's lifetime.