### PR TITLE
Fix for issue 1976 - Changed warning to info for log message causing unwanted/unneeded prints

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -1731,10 +1731,13 @@ private:
             pwdStat.st_dev == dotStat.st_dev) {
           return kj::mv(result);
         } else {
-          // This was set to INFO to avoid logging it unless specifically asking
-          // for INFO level debugging. In some docker containers and CICD pipelines
-          // this log message was printed when set to WARNING which was not really
-          // abnormal except that it caused issues for code that was monitoring stderr.
+          // It appears PWD doesn't actually point at the current directory. In practice, only
+          // shells tend to update PWD. Other programs, like build tools, may do `chdir()` without
+          // actually updating PWD to match. Arguably they are buggy, but realistically we have to
+          // live with them. So, we will treat an incorrect PWD the same as an absent PWD, and fall
+          // back to using the current directory's canonical path.
+          //
+          // We used to log a WARNING here but it was deemed too noisy, so we changed it to INFO.
           KJ_LOG(INFO, "PWD environment variable doesn't match current directory", pwd);
         }
       }

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -1731,7 +1731,11 @@ private:
             pwdStat.st_dev == dotStat.st_dev) {
           return kj::mv(result);
         } else {
-          KJ_LOG(WARNING, "PWD environment variable doesn't match current directory", pwd);
+          // This was set to INFO to avoid logging it unless specifically asking
+          // for INFO level debugging. In some docker containers and CICD pipelines
+          // this log message was printed when set to WARNING which was not really
+          // abnormal except that it caused issues for code that was monitoring stderr.
+          KJ_LOG(INFO, "PWD environment variable doesn't match current directory", pwd);
         }
       }
     }


### PR DESCRIPTION
The title pretty much says it. INFO messages are not printed by default, so changing the log message from WARNING to INFO suppresses it by default. 

The issue was that this warning was printing inside a container and in a CICD pipeline when it was not needed and unwanted since processes were monitoring stderr and tests were failing as a result.