### PR TITLE
make Membrane refcounted

### DIFF
--- a/c++/src/capnp/membrane-test.c++
+++ b/c++/src/capnp/membrane-test.c++
@@ -166,7 +166,7 @@ void testThingImpl(kj::WaitScope& waitScope, test::TestMembrane::Client membrane
 struct TestEnv {
   kj::EventLoop loop;
   kj::WaitScope waitScope;
-  kj::Rc<MembranePolicyImpl> policy;
+  kj::Rc<MembranePolicy> policy;
   test::TestMembrane::Client membraned;
 
   TestEnv()
@@ -239,7 +239,7 @@ KJ_TEST("apply membrane using copyOutOfMembrane() on struct") {
     root.setCap(kj::heap<ThingImpl>("inside"));
     MallocMessageBuilder insideBuilder;
     insideBuilder.adoptRoot(copyOutOfMembrane(
-        root.asReader(), insideBuilder.getOrphanage(), env.policy.addRef()));
+        root.asReader(), insideBuilder.getOrphanage(), env.policy));
     return insideBuilder.getRoot<test::TestContainMembrane>().getCap();
   }, "inside", "inbound", "inside", "inside");
 }
@@ -253,7 +253,7 @@ KJ_TEST("apply membrane using copyOutOfMembrane() on list") {
     list.set(0, kj::heap<ThingImpl>("inside"));
     MallocMessageBuilder insideBuilder;
     insideBuilder.initRoot<test::TestContainMembrane>().adoptList(copyOutOfMembrane(
-        list.asReader(), insideBuilder.getOrphanage(), env.policy.addRef()));
+        list.asReader(), insideBuilder.getOrphanage(), env.policy));
     return insideBuilder.getRoot<test::TestContainMembrane>().getList()[0];
   }, "inside", "inbound", "inside", "inside");
 }
@@ -267,7 +267,7 @@ KJ_TEST("apply membrane using copyOutOfMembrane() on AnyPointer") {
     ptr.setAs<test::TestMembrane::Thing>(kj::heap<ThingImpl>("inside"));
     MallocMessageBuilder insideBuilder;
     insideBuilder.initRoot<test::TestAnyPointer>().getAnyPointerField().adopt(copyOutOfMembrane(
-        ptr.asReader(), insideBuilder.getOrphanage(), env.policy.addRef()));
+        ptr.asReader(), insideBuilder.getOrphanage(), env.policy));
     return insideBuilder.getRoot<test::TestAnyPointer>().getAnyPointerField()
         .getAs<test::TestMembrane::Thing>();
   }, "inside", "inbound", "inside", "inside");

--- a/c++/src/capnp/membrane-test.c++
+++ b/c++/src/capnp/membrane-test.c++
@@ -94,7 +94,7 @@ protected:
   }
 };
 
-class MembranePolicyImpl: public MembranePolicy, public kj::Refcounted {
+class MembranePolicyImpl: public MembranePolicy {
 public:
   MembranePolicyImpl() = default;
   MembranePolicyImpl(kj::Maybe<kj::Promise<void>> revokePromise)
@@ -116,10 +116,6 @@ public:
     } else {
       return kj::none;
     }
-  }
-
-  kj::Own<MembranePolicy> addRef() override {
-    return kj::addRef(*this);
   }
 
   kj::Maybe<kj::Promise<void>> onRevoked() override {
@@ -170,13 +166,13 @@ void testThingImpl(kj::WaitScope& waitScope, test::TestMembrane::Client membrane
 struct TestEnv {
   kj::EventLoop loop;
   kj::WaitScope waitScope;
-  kj::Own<MembranePolicyImpl> policy;
+  kj::Rc<MembranePolicyImpl> policy;
   test::TestMembrane::Client membraned;
 
   TestEnv()
       : waitScope(loop),
-        policy(kj::refcounted<MembranePolicyImpl>()),
-        membraned(membrane(kj::heap<TestMembraneImpl>(), policy->addRef())) {}
+        policy(kj::rc<MembranePolicyImpl>()),
+        membraned(membrane(kj::heap<TestMembraneImpl>(), policy.addRef())) {}
 
   void testThing(kj::Function<Thing::Client()> makeThing,
                  kj::StringPtr localPassThrough, kj::StringPtr localIntercept,
@@ -243,7 +239,7 @@ KJ_TEST("apply membrane using copyOutOfMembrane() on struct") {
     root.setCap(kj::heap<ThingImpl>("inside"));
     MallocMessageBuilder insideBuilder;
     insideBuilder.adoptRoot(copyOutOfMembrane(
-        root.asReader(), insideBuilder.getOrphanage(), env.policy->addRef()));
+        root.asReader(), insideBuilder.getOrphanage(), env.policy.addRef()));
     return insideBuilder.getRoot<test::TestContainMembrane>().getCap();
   }, "inside", "inbound", "inside", "inside");
 }
@@ -257,7 +253,7 @@ KJ_TEST("apply membrane using copyOutOfMembrane() on list") {
     list.set(0, kj::heap<ThingImpl>("inside"));
     MallocMessageBuilder insideBuilder;
     insideBuilder.initRoot<test::TestContainMembrane>().adoptList(copyOutOfMembrane(
-        list.asReader(), insideBuilder.getOrphanage(), env.policy->addRef()));
+        list.asReader(), insideBuilder.getOrphanage(), env.policy.addRef()));
     return insideBuilder.getRoot<test::TestContainMembrane>().getList()[0];
   }, "inside", "inbound", "inside", "inside");
 }
@@ -271,7 +267,7 @@ KJ_TEST("apply membrane using copyOutOfMembrane() on AnyPointer") {
     ptr.setAs<test::TestMembrane::Thing>(kj::heap<ThingImpl>("inside"));
     MallocMessageBuilder insideBuilder;
     insideBuilder.initRoot<test::TestAnyPointer>().getAnyPointerField().adopt(copyOutOfMembrane(
-        ptr.asReader(), insideBuilder.getOrphanage(), env.policy->addRef()));
+        ptr.asReader(), insideBuilder.getOrphanage(), env.policy.addRef()));
     return insideBuilder.getRoot<test::TestAnyPointer>().getAnyPointerField()
         .getAs<test::TestMembrane::Thing>();
   }, "inside", "inbound", "inside", "inside");
@@ -285,7 +281,7 @@ KJ_TEST("MembraneHook::whenMoreResolved returns same value even when called conc
 
   auto prom = promCap.whenResolved();
   prom = prom.then([promCap = kj::mv(promCap), &env]() mutable {
-    auto membraned = membrane(kj::mv(promCap), env.policy->addRef());
+    auto membraned = membrane(kj::mv(promCap), env.policy.addRef());
     auto hook = ClientHook::from(membraned);
 
     auto arr = kj::heapArrayBuilder<kj::Promise<kj::Own<ClientHook>>>(2);
@@ -318,7 +314,7 @@ struct TestRpcEnv {
         client(*pipe.ends[0]),
         server(*pipe.ends[1],
                membrane(kj::heap<TestMembraneImpl>(),
-                        kj::refcounted<MembranePolicyImpl>(kj::mv(revokePromise))),
+                        kj::rc<MembranePolicyImpl>(kj::mv(revokePromise))),
                rpc::twoparty::Side::SERVER),
         membraned(client.bootstrap().castAs<test::TestMembrane>()) {}
 

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -75,8 +75,8 @@ private:
 
 class MembraneCapTableBuilder final: public _::CapTableBuilder {
 public:
-  MembraneCapTableBuilder(kj::Rc<MembranePolicy> policy, bool reverse)
-      : policy(kj::mv(policy)), reverse(reverse) {}
+  MembraneCapTableBuilder(kj::Rc<MembranePolicy>& policy, bool reverse)
+      : policy(policy), reverse(reverse) {}
 
   AnyPointer::Builder imbue(AnyPointer::Builder builder) {
     KJ_REQUIRE(inner == nullptr, "can only call this once");
@@ -111,7 +111,7 @@ public:
 
 private:
   _::CapTableBuilder* inner = nullptr;
-  kj::Rc<MembranePolicy> policy;
+  kj::Rc<MembranePolicy>& policy;
   bool reverse;
 };
 
@@ -158,7 +158,7 @@ public:
   MembraneRequestHook(kj::Own<RequestHook>&& inner, kj::Rc<MembranePolicy> policy, bool reverse)
       : RequestHook(&MEMBRANE_BRAND),
         inner(kj::mv(inner)), policy(kj::mv(policy)),
-        reverse(reverse), capTable(this->policy.addRef(), reverse) {}
+        reverse(reverse), capTable(this->policy, reverse) {}
 
   static Request<AnyPointer, AnyPointer> wrap(
       Request<AnyPointer, AnyPointer>&& inner, kj::Rc<MembranePolicy> policy, bool reverse) {
@@ -250,7 +250,7 @@ public:
                           kj::Rc<MembranePolicy> policy, bool reverse)
       : inner(kj::mv(inner)), policy(kj::mv(policy)), reverse(reverse),
         paramsCapTable(this->policy.addRef(), reverse),
-        resultsCapTable(this->policy.addRef(), reverse) {}
+        resultsCapTable(this->policy, reverse) {}
 
   AnyPointer::Reader getParams() override {
     KJ_REQUIRE(!releasedParams);

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -33,8 +33,8 @@ kj::Own<ClientHook> membrane(kj::Own<ClientHook> inner, kj::Rc<MembranePolicy> p
 
 class MembraneCapTableReader final: public _::CapTableReader {
 public:
-  MembraneCapTableReader(kj::Rc<MembranePolicy> policy, bool reverse)
-      : policy(kj::mv(policy)), reverse(reverse) {}
+  MembraneCapTableReader(kj::Rc<MembranePolicy>& policy, bool reverse)
+      : policy(policy), reverse(reverse) {}
 
   AnyPointer::Reader imbue(AnyPointer::Reader reader) {
     return AnyPointer::Reader(imbue(
@@ -69,7 +69,7 @@ public:
 
 private:
   _::CapTableReader* inner = nullptr;
-  kj::Rc<MembranePolicy> policy;
+  kj::Rc<MembranePolicy>& policy;
   bool reverse;
 };
 
@@ -143,7 +143,7 @@ class MembraneResponseHook final: public ResponseHook {
 public:
   MembraneResponseHook(
       kj::Own<ResponseHook>&& inner, kj::Rc<MembranePolicy> policy, bool reverse)
-      : inner(kj::mv(inner)), policy(kj::mv(policy)), capTable(this->policy.addRef(), reverse) {}
+      : inner(kj::mv(inner)), policy(kj::mv(policy)), capTable(this->policy, reverse) {}
 
   AnyPointer::Reader imbue(AnyPointer::Reader reader) { return capTable.imbue(reader); }
 
@@ -249,7 +249,7 @@ public:
   MembraneCallContextHook(kj::Own<CallContextHook>&& inner,
                           kj::Rc<MembranePolicy> policy, bool reverse)
       : inner(kj::mv(inner)), policy(kj::mv(policy)), reverse(reverse),
-        paramsCapTable(this->policy.addRef(), reverse),
+        paramsCapTable(this->policy, reverse),
         resultsCapTable(this->policy, reverse) {}
 
   AnyPointer::Reader getParams() override {
@@ -595,8 +595,8 @@ Capability::Client reverseMembrane(Capability::Client inner, kj::Rc<MembranePoli
 namespace _ {  // private
 
 _::OrphanBuilder copyOutOfMembrane(PointerReader from, Orphanage to,
-                                   kj::Rc<MembranePolicy> policy, bool reverse) {
-  MembraneCapTableReader capTable(kj::mv(policy), reverse);
+                                   kj::Rc<MembranePolicy>& policy, bool reverse) {
+  MembraneCapTableReader capTable(policy, reverse);
   return _::OrphanBuilder::copy(
       OrphanageInternal::getArena(to),
       OrphanageInternal::getCapTable(to),
@@ -604,8 +604,8 @@ _::OrphanBuilder copyOutOfMembrane(PointerReader from, Orphanage to,
 }
 
 _::OrphanBuilder copyOutOfMembrane(StructReader from, Orphanage to,
-                                   kj::Rc<MembranePolicy> policy, bool reverse) {
-  MembraneCapTableReader capTable(kj::mv(policy), reverse);
+                                   kj::Rc<MembranePolicy>& policy, bool reverse) {
+  MembraneCapTableReader capTable(policy, reverse);
   return _::OrphanBuilder::copy(
       OrphanageInternal::getArena(to),
       OrphanageInternal::getCapTable(to),
@@ -613,8 +613,8 @@ _::OrphanBuilder copyOutOfMembrane(StructReader from, Orphanage to,
 }
 
 _::OrphanBuilder copyOutOfMembrane(ListReader from, Orphanage to,
-                                   kj::Rc<MembranePolicy> policy, bool reverse) {
-  MembraneCapTableReader capTable(kj::mv(policy), reverse);
+                                   kj::Rc<MembranePolicy>& policy, bool reverse) {
+  MembraneCapTableReader capTable(policy, reverse);
   return _::OrphanBuilder::copy(
       OrphanageInternal::getArena(to),
       OrphanageInternal::getCapTable(to),

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -29,12 +29,12 @@ namespace {
 static const char DUMMY = 0;
 static constexpr const void* MEMBRANE_BRAND = &DUMMY;
 
-kj::Own<ClientHook> membrane(kj::Own<ClientHook> inner, MembranePolicy& policy, bool reverse);
+kj::Own<ClientHook> membrane(kj::Own<ClientHook> inner, kj::Rc<MembranePolicy> policy, bool reverse);
 
 class MembraneCapTableReader final: public _::CapTableReader {
 public:
-  MembraneCapTableReader(MembranePolicy& policy, bool reverse)
-      : policy(policy), reverse(reverse) {}
+  MembraneCapTableReader(kj::Rc<MembranePolicy> policy, bool reverse)
+      : policy(kj::mv(policy)), reverse(reverse) {}
 
   AnyPointer::Reader imbue(AnyPointer::Reader reader) {
     return AnyPointer::Reader(imbue(
@@ -63,20 +63,20 @@ public:
     // The underlying message is inside the membrane, and we're pulling a cap out of it. Therefore,
     // we want to wrap the extracted capability in the membrane.
     return inner->extractCap(index).map([this](kj::Own<ClientHook>&& cap) {
-      return membrane(kj::mv(cap), policy, reverse);
+      return membrane(kj::mv(cap), policy.addRef(), reverse);
     });
   }
 
 private:
   _::CapTableReader* inner = nullptr;
-  MembranePolicy& policy;
+  kj::Rc<MembranePolicy> policy;
   bool reverse;
 };
 
 class MembraneCapTableBuilder final: public _::CapTableBuilder {
 public:
-  MembraneCapTableBuilder(MembranePolicy& policy, bool reverse)
-      : policy(policy), reverse(reverse) {}
+  MembraneCapTableBuilder(kj::Rc<MembranePolicy> policy, bool reverse)
+      : policy(kj::mv(policy)), reverse(reverse) {}
 
   AnyPointer::Builder imbue(AnyPointer::Builder builder) {
     KJ_REQUIRE(inner == nullptr, "can only call this once");
@@ -95,14 +95,14 @@ public:
     // The underlying message is inside the membrane, and we're pulling a cap out of it. Therefore,
     // we want to wrap the extracted capability in the membrane.
     return inner->extractCap(index).map([this](kj::Own<ClientHook>&& cap) {
-      return membrane(kj::mv(cap), policy, reverse);
+      return membrane(kj::mv(cap), policy.addRef(), reverse);
     });
   }
 
   uint injectCap(kj::Own<ClientHook>&& cap) override {
     // The underlying message is inside the membrane, and we're inserting a cap from outside into
     // it. Therefore we want to add a reverse membrane.
-    return inner->injectCap(membrane(kj::mv(cap), policy, !reverse));
+    return inner->injectCap(membrane(kj::mv(cap), policy.addRef(), !reverse));
   }
 
   void dropCap(uint index) override {
@@ -111,14 +111,14 @@ public:
 
 private:
   _::CapTableBuilder* inner = nullptr;
-  MembranePolicy& policy;
+  kj::Rc<MembranePolicy> policy;
   bool reverse;
 };
 
 class MembranePipelineHook final: public PipelineHook, public kj::Refcounted {
 public:
   MembranePipelineHook(
-      kj::Own<PipelineHook>&& inner, kj::Own<MembranePolicy>&& policy, bool reverse)
+      kj::Own<PipelineHook>&& inner, kj::Rc<MembranePolicy> policy, bool reverse)
       : inner(kj::mv(inner)), policy(kj::mv(policy)), reverse(reverse) {}
 
   kj::Own<PipelineHook> addRef() override {
@@ -126,47 +126,47 @@ public:
   }
 
   kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
-    return membrane(inner->getPipelinedCap(ops), *policy, reverse);
+    return membrane(inner->getPipelinedCap(ops), policy.addRef(), reverse);
   }
 
   kj::Own<ClientHook> getPipelinedCap(kj::Array<PipelineOp>&& ops) override {
-    return membrane(inner->getPipelinedCap(kj::mv(ops)), *policy, reverse);
+    return membrane(inner->getPipelinedCap(kj::mv(ops)), policy.addRef(), reverse);
   }
 
 private:
   kj::Own<PipelineHook> inner;
-  kj::Own<MembranePolicy> policy;
+  kj::Rc<MembranePolicy> policy;
   bool reverse;
 };
 
 class MembraneResponseHook final: public ResponseHook {
 public:
   MembraneResponseHook(
-      kj::Own<ResponseHook>&& inner, kj::Own<MembranePolicy>&& policy, bool reverse)
-      : inner(kj::mv(inner)), policy(kj::mv(policy)), capTable(*this->policy, reverse) {}
+      kj::Own<ResponseHook>&& inner, kj::Rc<MembranePolicy> policy, bool reverse)
+      : inner(kj::mv(inner)), policy(kj::mv(policy)), capTable(this->policy.addRef(), reverse) {}
 
   AnyPointer::Reader imbue(AnyPointer::Reader reader) { return capTable.imbue(reader); }
 
 private:
   kj::Own<ResponseHook> inner;
-  kj::Own<MembranePolicy> policy;
+  kj::Rc<MembranePolicy> policy;
   MembraneCapTableReader capTable;
 };
 
 class MembraneRequestHook final: public RequestHook {
 public:
-  MembraneRequestHook(kj::Own<RequestHook>&& inner, kj::Own<MembranePolicy>&& policy, bool reverse)
+  MembraneRequestHook(kj::Own<RequestHook>&& inner, kj::Rc<MembranePolicy> policy, bool reverse)
       : RequestHook(&MEMBRANE_BRAND),
         inner(kj::mv(inner)), policy(kj::mv(policy)),
-        reverse(reverse), capTable(*this->policy, reverse) {}
+        reverse(reverse), capTable(this->policy.addRef(), reverse) {}
 
   static Request<AnyPointer, AnyPointer> wrap(
-      Request<AnyPointer, AnyPointer>&& inner, MembranePolicy& policy, bool reverse) {
+      Request<AnyPointer, AnyPointer>&& inner, kj::Rc<MembranePolicy> policy, bool reverse) {
     AnyPointer::Builder builder = inner;
     auto innerHook = RequestHook::from(kj::mv(inner));
     if (innerHook->isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneRequestHook>(*innerHook);
-      if (otherMembrane.policy.get() == &policy && otherMembrane.reverse == !reverse) {
+      if (otherMembrane.policy == policy && otherMembrane.reverse == !reverse) {
         // Request that passed across the membrane one way is now passing back the other way.
         // Unwrap it rather than double-wrap it.
         builder = otherMembrane.capTable.unimbue(builder);
@@ -180,10 +180,10 @@ public:
   }
 
   static kj::Own<RequestHook> wrap(
-      kj::Own<RequestHook>&& inner, MembranePolicy& policy, bool reverse) {
+      kj::Own<RequestHook>&& inner, kj::Rc<MembranePolicy> policy, bool reverse) {
     if (inner->isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneRequestHook>(*inner);
-      if (otherMembrane.policy.get() == &policy && otherMembrane.reverse == !reverse) {
+      if (otherMembrane.policy == policy && otherMembrane.reverse == !reverse) {
         // Request that passed across the membrane one way is now passing back the other way.
         // Unwrap it rather than double-wrap it.
         return kj::mv(otherMembrane.inner);
@@ -197,7 +197,7 @@ public:
     auto promise = inner->send();
 
     auto newPipeline = AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(
-        PipelineHook::from(kj::mv(promise)), policy->addRef(), reverse));
+        PipelineHook::from(kj::mv(promise)), policy.addRef(), reverse));
 
     auto onRevoked = policy->onRevoked();
 
@@ -206,7 +206,7 @@ public:
         [reverse,policy=kj::mv(policy)](Response<AnyPointer>&& response) mutable {
       AnyPointer::Reader reader = response;
       auto newRespHook = kj::heap<MembraneResponseHook>(
-          ResponseHook::from(kj::mv(response)), policy->addRef(), reverse);
+          ResponseHook::from(kj::mv(response)), policy.addRef(), reverse);
       reader = newRespHook->imbue(reader);
       return Response<AnyPointer>(reader, kj::mv(newRespHook));
     });
@@ -234,12 +234,12 @@ public:
 
   AnyPointer::Pipeline sendForPipeline() override {
     return AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(
-        PipelineHook::from(inner->sendForPipeline()), policy->addRef(), reverse));
+        PipelineHook::from(inner->sendForPipeline()), policy.addRef(), reverse));
   }
 
 private:
   kj::Own<RequestHook> inner;
-  kj::Own<MembranePolicy> policy;
+  kj::Rc<MembranePolicy> policy;
   bool reverse;
   MembraneCapTableBuilder capTable;
 };
@@ -247,10 +247,10 @@ private:
 class MembraneCallContextHook final: public CallContextHook, public kj::Refcounted {
 public:
   MembraneCallContextHook(kj::Own<CallContextHook>&& inner,
-                          kj::Own<MembranePolicy>&& policy, bool reverse)
+                          kj::Rc<MembranePolicy> policy, bool reverse)
       : inner(kj::mv(inner)), policy(kj::mv(policy)), reverse(reverse),
-        paramsCapTable(*this->policy, reverse),
-        resultsCapTable(*this->policy, reverse) {}
+        paramsCapTable(this->policy.addRef(), reverse),
+        resultsCapTable(this->policy.addRef(), reverse) {}
 
   AnyPointer::Reader getParams() override {
     KJ_REQUIRE(!releasedParams);
@@ -281,27 +281,27 @@ public:
 
   void setPipeline(kj::Own<PipelineHook>&& pipeline) override {
     inner->setPipeline(kj::refcounted<MembranePipelineHook>(
-        kj::mv(pipeline), policy->addRef(), !reverse));
+        kj::mv(pipeline), policy.addRef(), !reverse));
   }
 
   kj::Promise<void> tailCall(kj::Own<RequestHook>&& request) override {
-    return inner->tailCall(MembraneRequestHook::wrap(kj::mv(request), *policy, !reverse));
+    return inner->tailCall(MembraneRequestHook::wrap(kj::mv(request), policy.addRef(), !reverse));
   }
 
   kj::Promise<AnyPointer::Pipeline> onTailCall() override {
     return inner->onTailCall().then([this](AnyPointer::Pipeline&& innerPipeline) {
       return AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(
-          PipelineHook::from(kj::mv(innerPipeline)), policy->addRef(), reverse));
+          PipelineHook::from(kj::mv(innerPipeline)), policy.addRef(), reverse));
     });
   }
 
   ClientHook::VoidPromiseAndPipeline directTailCall(kj::Own<RequestHook>&& request) override {
     auto pair = inner->directTailCall(
-        MembraneRequestHook::wrap(kj::mv(request), *policy, !reverse));
+        MembraneRequestHook::wrap(kj::mv(request), policy.addRef(), !reverse));
 
     return {
       kj::mv(pair.promise),
-      kj::refcounted<MembranePipelineHook>(kj::mv(pair.pipeline), policy->addRef(), reverse)
+      kj::refcounted<MembranePipelineHook>(kj::mv(pair.pipeline), policy.addRef(), reverse)
     };
   }
 
@@ -311,7 +311,7 @@ public:
 
 private:
   kj::Own<CallContextHook> inner;
-  kj::Own<MembranePolicy> policy;
+  kj::Rc<MembranePolicy> policy;
   bool reverse;
 
   MembraneCapTableReader paramsCapTable;
@@ -326,7 +326,7 @@ private:
 
 class MembraneHook final: public ClientHook, public kj::Refcounted {
 public:
-  MembraneHook(kj::Own<ClientHook>&& inner, kj::Own<MembranePolicy>&& policyParam, bool reverse)
+  MembraneHook(kj::Own<ClientHook>&& inner, kj::Rc<MembranePolicy> policyParam, bool reverse)
       : ClientHook(MEMBRANE_BRAND), inner(kj::mv(inner)), policy(kj::mv(policyParam)),
         reverse(reverse) {
     KJ_IF_SOME(r, policy->onRevoked()) {
@@ -346,29 +346,29 @@ public:
     }
   }
 
-  static kj::Own<ClientHook> wrap(ClientHook& cap, MembranePolicy& policy, bool reverse) {
+  static kj::Own<ClientHook> wrap(ClientHook& cap, kj::Rc<MembranePolicy> policy, bool reverse) {
     if (cap.isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneHook>(cap);
-      auto& rootPolicy = policy.rootPolicy();
+      auto& rootPolicy = policy->rootPolicy();
       if (&otherMembrane.policy->rootPolicy() == &rootPolicy &&
           otherMembrane.reverse == !reverse) {
         // Capability that passed across the membrane one way is now passing back the other way.
         // Unwrap it rather than double-wrap it.
         Capability::Client unwrapped(otherMembrane.inner->addRef());
         return ClientHook::from(
-            reverse ? rootPolicy.importInternal(kj::mv(unwrapped), *otherMembrane.policy, policy)
-                    : rootPolicy.exportExternal(kj::mv(unwrapped), *otherMembrane.policy, policy));
+            reverse ? rootPolicy.importInternal(kj::mv(unwrapped), otherMembrane.policy.addRef(), policy.addRef())
+                    : rootPolicy.exportExternal(kj::mv(unwrapped), otherMembrane.policy.addRef(), policy.addRef()));
       }
     }
 
-    auto& map = reverse ? policy.reverseWrappers : policy.wrappers;
+    auto& map = reverse ? policy->reverseWrappers : policy->wrappers;
     ClientHook*& slot = map.findOrCreate(&cap, [&]() -> kj::Decay<decltype(map)>::Entry {
       return { &cap, nullptr };
     });
     if (slot == nullptr) {
       auto result = ClientHook::from(
-          reverse ? policy.importExternal(Capability::Client(cap.addRef()))
-                  : policy.exportInternal(Capability::Client(cap.addRef())));
+          reverse ? policy->importExternal(Capability::Client(cap.addRef()))
+                  : policy->exportInternal(Capability::Client(cap.addRef())));
       slot = result;
       return result;
     } else {
@@ -376,29 +376,29 @@ public:
     }
   }
 
-  static kj::Own<ClientHook> wrap(kj::Own<ClientHook> cap, MembranePolicy& policy, bool reverse) {
+  static kj::Own<ClientHook> wrap(kj::Own<ClientHook> cap, kj::Rc<MembranePolicy> policy, bool reverse) {
     if (cap->isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneHook>(*cap);
-      auto& rootPolicy = policy.rootPolicy();
+      auto& rootPolicy = policy->rootPolicy();
       if (&otherMembrane.policy->rootPolicy() == &rootPolicy &&
           otherMembrane.reverse == !reverse) {
         // Capability that passed across the membrane one way is now passing back the other way.
         // Unwrap it rather than double-wrap it.
         Capability::Client unwrapped(otherMembrane.inner->addRef());
         return ClientHook::from(
-            reverse ? rootPolicy.importInternal(kj::mv(unwrapped), *otherMembrane.policy, policy)
-                    : rootPolicy.exportExternal(kj::mv(unwrapped), *otherMembrane.policy, policy));
+            reverse ? rootPolicy.importInternal(kj::mv(unwrapped), otherMembrane.policy.addRef(), policy.addRef())
+                    : rootPolicy.exportExternal(kj::mv(unwrapped), otherMembrane.policy.addRef(), policy.addRef()));
       }
     }
 
-    auto& map = reverse ? policy.reverseWrappers : policy.wrappers;
+    auto& map = reverse ? policy->reverseWrappers : policy->wrappers;
     ClientHook*& slot = map.findOrCreate(cap.get(), [&]() -> kj::Decay<decltype(map)>::Entry {
       return { cap.get(), nullptr };
     });
     if (slot == nullptr) {
       auto result = ClientHook::from(
-          reverse ? policy.importExternal(Capability::Client(kj::mv(cap)))
-                  : policy.exportInternal(Capability::Client(kj::mv(cap))));
+          reverse ? policy->importExternal(Capability::Client(kj::mv(cap)))
+                  : policy->exportInternal(Capability::Client(kj::mv(cap))));
       slot = result;
       return result;
     } else {
@@ -433,7 +433,7 @@ public:
       // For pass-through calls, we don't worry about promises, because if the capability resolves
       // to something outside the membrane, then the call will pass back out of the membrane too.
       return MembraneRequestHook::wrap(
-          inner->newCall(interfaceId, methodId, sizeHint, hints), *policy, reverse);
+          inner->newCall(interfaceId, methodId, sizeHint, hints), policy.addRef(), reverse);
     }
   }
 
@@ -463,7 +463,7 @@ public:
     } else {
       // !reverse because calls to the CallContext go in the opposite direction.
       auto result = inner->call(interfaceId, methodId,
-          kj::refcounted<MembraneCallContextHook>(kj::mv(context), policy->addRef(), !reverse),
+          kj::refcounted<MembraneCallContextHook>(kj::mv(context), policy.addRef(), !reverse),
           hints);
 
       if (hints.onlyPromisePipeline) {
@@ -475,7 +475,7 @@ public:
 
       return {
         kj::mv(result.promise),
-        kj::refcounted<MembranePipelineHook>(kj::mv(result.pipeline), policy->addRef(), reverse)
+        kj::refcounted<MembranePipelineHook>(kj::mv(result.pipeline), policy.addRef(), reverse)
       };
     }
   }
@@ -486,7 +486,7 @@ public:
     }
 
     KJ_IF_SOME(newInner, inner->getResolved()) {
-      kj::Own<ClientHook> newResolved = wrap(newInner, *policy, reverse);
+      kj::Own<ClientHook> newResolved = wrap(newInner, policy.addRef(), reverse);
       ClientHook& result = *newResolved;
       resolved = kj::mv(newResolved);
       return result;
@@ -514,7 +514,7 @@ public:
         KJ_IF_SOME(r, resolved) {
           return r->addRef();
         } else {
-          return resolved.emplace(wrap(*newInner, *policy, reverse))->addRef();
+          return resolved.emplace(wrap(*newInner, policy.addRef(), reverse))->addRef();
         }
       });
     } else {
@@ -537,7 +537,7 @@ public:
 
 private:
   kj::Own<ClientHook> inner;
-  kj::Own<MembranePolicy> policy;
+  kj::Rc<MembranePolicy> policy;
   bool reverse;
   bool revoked = false;
   kj::Maybe<kj::Own<ClientHook>> resolved;
@@ -556,47 +556,47 @@ private:
 
 namespace {
 
-kj::Own<ClientHook> membrane(kj::Own<ClientHook> inner, MembranePolicy& policy, bool reverse) {
-  return MembraneHook::wrap(kj::mv(inner), policy, reverse);
+kj::Own<ClientHook> membrane(kj::Own<ClientHook> inner, kj::Rc<MembranePolicy> policy, bool reverse) {
+  return MembraneHook::wrap(kj::mv(inner), kj::mv(policy), reverse);
 }
 
 }  // namespace
 
 Capability::Client MembranePolicy::importExternal(Capability::Client external) {
   return Capability::Client(kj::refcounted<MembraneHook>(
-      ClientHook::from(kj::mv(external)), addRef(), true));
+      ClientHook::from(kj::mv(external)), addRefToThis(), true));
 }
 
 Capability::Client MembranePolicy::exportInternal(Capability::Client internal) {
   return Capability::Client(kj::refcounted<MembraneHook>(
-      ClientHook::from(kj::mv(internal)), addRef(), false));
+      ClientHook::from(kj::mv(internal)), addRefToThis(), false));
 }
 
 Capability::Client MembranePolicy::importInternal(
-    Capability::Client internal, MembranePolicy& exportPolicy, MembranePolicy& importPolicy) {
+    Capability::Client internal, kj::Rc<MembranePolicy> exportPolicy, kj::Rc<MembranePolicy> importPolicy) {
   return kj::mv(internal);
 }
 
 Capability::Client MembranePolicy::exportExternal(
-    Capability::Client external, MembranePolicy& importPolicy, MembranePolicy& exportPolicy) {
+    Capability::Client external, kj::Rc<MembranePolicy> importPolicy, kj::Rc<MembranePolicy> exportPolicy) {
   return kj::mv(external);
 }
 
-Capability::Client membrane(Capability::Client inner, kj::Own<MembranePolicy> policy) {
+Capability::Client membrane(Capability::Client inner, kj::Rc<MembranePolicy> policy) {
   return Capability::Client(membrane(
-      ClientHook::from(kj::mv(inner)), *policy, false));
+      ClientHook::from(kj::mv(inner)), kj::mv(policy), false));
 }
 
-Capability::Client reverseMembrane(Capability::Client inner, kj::Own<MembranePolicy> policy) {
+Capability::Client reverseMembrane(Capability::Client inner, kj::Rc<MembranePolicy> policy) {
   return Capability::Client(membrane(
-      ClientHook::from(kj::mv(inner)), *policy, true));
+      ClientHook::from(kj::mv(inner)), kj::mv(policy), true));
 }
 
 namespace _ {  // private
 
 _::OrphanBuilder copyOutOfMembrane(PointerReader from, Orphanage to,
-                                   kj::Own<MembranePolicy> policy, bool reverse) {
-  MembraneCapTableReader capTable(*policy, reverse);
+                                   kj::Rc<MembranePolicy> policy, bool reverse) {
+  MembraneCapTableReader capTable(kj::mv(policy), reverse);
   return _::OrphanBuilder::copy(
       OrphanageInternal::getArena(to),
       OrphanageInternal::getCapTable(to),
@@ -604,8 +604,8 @@ _::OrphanBuilder copyOutOfMembrane(PointerReader from, Orphanage to,
 }
 
 _::OrphanBuilder copyOutOfMembrane(StructReader from, Orphanage to,
-                                   kj::Own<MembranePolicy> policy, bool reverse) {
-  MembraneCapTableReader capTable(*policy, reverse);
+                                   kj::Rc<MembranePolicy> policy, bool reverse) {
+  MembraneCapTableReader capTable(kj::mv(policy), reverse);
   return _::OrphanBuilder::copy(
       OrphanageInternal::getArena(to),
       OrphanageInternal::getCapTable(to),
@@ -613,8 +613,8 @@ _::OrphanBuilder copyOutOfMembrane(StructReader from, Orphanage to,
 }
 
 _::OrphanBuilder copyOutOfMembrane(ListReader from, Orphanage to,
-                                   kj::Own<MembranePolicy> policy, bool reverse) {
-  MembraneCapTableReader capTable(*policy, reverse);
+                                   kj::Rc<MembranePolicy> policy, bool reverse) {
+  MembraneCapTableReader capTable(kj::mv(policy), reverse);
   return _::OrphanBuilder::copy(
       OrphanageInternal::getArena(to),
       OrphanageInternal::getCapTable(to),

--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -49,12 +49,13 @@
 
 #include "capability.h"
 #include <kj/map.h>
+#include <kj/refcount.h>
 
 CAPNP_BEGIN_HEADER
 
 namespace capnp {
 
-class MembranePolicy {
+class MembranePolicy: public kj::Refcounted {
   // Applications may implement this interface to define a membrane policy, which allows some
   // calls crossing the membrane to be blocked or redirected.
 
@@ -95,17 +96,6 @@ public:
   //   later resolves to a capability on the other side of the membrane: calls on the promise
   //   will enter and then exit the membrane, but calls on the eventual resolution will not cross
   //   the membrane at all, so it is important that these two cases behave the same.
-
-  virtual kj::Own<MembranePolicy> addRef() = 0;
-  // Return a new owned pointer to the same policy.
-  //
-  // Typically an implementation of MembranePolicy should also inherit kj::Refcounted and implement
-  // `addRef()` as `return kj::addRef(*this);`.
-  //
-  // Note that the membraning system considers two membranes created with the same MembranePolicy
-  // object actually to be the *same* membrane. This is relevant when an object passes into the
-  // membrane and then back out (or out and then back in): instead of double-wrapping the object,
-  // the wrapping will be removed.
 
   virtual kj::Maybe<kj::Promise<void>> onRevoked() { return kj::none; }
   // If this returns non-null, then it is a promise that will reject (throw an exception) when the
@@ -180,14 +170,14 @@ public:
   // importInternal() and exportExternal() will always be references to *this.
 
   virtual Capability::Client importInternal(
-      Capability::Client internal, MembranePolicy& exportPolicy, MembranePolicy& importPolicy);
+      Capability::Client internal, kj::Rc<MembranePolicy> exportPolicy, kj::Rc<MembranePolicy> importPolicy);
   // An internal capability which was previously exported is now being re-imported, i.e. a
   // capability passed out of the membrane and then back in.
   //
   // The default implementation simply returns `internal`.
 
   virtual Capability::Client exportExternal(
-      Capability::Client external, MembranePolicy& importPolicy, MembranePolicy& exportPolicy);
+      Capability::Client external, kj::Rc<MembranePolicy> importPolicy, kj::Rc<MembranePolicy> exportPolicy);
   // An external capability which was previously imported is now being re-exported, i.e. a
   // capability passed into the membrane and then back out.
   //
@@ -203,11 +193,11 @@ private:
   friend class MembraneHook;
 };
 
-Capability::Client membrane(Capability::Client inner, kj::Own<MembranePolicy> policy);
+Capability::Client membrane(Capability::Client inner, kj::Rc<MembranePolicy> policy);
 // Wrap `inner` in a membrane specified by `policy`. `inner` is considered "inside" the membrane,
 // while the returned capability should only be called from outside the membrane.
 
-Capability::Client reverseMembrane(Capability::Client outer, kj::Own<MembranePolicy> policy);
+Capability::Client reverseMembrane(Capability::Client outer, kj::Rc<MembranePolicy> policy);
 // Like `membrane` but treat the input capability as "outside" the membrane, and return a
 // capability appropriate for use inside.
 //
@@ -215,60 +205,60 @@ Capability::Client reverseMembrane(Capability::Client outer, kj::Own<MembranePol
 // reverse membranes where needed.
 
 template <typename ClientType>
-ClientType membrane(ClientType inner, kj::Own<MembranePolicy> policy);
+ClientType membrane(ClientType inner, kj::Rc<MembranePolicy> policy);
 template <typename ClientType>
-ClientType reverseMembrane(ClientType inner, kj::Own<MembranePolicy> policy);
+ClientType reverseMembrane(ClientType inner, kj::Rc<MembranePolicy> policy);
 // Convenience templates which return the same interface type as the input.
 
 template <typename ServerType>
 typename ServerType::Serves::Client membrane(
-    kj::Own<ServerType> inner, kj::Own<MembranePolicy> policy);
+    kj::Own<ServerType> inner, kj::Rc<MembranePolicy> policy);
 template <typename ServerType>
 typename ServerType::Serves::Client reverseMembrane(
-    kj::Own<ServerType> inner, kj::Own<MembranePolicy> policy);
+    kj::Own<ServerType> inner, kj::Rc<MembranePolicy> policy);
 // Convenience templates which input a capability server type and return the appropriate client
 // type.
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyIntoMembrane(
-    Reader&& from, Orphanage to, kj::Own<MembranePolicy> policy);
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy);
 // Copy a Cap'n Proto object (e.g. struct or list), adding the given membrane to any capabilities
 // found within it. `from` is interpreted as "outside" the membrane while `to` is "inside".
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyOutOfMembrane(
-    Reader&& from, Orphanage to, kj::Own<MembranePolicy> policy);
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy);
 // Like copyIntoMembrane() except that `from` is "inside" the membrane and `to` is "outside".
 
 // =======================================================================================
 // inline implementation details
 
 template <typename ClientType>
-ClientType membrane(ClientType inner, kj::Own<MembranePolicy> policy) {
+ClientType membrane(ClientType inner, kj::Rc<MembranePolicy> policy) {
   return membrane(Capability::Client(kj::mv(inner)), kj::mv(policy))
       .castAs<typename ClientType::Calls>();
 }
 template <typename ClientType>
-ClientType reverseMembrane(ClientType inner, kj::Own<MembranePolicy> policy) {
+ClientType reverseMembrane(ClientType inner, kj::Rc<MembranePolicy> policy) {
   return reverseMembrane(Capability::Client(kj::mv(inner)), kj::mv(policy))
       .castAs<typename ClientType::Calls>();
 }
 
 template <typename ServerType>
 typename ServerType::Serves::Client membrane(
-    kj::Own<ServerType> inner, kj::Own<MembranePolicy> policy) {
+    kj::Own<ServerType> inner, kj::Rc<MembranePolicy> policy) {
   return membrane(Capability::Client(kj::mv(inner)), kj::mv(policy))
       .castAs<typename ServerType::Serves>();
 }
 template <typename ServerType>
 typename ServerType::Serves::Client membrane(
-    kj::Rc<ServerType> inner, kj::Own<MembranePolicy> policy) {
+    kj::Rc<ServerType> inner, kj::Rc<MembranePolicy> policy) {
   return membrane(Capability::Client(kj::mv(inner)), kj::mv(policy))
       .castAs<typename ServerType::Serves>();
 }
 template <typename ServerType>
 typename ServerType::Serves::Client reverseMembrane(
-    kj::Own<ServerType> inner, kj::Own<MembranePolicy> policy) {
+    kj::Own<ServerType> inner, kj::Rc<MembranePolicy> policy) {
   return reverseMembrane(Capability::Client(kj::mv(inner)), kj::mv(policy))
       .castAs<typename ServerType::Serves>();
 }
@@ -276,17 +266,17 @@ typename ServerType::Serves::Client reverseMembrane(
 namespace _ {  // private
 
 OrphanBuilder copyOutOfMembrane(PointerReader from, Orphanage to,
-                                kj::Own<MembranePolicy> policy, bool reverse);
+                                kj::Rc<MembranePolicy> policy, bool reverse);
 OrphanBuilder copyOutOfMembrane(StructReader from, Orphanage to,
-                                kj::Own<MembranePolicy> policy, bool reverse);
+                                kj::Rc<MembranePolicy> policy, bool reverse);
 OrphanBuilder copyOutOfMembrane(ListReader from, Orphanage to,
-                                kj::Own<MembranePolicy> policy, bool reverse);
+                                kj::Rc<MembranePolicy> policy, bool reverse);
 
 }  // namespace _ (private)
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyIntoMembrane(
-    Reader&& from, Orphanage to, kj::Own<MembranePolicy> policy) {
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy) {
   return _::copyOutOfMembrane(
       _::PointerHelpers<typename kj::Decay<Reader>::Reads>::getInternalReader(from),
       to, kj::mv(policy), true);
@@ -294,7 +284,7 @@ Orphan<typename kj::Decay<Reader>::Reads> copyIntoMembrane(
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyOutOfMembrane(
-    Reader&& from, Orphanage to, kj::Own<MembranePolicy> policy) {
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy) {
   return _::copyOutOfMembrane(
       _::PointerHelpers<typename kj::Decay<Reader>::Reads>::getInternalReader(from),
       to, kj::mv(policy), false);

--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -221,13 +221,13 @@ typename ServerType::Serves::Client reverseMembrane(
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyIntoMembrane(
-    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy);
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy>& policy);
 // Copy a Cap'n Proto object (e.g. struct or list), adding the given membrane to any capabilities
 // found within it. `from` is interpreted as "outside" the membrane while `to` is "inside".
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyOutOfMembrane(
-    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy);
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy>& policy);
 // Like copyIntoMembrane() except that `from` is "inside" the membrane and `to` is "outside".
 
 // =======================================================================================
@@ -266,28 +266,28 @@ typename ServerType::Serves::Client reverseMembrane(
 namespace _ {  // private
 
 OrphanBuilder copyOutOfMembrane(PointerReader from, Orphanage to,
-                                kj::Rc<MembranePolicy> policy, bool reverse);
+                                kj::Rc<MembranePolicy>& policy, bool reverse);
 OrphanBuilder copyOutOfMembrane(StructReader from, Orphanage to,
-                                kj::Rc<MembranePolicy> policy, bool reverse);
+                                kj::Rc<MembranePolicy>& policy, bool reverse);
 OrphanBuilder copyOutOfMembrane(ListReader from, Orphanage to,
-                                kj::Rc<MembranePolicy> policy, bool reverse);
+                                kj::Rc<MembranePolicy>& policy, bool reverse);
 
 }  // namespace _ (private)
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyIntoMembrane(
-    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy) {
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy>& policy) {
   return _::copyOutOfMembrane(
       _::PointerHelpers<typename kj::Decay<Reader>::Reads>::getInternalReader(from),
-      to, kj::mv(policy), true);
+      to, policy, true);
 }
 
 template <typename Reader>
 Orphan<typename kj::Decay<Reader>::Reads> copyOutOfMembrane(
-    Reader&& from, Orphanage to, kj::Rc<MembranePolicy> policy) {
+    Reader&& from, Orphanage to, kj::Rc<MembranePolicy>& policy) {
   return _::copyOutOfMembrane(
       _::PointerHelpers<typename kj::Decay<Reader>::Reads>::getInternalReader(from),
-      to, kj::mv(policy), false);
+      to, policy, false);
 }
 
 } // namespace capnp


### PR DESCRIPTION
All real membrane implementations already are. Explicit refcounting makes reasoning about lifetime much easier.

You could argue that this style makes memory leaks more possible, but arguably this is the right tradeoff to make instead of lifetime issue.

I'm seeking for initial feedback (yay/nay) before I spend too much time cleaning this up.

Corresponding downstream pull requests are:

https://github.com/cloudflare/workerd/pull/2029 and EW/7744

WDYT @kentonv  ?