### PR TITLE
kj::memzero<T>() - zero-initialize memory region

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -1010,5 +1010,31 @@ KJ_TEST("arrayPtr()") {
   KJ_EXPECT(ptr.size() == 1024);
 }
 
+KJ_TEST("memzero<T>()") {
+  // memzero() works for primitive types
+  int64_t x = 42;
+  memzero(x);
+  KJ_EXPECT(x == 0);
+
+  // memzero() works for trivially constructible types
+  struct ZeroTest {
+    int64_t x;
+    double pi;
+  };
+  ZeroTest t1;
+    
+  memzero(t1);
+  KJ_EXPECT(t1.x == 0);
+  KJ_EXPECT(t1.pi == 0.0);
+
+  // memzero works on statically-sized arrays
+  ZeroTest arr[256];
+  memset(arr, 0xff, 256 * sizeof(ZeroTest));
+  memzero(arr);
+  for (auto& t: arr) {
+    KJ_EXPECT(t.pi == 0);
+  }
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2158,6 +2158,12 @@ constexpr bool isDisallowedInCoroutine() {
 // }
 //
 
+template<typename T, typename = EnableIf<KJ_HAS_TRIVIAL_CONSTRUCTOR(T)>>
+inline void memzero(T& t) {
+  // Zero-initialize memory region belonging to t. Type-safe wrapper around `memset`.
+  memset(&t, 0, sizeof(T));
+}
+
 }  // namespace kj
 
 constexpr kj::ArrayPtr<const kj::byte> operator "" _kjb(const char* str, size_t n) {


### PR DESCRIPTION
This PR introduces `kj::memzero<T>()` utility to 0-initialize memory. It is intended to be used as a type-safe alternative to some usages of `memset` (other additions are coming).

The provided `kj::memzero<T>(T&)` version works for normal storage as well as for arrays.

An alternative design is to define `kj::memzero<T>(T*)` but that wouldn't let us provide array version and is
less type-safe (because you can pass array to it).