### PR TITLE
kj::ArrrayPtr<T>::fill()

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -926,6 +926,33 @@ KJ_TEST("kj::ArrayPtr startsWith / endsWith / findFirst / findLast") {
   KJ_EXPECT(arr.findLast(78).orDefault(100) == 100);
 }
 
+KJ_TEST("kj::ArrayPtr fill") {
+  int64_t int64Array[] = {12, 34, 56, 34, 12};
+  arrayPtr(int64Array).fill(42);
+  for (auto i: int64Array) {
+    KJ_EXPECT(i == 42);
+  }
+
+  // test small sizes separately, since compilers do a memset optimization
+  byte byteArray[256];
+  arrayPtr(byteArray).fill(42);
+  for (auto b: byteArray) {
+    KJ_EXPECT(b == 42);
+  }
+
+  // test an object
+  struct SomeObject {
+    int64_t i;
+    double d;
+  };
+  SomeObject objs[256];
+  arrayPtr(objs).fill(SomeObject{42, 3.1415926});
+  for (auto& o: objs) {
+    KJ_EXPECT(o.i == 42);
+    KJ_EXPECT(o.d == 3.1415926);
+  }
+}
+
 struct Std {
   template<typename T>
   static std::span<T> from(ArrayPtr<T>* arr) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1935,6 +1935,14 @@ public:
   // Syntax sugar for invoking U::from.
   // Used to chain conversion calls rather than wrap with function.
 
+  inline void fill(T t) { 
+    // Fill the area by copying t over every element.
+
+    for (size_t i = 0; i < size_; i++) { ptr[i] = t; } 
+    // All modern compilers are smart enough to optimize this loop for simple T's.
+    // libc++ std::fill doesn't have memset specialization either.
+  }
+
 private:
   T* ptr;
   size_t size_;


### PR DESCRIPTION
This is another memset alternative: `kj::ArrayPtr::fill()` function.

The implementation uses memset for small T and normal for-loop otherwise which should be easy to vectorize.