### PR TITLE
Add Array::slice(start) methods

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -523,5 +523,51 @@ KJ_TEST("Array::as<Std>") {
   KJ_EXPECT(stdArr.size() == 3);
 }
 
+KJ_TEST("Array::slice(start, end)") {
+  kj::Array<int> arr = kj::arr(0, 1, 2, 3);
+
+  // full slice
+  KJ_EXPECT(arr.slice(0, 4) == arr);
+  // slice from only start
+  KJ_EXPECT(arr.slice(1, 4) == kj::arr(1, 2, 3));
+  // slice from only end
+  KJ_EXPECT(arr.slice(0, 3) == kj::arr(0, 1, 2));
+  // slice from start and end
+  KJ_EXPECT(arr.slice(1, 3) == kj::arr(1, 2));
+
+  // empty slices
+  for (auto i : kj::zeroTo(arr.size())) {
+    KJ_EXPECT(arr.slice(i, i).size() == 0);
+  }
+
+  // start > end
+  KJ_EXPECT_THROW(FAILED, arr.slice(2, 1));
+  // end > size
+  KJ_EXPECT_THROW(FAILED, arr.slice(2, 5));
+}
+
+KJ_TEST("Array::slice(start, end) const") {
+  const kj::Array<int> arr = kj::arr(0, 1, 2, 3);
+
+  // full slice
+  KJ_EXPECT(arr.slice(0, 4) == arr);
+  // slice from only start
+  KJ_EXPECT(arr.slice(1, 4) == kj::arr(1, 2, 3));
+  // slice from only end
+  KJ_EXPECT(arr.slice(0, 3) == kj::arr(0, 1, 2));
+  // slice from start and end
+  KJ_EXPECT(arr.slice(1, 3) == kj::arr(1, 2));
+
+  // empty slices
+  for (auto i : kj::zeroTo(arr.size())) {
+    KJ_EXPECT(arr.slice(i, i).size() == 0);
+  }
+
+  // start > end
+  KJ_EXPECT_THROW(FAILED, arr.slice(2, 1));
+  // end > size
+  KJ_EXPECT_THROW(FAILED, arr.slice(2, 5));
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -569,5 +569,31 @@ KJ_TEST("Array::slice(start, end) const") {
   KJ_EXPECT_THROW(FAILED, arr.slice(2, 5));
 }
 
+KJ_TEST("Array::slice(start)") {
+  kj::Array<int> arr = kj::arr(0, 1, 2, 3);
+
+  KJ_EXPECT(arr.slice(0) == arr);
+  KJ_EXPECT(arr.slice(1) == kj::arr(1, 2, 3));
+  KJ_EXPECT(arr.slice(2) == kj::arr(2, 3));
+  KJ_EXPECT(arr.slice(3) == kj::arr(3));
+  KJ_EXPECT(arr.slice(4).size() == 0);
+
+  // start > size
+  KJ_EXPECT_THROW(FAILED, arr.slice(5));
+}
+
+KJ_TEST("Array::slice(start) const") {
+  const kj::Array<int> arr = kj::arr(0, 1, 2, 3);
+
+  KJ_EXPECT(arr.slice(0) == arr);
+  KJ_EXPECT(arr.slice(1) == kj::arr(1, 2, 3));
+  KJ_EXPECT(arr.slice(2) == kj::arr(2, 3));
+  KJ_EXPECT(arr.slice(3) == kj::arr(3));
+  KJ_EXPECT(arr.slice(4).size() == 0);
+
+  // start > size
+  KJ_EXPECT_THROW(FAILED, arr.slice(5));
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -189,6 +189,14 @@ public:
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().");
     return ArrayPtr<const T>(ptr + start, end - start);
   }
+  inline ArrayPtr<T> slice(size_t start) KJ_LIFETIMEBOUND {
+    KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().");
+    return ArrayPtr<T>(ptr + start, size_ - start);
+  }
+  inline ArrayPtr<const T> slice(size_t start) const KJ_LIFETIMEBOUND {
+    KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().");
+    return ArrayPtr<const T>(ptr + start, size_ - start);
+  }
 
   inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asPtr().asBytes(); }
   inline ArrayPtr<PropagateConst<T, byte>> asBytes() KJ_LIFETIMEBOUND { return asPtr().asBytes(); }


### PR DESCRIPTION
We have the single-parameter slice methods in ArrayPtr and they’re
really convenient.  While it’s always possible to use Array::asPtr()
to convert an Array to an ArrayPtr, that’s extra noise when we could
add these methods on Array directly.
