### PR TITLE
first(size_t count) sequences helper method

### DIFF
--- a/c++/src/capnp/blob.h
+++ b/c++/src/capnp/blob.h
@@ -182,19 +182,19 @@ inline kj::StringPtr Text::Builder::asString() const {
 }
 
 inline Text::Builder::operator kj::ArrayPtr<char>() {
-  return content.slice(0, content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline kj::ArrayPtr<char> Text::Builder::asArray() {
-  return content.slice(0, content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline Text::Builder::operator kj::ArrayPtr<const char>() const {
-  return content.slice(0, content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline kj::ArrayPtr<const char> Text::Builder::asArray() const {
-  return content.slice(0, content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline kj::StringPtr Text::Builder::slice(size_t start) const {

--- a/c++/src/capnp/compat/byte-stream-test.c++
+++ b/c++/src/capnp/compat/byte-stream-test.c++
@@ -38,7 +38,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
 
-    auto actual = buffer.slice(0, amount);
+    auto actual = buffer.first(amount);
     if (memcmp(actual.begin(), expected.begin(), actual.size()) != 0) {
       KJ_FAIL_ASSERT("data from stream doesn't match expected", expected, actual);
     }

--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -1147,7 +1147,7 @@ private:
     if (splitByte == 0) {
       // Oh thank god, the split is between two pieces.
       auto rest = pieces.slice(splitPiece, pieces.size());
-      return writeFirstPieces(pieces.slice(0, splitPiece))
+      return writeFirstPieces(pieces.first(splitPiece))
           .then([this,rest]() mutable {
         return write(rest);
       });
@@ -1161,7 +1161,7 @@ private:
       for (auto i: kj::zeroTo(right.size())) {
         right[i] = pieces[splitPiece + i];
       }
-      left.back() = pieces[splitPiece].slice(0, splitByte);
+      left.back() = pieces[splitPiece].first(splitByte);
       right.front() = pieces[splitPiece].slice(splitByte, pieces[splitPiece].size());
 
       return writeFirstPieces(left).attach(kj::mv(left))

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -51,7 +51,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
 
-    auto actual = buffer.slice(0, amount);
+    auto actual = buffer.first(amount);
     if (memcmp(actual.begin(), expected.begin(), actual.size()) != 0) {
       KJ_FAIL_ASSERT("data from stream doesn't match expected", expected, actual);
     }

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -576,7 +576,7 @@ public:
   void consume(kj::ArrayPtr<const char> expected) {
     KJ_REQUIRE(wrapped.size() >= expected.size());
 
-    auto prefix = wrapped.slice(0, expected.size());
+    auto prefix = wrapped.first(expected.size());
     KJ_REQUIRE(prefix == expected, "Unexpected input in JSON message.");
 
     advance(expected.size());

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -387,7 +387,7 @@ public:
   kj::MainBuilder::Validity addOutput(kj::StringPtr spec) {
     KJ_IF_SOME(split, spec.findFirst(':')) {
       kj::StringPtr dir = spec.slice(split + 1);
-      auto plugin = spec.slice(0, split);
+      auto plugin = spec.first(split);
 
       if (split == 1 && (dir.startsWith("/") || dir.startsWith("\\"))) {
         // The colon is the second character and is immediately followed by a slash or backslash.
@@ -420,7 +420,7 @@ public:
           // We therefore conclude that the *second* colon is in fact the plugin/location separator.
 
           dir = dir.slice(split2 + 1);
-          plugin = spec.slice(0, split2 + 2);
+          plugin = spec.first(split2 + 2);
 #if _WIN32
         } else {
           // The user wrote something like:
@@ -716,7 +716,7 @@ private:
 public:
   kj::MainBuilder::Validity setConversion(kj::StringPtr conversion) {
     KJ_IF_SOME(colon, conversion.findFirst(':')) {
-      auto from = kj::str(conversion.slice(0, colon));
+      auto from = kj::str(conversion.first(colon));
       auto to = conversion.slice(colon + 1);
 
       KJ_IF_SOME(f, parseFormatName(from)) {
@@ -823,7 +823,7 @@ private:
                 if (depth == 0 && sawClose) {
                   // We already got one complete message. This is the start of the next message.
                   // Stop here.
-                  chars.addAll(buffer.slice(0, i));
+                  chars.addAll(buffer.first(i));
                   chars.add('\0');
                   input.skip(i);
                   return kj::String(chars.releaseAsArray());
@@ -918,7 +918,7 @@ private:
                 if (depth == 0 && sawClose) {
                   // We already got one complete message. This is the start of the next message.
                   // Stop here.
-                  chars.addAll(buffer.slice(0, i));
+                  chars.addAll(buffer.first(i));
                   chars.add('\0');
                   input.skip(i);
                   return kj::String(chars.releaseAsArray());
@@ -1757,12 +1757,12 @@ public:
           if (subscript < listValue.size()) {
             value = listValue[subscript];
           } else {
-            return kj::str("'", partName, "[", kj::strArray(subscripts.slice(0, i + 1), "]["),
+            return kj::str("'", partName, "[", kj::strArray(subscripts.first(i + 1), "]["),
                            "]' is out-of-bounds.");
           }
         } else {
           if (i > 0) {
-            return kj::str("'", partName, "[", kj::strArray(subscripts.slice(0, i), "]["),
+            return kj::str("'", partName, "[", kj::strArray(subscripts.first(i), "]["),
                            "]' is not a list.");
           } else {
             return kj::str("'", partName, "' is not a list.");

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -3010,7 +3010,7 @@ private:
 
         for (;;) {
           KJ_IF_SOME(colonPos, ns.findFirst(':')) {
-            namespaceParts.add(ns.slice(0, colonPos));
+            namespaceParts.add(ns.first(colonPos));
             ns = ns.slice(colonPos);
             if (!ns.startsWith("::")) {
               context.exitError(kj::str(displayName, ": invalid namespace spec: ", ns2));

--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -1498,7 +1498,7 @@ const _::RawBrandedSchema* SchemaLoader::Impl::makeBranded(
     }
   }
 
-  dstScopes = dstScopes.slice(0, dstScopeCount);
+  dstScopes = dstScopes.first(dstScopeCount);
 
   std::sort(dstScopes.begin(), dstScopes.end(),
       [](const _::RawBrandedSchema::Scope& a, const _::RawBrandedSchema::Scope& b) {

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -219,7 +219,7 @@ kj::Promise<MessageReaderAndFds> readMessage(
   return promise.then([reader = kj::mv(reader), fdSpace](kj::Maybe<size_t> nfds) mutable
                       -> MessageReaderAndFds {
     KJ_IF_SOME(n, nfds) {
-      return { kj::mv(reader), fdSpace.slice(0, n) };
+      return { kj::mv(reader), fdSpace.first(n) };
     } else {
       kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED, "Premature EOF."));
       return { kj::mv(reader), nullptr };
@@ -235,7 +235,7 @@ kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
   return promise.then([reader = kj::mv(reader), fdSpace](kj::Maybe<size_t> nfds) mutable
                       -> kj::Maybe<MessageReaderAndFds> {
     KJ_IF_SOME(n, nfds) {
-      return MessageReaderAndFds { kj::mv(reader), fdSpace.slice(0, n) };
+      return MessageReaderAndFds { kj::mv(reader), fdSpace.first(n) };
     } else {
       return kj::none;
     }
@@ -693,7 +693,7 @@ kj::Promise<kj::Maybe<MessageReaderAndFds>> BufferedMessageStream::tryReadMessag
 
     return kj::Maybe<MessageReaderAndFds>(MessageReaderAndFds {
       kj::mv(reader),
-      fdSpace.slice(0, fdsSoFar)
+      fdSpace.first(fdsSoFar)
     });
   }
 
@@ -834,7 +834,7 @@ kj::Promise<kj::Maybe<MessageReaderAndFds>> BufferedMessageStream::readEntireMes
 
     return kj::Maybe<MessageReaderAndFds>(MessageReaderAndFds {
       kj::heap<MessageReaderImpl>(kj::mv(msgBuffer), options),
-      fdSpace.slice(0, fdsSoFar)
+      fdSpace.first(fdsSoFar)
     });
   });
 }

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -113,10 +113,10 @@ TEST(Serialize, FlatArray) {
   {
     // Test expectedSizeInWordsFromPrefix(). We pass in a copy of the slice so that valgrind can
     // detect out-of-bounds access.
-    EXPECT_EQ(1, expectedSizeInWordsFromPrefix(copyWords(serialized.slice(0, 0))));
+    EXPECT_EQ(1, expectedSizeInWordsFromPrefix(copyWords(serialized.first(0))));
     for (uint i = 1; i <= serialized.size(); i++) {
       EXPECT_EQ(serialized.size(),
-          expectedSizeInWordsFromPrefix(copyWords(serialized.slice(0, i))));
+          expectedSizeInWordsFromPrefix(copyWords(serialized.first(i))));
     }
   }
 }
@@ -148,14 +148,14 @@ TEST(Serialize, FlatArrayOddSegmentCount) {
 
     // Segment table is 4 words, so with fewer words we'll have incomplete information.
     for (uint i = 0; i < 4; i++) {
-      size_t expectedSize = expectedSizeInWordsFromPrefix(copyWords(serialized.slice(0, i)));
+      size_t expectedSize = expectedSizeInWordsFromPrefix(copyWords(serialized.first(i)));
       EXPECT_LT(expectedSize, serialized.size());
       EXPECT_GT(expectedSize, i);
     }
     // After that, we get the exact length.
     for (uint i = 4; i <= serialized.size(); i++) {
       EXPECT_EQ(serialized.size(),
-          expectedSizeInWordsFromPrefix(copyWords(serialized.slice(0, i))));
+          expectedSizeInWordsFromPrefix(copyWords(serialized.first(i))));
     }
   }
 }
@@ -187,14 +187,14 @@ TEST(Serialize, FlatArrayEvenSegmentCount) {
 
     // Segment table is 6 words, so with fewer words we'll have incomplete information.
     for (uint i = 0; i < 6; i++) {
-      size_t expectedSize = expectedSizeInWordsFromPrefix(copyWords(serialized.slice(0, i)));
+      size_t expectedSize = expectedSizeInWordsFromPrefix(copyWords(serialized.first(i)));
       EXPECT_LT(expectedSize, serialized.size());
       EXPECT_GT(expectedSize, i);
     }
     // After that, we get the exact length.
     for (uint i = 6; i <= serialized.size(); i++) {
       EXPECT_EQ(serialized.size(),
-          expectedSizeInWordsFromPrefix(copyWords(serialized.slice(0, i))));
+          expectedSizeInWordsFromPrefix(copyWords(serialized.first(i))));
     }
   }
 }

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -212,7 +212,7 @@ InputStreamMessageReader::InputStreamMessageReader(
     scratchSpace = ownedSpace;
   }
 
-  segment0 = scratchSpace.slice(0, segment0Size);
+  segment0 = scratchSpace.first(segment0Size);
 
   if (segmentCount > 1) {
     moreSegments = kj::heapArray<kj::ArrayPtr<const word>>(segmentCount - 1);

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -198,6 +198,9 @@ public:
     return ArrayPtr<const T>(ptr + start, size_ - start);
   }
 
+  inline ArrayPtr<T> first(size_t count) KJ_LIFETIMEBOUND { return slice(0, count); }
+  inline ArrayPtr<const T> first(size_t count) const KJ_LIFETIMEBOUND { return slice(0, count); }
+
   inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asPtr().asBytes(); }
   inline ArrayPtr<PropagateConst<T, byte>> asBytes() KJ_LIFETIMEBOUND { return asPtr().asBytes(); }
   inline ArrayPtr<const char> asChars() const KJ_LIFETIMEBOUND { return asPtr().asChars(); }

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1068,7 +1068,7 @@ public:
         if (str.slice(colon + 1).findFirst(':') == kj::none) {
           // There is exactly one colon and no brackets, so it must be an ip4 address with port.
           af = AF_INET;
-          addrPart = str.slice(0, colon);
+          addrPart = str.first(colon);
           portPart = str.slice(colon + 1);
         } else {
           // There are two or more colons and no brackets, so the whole thing must be an ip6
@@ -1923,7 +1923,7 @@ public:
   }
 
   MaybeTruncated<ArrayPtr<const byte>> getContent() override {
-    return { contentBuffer.slice(0, receivedSize), contentTruncated };
+    return { contentBuffer.first(receivedSize), contentTruncated };
   }
 
   MaybeTruncated<ArrayPtr<const AncillaryMessage>> getAncillary() override {

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -584,7 +584,7 @@ public:
         if (str.slice(colon + 1).findFirst(':') == kj::none) {
           // There is exactly one colon and no brackets, so it must be an ip4 address with port.
           af = AF_INET;
-          addrPart = str.slice(0, colon);
+          addrPart = str.first(colon);
           portPart = str.slice(colon + 1);
         } else {
           // There are two or more colons and no brackets, so the whole thing must be an ip6

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1869,6 +1869,9 @@ public:
     return other.size() <= size_ && slice(size_ - other.size(), size_) == other;
   }
 
+  inline ArrayPtr first(size_t count) { return slice(0, count); }
+  inline ArrayPtr<const T> first(size_t count) const { return slice(0, count); }
+
   inline Maybe<size_t> findFirst(const T& match) const {
     for (size_t i = 0; i < size_; i++) {
       if (ptr[i] == match) {

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -523,7 +523,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
 
-    auto actual = buffer.slice(0, amount);
+    auto actual = buffer.first(amount);
     if (memcmp(actual.begin(), expected.begin(), actual.size()) != 0) {
       KJ_FAIL_ASSERT("data from stream doesn't match expected", expected, actual);
     }
@@ -543,7 +543,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::ArrayPtr<const byte> 
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
 
-    auto actual = buffer.slice(0, amount);
+    auto actual = buffer.first(amount);
     if (memcmp(actual.begin(), expected.begin(), actual.size()) != 0) {
       KJ_FAIL_ASSERT("data from stream doesn't match expected", expected, actual);
     }
@@ -1935,7 +1935,7 @@ KJ_TEST("WebSocket unexpected RSV bits") {
   }
 
   auto nread = clientTask.wait(waitScope);
-  assertContainsWebSocketClose(rawCloseMessage.slice(0, nread), 1002, "RSV bits"_kjc);
+  assertContainsWebSocketClose(rawCloseMessage.first(nread), 1002, "RSV bits"_kjc);
 }
 
 KJ_TEST("WebSocket unexpected continuation frame") {
@@ -1965,7 +1965,7 @@ KJ_TEST("WebSocket unexpected continuation frame") {
   }
 
   auto nread = clientTask.wait(waitScope);
-  assertContainsWebSocketClose(rawCloseMessage.slice(0, nread), 1002, "Unexpected continuation frame"_kjc);
+  assertContainsWebSocketClose(rawCloseMessage.first(nread), 1002, "Unexpected continuation frame"_kjc);
 }
 
 KJ_TEST("WebSocket missing continuation frame") {
@@ -1995,7 +1995,7 @@ KJ_TEST("WebSocket missing continuation frame") {
   }
 
   auto nread = clientTask.wait(waitScope);
-  assertContainsWebSocketClose(rawCloseMessage.slice(0, nread), 1002, "Missing continuation frame"_kjc);
+  assertContainsWebSocketClose(rawCloseMessage.first(nread), 1002, "Missing continuation frame"_kjc);
 }
 
 KJ_TEST("WebSocket fragmented control frame") {
@@ -2025,7 +2025,7 @@ KJ_TEST("WebSocket fragmented control frame") {
   }
 
   auto nread = clientTask.wait(waitScope);
-  assertContainsWebSocketClose(rawCloseMessage.slice(0, nread), 1002, "Received fragmented control frame"_kjc);
+  assertContainsWebSocketClose(rawCloseMessage.first(nread), 1002, "Received fragmented control frame"_kjc);
 }
 
 KJ_TEST("WebSocket unknown opcode") {
@@ -2055,7 +2055,7 @@ KJ_TEST("WebSocket unknown opcode") {
   }
 
   auto nread = clientTask.wait(waitScope);
-  assertContainsWebSocketClose(rawCloseMessage.slice(0, nread), 1002, "Unknown opcode 5"_kjc);
+  assertContainsWebSocketClose(rawCloseMessage.first(nread), 1002, "Unknown opcode 5"_kjc);
 }
 
 KJ_TEST("WebSocket unsolicited pong") {
@@ -2463,7 +2463,7 @@ KJ_TEST("WebSocket maximum message size") {
   }
 
   auto nread = clientTask.wait(waitScope);
-  assertContainsWebSocketClose(rawCloseMessage.slice(0, nread), 1009, "too large"_kjc);
+  assertContainsWebSocketClose(rawCloseMessage.first(nread), 1009, "too large"_kjc);
 }
 
 class TestWebSocketService final: public HttpService, private kj::TaskSet::ErrorHandler {

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1519,7 +1519,7 @@ public:
         co_return false;
       }
 
-      leftover = headerBuffer.slice(0, amount);
+      leftover = headerBuffer.first(amount);
     }
   }
 
@@ -2707,7 +2707,7 @@ public:
         if (recvData.size() > 0) {
           memmove(recvBuffer.begin(), recvData.begin(), recvData.size());
         }
-        recvData = recvBuffer.slice(0, recvData.size());
+        recvData = recvBuffer.first(recvData.size());
       }
 
       return stream->tryRead(recvData.end(), 1, recvBuffer.end() - recvData.end())
@@ -2723,7 +2723,7 @@ public:
           }
         }
 
-        recvData = recvBuffer.slice(0, recvData.size() + actual);
+        recvData = recvBuffer.first(recvData.size() + actual);
         return receive(maxSize);
       });
     }
@@ -3520,7 +3520,7 @@ private:
         auto& innerMessage = compressedMessage.emplace(compressor.processMessage(message));
         if (message.size() > 0) {
           KJ_ASSERT(innerMessage.asPtr().endsWith({0x00, 0x00, 0xFF, 0xFF}));
-          message = innerMessage.slice(0, innerMessage.size() - 4);
+          message = innerMessage.first(innerMessage.size() - 4);
           // Strip 0x00 0x00 0xFF 0xFF off the tail.
           // See: https://datatracker.ietf.org/doc/html/rfc7692#section-7.2.1
         } else {
@@ -4785,7 +4785,7 @@ kj::ArrayPtr<const char> splitNext(kj::ArrayPtr<const char>& cursor, char delimi
   //
   // (It's up to the caller to stop the loop once `cursor` is empty.)
   KJ_IF_SOME(index, cursor.findFirst(delimiter)) {
-    auto part = cursor.slice(0, index);
+    auto part = cursor.first(index);
     cursor = cursor.slice(index + 1, cursor.size());
     return part;
   }
@@ -4801,7 +4801,7 @@ void stripLeadingAndTrailingSpace(ArrayPtr<const char>& str) {
     str = str.slice(1, str.size());
   }
   while (str.size() > 0 && (str.back() == ' ' || str.back() == '\t')) {
-    str = str.slice(0, str.size() - 1);
+    str = str.first(str.size() - 1);
   }
 }
 
@@ -4832,7 +4832,7 @@ kj::Array<KeyMaybeVal> toKeysAndVals(const kj::ArrayPtr<kj::ArrayPtr<const char>
 
     KJ_IF_SOME(index, param.findFirst('=')) {
       // Found '=' so we have a value.
-      key = param.slice(0, index);
+      key = param.first(index);
       stripLeadingAndTrailingSpace(key);
       value = param.slice(index + 1, param.size());
       KJ_IF_SOME(v, value) {
@@ -7888,7 +7888,7 @@ private:
       if (headers.get(HttpHeaderId::CONTENT_LENGTH) != kj::none ||
           headers.get(HttpHeaderId::TRANSFER_ENCODING) != kj::none) {
         connectionHeadersArray = connectionHeadersArray
-            .slice(0, HttpHeaders::HEAD_RESPONSE_CONNECTION_HEADERS_COUNT);
+            .first(HttpHeaders::HEAD_RESPONSE_CONNECTION_HEADERS_COUNT);
       }
     }
 

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -1203,7 +1203,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
 
-    auto actual = buffer.slice(0, amount);
+    auto actual = buffer.first(amount);
     if (memcmp(actual.begin(), expected.begin(), actual.size()) != 0) {
       KJ_FAIL_ASSERT("data from stream doesn't match expected", expected, actual);
     }

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -670,7 +670,7 @@ public:
         // rather cumbersome and actually broke code in the Workers Runtime that does complicated
         // stacking of kj::Network implementations.
         KJ_IF_SOME(pos, addr.findFirst(':')) {
-          hostname = kj::heapString(addr.slice(0, pos));
+          hostname = kj::heapString(addr.first(pos));
         } else {
           hostname = kj::heapString(addr);
         }

--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -85,7 +85,7 @@ void toLower(String& text) {
 
 Maybe<ArrayPtr<const char>> trySplit(StringPtr& text, char c) {
   KJ_IF_SOME(pos, text.findFirst(c)) {
-    ArrayPtr<const char> result = text.slice(0, pos);
+    ArrayPtr<const char> result = text.first(pos);
     text = text.slice(pos + 1);
     return result;
   } else {
@@ -96,7 +96,7 @@ Maybe<ArrayPtr<const char>> trySplit(StringPtr& text, char c) {
 Maybe<ArrayPtr<const char>> trySplit(ArrayPtr<const char>& text, char c) {
   for (auto i: kj::indices(text)) {
     if (text[i] == c) {
-      ArrayPtr<const char> result = text.slice(0, i);
+      ArrayPtr<const char> result = text.first(i);
       text = text.slice(i + 1, text.size());
       return result;
     }
@@ -107,7 +107,7 @@ Maybe<ArrayPtr<const char>> trySplit(ArrayPtr<const char>& text, char c) {
 ArrayPtr<const char> split(StringPtr& text, const parse::CharGroup_& chars) {
   for (auto i: kj::indices(text)) {
     if (chars.contains(text[i])) {
-      ArrayPtr<const char> result = text.slice(0, i);
+      ArrayPtr<const char> result = text.first(i);
       text = text.slice(i);
       return result;
     }
@@ -295,7 +295,7 @@ Maybe<Url> Url::tryParseRelative(StringPtr text) const {
     for (auto i: kj::indices(text)) {
       if (text[i] == ':') {
         // found valid scheme
-        result.scheme = kj::str(text.slice(0, i));
+        result.scheme = kj::str(text.first(i));
         text = text.slice(i + 1);
         gotScheme = true;
         break;
@@ -357,7 +357,7 @@ Maybe<Url> Url::tryParseRelative(StringPtr text) const {
     } else if (this->path.size() > 0) {
       // New path is relative, so start from the old path, dropping everything after the last
       // slash.
-      auto slice = this->path.slice(0, this->path.size() - (this->hasTrailingSlash ? 0 : 1));
+      auto slice = this->path.first(this->path.size() - (this->hasTrailingSlash ? 0 : 1));
       result.path = KJ_MAP(part, slice) { return kj::str(part); };
       result.hasTrailingSlash = true;
     }

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -289,7 +289,7 @@ TEST(Debug, Catch) {
     KJ_IF_SOME(e, exception) {
       String what = str(e);
       KJ_IF_SOME(eol, what.findFirst('\n')) {
-        what = kj::str(what.slice(0, eol));
+        what = kj::str(what.first(eol));
       }
       std::string text(what.cStr());
       EXPECT_EQ(fileLine(__FILE__, line) + ": failed: foo", text);
@@ -307,7 +307,7 @@ TEST(Debug, Catch) {
     KJ_IF_SOME(e, exception) {
       String what = str(e);
       KJ_IF_SOME(eol, what.findFirst('\n')) {
-        what = kj::str(what.slice(0, eol));
+        what = kj::str(what.first(eol));
       }
       std::string text(what.cStr());
       EXPECT_EQ(fileLine(__FILE__, line) + ": failed: foo", text);

--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -331,7 +331,7 @@ KJ_TEST("URI encoding/decoding") {
     auto bytesWithNul = decodeBinaryUriComponent(encodeUriComponent(bytes), true);
     KJ_ASSERT(bytesWithNul.size() == 4);
     KJ_EXPECT(bytesWithNul[3] == '\0');
-    KJ_EXPECT(bytesWithNul.slice(0, 3) == bytes);
+    KJ_EXPECT(bytesWithNul.first(3) == bytes);
   }
 }
 

--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -1021,7 +1021,7 @@ String encodeBase64Url(ArrayPtr<const byte> bytes) {
   // Remove trailing '='s.
   kj::ArrayPtr<const char> slice = base64;
   while (slice.size() > 0 && slice.back() == '=') {
-    slice = slice.slice(0, slice.size() - 1);
+    slice = slice.first(slice.size() - 1);
   }
 
   return kj::str(slice);

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -237,7 +237,7 @@ ArrayPtr<void* const> getStackTrace(ArrayPtr<void*> space, uint ignoreCount) {
   return getStackTrace(space, ignoreCount, GetCurrentThread(), context);
 #elif KJ_HAS_BACKTRACE
   size_t size = backtrace(space.begin(), space.size());
-  for (auto& addr: space.slice(0, size)) {
+  for (auto& addr: space.first(size)) {
     // The addresses produced by backtrace() are return addresses, which means they point to the
     // instruction immediately after the call. Invoking addr2line on these can be confusing because
     // it often points to the next line. If the next instruction is inlined from another function,
@@ -845,7 +845,7 @@ void Exception::extendTrace(uint ignoreCount, uint limit) {
   auto newTrace = kj::getStackTrace(newTraceSpace, ignoreCount + 1);
   if (newTrace.size() > ignoreCount + 2) {
     // Remove suffix that won't fit into our static-sized trace.
-    newTrace = newTrace.slice(0, kj::min(kj::size(trace) - traceCount, newTrace.size()));
+    newTrace = newTrace.first(kj::min(kj::size(trace) - traceCount, newTrace.size()));
 
     // Copy the rest into our trace.
     memcpy(trace + traceCount, newTrace.begin(), newTrace.asBytes().size());
@@ -1272,8 +1272,8 @@ size_t sharedSuffixLength(kj::ArrayPtr<void* const> a, kj::ArrayPtr<void* const>
   size_t result = 0;
   while (a.size() > 0 && b.size() > 0 && a.back() == b.back())  {
     ++result;
-    a = a.slice(0, a.size() - 1);
-    b = b.slice(0, b.size() - 1);
+    a = a.first(a.size() - 1);
+    b = b.first(b.size() - 1);
   }
   return result;
 }
@@ -1299,14 +1299,14 @@ kj::ArrayPtr<void* const> computeRelativeTrace(
        i <= (ssize_t)(relativeTo.size() - MIN_MATCH_LEN);
        i++) {
     // Negative values truncate `trace`, positive values truncate `relativeTo`.
-    kj::ArrayPtr<void* const> subtrace = trace.slice(0, trace.size() - kj::max<ssize_t>(0, -i));
+    kj::ArrayPtr<void* const> subtrace = trace.first(trace.size() - kj::max<ssize_t>(0, -i));
     kj::ArrayPtr<void* const> subrt = relativeTo
-        .slice(0, relativeTo.size() - kj::max<ssize_t>(0, i));
+        .first(relativeTo.size() - kj::max<ssize_t>(0, i));
 
     uint matchLen = sharedSuffixLength(subtrace, subrt);
     if (matchLen > bestMatchLen) {
       bestMatchLen = matchLen;
-      bestMatch = subtrace.slice(0, subtrace.size() - matchLen + 1);
+      bestMatch = subtrace.first(subtrace.size() - matchLen + 1);
     }
   }
 

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -326,25 +326,25 @@ KJ_TEST("DiskFile") {
     KJ_EXPECT(privateMapping.begin() != mapping.begin());
     KJ_EXPECT(writableMapping->get().begin() != privateMapping.begin());
 
-    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "foobaz");
-    KJ_EXPECT(kj::str(writableMapping->get().slice(0, 6).asChars()) == "foobaz");
-    KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(writableMapping->get().first(6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "foobaz");
 
     privateMapping[0] = 'F';
-    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "foobaz");
-    KJ_EXPECT(kj::str(writableMapping->get().slice(0, 6).asChars()) == "foobaz");
-    KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "Foobaz");
+    KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(writableMapping->get().first(6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "Foobaz");
 
     writableMapping->get()[1] = 'D';
     writableMapping->changed(writableMapping->get().slice(1, 2));
-    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "fDobaz");
-    KJ_EXPECT(kj::str(writableMapping->get().slice(0, 6).asChars()) == "fDobaz");
-    KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "Foobaz");
+    KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "fDobaz");
+    KJ_EXPECT(kj::str(writableMapping->get().first(6).asChars()) == "fDobaz");
+    KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "Foobaz");
 
     file->write(0, StringPtr("qux").asBytes());
-    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "quxbaz");
-    KJ_EXPECT(kj::str(writableMapping->get().slice(0, 6).asChars()) == "quxbaz");
-    KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "Foobaz");
+    KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "quxbaz");
+    KJ_EXPECT(kj::str(writableMapping->get().first(6).asChars()) == "quxbaz");
+    KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "Foobaz");
 
     file->write(12, StringPtr("corge").asBytes());
     KJ_EXPECT(kj::str(mapping.slice(12, 17).asChars()) == "corge");

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -149,7 +149,7 @@ static Array<wchar_t> join16(ArrayPtr<const wchar_t> path, const wchar_t* file) 
 
 static String dbgStr(ArrayPtr<const wchar_t> wstr) {
   if (wstr.size() > 0 && wstr[wstr.size() - 1] == L'\0') {
-    wstr = wstr.slice(0, wstr.size() - 1);
+    wstr = wstr.first(wstr.size() - 1);
   }
   return decodeWideString(wstr);
 }
@@ -261,7 +261,7 @@ static Path getPathFromHandle(HANDLE handle) {
       KJ_FAIL_WIN32("GetFinalPathNameByHandleW", GetLastError());
     }
     if (len < temp.size()) {
-      return Path::parseWin32Api(temp.slice(0, len));
+      return Path::parseWin32Api(temp.first(len));
     }
     // Try again with new length.
     tryLen = len;
@@ -1543,7 +1543,7 @@ private:
         return Path(".");
       }
       if (len < temp.size()) {
-        return Path::parseWin32Api(temp.slice(0, len));
+        return Path::parseWin32Api(temp.first(len));
       }
       // Try again with new length.
       tryLen = len;

--- a/c++/src/kj/filesystem-test.c++
+++ b/c++/src/kj/filesystem-test.c++
@@ -337,14 +337,14 @@ KJ_TEST("InMemoryFile") {
     KJ_EXPECT(writableMapping->get().begin() == mapping.begin());
     KJ_EXPECT(privateMapping.begin() != mapping.begin());
 
-    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "foobaz");
-    KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "foobaz");
     clock.expectUnchanged(*file);
 
     file->write(0, StringPtr("qux").asBytes());
     clock.expectChanged(*file);
-    KJ_EXPECT(kj::str(mapping.slice(0, 6).asChars()) == "quxbaz");
-    KJ_EXPECT(kj::str(privateMapping.slice(0, 6).asChars()) == "foobaz");
+    KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "quxbaz");
+    KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "foobaz");
 
     file->write(12, StringPtr("corge").asBytes());
     KJ_EXPECT(kj::str(mapping.slice(12, 17).asChars()) == "corge");
@@ -361,9 +361,9 @@ KJ_TEST("InMemoryFile") {
     KJ_EXPECT_THROW_MESSAGE("cannot resize the file backing store", file->truncate(100));
 
     clock.expectChanged(*file);
-    writableMapping->changed(writableMapping->get().slice(0, 3));
+    writableMapping->changed(writableMapping->get().first(3));
     clock.expectChanged(*file);
-    writableMapping->sync(writableMapping->get().slice(0, 3));
+    writableMapping->sync(writableMapping->get().first(3));
     clock.expectChanged(*file);
   }
 

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -125,11 +125,11 @@ Path Path::basename() && {
 
 PathPtr PathPtr::parent() const {
   KJ_REQUIRE(parts.size() > 0, "root path has no parent");
-  return PathPtr(parts.slice(0, parts.size() - 1));
+  return PathPtr(parts.first(parts.size() - 1));
 }
 Path Path::parent() && {
   KJ_REQUIRE(parts.size() > 0, "root path has no parent");
-  return Path(KJ_MAP(p, parts.slice(0, parts.size() - 1)) { return kj::mv(p); }, ALREADY_CHECKED);
+  return Path(KJ_MAP(p, parts.first(parts.size() - 1)) { return kj::mv(p); }, ALREADY_CHECKED);
 }
 
 String PathPtr::toString(bool absolute) const {
@@ -175,7 +175,7 @@ bool PathPtr::operator< (PathPtr other) const {
 
 bool PathPtr::startsWith(PathPtr prefix) const {
   return parts.size() >= prefix.parts.size() &&
-         parts.slice(0, prefix.parts.size()) == prefix.parts;
+         parts.first(prefix.parts.size()) == prefix.parts;
 }
 
 bool PathPtr::endsWith(PathPtr suffix) const {
@@ -395,7 +395,7 @@ Path Path::evalWin32Impl(Vector<String>&& parts, StringPtr path, bool fromApi) {
       }
     }
   } else if ((path.size() == 2 || (path.size() > 2 && path[2] == '\\')) &&
-             isWin32Drive(path.slice(0, 2))) {
+             isWin32Drive(path.first(2))) {
     // Starts with a drive letter.
     parts.clear();
   } else {
@@ -494,7 +494,7 @@ String ReadableFile::readAllText() const {
   size_t n = read(0, result.asBytes());
   if (n < result.size()) {
     // Apparently file was truncated concurrently. Reduce to new size to match.
-    result = heapString(result.slice(0, n));
+    result = heapString(result.first(n));
   }
   return result;
 }
@@ -504,7 +504,7 @@ Array<byte> ReadableFile::readAllBytes() const {
   size_t n = read(0, result.asBytes());
   if (n < result.size()) {
     // Apparently file was truncated concurrently. Reduce to new size to match.
-    result = heapArray(result.slice(0, n));
+    result = heapArray(result.first(n));
   }
   return result;
 }

--- a/c++/src/kj/io-test.c++
+++ b/c++/src/kj/io-test.c++
@@ -160,7 +160,7 @@ KJ_TEST("InputStream::readAllText() / readAllBytes()") {
     for (size_t blockSize: blockSizes) {
       for (uint64_t limit: limits) {
         KJ_CONTEXT(inputSize, blockSize, limit);
-        auto textSlice = bigText.asBytes().slice(0, inputSize);
+        auto textSlice = bigText.asBytes().first(inputSize);
         auto readAllText = [&]() {
           MockInputStream input(textSlice, blockSize);
           return input.readAllText(limit);

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -129,7 +129,7 @@ BufferedInputStreamWrapper::~BufferedInputStreamWrapper() noexcept(false) {}
 ArrayPtr<const byte> BufferedInputStreamWrapper::tryGetReadBuffer() {
   if (bufferAvailable.size() == 0) {
     size_t n = inner.tryRead(buffer.begin(), 1, buffer.size());
-    bufferAvailable = buffer.slice(0, n);
+    bufferAvailable = buffer.first(n);
   }
 
   return bufferAvailable;
@@ -379,7 +379,7 @@ void FdOutputStream::write(ArrayPtr<const ArrayPtr<const byte>> pieces) {
 #else
   const size_t iovmax = miniposix::iovMax();
   while (pieces.size() > iovmax) {
-    write(pieces.slice(0, iovmax));
+    write(pieces.first(iovmax));
     pieces = pieces.slice(iovmax, pieces.size());
   }
 

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -773,7 +773,7 @@ void MainBuilder::MainImpl::wrapText(Vector<char>& output, StringPtr indent, Str
 
     KJ_IF_SOME(lineEnd, text.findFirst('\n')) {
       if (lineEnd <= width) {
-        output.addAll(text.slice(0, lineEnd + 1));
+        output.addAll(text.first(lineEnd + 1));
         text = text.slice(lineEnd + 1);
         continue;
       }
@@ -797,7 +797,7 @@ void MainBuilder::MainImpl::wrapText(Vector<char>& output, StringPtr indent, Str
       }
     }
 
-    output.addAll(text.slice(0, wrapPos));
+    output.addAll(text.first(wrapPos));
     output.add('\n');
 
     // Skip spaces after the text that was printed.

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -145,6 +145,9 @@ public:
   // A string slice is only NUL-terminated if it is a suffix, so slice() has a one-parameter
   // version that assumes end = size().
 
+  inline ArrayPtr<const char> first(size_t count) const;
+  // Return string prefix.
+
   inline bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
   inline bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
 
@@ -315,6 +318,9 @@ public:
   }
   inline ArrayPtr<const char> slice(size_t start, size_t end) const KJ_LIFETIMEBOUND {
     return StringPtr(*this).slice(start, end);
+  }
+  inline ArrayPtr<const char> first(size_t count) const KJ_LIFETIMEBOUND {
+    return StringPtr(*this).first(count);
   }
 
   inline Maybe<size_t> findFirst(char c) const { return asArray().findFirst(c); }
@@ -733,6 +739,9 @@ inline StringPtr StringPtr::slice(size_t start) const {
 }
 inline ArrayPtr<const char> StringPtr::slice(size_t start, size_t end) const {
   return content.slice(start, end);
+}
+inline ArrayPtr<const char> StringPtr::first(size_t count) const {
+  return content.slice(0, count);
 }
 
 inline LiteralStringConst::operator ConstString() const {

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -319,9 +319,7 @@ public:
   inline ArrayPtr<const char> slice(size_t start, size_t end) const KJ_LIFETIMEBOUND {
     return StringPtr(*this).slice(start, end);
   }
-  inline ArrayPtr<const char> first(size_t count) const KJ_LIFETIMEBOUND {
-    return StringPtr(*this).first(count);
-  }
+  inline ArrayPtr<const char> first(size_t count) const KJ_LIFETIMEBOUND { return slice(0, count); }
 
   inline Maybe<size_t> findFirst(char c) const { return asArray().findFirst(c); }
   inline Maybe<size_t> findLast(char c) const { return asArray().findLast(c); }
@@ -740,9 +738,7 @@ inline StringPtr StringPtr::slice(size_t start) const {
 inline ArrayPtr<const char> StringPtr::slice(size_t start, size_t end) const {
   return content.slice(start, end);
 }
-inline ArrayPtr<const char> StringPtr::first(size_t count) const {
-  return content.slice(0, count);
-}
+inline ArrayPtr<const char> StringPtr::first(size_t count) const { return slice(0, count); }
 
 inline LiteralStringConst::operator ConstString() const {
   return ConstString(begin(), size(), NullArrayDisposer::instance);
@@ -759,23 +755,23 @@ inline ConstString StringPtr::attach(Attachments&&... attachments) const {
 }
 
 inline String::operator ArrayPtr<char>() {
-  return content == nullptr ? ArrayPtr<char>(nullptr) : content.slice(0, content.size() - 1);
+  return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
 }
 inline String::operator ArrayPtr<const char>() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.slice(0, content.size() - 1);
+  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
 inline ConstString::operator ArrayPtr<const char>() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.slice(0, content.size() - 1);
+  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
 
 inline ArrayPtr<char> String::asArray() {
-  return content == nullptr ? ArrayPtr<char>(nullptr) : content.slice(0, content.size() - 1);
+  return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
 }
 inline ArrayPtr<const char> String::asArray() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.slice(0, content.size() - 1);
+  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
 inline ArrayPtr<const char> ConstString::asArray() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.slice(0, content.size() - 1);
+  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
 
 inline const char* String::cStr() const { return content == nullptr ? "" : content.begin(); }

--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -157,7 +157,7 @@ public:
 
       if (parsedRange) {
         // We have an exact line number.
-        filePattern = pattern.slice(0, colonPos);
+        filePattern = pattern.first(colonPos);
       } else {
         // Can't parse as a number. Maybe the colon is part of a Windows path name or something.
         // Let's just keep it as part of the file pattern.
@@ -202,7 +202,7 @@ public:
     for (TestCase* testCase = testCasesHead; testCase != nullptr; testCase = testCase->next) {
       for (size_t i: kj::indices(commonPrefix)) {
         if (testCase->file[i] != commonPrefix[i]) {
-          commonPrefix = commonPrefix.slice(0, i);
+          commonPrefix = commonPrefix.first(i);
           break;
         }
       }
@@ -210,7 +210,7 @@ public:
 
     // Back off the prefix to the last '/'.
     while (commonPrefix.size() > 0 && commonPrefix.back() != '/' && commonPrefix.back() != '\\') {
-      commonPrefix = commonPrefix.slice(0, commonPrefix.size() - 1);
+      commonPrefix = commonPrefix.first(commonPrefix.size() - 1);
     }
 
     // Run the testts.

--- a/c++/src/kj/time.c++
+++ b/c++/src/kj/time.c++
@@ -305,13 +305,13 @@ CappedArray<char, _::TIME_STR_LEN> KJ_STRINGIFY(Duration d) {
     *begin++ = '-';
   }
   if (d % unit == 0 * kj::NANOSECONDS) {
-    end = _::fillLimited(begin, result.end(), arr.slice(0, point), suffix);
+    end = _::fillLimited(begin, result.end(), arr.first(point), suffix);
   } else {
     while (arr.back() == '0') {
-      arr = arr.slice(0, arr.size() - 1);
+      arr = arr.first(arr.size() - 1);
     }
     KJ_DASSERT(arr.size() > point);
-    end = _::fillLimited(begin, result.end(), arr.slice(0, point), "."_kj,
+    end = _::fillLimited(begin, result.end(), arr.first(point), "."_kj,
         arr.slice(point, arr.size()), suffix);
   }
   result.setSize(end - result.begin());

--- a/c++/src/kj/vector.h
+++ b/c++/src/kj/vector.h
@@ -80,6 +80,9 @@ public:
     return asPtr().slice(start, end);
   }
 
+  inline ArrayPtr<T> first(size_t count) KJ_LIFETIMEBOUND { return slice(0, count); }
+  inline ArrayPtr<const T> first(size_t count) const KJ_LIFETIMEBOUND { return slice(0, count); }
+
   template <typename... Params>
   inline T& add(Params&&... params) KJ_LIFETIMEBOUND {
     if (builder.isFull()) grow();


### PR DESCRIPTION
I found I have to use it a lot while writing IO slice-based code.

Doing `.slice(0, count)` is very common. `std::span` has `first` method, why shouldn't we?

`Path` and `PathPtr` is the only place I didn't add `.first` method. Let me know if you want it there too. 