### PR TITLE
arrayPtr() utility for fixed-sized arrays

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -976,5 +976,12 @@ KJ_TEST("_kjb") {
   KJ_EXPECT(arr[2] == 'c');
 }
 
+KJ_TEST("arrayPtr()") {
+  // arrayPtr can be used to create ArrayPtr from a fixed-size array without spelling out types
+  byte buffer[1024]{};
+  auto ptr = arrayPtr(buffer);
+  KJ_EXPECT(ptr.size() == 1024);
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1995,6 +1995,12 @@ inline constexpr ArrayPtr<T> arrayPtr(T* begin KJ_LIFETIMEBOUND, T* end KJ_LIFET
   return ArrayPtr<T>(begin, end);
 }
 
+template <typename T, size_t Size>
+inline constexpr ArrayPtr<T> arrayPtr(T (&arr)[Size]) {
+  // Use this function to construct ArrayPtrs without writing out the type name.
+  return ArrayPtr<T>(arr);
+}
+
 // =======================================================================================
 // Casts
 


### PR DESCRIPTION
This is very useful when working with local buffers.