### PR TITLE
Initialize TestExceptionCallback in new threads

### DIFF
--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -177,11 +177,11 @@ static void writeLineToFd(int fd, StringPtr message) {
 #endif
 }
 
-void TopLevelProcessContext::warning(StringPtr message) {
+void TopLevelProcessContext::warning(StringPtr message) const {
   writeLineToFd(STDERR_FILENO, message);
 }
 
-void TopLevelProcessContext::error(StringPtr message) {
+void TopLevelProcessContext::error(StringPtr message) const {
   hadErrors.store(true);
   writeLineToFd(STDERR_FILENO, message);
 }

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -59,7 +59,7 @@ StringPtr TopLevelProcessContext::getProgramName() {
 }
 
 void TopLevelProcessContext::exit() {
-  int exitCode = hadErrors ? 1 : 0;
+  int exitCode = hadErrors.load() ? 1 : 0;
   if (cleanShutdown) {
     throw CleanShutdownException { exitCode };
   }
@@ -182,7 +182,7 @@ void TopLevelProcessContext::warning(StringPtr message) {
 }
 
 void TopLevelProcessContext::error(StringPtr message) {
-  hadErrors = true;
+  hadErrors.store(true);
   writeLineToFd(STDERR_FILENO, message);
 }
 

--- a/c++/src/kj/main.h
+++ b/c++/src/kj/main.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "array.h"
 #include "string.h"
 #include "vector.h"
@@ -152,7 +154,7 @@ public:
 private:
   StringPtr programName;
   bool cleanShutdown;
-  bool hadErrors = false;
+  std::atomic_bool hadErrors = false;
 };
 
 typedef Function<void(StringPtr programName, ArrayPtr<const StringPtr> params)> MainFunc;

--- a/c++/src/kj/main.h
+++ b/c++/src/kj/main.h
@@ -105,13 +105,17 @@ public:
   //   available for those who really think they need it.  Unfortunately, it is not yet available
   //   on many platforms.
 
-  virtual void warning(StringPtr message) = 0;
+  virtual void warning(StringPtr message) const = 0;
   // Print the given message to standard error.  A newline is printed after the message if it
   // doesn't already have one.
+  //
+  // It is safe to call this method from multiple threads.
 
-  virtual void error(StringPtr message) = 0;
+  virtual void error(StringPtr message) const = 0;
   // Like `warning()`, but also sets a flag indicating that the process has failed, and that when
   // it eventually exits it should indicate an error status.
+  //
+  // It is safe to call this method from multiple threads.
 
   KJ_NORETURN(virtual void exitError(StringPtr message)) = 0;
   // Equivalent to `error(message)` followed by `exit()`.
@@ -145,8 +149,8 @@ public:
 
   StringPtr getProgramName() override;
   KJ_NORETURN(void exit() override);
-  void warning(StringPtr message) override;
-  void error(StringPtr message) override;
+  void warning(StringPtr message) const override;
+  void error(StringPtr message) const override;
   KJ_NORETURN(void exitError(StringPtr message) override);
   KJ_NORETURN(void exitInfo(StringPtr message) override);
   void increaseLoggingVerbosity() override;
@@ -154,7 +158,8 @@ public:
 private:
   StringPtr programName;
   bool cleanShutdown;
-  std::atomic_bool hadErrors = false;
+  // hadErrors is mutable because we need to modify it in const-for-multithreadedness methods.
+  mutable std::atomic_bool hadErrors = false;
 };
 
 typedef Function<void(StringPtr programName, ArrayPtr<const StringPtr> params)> MainFunc;

--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -23,6 +23,8 @@
 #define _GNU_SOURCE
 #endif
 
+#include <atomic>
+
 #include "test.h"
 #include "main.h"
 #include "io.h"
@@ -72,9 +74,17 @@ namespace {
 
 class TestExceptionCallback: public ExceptionCallback {
 public:
-  TestExceptionCallback(const ProcessContext& context): context(context) {}
+  TestExceptionCallback(const ProcessContext& context)
+      : context(context), mainThreadCallback(kj::none) {}
 
   bool failed() { return sawError; }
+
+  void fail() const {
+    sawError.store(true);
+    KJ_IF_SOME(callback, mainThreadCallback) {
+      callback.fail();
+    }
+  }
 
   void logMessage(LogSeverity severity, const char* file, int line, int contextDepth,
                   String&& text) override {
@@ -88,7 +98,7 @@ public:
     text = kj::str(kj::repeat('_', contextDepth), file, ':', line, ": ", kj::mv(text));
 
     if (severity == LogSeverity::ERROR || severity == LogSeverity::FATAL) {
-      sawError = true;
+      fail();
       context.error(kj::str(text, "\nstack: ", stringifyStackTraceAddresses(trace), stringifyStackTrace(trace)));
     } else {
       context.warning(text);
@@ -97,14 +107,31 @@ public:
 
   Function<void(Function<void()>)> getThreadInitializer() override {
     return [&](Function<void()> func) {
-      TestExceptionCallback exceptionCallback(context);
-      func();
+      KJ_IF_SOME(callback, mainThreadCallback) {
+        TestExceptionCallback exceptionCallback(context, callback);
+        func();
+      } else {
+        TestExceptionCallback exceptionCallback(context, *this);
+        func();
+      }
     };
   }
 
 private:
   const ProcessContext& context;
-  bool sawError = false;
+  // In the case where a thread spawns a thread, we report failure to the main thread's
+  // TestExceptionCallback, which I assume stays alive as long as all child threads.  If we reported
+  // failures to a thread's parent, we'd have to worry about a child thread spawning a grandchild
+  // thread and then immediately dying, leaving the grandchild thread with a dangling pointer to the
+  // now-dead child's TestExceptionCallback.
+  kj::Maybe<const TestExceptionCallback&> mainThreadCallback;
+  // sawError is mutable because we need to modify it in const-for-multithreadedness methods.
+  mutable std::atomic_bool sawError = false;
+
+  TestExceptionCallback(const ProcessContext& context,
+      const TestExceptionCallback& topLevelCallback)
+      : context(context), mainThreadCallback(topLevelCallback) {}
+
 };
 
 TimePoint readClock() {

--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -72,7 +72,7 @@ namespace {
 
 class TestExceptionCallback: public ExceptionCallback {
 public:
-  TestExceptionCallback(ProcessContext& context): context(context) {}
+  TestExceptionCallback(const ProcessContext& context): context(context) {}
 
   bool failed() { return sawError; }
 
@@ -95,8 +95,15 @@ public:
     }
   }
 
+  Function<void(Function<void()>)> getThreadInitializer() override {
+    return [&](Function<void()> func) {
+      TestExceptionCallback exceptionCallback(context);
+      func();
+    };
+  }
+
 private:
-  ProcessContext& context;
+  const ProcessContext& context;
   bool sawError = false;
 };
 


### PR DESCRIPTION
In a test that I wrote using threads, I noticed my test program still succeeded (by exiting with a 0 return code) when the program logged an ERROR-severity log message in the non-main thread.  This happens because TestExceptionCallback does not implement getThreadInitializer, so we get a default RootExceptionCallback.  The RootExceptionCallback will write errors to stderr, but doesn’t inform the ProcessContext that an error has occured and the process should exit with a non-zero return code.

The way to fix this is to implement getThreadInitializer in TestExceptionCallback.  My implementation is simple: in a new thread, I construct a new TestExceptionCallback and then run the thread’s main function.

Tehnically, such a construction is not thread-safe because the ProcessContext we use isn’t const.  Tests use the
TopLevelProcessContext whose error method is:

```
void TopLevelProcessContext::error(StringPtr message) {
  hadErrors = true;
  writeLineToFd(STDERR_FILENO, message);
}
```

`writeLineToFd` looks to be thread-safe, but I’m less sure that writing a boolean is safe to do on all architectures.  (It should be fine on x86_64.)