### PR TITLE
Use std::atomic_flag to set executorDone

### DIFF
--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -1272,7 +1272,7 @@ KJ_TEST("m:n threads:EventLoops") {
   static thread_local uint threadId = 0;
 
   threadId = 1;
-  bool executorDone = false;
+  std::atomic_flag executorDone;
 
   kj::Thread thread([&]() noexcept {
     threadId = 2;
@@ -1280,7 +1280,7 @@ KJ_TEST("m:n threads:EventLoops") {
     WaitScope ws1(loop1);
     promise1.wait(ws1);
     KJ_EXPECT(port1.getTimer().now() - startTime >= 10 * kj::MILLISECONDS);
-    KJ_EXPECT(executorDone);
+    KJ_EXPECT(executorDone.test());
 
     xpaf.promise.wait(ws1);
   });
@@ -1293,7 +1293,7 @@ KJ_TEST("m:n threads:EventLoops") {
     uint remoteThreadId = executor->executeAsync([&]() {
       return threadId;
     }).wait(ws2);
-    executorDone = true;
+    executorDone.test_and_set();
     KJ_EXPECT(remoteThreadId == 2);
     KJ_EXPECT(threadId == 1);
 


### PR DESCRIPTION
On arm64, I noticed that this test spews the following:

```
[ TEST ] async-unix-test.c++:1248: m:n threads:EventLoops
kj/async-unix-test.c++:1283: error: failed: expected executorDone
[ PASS ] async-unix-test.c++:1248: m:n threads:EventLoops
```

.  On x86_64, everything is fine, so it could be due to different memory semantics on arm64.  Given that we’re working across threads, we might as well use atomics.

Note that the default constructor of std::atomic_flag and std::atomic_flag::test_and_set() are new in C++20, but I think that’s the C++ version Cap’n Proto uses nowadays.