### PR TITLE
Remove `executorDone` check

### DIFF
--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -1272,7 +1272,6 @@ KJ_TEST("m:n threads:EventLoops") {
   static thread_local uint threadId = 0;
 
   threadId = 1;
-  bool executorDone = false;
 
   kj::Thread thread([&]() noexcept {
     threadId = 2;
@@ -1280,7 +1279,6 @@ KJ_TEST("m:n threads:EventLoops") {
     WaitScope ws1(loop1);
     promise1.wait(ws1);
     KJ_EXPECT(port1.getTimer().now() - startTime >= 10 * kj::MILLISECONDS);
-    KJ_EXPECT(executorDone);
 
     xpaf.promise.wait(ws1);
   });
@@ -1293,7 +1291,6 @@ KJ_TEST("m:n threads:EventLoops") {
     uint remoteThreadId = executor->executeAsync([&]() {
       return threadId;
     }).wait(ws2);
-    executorDone = true;
     KJ_EXPECT(remoteThreadId == 2);
     KJ_EXPECT(threadId == 1);
 


### PR DESCRIPTION
On arm64, I noticed that this test spews the following:

```
[ TEST ] async-unix-test.c++:1248: m:n threads:EventLoops
kj/async-unix-test.c++:1283: error: failed: expected executorDone
[ PASS ] async-unix-test.c++:1248: m:n threads:EventLoops
```

.  On x86_64, everything is fine.  I thought it might be due to different memory semantics, but I tried using `std::atomic_flag` in https://github.com/capnproto/capnproto/pull/2011 and that did not remove the error spew

After some offline discussion with @kentonv, we decided to remove the `executorDone` check since the `xpaf` check seems to implement what `executorDone` is trying to check in a more robust way.