### PR TITLE
Fix Maybe nullptr assignment deprecation notice loophole

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -558,7 +558,7 @@ public:
 
   ~LocalClient() noexcept(false) {
     KJ_IF_SOME(s, server) {
-      s->thisHook = nullptr;
+      s->thisHook = kj::none;
     }
   }
 
@@ -570,7 +570,7 @@ public:
     KJ_IF_SOME(s, server) {
       KJ_ASSERT_NONNULL(revoker).cancel(e);
       brokenException = kj::mv(e);
-      s->thisHook = nullptr;
+      s->thisHook = kj::none;
       server = kj::none;
     }
   }

--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -484,7 +484,7 @@ public:
       // will call this method to provide the shortened path.
 
       KJ_IF_SOME(currentParent, parent) {
-        parent = nullptr;
+        parent = kj::none;
 
         auto self = kj::mv(currentParent.state.get<kj::Own<PathProber>>());
         currentParent.state = Ended();  // temporary, we'll set this properly below
@@ -561,7 +561,7 @@ public:
             //   this task promise, which is an error... let the event loop do it later by
             //   detaching.
             task.attach(kj::mv(prober)).detach([](kj::Exception&&){});
-            parent = nullptr;
+            parent = kj::none;
 
             // OK, now we can change the parent state and signal it to proceed.
             currentParent.state = kj::mv(inner);

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -65,7 +65,7 @@ public:
 
     // Null out our self-ref, if any.
     KJ_IF_SOME(s, selfRef) {
-      s = nullptr;
+      s = kj::none;
     }
 
     // Arrange to call disconnect() and then notify the observer that the stream has finished.
@@ -458,13 +458,13 @@ public:
     KJ_IF_SOME(s, requestBody.tryGetLength()) {
       metadata.getBodySize().setFixed(s);
       if (s == 0) {
-        maybeRequestBody = nullptr;
+        maybeRequestBody = kj::none;
       } else {
         maybeRequestBody = requestBody;
       }
     } else if ((method == kj::HttpMethod::GET || method == kj::HttpMethod::HEAD) &&
                headers.get(kj::HttpHeaderId::TRANSFER_ENCODING) == kj::none) {
-      maybeRequestBody = nullptr;
+      maybeRequestBody = kj::none;
       metadata.getBodySize().setFixed(0);
     } else {
       metadata.getBodySize().setUnknown();

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -399,7 +399,7 @@ public:
     // After disconnect(), the RpcSystem could be destroyed, making `traceEncoder` a dangling
     // reference, so null it out before we return from here. We don't need it anymore once
     // disconnected anyway.
-    KJ_DEFER(traceEncoder = nullptr);
+    KJ_DEFER(traceEncoder = kj::none);
 
     if (!connection.is<Connected>()) {
       // Already disconnected.
@@ -1692,7 +1692,7 @@ private:
         // the ID is not re-allocated before the `Finish` message can be sent.
         if (question.isAwaitingReturn) {
           // Still waiting for return, so just remove the QuestionRef pointer from the table.
-          question.selfRef = nullptr;
+          question.selfRef = kj::none;
         } else {
           // Call has already returned, so we can now remove it from the table.
           connectionState->questions.erase(id, question);
@@ -2725,7 +2725,7 @@ private:
       } else {
         // We just have to null out callContext and set the exports.
         auto& answer = connectionState->answers[answerId];
-        answer.callContext = nullptr;
+        answer.callContext = kj::none;
         answer.resultExports = kj::mv(resultExports);
 
         if (shouldFreePipeline) {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -260,8 +260,8 @@ void Canceler::AdapterBase::unlink() {
   KJ_IF_SOME(n, next) {
     n.prev = prev;
   }
-  next = nullptr;
-  prev = nullptr;
+  next = kj::none;
+  prev = kj::none;
 }
 
 Canceler::AdapterImpl<void>::AdapterImpl(kj::PromiseFulfiller<void>& fulfiller,
@@ -833,7 +833,7 @@ struct Executor::Impl {
   }
 
   void disconnect() {
-    state.lockExclusive()->loop = nullptr;
+    state.lockExclusive()->loop = kj::none;
 
     // Now that `loop` is set null in `state`, other threads will no longer try to manipulate our
     // lists, so we can access them without a lock. That's convenient because a bunch of the things
@@ -3038,7 +3038,7 @@ Maybe<Own<Event>> CoroutineBase::fire() {
   // already know where it's going. But, we don't really know: the `co_await` might be in a
   // try-catch block, so we have no choice but to resume and throw later.
 
-  promiseNodeForTrace = nullptr;
+  promiseNodeForTrace = kj::none;
 
   coroutine.resume();
 
@@ -3103,7 +3103,7 @@ CoroutineBase::AwaiterBase::~AwaiterBase() noexcept(false) {
   // Make sure it's safe to generate an async stack trace between now and when the Coroutine is
   // destroyed.
   KJ_IF_SOME(coroutineEvent, maybeCoroutineEvent) {
-    coroutineEvent.promiseNodeForTrace = nullptr;
+    coroutineEvent.promiseNodeForTrace = kj::none;
   }
 
   unwindDetector.catchExceptionsIfUnwinding([this]() {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1892,7 +1892,7 @@ public:
     return kj::none;
   }
 
-  inline ArrayPtr<PropagateConst<T, byte>> asBytes() const {
+  constexpr ArrayPtr<PropagateConst<T, byte>> asBytes() const {
     // Reinterpret the array as a byte array. This is explicitly legal under C++ aliasing
     // rules.
     return { reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_ * sizeof(T) };

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1675,6 +1675,9 @@ public:
 
   inline constexpr Maybe(kj::None): ptr(nullptr) {}
 
+  KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR_ATTR
+  inline Maybe& operator=(decltype(nullptr)) { ptr = nullptr; return *this; }
+
   inline Maybe& operator=(T& other) { ptr = &other; return *this; }
   inline Maybe& operator=(T* other) { ptr = other; return *this; }
   inline Maybe& operator=(PropagateConst<T, Maybe>& other) { ptr = other.ptr; return *this; }

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1299,7 +1299,7 @@ public:
     KJ_IF_SOME(w, currentWrapper) {
       KJ_LOG(ERROR, "HTTP connection destroyed while HTTP body streams still exist",
           kj::getStackTrace());
-      w = nullptr;
+      w = kj::none;
     }
   }
 

--- a/c++/src/kj/compat/readiness-io.h
+++ b/c++/src/kj/compat/readiness-io.h
@@ -115,7 +115,7 @@ public:
     }
   }
   Cork(Cork&& other) : parent(kj::mv(other.parent)) {
-    other.parent = nullptr;
+    other.parent = kj::none;
   }
   KJ_DISALLOW_COPY(Cork);
 

--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -139,7 +139,7 @@ Maybe<uint64_t> TimerImpl::timeoutToNextEvent(TimePoint start, Duration unit, ui
 }
 
 void TimerImpl::advanceTo(TimePoint newTime) {
-  sleepHooks = nullptr;
+  sleepHooks = kj::none;
 
   // On Macs running an Intel processor, it has been observed that clock_gettime
   // may return non monotonic time, even when CLOCK_MONOTONIC is used.


### PR DESCRIPTION
While reading some code in async.c++, I noticed a place where we nullify a Maybe with a nullptr, which surprised me, because I thought we had deprecated all such code. It turns out that while our default Maybe<T> implementation bans pointer assignment,  our Maybe<T&> specialization does not. This commit adds a deprecated nullptr assignment operator overload to Maybe<T&> to flush out any last remaining nullptr nullifications.

Note that this doesn't fix any bug in our code or anything, it just makes the nullification call sites a bit clearer.