### PR TITLE
Attempt to fix an obscure tracePromise() UaF

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2232,9 +2232,11 @@ private:
   // preserve that assertion.
 #endif
 
-  Maybe<PromiseNode&> promiseNodeForTrace;
+  Maybe<OwnPromiseNode&> promiseNodeForTrace;
   // Whenever this coroutine is suspended waiting on another promise, we keep a reference to that
-  // promise so tracePromise()/traceEvent() can trace into it.
+  // promise so tracePromise()/traceEvent() can trace into it. Since ChainPromiseNodes have the
+  // ability to destroy themselves, replacing their own Own, we hold a reference to the owning Own
+  // instead of directly to the PromiseNode.
 
   UnwindDetector unwindDetector;
 

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3028,7 +3028,7 @@ void CoroutineBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
   if (stopAtNextEvent) return;
 
   KJ_IF_SOME(promise, promiseNodeForTrace) {
-    promise.tracePromise(builder, stopAtNextEvent);
+    promise->tracePromise(builder, stopAtNextEvent);
   }
 
   // Maybe returning the address of coroutine() will give us a function name with meaningful type
@@ -3055,7 +3055,7 @@ Maybe<Own<Event>> CoroutineBase::fire() {
 
 void CoroutineBase::traceEvent(TraceBuilder& builder) {
   KJ_IF_SOME(promise, promiseNodeForTrace) {
-    promise.tracePromise(builder, true);
+    promise->tracePromise(builder, true);
   }
 
   // Maybe returning the address of coroutine() will give us a function name with meaningful type
@@ -3152,9 +3152,9 @@ bool CoroutineBase::AwaiterBase::awaitSuspendImpl(CoroutineBase& coroutineEvent)
     // returned true from await_ready().
     return false;
   } else {
-    // Otherwise, we must suspend. Store a reference to the promise we're waiting on for tracing
-    // purposes; coroutineEvent.fire() and/or ~Adapter() will null this out.
-    coroutineEvent.promiseNodeForTrace = *node;
+    // Otherwise, we must suspend. Store a reference to the OwnPromiseNode we're waiting on for
+    // tracing purposes; coroutineEvent.fire() and/or ~Adapter() will null this out.
+    coroutineEvent.promiseNodeForTrace = node;
     maybeCoroutineEvent = coroutineEvent;
 
     coroutineEvent.hasSuspendedAtLeastOnce = true;


### PR DESCRIPTION
I've observed null pointer dereferences with stack traces showing CoroutineBase::tracePromise() calling into ChainPromiseNode::tracePromise(). The only explanation I could think of is that perhaps the coroutine's tracePromise() function is being called after a currently-awaited ChainPromiseNode has transitioned to STEP2, which could invalidate the promiseNodeForTrace reference stored in AwaiterBase. To fix this, I'm storing a reference to the currently-awaited OwnPromiseNode, rather than to PromiseNode directly.

I tried to modify async-coroutine-test.c++'s trace test case to validate this change (by modifying the awaited .then() promise to return NEVER_DONE, and tracing after fulfilling the base promise on which .then() was called), but was unable to reproduce the buggy behavior. I'm open to ideas.