### PR TITLE
explicitly initializing arrays

### DIFF
--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -504,7 +504,7 @@ public:
         continue;
       }
 
-      int pipeFds[2];
+      int pipeFds[2]{};
       KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
 
       kj::String exeName;

--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -979,7 +979,7 @@ CapnpParser::CapnpParser(Orphanage orphanageParam, ErrorReporter& errorReporterP
                 errorReporter.addError(target.startByte, target.endByte,
                                        "Not a valid annotation target.");
               } else {
-                char buffer[64];
+                char buffer[64]{};
                 strcpy(buffer, "targets");
                 strcat(buffer, target.value.cStr());
                 buffer[strlen("targets")] += 'A' - 'a';

--- a/c++/src/capnp/compiler/type-id.c++
+++ b/c++/src/capnp/compiler/type-id.c++
@@ -65,7 +65,7 @@ uint64_t generateChildId(uint64_t parentId, kj::StringPtr childName) {
   // Compute ID by hashing the concatenation of the parent ID and the declaration name, and
   // then taking the first 8 bytes.
 
-  kj::byte parentIdBytes[sizeof(uint64_t)];
+  kj::byte parentIdBytes[sizeof(uint64_t)]{};
   for (uint i = 0; i < sizeof(uint64_t); i++) {
     parentIdBytes[i] = (parentId >> (i * 8)) & 0xff;
   }
@@ -88,7 +88,7 @@ uint64_t generateGroupId(uint64_t parentId, uint16_t groupIndex) {
   // Compute ID by hashing the concatenation of the parent ID and the group index, and
   // then taking the first 8 bytes.
 
-  kj::byte bytes[sizeof(uint64_t) + sizeof(uint16_t)];
+  kj::byte bytes[sizeof(uint64_t) + sizeof(uint16_t)]{};
   for (uint i = 0; i < sizeof(uint64_t); i++) {
     bytes[i] = (parentId >> (i * 8)) & 0xff;
   }
@@ -114,7 +114,7 @@ uint64_t generateMethodParamsId(uint64_t parentId, uint16_t methodOrdinal, bool 
   // boolean indicating whether this is the params or the results, and then taking the first 8
   // bytes.
 
-  kj::byte bytes[sizeof(uint64_t) + sizeof(uint16_t) + 1];
+  kj::byte bytes[sizeof(uint64_t) + sizeof(uint16_t) + 1]{};
   for (uint i = 0; i < sizeof(uint64_t); i++) {
     bytes[i] = (parentId >> (i * 8)) & 0xff;
   }

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -539,7 +539,7 @@ KJ_TEST("send FD over RPC") {
 
   auto cap = client.bootstrap().castAs<test::TestMoreStuff>();
 
-  int pipeFds[2];
+  int pipeFds[2]{};
   KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
   kj::AutoCloseFd in1(pipeFds[0]);
   kj::AutoCloseFd out1(pipeFds[1]);
@@ -586,7 +586,7 @@ KJ_TEST("FD per message limit") {
 
   auto cap = client.bootstrap().castAs<test::TestMoreStuff>();
 
-  int pipeFds[2];
+  int pipeFds[2]{};
   KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
   kj::AutoCloseFd in1(pipeFds[0]);
   kj::AutoCloseFd out1(pipeFds[1]);

--- a/c++/src/capnp/serialize-packed.c++
+++ b/c++/src/capnp/serialize-packed.c++
@@ -304,7 +304,7 @@ PackedOutputStream::~PackedOutputStream() noexcept(false) {}
 
 void PackedOutputStream::write(const void* src, size_t size) {
   kj::ArrayPtr<byte> buffer = inner.getWriteBuffer();
-  byte slowBuffer[20];
+  byte slowBuffer[20]{};
 
   uint8_t* __restrict__ out = reinterpret_cast<uint8_t*>(buffer.begin());
 
@@ -466,7 +466,7 @@ void writePackedMessage(kj::OutputStream& output,
   KJ_IF_SOME(bufferedOutputPtr, kj::dynamicDowncastIfAvailable<kj::BufferedOutputStream>(output)) {
     writePackedMessage(bufferedOutputPtr, segments);
   } else {
-    byte buffer[8192];
+    byte buffer[8192]{};
     kj::BufferedOutputStreamWrapper bufferedOutput(output, kj::arrayPtr(buffer, sizeof(buffer)));
     writePackedMessage(bufferedOutput, segments);
   }

--- a/c++/src/capnp/stringify.c++
+++ b/c++/src/capnp/stringify.c++
@@ -85,7 +85,7 @@ private:
       return false;
     }
 
-    char flat[maxInlineValueSize + 1];
+    char flat[maxInlineValueSize + 1]{};
     text.flattenTo(flat);
     flat[text.size()] = '\0';
     if (strchr(flat, '\n') != nullptr) {

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -1173,7 +1173,7 @@ kj::Promise<void> TestMoreStuffImpl::writeToFd(WriteToFdContext context) {
     }
   }));
 
-  int pair[2];
+  int pair[2]{};
   KJ_SYSCALL(kj::miniposix::pipe(pair));
   kj::AutoCloseFd in(pair[0]);
   kj::AutoCloseFd out(pair[1]);

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -442,7 +442,7 @@ Promise<void> sendData(Promise<Own<NetworkAddress>> addressPromise) {
 
 Promise<String> receiveDataCoroutine(Own<ConnectionReceiver> listener) {
   auto server = co_await listener->accept();
-  char buffer[4];
+  char buffer[4]{};
   auto n = co_await server->read(buffer, 3, 4);
   KJ_EXPECT(3u == n);
   co_return heapString(buffer, n);

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -61,7 +61,7 @@ TEST(AsyncIo, SimpleNetwork) {
   Own<AsyncIoStream> server;
   Own<AsyncIoStream> client;
 
-  char receiveBuffer[4];
+  char receiveBuffer[4]{};
 
   auto port = newPromiseAndFulfiller<uint>();
 
@@ -100,7 +100,7 @@ TEST(AsyncIo, SimpleNetworkAuthentication) {
   Own<AsyncIoStream> server;
   Own<AsyncIoStream> client;
 
-  char receiveBuffer[4];
+  char receiveBuffer[4]{};
 
   auto port = newPromiseAndFulfiller<uint>();
 
@@ -184,7 +184,7 @@ TEST(AsyncIo, UnixSocket) {
   Own<AsyncIoStream> server;
   Own<AsyncIoStream> client;
 
-  char receiveBuffer[4];
+  char receiveBuffer[4]{};
 
   auto ready = newPromiseAndFulfiller<void>();
 
@@ -254,7 +254,7 @@ TEST(AsyncIo, AncillaryMessageHandlerNoMsg) {
   Own<AsyncIoStream> server;
   Own<AsyncIoStream> client;
 
-  char receiveBuffer[4];
+  char receiveBuffer[4]{};
 
   bool clientHandlerCalled = false;
   kj::Function<void(kj::ArrayPtr<AncillaryMessage>)> clientHandler =
@@ -314,7 +314,7 @@ TEST(AsyncIo, AncillaryMessageHandler) {
   Own<AsyncIoStream> server;
   Own<AsyncIoStream> client;
 
-  char receiveBuffer[4];
+  char receiveBuffer[4]{};
 
   bool clientHandlerCalled = false;
   kj::Function<void(kj::ArrayPtr<AncillaryMessage>)> clientHandler =
@@ -443,7 +443,7 @@ TEST(AsyncIo, OneWayPipe) {
   auto ioContext = setupAsyncIo();
 
   auto pipe = ioContext.provider->newOneWayPipe();
-  char receiveBuffer[4];
+  char receiveBuffer[4]{};
 
   pipe.out->write("foo", 3).detach([](kj::Exception&& exception) {
     KJ_FAIL_EXPECT(exception);
@@ -461,8 +461,8 @@ TEST(AsyncIo, TwoWayPipe) {
   auto ioContext = setupAsyncIo();
 
   auto pipe = ioContext.provider->newTwoWayPipe();
-  char receiveBuffer1[4];
-  char receiveBuffer2[4];
+  char receiveBuffer1[4]{};
+  char receiveBuffer2[4]{};
 
   auto promise = pipe.ends[0]->write("foo", 3).then([&]() {
     return pipe.ends[0]->tryRead(receiveBuffer1, 3, 4);
@@ -490,8 +490,8 @@ TEST(AsyncIo, InMemoryCapabilityPipe) {
 
   auto pipe = newCapabilityPipe();
   auto pipe2 = newCapabilityPipe();
-  char receiveBuffer1[4];
-  char receiveBuffer2[4];
+  char receiveBuffer1[4]{};
+  char receiveBuffer2[4]{};
 
   // Expect to receive a stream, then read "foo" from it, then write "bar" to it.
   Own<AsyncCapabilityStream> receivedStream;
@@ -530,8 +530,8 @@ TEST(AsyncIo, CapabilityPipe) {
 
   auto pipe = ioContext.provider->newCapabilityPipe();
   auto pipe2 = ioContext.provider->newCapabilityPipe();
-  char receiveBuffer1[4];
-  char receiveBuffer2[4];
+  char receiveBuffer1[4]{};
+  char receiveBuffer2[4]{};
 
   // Expect to receive a stream, then write "bar" to it, then receive "foo" from it.
   Own<AsyncCapabilityStream> receivedStream;
@@ -620,7 +620,7 @@ TEST(AsyncIo, CapabilityPipeMultiStreamMessage) {
   pipe.ends[0]->writeWithStreams("foo"_kjb, arrayPtr(&secondBuf, 1), streams.finish())
       .wait(ioContext.waitScope);
 
-  char receiveBuffer[7];
+  char receiveBuffer[7]{};
   Own<AsyncCapabilityStream> receiveStreams[3];
   auto result = pipe.ends[1]->tryReadWithStreams(receiveBuffer, 6, 7, receiveStreams, 3)
       .wait(ioContext.waitScope);
@@ -648,7 +648,7 @@ TEST(AsyncIo, ScmRightsTruncatedOdd) {
 
   auto capPipe = io.provider->newCapabilityPipe();
 
-  int pipeFds[2];
+  int pipeFds[2]{};
   KJ_SYSCALL(miniposix::pipe(pipeFds));
   kj::AutoCloseFd in1(pipeFds[0]);
   kj::AutoCloseFd out1(pipeFds[1]);
@@ -663,7 +663,7 @@ TEST(AsyncIo, ScmRightsTruncatedOdd) {
   }
 
   {
-    char buffer[4];
+    char buffer[4]{};
     AutoCloseFd fdBuffer[1];
     auto result = capPipe.ends[1]->tryReadWithFds(buffer, 3, 3, fdBuffer, 1).wait(io.waitScope);
     KJ_ASSERT(result.capCount == 1);
@@ -675,7 +675,7 @@ TEST(AsyncIo, ScmRightsTruncatedOdd) {
   KJ_SYSCALL(fcntl(in1, F_SETFL, O_NONBLOCK));
   KJ_SYSCALL(fcntl(in2, F_SETFL, O_NONBLOCK));
 
-  char buffer[4];
+  char buffer[4]{};
   ssize_t n;
 
   // First we read "bar" from in1.
@@ -720,7 +720,7 @@ TEST(AsyncIo, ScmRightsTruncatedEven) {
 
   auto capPipe = io.provider->newCapabilityPipe();
 
-  int pipeFds[2];
+  int pipeFds[2]{};
   KJ_SYSCALL(miniposix::pipe(pipeFds));
   kj::AutoCloseFd in1(pipeFds[0]);
   kj::AutoCloseFd out1(pipeFds[1]);
@@ -739,7 +739,7 @@ TEST(AsyncIo, ScmRightsTruncatedEven) {
   }
 
   {
-    char buffer[4];
+    char buffer[4]{};
     AutoCloseFd fdBuffer[2];
     auto result = capPipe.ends[1]->tryReadWithFds(buffer, 3, 3, fdBuffer, 2).wait(io.waitScope);
     KJ_ASSERT(result.capCount == 2);
@@ -753,7 +753,7 @@ TEST(AsyncIo, ScmRightsTruncatedEven) {
   KJ_SYSCALL(fcntl(in2, F_SETFL, O_NONBLOCK));
   KJ_SYSCALL(fcntl(in3, F_SETFL, O_NONBLOCK));
 
-  char buffer[4];
+  char buffer[4]{};
   ssize_t n;
 
   // First we read "bar" from in1.
@@ -803,7 +803,7 @@ TEST(AsyncIo, PipeThread) {
 
   auto pipeThread = ioContext.provider->newPipeThread(
       [](AsyncIoProvider& ioProvider, AsyncIoStream& stream, WaitScope& waitScope) {
-    char buf[4];
+    char buf[4]{};
     stream.write("foo", 3).wait(waitScope);
     EXPECT_EQ(3u, stream.tryRead(buf, 3, 4).wait(waitScope));
     EXPECT_EQ("bar", heapString(buf, 3));
@@ -812,7 +812,7 @@ TEST(AsyncIo, PipeThread) {
     EXPECT_EQ(0, stream.tryRead(buf, 1, 1).wait(waitScope));
   });
 
-  char buf[4];
+  char buf[4]{};
   pipeThread.pipe->write("bar", 3).wait(ioContext.waitScope);
   EXPECT_EQ(3u, pipeThread.pipe->tryRead(buf, 3, 4).wait(ioContext.waitScope));
   EXPECT_EQ("foo", heapString(buf, 3));
@@ -825,13 +825,13 @@ TEST(AsyncIo, PipeThreadDisconnects) {
 
   auto pipeThread = ioContext.provider->newPipeThread(
       [](AsyncIoProvider& ioProvider, AsyncIoStream& stream, WaitScope& waitScope) {
-    char buf[4];
+    char buf[4]{};
     stream.write("foo", 3).wait(waitScope);
     EXPECT_EQ(3u, stream.tryRead(buf, 3, 4).wait(waitScope));
     EXPECT_EQ("bar", heapString(buf, 3));
   });
 
-  char buf[4];
+  char buf[4]{};
   EXPECT_EQ(3u, pipeThread.pipe->tryRead(buf, 3, 4).wait(ioContext.waitScope));
   EXPECT_EQ("foo", heapString(buf, 3));
 
@@ -879,7 +879,7 @@ bool isMsgTruncBroken() {
   KJ_SYSCALL(sendto(fd, message, strlen(message), 0,
       reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)));
 
-  char buf[4];
+  char buf[4]{};
   struct iovec iov;
   iov.iov_base = buf;
   iov.iov_len = 3;
@@ -1377,7 +1377,7 @@ KJ_TEST("Userland pipe") {
   auto promise = pipe.out->write("foo", 3);
   KJ_EXPECT(!promise.poll(ws));
 
-  char buf[4];
+  char buf[4]{};
   KJ_EXPECT(pipe.in->tryRead(buf, 1, 4).wait(ws) == 3);
   buf[3] = '\0';
   KJ_EXPECT(buf == "foo"_kj);
@@ -2123,7 +2123,7 @@ KJ_TEST("Userland pipe BlockedRead gets empty tryPumpFrom") {
   auto pipe2 = newOneWayPipe();
 
   // First start a read from the back end.
-  char buffer[4];
+  char buffer[4]{};
   auto readPromise = pipe2.in->tryRead(buffer, 1, 4);
 
   // Now arrange a pump between the pipes, using tryPumpFrom().
@@ -2976,7 +2976,7 @@ KJ_TEST("OS TwoWayPipe whenWriteDisconnected()") {
   KJ_ASSERT(abortedPromise.poll(io.waitScope));
   abortedPromise.wait(io.waitScope);
 
-  char buffer[4];
+  char buffer[4]{};
   KJ_ASSERT(pipe.ends[0]->tryRead(&buffer, 3, 3).wait(io.waitScope) == 3);
   buffer[3] = '\0';
   KJ_EXPECT(buffer == "bar"_kj);
@@ -2987,7 +2987,7 @@ KJ_TEST("OS TwoWayPipe whenWriteDisconnected()") {
 KJ_TEST("import socket FD that's already broken") {
   auto io = setupAsyncIo();
 
-  int fds[2];
+  int fds[2]{};
   KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
   KJ_SYSCALL(write(fds[1], "foo", 3));
   KJ_SYSCALL(close(fds[1]));
@@ -2998,7 +2998,7 @@ KJ_TEST("import socket FD that's already broken") {
   KJ_ASSERT(abortedPromise.poll(io.waitScope));
   abortedPromise.wait(io.waitScope);
 
-  char buffer[4];
+  char buffer[4]{};
   KJ_ASSERT(stream->tryRead(&buffer, sizeof(buffer), sizeof(buffer)).wait(io.waitScope) == 3);
   buffer[3] = '\0';
   KJ_EXPECT(buffer == "foo"_kj);

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -317,7 +317,7 @@ private:
     // be fully satisfied immediately. This optimizes for the case of small streams, e.g. a short
     // HTTP body.
 
-    byte buffer[4096];
+    byte buffer[4096]{};
     size_t pos = 0;
     size_t initialAmount = kj::min(sizeof(buffer), amount);
 
@@ -408,7 +408,7 @@ private:
     // we allocate here to avoid coming close to the hard limit, but that's a lot of effort so I'm
     // not going to bother!
 
-    int pipeFds[2];
+    int pipeFds[2]{};
     KJ_SYSCALL_HANDLE_ERRORS(pipe2(pipeFds, O_NONBLOCK | O_CLOEXEC)) {
       case ENFILE:
         // Probably hit the limit on pipe buffers, fall back to unoptimized pump.
@@ -960,7 +960,7 @@ public:
 
     switch (addr.generic.sa_family) {
       case AF_INET: {
-        char buffer[INET6_ADDRSTRLEN];
+        char buffer[INET6_ADDRSTRLEN]{};
         if (inet_ntop(addr.inet4.sin_family, &addr.inet4.sin_addr,
                       buffer, sizeof(buffer)) == nullptr) {
           KJ_FAIL_SYSCALL("inet_ntop", errno) { break; }
@@ -969,7 +969,7 @@ public:
         return str(buffer, ':', ntohs(addr.inet4.sin_port));
       }
       case AF_INET6: {
-        char buffer[INET6_ADDRSTRLEN];
+        char buffer[INET6_ADDRSTRLEN]{};
         if (inet_ntop(addr.inet6.sin6_family, &addr.inet6.sin6_addr,
                       buffer, sizeof(buffer)) == nullptr) {
           KJ_FAIL_SYSCALL("inet_ntop", errno) { break; }
@@ -1134,7 +1134,7 @@ public:
 
     if (addrPart.size() < INET6_ADDRSTRLEN - 1) {
       // addrPart is not necessarily NUL-terminated so we have to make a copy.  :(
-      char buffer[INET6_ADDRSTRLEN];
+      char buffer[INET6_ADDRSTRLEN]{};
       memcpy(buffer, addrPart.begin(), addrPart.size());
       buffer[addrPart.size()] = '\0';
 
@@ -1968,7 +1968,7 @@ public:
       : lowLevel(lowLevel), network(lowLevel) {}
 
   OneWayPipe newOneWayPipe() override {
-    int fds[2];
+    int fds[2]{};
 #if __linux__ && !__BIONIC__
     KJ_SYSCALL(pipe2(fds, O_NONBLOCK | O_CLOEXEC));
 #else
@@ -1981,7 +1981,7 @@ public:
   }
 
   TwoWayPipe newTwoWayPipe() override {
-    int fds[2];
+    int fds[2]{};
     int type = SOCK_STREAM;
 #if __linux__ && !__BIONIC__
     type |= SOCK_NONBLOCK | SOCK_CLOEXEC;
@@ -1994,7 +1994,7 @@ public:
   }
 
   CapabilityPipe newCapabilityPipe() override {
-    int fds[2];
+    int fds[2]{};
     int type = SOCK_STREAM;
 #if __linux__ && !__BIONIC__
     type |= SOCK_NONBLOCK | SOCK_CLOEXEC;
@@ -2012,7 +2012,7 @@ public:
 
   PipeThread newPipeThread(
       Function<void(AsyncIoProvider&, AsyncIoStream&, WaitScope&)> startFunc) override {
-    int fds[2];
+    int fds[2]{};
     int type = SOCK_STREAM;
 #if __linux__ && !__BIONIC__
     type |= SOCK_NONBLOCK | SOCK_CLOEXEC;

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -3245,13 +3245,13 @@ public:
   LocalPeerIdentityImpl(Credentials creds): creds(creds) {}
 
   kj::String toString() override {
-    char pidBuffer[16];
+    char pidBuffer[16]{};
     kj::StringPtr pidStr = nullptr;
     KJ_IF_SOME(p, creds.pid) {
       pidStr = strPreallocated(pidBuffer, " pid:", p);
     }
 
-    char uidBuffer[16];
+    char uidBuffer[16]{};
     kj::StringPtr uidStr = nullptr;
     KJ_IF_SOME(u, creds.uid) {
       uidStr = strPreallocated(uidBuffer, " uid:", u);

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -367,7 +367,7 @@ TEST(AsyncUnixTest, ReadObserver) {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
 
@@ -380,7 +380,7 @@ TEST(AsyncUnixTest, ReadObserver) {
 #if __linux__  // platform known to support POLLRDHUP
   EXPECT_FALSE(KJ_ASSERT_NONNULL(observer.atEndHint()));
 
-  char buffer[4096];
+  char buffer[4096]{};
   ssize_t n;
   KJ_SYSCALL(n = read(infd, &buffer, sizeof(buffer)));
   EXPECT_EQ(3, n);
@@ -400,7 +400,7 @@ TEST(AsyncUnixTest, ReadObserverMultiListen) {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  int bogusPipefds[2];
+  int bogusPipefds[2]{};
   KJ_SYSCALL(pipe(bogusPipefds));
   KJ_DEFER({ close(bogusPipefds[1]); close(bogusPipefds[0]); });
 
@@ -413,7 +413,7 @@ TEST(AsyncUnixTest, ReadObserverMultiListen) {
     ADD_FAILURE() << kj::str(exception).cStr();
   });
 
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   KJ_DEFER({ close(pipefds[1]); close(pipefds[0]); });
 
@@ -430,7 +430,7 @@ TEST(AsyncUnixTest, ReadObserverMultiReceive) {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   KJ_DEFER({ close(pipefds[1]); close(pipefds[0]); });
 
@@ -438,7 +438,7 @@ TEST(AsyncUnixTest, ReadObserverMultiReceive) {
       UnixEventPort::FdObserver::OBSERVE_READ);
   KJ_SYSCALL(write(pipefds[1], "foo", 3));
 
-  int pipefds2[2];
+  int pipefds2[2]{};
   KJ_SYSCALL(pipe(pipefds2));
   KJ_DEFER({ close(pipefds2[1]); close(pipefds2[0]); });
 
@@ -463,7 +463,7 @@ TEST(AsyncUnixTest, ReadObserverAndSignals) {
 
   auto signalPromise = port.onSignal(SIGIO);
 
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
 
@@ -485,7 +485,7 @@ TEST(AsyncUnixTest, ReadObserverAsync) {
   WaitScope waitScope(loop);
 
   // Make a pipe and wait on its read end while another thread writes to it.
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   KJ_DEFER({ close(pipefds[1]); close(pipefds[0]); });
   UnixEventPort::FdObserver observer(port, pipefds[0],
@@ -508,13 +508,13 @@ TEST(AsyncUnixTest, ReadObserverNoWait) {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   KJ_DEFER({ close(pipefds[1]); close(pipefds[0]); });
   UnixEventPort::FdObserver observer(port, pipefds[0],
       UnixEventPort::FdObserver::OBSERVE_READ);
 
-  int pipefds2[2];
+  int pipefds2[2]{};
   KJ_SYSCALL(pipe(pipefds2));
   KJ_DEFER({ close(pipefds2[1]); close(pipefds2[0]); });
   UnixEventPort::FdObserver observer2(port, pipefds2[0],
@@ -560,7 +560,7 @@ TEST(AsyncUnixTest, WriteObserver) {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
   setNonblocking(outfd);
@@ -588,7 +588,7 @@ TEST(AsyncUnixTest, WriteObserver) {
   // high watermark / low watermark heuristic which means that only reading one byte is not
   // sufficient. The amount we have to read is in fact architecture-dependent -- it appears to be
   // 1 page. To be safe, we read everything.
-  char buffer[4096];
+  char buffer[4096]{};
   do {
     KJ_NONBLOCKING_SYSCALL(n = read(infd, &buffer, sizeof(buffer)));
   } while (n > 0);
@@ -628,7 +628,7 @@ TEST(AsyncUnixTest, UrgentObserver) {
   KJ_SYSCALL(listen(serverFd, 1));
 
   // Create a pipe that we'll use to signal if MSG_OOB return EINVAL.
-  int failpipe[2];
+  int failpipe[2]{};
   KJ_SYSCALL(pipe(failpipe));
   KJ_DEFER({
     close(failpipe[0]);
@@ -945,7 +945,7 @@ KJ_TEST("UnixEventPort whenWriteDisconnected()") {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  int fds_[2];
+  int fds_[2]{};
   KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds_));
   kj::AutoCloseFd fds[2] = { kj::AutoCloseFd(fds_[0]), kj::AutoCloseFd(fds_[1]) };
 
@@ -966,7 +966,7 @@ KJ_TEST("UnixEventPort whenWriteDisconnected()") {
   readablePromise.wait(waitScope);
 
   {
-    char junk[16];
+    char junk[16]{};
     ssize_t n;
     KJ_SYSCALL(n = read(fds[0], junk, 16));
     KJ_EXPECT(n == 3);
@@ -991,7 +991,7 @@ KJ_TEST("UnixEventPort FdObserver(..., flags=0)::whenWriteDisconnected()") {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  int pipefds[2];
+  int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
   kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
 
@@ -1139,7 +1139,7 @@ KJ_TEST("UnixEventPoll::getPollableFd() for external waiting") {
 
   // Test wakeup on observed FD.
   {
-    int pair[2];
+    int pair[2]{};
     KJ_SYSCALL(pipe(pair));
     kj::AutoCloseFd in(pair[0]);
     kj::AutoCloseFd out(pair[1]);

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -652,7 +652,7 @@ bool UnixEventPort::processEpollEvents(struct epoll_event events[], int n) {
     } else if (events[i].data.u64 == 1) {
       // timerfd fired. We need to clear it by reading it.
       int tfd = KJ_ASSERT_NONNULL(timerFd).get();
-      char buffer[16];
+      char buffer[16]{};
       ssize_t n;
       KJ_NONBLOCKING_SYSCALL(n = read(tfd, buffer, sizeof(buffer)));
       KJ_ASSERT(n == 8 || n < 0);

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -307,7 +307,7 @@ public:
   Maybe<OwnTask>* prev = nullptr;
 
   kj::String trace() {
-    void* space[32];
+    void* space[32]{};
     _::TraceBuilder builder(space);
     node->tracePromise(builder, false);
     return kj::str("task: ", builder);
@@ -2285,7 +2285,7 @@ void Event::disarm() noexcept {
 }
 
 String Event::traceEvent() {
-  void* space[32];
+  void* space[32]{};
   TraceBuilder builder(space);
   traceEvent(builder);
   return kj::str(builder);
@@ -2310,7 +2310,7 @@ ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space) {
 }
 
 kj::String getAsyncTrace() {
-  void* space[32];
+  void* space[32]{};
   auto trace = getAsyncTrace(space);
   return kj::str(stringifyStackTraceAddresses(trace), stringifyStackTrace(trace));
 }
@@ -2320,7 +2320,7 @@ kj::String getAsyncTrace() {
 namespace _ {  // private
 
 kj::String PromiseBase::trace() {
-  void* space[32];
+  void* space[32]{};
   TraceBuilder builder(space);
   node->tracePromise(builder, false);
   return kj::str(builder);

--- a/c++/src/kj/cidr.c++
+++ b/c++/src/kj/cidr.c++
@@ -156,7 +156,7 @@ bool CidrRange::matchesFamily(int family) const {
 }
 
 String CidrRange::toString() const {
-  char result[128];
+  char result[128]{};
   KJ_ASSERT(inet_ntop(family, (void*)bits, result, sizeof(result)) == result);
   return kj::str(result, '/', bitCount);
 }

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -934,7 +934,7 @@ KJ_TEST("kj::ArrayPtr fill") {
   }
 
   // test small sizes separately, since compilers do a memset optimization
-  byte byteArray[256];
+  byte byteArray[256]{};
   arrayPtr(byteArray).fill(42);
   for (auto b: byteArray) {
     KJ_EXPECT(b == 42);
@@ -1022,7 +1022,7 @@ KJ_TEST("memzero<T>()") {
     double pi;
   };
   ZeroTest t1;
-    
+
   memzero(t1);
   KJ_EXPECT(t1.x == 0);
   KJ_EXPECT(t1.pi == 0.0);

--- a/c++/src/kj/compat/brotli-test.c++
+++ b/c++/src/kj/compat/brotli-test.c++
@@ -155,7 +155,7 @@ KJ_TEST("brotli decompression") {
     MockInputStream rawInput(kj::arrayPtr(FOOBAR_BR, sizeof(FOOBAR_BR) / 2), kj::maxValue);
     BrotliInputStream brotli(rawInput);
 
-    char text[16];
+    char text[16]{};
     size_t n = brotli.tryRead(text, 1, sizeof(text));
     text[n] = '\0';
     KJ_EXPECT(StringPtr(text, n) == "fo");
@@ -219,7 +219,7 @@ KJ_TEST("async brotli decompression") {
     MockAsyncInputStream rawInput(kj::arrayPtr(FOOBAR_BR, sizeof(FOOBAR_BR) / 2), kj::maxValue);
     BrotliAsyncInputStream brotli(rawInput);
 
-    char text[16];
+    char text[16]{};
     size_t n = brotli.tryRead(text, 1, sizeof(text)).wait(io.waitScope);
     text[n] = '\0';
     KJ_EXPECT(StringPtr(text, n) == "fo");

--- a/c++/src/kj/compat/gzip-test.c++
+++ b/c++/src/kj/compat/gzip-test.c++
@@ -150,7 +150,7 @@ KJ_TEST("gzip decompression") {
     MockInputStream rawInput(kj::arrayPtr(FOOBAR_GZIP, sizeof(FOOBAR_GZIP) / 2), kj::maxValue);
     GzipInputStream gzip(rawInput);
 
-    char text[16];
+    char text[16]{};
     size_t n = gzip.tryRead(text, 1, sizeof(text));
     text[n] = '\0';
     KJ_EXPECT(StringPtr(text, n) == "fo");
@@ -193,7 +193,7 @@ KJ_TEST("async gzip decompression") {
     MockAsyncInputStream rawInput(kj::arrayPtr(FOOBAR_GZIP, sizeof(FOOBAR_GZIP) / 2), kj::maxValue);
     GzipAsyncInputStream gzip(rawInput);
 
-    char text[16];
+    char text[16]{};
     size_t n = gzip.tryRead(text, 1, sizeof(text)).wait(io.waitScope);
     text[n] = '\0';
     KJ_EXPECT(StringPtr(text, n) == "fo");

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -2369,7 +2369,7 @@ KJ_TEST("WebSocket pump disconnect on send") {
   auto sendTask = client1->send("hello"_kj);
 
   // Endpoint reads three bytes and then disconnects.
-  char buffer[3];
+  char buffer[3]{};
   pipe2.ends[1]->read(buffer, 3).wait(waitScope);
   pipe2.ends[1] = nullptr;
 
@@ -5304,7 +5304,7 @@ void doDelayedCompletionTest(bool exception, kj::Maybe<uint64_t> expectedLength)
   KJ_EXPECT(resp.statusCode == 200);
 
   // Read "foo" from the response body: works
-  char buffer[16];
+  char buffer[16]{};
   KJ_ASSERT(resp.body->tryRead(buffer, 1, sizeof(buffer)).wait(waitScope) == 3);
   buffer[3] = '\0';
   KJ_EXPECT(buffer == "foo"_kj);
@@ -5963,7 +5963,7 @@ KJ_TEST("HttpClientImpl connect()") {
 
   auto req = client->connect("foo:123", HttpHeaders(headerTable), {});
 
-  char buffer[16];
+  char buffer[16]{};
   auto readPromise = req.connection->tryRead(buffer, 16, 16);
 
   expectRead(*pipe.ends[1], "CONNECT foo:123 HTTP/1.1\r\n\r\n").wait(waitScope);

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -286,7 +286,7 @@ void SHA1Final(
 {
     unsigned i;
 
-    unsigned char finalcount[8];
+    unsigned char finalcount[8]{};
 
     unsigned char c;
 
@@ -470,7 +470,7 @@ constexpr char WEBSOCKET_GUID[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 static kj::String generateWebSocketAccept(kj::StringPtr key) {
   // WebSocket demands we do a SHA-1 here. ARRGHH WHY SHA-1 WHYYYYYY?
   SHA1_CTX ctx;
-  byte digest[20];
+  byte digest[20]{};
   SHA1Init(&ctx);
   SHA1Update(&ctx, key.asBytes().begin(), key.size());
   SHA1Update(&ctx, reinterpret_cast<const byte*>(WEBSOCKET_GUID), strlen(WEBSOCKET_GUID));
@@ -5431,7 +5431,7 @@ public:
     // requests in the meantime.
     upgraded = true;
 
-    byte keyBytes[16];
+    byte keyBytes[16]{};
     KJ_ASSERT_NONNULL(settings.entropySource,
         "can't use openWebSocket() because no EntropySource was provided when creating the "
         "HttpClient").generate(keyBytes);

--- a/c++/src/kj/compat/readiness-io-test.c++
+++ b/c++/src/kj/compat/readiness-io-test.c++
@@ -30,7 +30,7 @@ KJ_TEST("readiness IO: write small") {
   auto io = setupAsyncIo();
   auto pipe = io.provider->newOneWayPipe();
 
-  char buf[4];
+  char buf[4]{};
   auto readPromise = pipe.in->read(buf, 3, 4);
 
   ReadyOutputStreamWrapper out(*pipe.out);
@@ -97,7 +97,7 @@ KJ_TEST("readiness IO: write while corked") {
   auto io = setupAsyncIo();
   auto pipe = io.provider->newOneWayPipe();
 
-  char buf[7];
+  char buf[7]{};
   auto readPromise = pipe.in->read(buf, 3, 7);
 
   ReadyOutputStreamWrapper out(*pipe.out);
@@ -193,7 +193,7 @@ KJ_TEST("readiness IO: read small") {
   auto pipe = io.provider->newOneWayPipe();
 
   ReadyInputStreamWrapper in(*pipe.in);
-  char buf[4];
+  char buf[4]{};
   KJ_ASSERT(in.read(kj::ArrayPtr<char>(buf).asBytes()) == nullptr);
 
   pipe.out->write("foo", 3).wait(io.waitScope);
@@ -221,7 +221,7 @@ KJ_TEST("readiness IO: read many odd") {
   auto io = setupAsyncIo();
   auto pipe = io.provider->newOneWayPipe();
 
-  char dummy[8192];
+  char dummy[8192]{};
   for (auto i: kj::indices(dummy)) {
     dummy[i] = "bar"[i%3];
   }
@@ -231,7 +231,7 @@ KJ_TEST("readiness IO: read many odd") {
   }).eagerlyEvaluate(nullptr);
 
   ReadyInputStreamWrapper in(*pipe.in);
-  char buf[3];
+  char buf[3]{};
 
   for (;;) {
     auto result = in.read(kj::ArrayPtr<char>(buf).asBytes());
@@ -264,7 +264,7 @@ KJ_TEST("readiness IO: read many even") {
   auto io = setupAsyncIo();
   auto pipe = io.provider->newOneWayPipe();
 
-  char dummy[8192];
+  char dummy[8192]{};
   for (auto i: kj::indices(dummy)) {
     dummy[i] = "ba"[i%2];
   }
@@ -274,7 +274,7 @@ KJ_TEST("readiness IO: read many even") {
   }).eagerlyEvaluate(nullptr);
 
   ReadyInputStreamWrapper in(*pipe.in);
-  char buf[2];
+  char buf[2]{};
 
   for (;;) {
     auto result = in.read(kj::ArrayPtr<char>(buf).asBytes());

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -508,7 +508,7 @@ KJ_TEST("TLS half-duplex") {
   KJ_EXPECT(server->readAllText().wait(test.io.waitScope) == "");
 
   for (uint i = 0; i < 100; i++) {
-    char buffer[7];
+    char buffer[7]{};
     auto writePromise = server->write("foobar", 6);
     auto readPromise = client->read(buffer, 6);
     writePromise.wait(test.io.waitScope);
@@ -576,7 +576,7 @@ KJ_TEST("TLS multiple messages") {
   auto writePromise = client->write("foo", 3)
       .then([&]() { return client->write("bar", 3); });
 
-  char buf[4];
+  char buf[4]{};
   buf[3] = '\0';
 
   server->read(&buf, 3).wait(test.io.waitScope);
@@ -613,7 +613,7 @@ KJ_TEST("TLS zero-sized write") {
   auto client = clientPromise.wait(test.io.waitScope);
   auto server = serverPromise.wait(test.io.waitScope);
 
-  char buf[7];
+  char buf[7]{};
   auto readPromise = server->read(&buf, 6);
 
   client->write("", 0).wait(test.io.waitScope);

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -64,7 +64,7 @@ kj::Exception getOpensslError() {
     }
 #endif
 
-    char message[1024];
+    char message[1024]{};
     ERR_error_string_n(error, message, sizeof(message));
     lines.add(kj::heapString(message));
   }

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -63,7 +63,7 @@ public:
     return false;
 
 #else
-    int pipeFds[2];
+    int pipeFds[2]{};
     KJ_SYSCALL(pipe(pipeFds));
     pid_t child = fork();
     if (child == 0) {
@@ -76,7 +76,7 @@ public:
       close(pipeFds[1]);
 
       // Read child error messages into our local buffer.
-      char buf[1024];
+      char buf[1024]{};
       for (;;) {
         ssize_t n = read(pipeFds[0], buf, sizeof(buf));
         if (n < 0) {
@@ -182,7 +182,7 @@ std::string fileLine(std::string file, int line) {
   file = trimSourceFilename(file.c_str()).cStr();
 
   file += ':';
-  char buffer[32];
+  char buffer[32]{};
   snprintf(buffer, sizeof(buffer), "%d", line);
   file += buffer;
   return file;

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -253,7 +253,7 @@ static String makeDescriptionImpl(DescriptionStyle style, const char* code, int 
 // On android before marshmallow only the posix version of stderror_r was
 // available, even with __USE_GNU.
 #if __USE_GNU && !(defined(__ANDROID_API__) && __ANDROID_API__ < 23)
-    char buffer[256];
+    char buffer[256]{};
     if (style == SYSCALL) {
       if (sysErrorString == nullptr) {
         sysErrorArray = strerror_r(errorNumber, buffer, sizeof(buffer));

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -350,7 +350,7 @@ String stringifyStackTrace(ArrayPtr<void* const> trace) {
     return nullptr;
   }
 
-  char line[512];
+  char line[512]{};
   size_t i = 0;
   while (i < kj::size(lines) && fgets(line, sizeof(line), p) != nullptr) {
     // Don't include exception-handling infrastructure or promise infrastructure in stack trace.
@@ -443,7 +443,7 @@ StringPtr stringifyStackTraceAddresses(ArrayPtr<void* const> trace, ArrayPtr<cha
 }
 
 String getStackTrace() {
-  void* space[32];
+  void* space[32]{};
   auto trace = getStackTrace(space, 2);
   return kj::str(stringifyStackTraceAddresses(trace), stringifyStackTrace(trace));
 }
@@ -451,7 +451,7 @@ String getStackTrace() {
 namespace {
 
 [[noreturn]] void terminateHandler() {
-  void* traceSpace[32];
+  void* traceSpace[32]{};
 
   // ignoreCount = 3 to ignore std::terminate entry.
   auto trace = kj::getStackTrace(traceSpace, 3);
@@ -585,7 +585,7 @@ void printStackTraceOnCrash() {
 namespace {
 
 [[noreturn]] void crashHandler(int signo, siginfo_t* info, void* context) {
-  void* traceSpace[32];
+  void* traceSpace[32]{};
 
 #if KJ_USE_WIN32_DBGHELP
   // Win32 backtracing can't trace its way out of a Cygwin signal handler. However, Cygwin gives
@@ -872,7 +872,7 @@ void Exception::truncateCommonTrace() {
 
   if (traceCount > 0) {
     // Create a "reference" stack trace that is a little bit deeper than the one in the exception.
-    void* refTraceSpace[sizeof(this->trace) / sizeof(this->trace[0]) + 4];
+    void* refTraceSpace[sizeof(this->trace) / sizeof(this->trace[0]) + 4]{};
     auto refTrace = kj::getStackTrace(refTraceSpace, 0);
 
     // We expect that the deepest frame in the exception's stack trace should be somewhere in our

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -898,7 +898,7 @@ KJ_TEST("DiskFile holes") {
 #endif
   KJ_EXPECT(meta.spaceUsed <= 2 * 65536);
 
-  byte buf[7];
+  byte buf[7]{};
 
 #if !_WIN32  // Win32 CopyFile() does NOT preserve sparseness.
   {

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -537,7 +537,7 @@ public:
 #endif
     uint64_t total = 0;
     while (size > 0) {
-      byte buffer[4096];
+      byte buffer[4096]{};
       ssize_t n;
       KJ_SYSCALL(n = pread(fromFd, buffer, kj::min(sizeof(buffer), size), fromOffset));
       if (n == 0) break;

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -468,7 +468,7 @@ bool Path::isWin32Special(StringPtr part) {
 
   // OK, this could be a Win32 special filename. We need to match the first three letters against
   // the list of specials, case-insensitively.
-  char tmp[4];
+  char tmp[4]{};
   memcpy(tmp, part.begin(), 3);
   tmp[3] = '\0';
   for (char& c: tmp) {
@@ -520,7 +520,7 @@ void File::writeAll(StringPtr text) const {
 
 size_t File::copy(uint64_t offset, const ReadableFile& from,
                   uint64_t fromOffset, uint64_t size) const {
-  byte buffer[8192];
+  byte buffer[8192]{};
 
   size_t result = 0;
   while (size > 0) {

--- a/c++/src/kj/io-test.c++
+++ b/c++/src/kj/io-test.c++
@@ -35,7 +35,7 @@ TEST(Io, WriteVec) {
   // Check that writing an array of arrays works even when some of the arrays are empty.  (This
   // used to not work in some cases.)
 
-  int fds[2];
+  int fds[2]{};
   KJ_SYSCALL(miniposix::pipe(fds));
 
   FdInputStream in((AutoCloseFd(fds[0])));
@@ -51,7 +51,7 @@ TEST(Io, WriteVec) {
 
   out.write(pieces);
 
-  char buf[7];
+  char buf[7]{};
   in.read(buf, 6);
   buf[6] = '\0';
 
@@ -59,7 +59,7 @@ TEST(Io, WriteVec) {
 }
 
 KJ_TEST("stringify AutoCloseFd") {
-  int fds[2];
+  int fds[2]{};
   KJ_SYSCALL(miniposix::pipe(fds));
   AutoCloseFd in(fds[0]), out(fds[1]);
 
@@ -93,7 +93,7 @@ KJ_TEST("VectorOutputStream") {
   KJ_ASSERT(output.getArray().end() == buf3.begin());
   KJ_ASSERT(kj::str(output.getArray().asChars()) == "abcdefghijklmnop");
 
-  byte junk[24];
+  byte junk[24]{};
   for (auto i: kj::indices(junk)) {
     junk[i] = 'A' + i;
   }

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -59,7 +59,7 @@ size_t InputStream::read(void* buffer, size_t minBytes, size_t maxBytes) {
 }
 
 void InputStream::skip(size_t bytes) {
-  char scratch[8192];
+  char scratch[8192]{};
   while (bytes > 0) {
     size_t amount = std::min(bytes, sizeof(scratch));
     read(scratch, amount);

--- a/c++/src/kj/std/iostream-test.c++
+++ b/c++/src/kj/std/iostream-test.c++
@@ -46,7 +46,7 @@ TEST(StdIoStream, WriteVec) {
 
   out.write(pieces);
 
-  char buf[7];
+  char buf[7]{};
   in.read(buf, 6);
   buf[6] = '\0';
 
@@ -65,7 +65,7 @@ TEST(StdIoStream, TryReadToEndOfFile) {
 
   out.write(bytes, 6);
 
-  char buf[9];
+  char buf[9]{};
   in.tryRead(buf, 8, 8);
   buf[6] = '\0';
 
@@ -85,7 +85,7 @@ TEST(StdIoStream, ReadToEndOfFile) {
 
   out.write(bytes, 6);
 
-  char buf[9];
+  char buf[9]{};
 
   Maybe<Exception> e = kj::runCatchingExceptions([&]() {
     in.read(buf, 8, 8);

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -290,14 +290,14 @@ KJ_TEST("kj::delimited() and kj::strPreallocated()") {
   KJ_EXPECT(str(delimited(array, "::")) == "1::23::456::78");
 
   {
-    char buffer[256];
+    char buffer[256]{};
     KJ_EXPECT(strPreallocated(buffer, delimited(array, "::"), 'x')
         == "1::23::456::78x");
     KJ_EXPECT(strPreallocated(buffer, "foo", 123, true) == "foo123true");
   }
 
   {
-    char buffer[5];
+    char buffer[5]{};
     KJ_EXPECT(strPreallocated(buffer, delimited(array, "::"), 'x') == "1::2");
     KJ_EXPECT(strPreallocated(buffer, "foo", 123, true) == "foo1");
   }
@@ -450,7 +450,7 @@ KJ_TEST("as<Std>") {
   std::string stdStr = str.as<Std>();
   KJ_EXPECT(stdStr == "foo");
 
-  StringPtr ptr = "bar"_kj; 
+  StringPtr ptr = "bar"_kj;
   std::string stdPtr = ptr.as<Std>();
   KJ_EXPECT(stdPtr == "bar");
 }

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -157,7 +157,7 @@ template <typename T>
 static CappedArray<char, sizeof(T) * 2 + 1> hexImpl(T i) {
   // We don't use sprintf() because it's not async-signal-safe (for strPreallocated()).
   CappedArray<char, sizeof(T) * 2 + 1> result;
-  uint8_t reverse[sizeof(T) * 2];
+  uint8_t reverse[sizeof(T) * 2]{};
   uint8_t* p = reverse;
   if (i == 0) {
     *p++ = 0;
@@ -209,7 +209,7 @@ static CappedArray<char, sizeof(T) * 3 + 2> stringifyImpl(T i) {
   // unsigned first, then negate it, to avoid ubsan complaining.
   Unsigned u = i;
   if (negative) u = -u;
-  uint8_t reverse[sizeof(T) * 3 + 1];
+  uint8_t reverse[sizeof(T) * 3 + 1]{};
   uint8_t* p = reverse;
   if (u == 0) {
     *p++ = 0;
@@ -522,7 +522,7 @@ kj::String LocalizeRadix(const char* input, const char* radix_pos) {
   // tell, this is the only portable, thread-safe way to get the C library
   // to divuldge the locale's radix character.  No, localeconv() is NOT
   // thread-safe.
-  char temp[16];
+  char temp[16]{};
   int size = snprintf(temp, sizeof(temp), "%.1f", 1.5);
   KJ_ASSERT(temp[0] == '1');
   KJ_ASSERT(temp[size-1] == '5');

--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -88,7 +88,7 @@ public:
 
   void logMessage(LogSeverity severity, const char* file, int line, int contextDepth,
                   String&& text) override {
-    void* traceSpace[32];
+    void* traceSpace[32]{};
     auto trace = getStackTrace(traceSpace, 2);
 
     if (text.size() == 0) {


### PR DESCRIPTION
Uninitialized arrays are a security risk. Fixing downstream clang-tidy warnings.