### PR TITLE
Fix undefined behavior violations

### DIFF
--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -2340,7 +2340,7 @@ private:
     RpcServerResponseImpl& response;
     kj::Own<RpcCallContext> context;  // owns `response`
 
-    kj::Own<ClientHook> getResolutionAtReturnTime(
+    static kj::Own<ClientHook> getResolutionAtReturnTime(
         kj::Own<ClientHook> original, RpcServerResponseImpl::Resolution resolution) {
       // Wait for `original` to resolve to `resolution.returnedCap`, then return
       // `resolution.unwrapped`.
@@ -2358,7 +2358,7 @@ private:
 
       KJ_IF_SOME(p, ptr->whenMoreResolved()) {
         return newLocalPromiseClient(p.then(
-            [this, original = kj::mv(original), resolution = kj::mv(resolution)]
+            [original = kj::mv(original), resolution = kj::mv(resolution)]
             (kj::Own<ClientHook> r) mutable {
           return getResolutionAtReturnTime(kj::mv(r), kj::mv(resolution));
         }));

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -210,6 +210,7 @@ public:
     // Like asBytes() but transfers ownership.
     static_assert(sizeof(T) == sizeof(byte),
         "releaseAsBytes() only possible on arrays with byte-size elements (e.g. chars).");
+    if (disposer == nullptr) return nullptr;
     Array<PropagateConst<T, byte>> result(
         reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_, *disposer);
     ptr = nullptr;
@@ -220,6 +221,7 @@ public:
     // Like asChars() but transfers ownership.
     static_assert(sizeof(T) == sizeof(PropagateConst<T, char>),
         "releaseAsChars() only possible on arrays with char-size elements (e.g. bytes).");
+    if (disposer == nullptr) return nullptr;
     Array<PropagateConst<T, char>> result(
         reinterpret_cast<PropagateConst<T, char>*>(ptr), size_, *disposer);
     ptr = nullptr;


### PR DESCRIPTION
Fixes an instance of undefined behavior when calling `releaseAs*()` on a kj::Array that has been allocated using a nullptr to indicate an empty array and thus has a nullptr disposer.
There might be more places where releaseAs is used in this way and a better way to fix this, open to suggestions here but also want to ship this soon.

Added a second commit to fix a remaining issue. Also see the downstream branch.