### PR TITLE
Add clang::musttail attributes to a couple recursive calls

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -259,6 +259,14 @@ typedef unsigned char byte;
 // by allowing a syntax like `[[clang::lifetimebound(*this)]]`.
 // https://clang.llvm.org/docs/AttributeReference.html#lifetimebound
 
+#if KJ_HAS_CPP_ATTRIBUTE(clang::musttail)
+#define KJ_MUSTTAIL [[clang::musttail]]
+#else
+#define KJ_MUSTTAIL
+#endif
+// Annotation for "return" statements to require that they be compiled as tail calls.
+// https://clang.llvm.org/docs/AttributeReference.html#musttail
+
 #if __clang__
 #define KJ_UNUSED_MEMBER __attribute__((unused))
 // Inhibits "unused" warning for member variables.  Only Clang produces such a warning, while GCC

--- a/c++/src/kj/compat/brotli.c++
+++ b/c++/src/kj/compat/brotli.c++
@@ -215,7 +215,7 @@ size_t BrotliInputStream::readImpl(
   if (n >= minBytes) {
     return n + alreadyRead;
   } else {
-    return readImpl(out + n, minBytes - n, maxBytes - n, alreadyRead + n);
+    KJ_MUSTTAIL return readImpl(out + n, minBytes - n, maxBytes - n, alreadyRead + n);
   }
 }
 

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -135,7 +135,7 @@ size_t GzipInputStream::readImpl(
     if (n >= minBytes) {
       return n + alreadyRead;
     } else {
-      return readImpl(out + n, minBytes - n, maxBytes - n, alreadyRead + n);
+      KJ_MUSTTAIL return readImpl(out + n, minBytes - n, maxBytes - n, alreadyRead + n);
     }
   } else {
     if (ctx.msg == nullptr) {


### PR DESCRIPTION
Should reduce noise in stack traces, and also ensures that clang will tell us if future code changes inadvertently prevent tail call optimization.