### PR TITLE
enable CI on v2 branch

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
     - master
+    - v2
     - 'release-*'
 
 jobs:


### PR DESCRIPTION
I look at https://github.com/capnproto/capnproto/commits/v2/ and it doesn't seem that we have builds enabled.