### PR TITLE
heapArray filled version

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -110,6 +110,11 @@ TEST(Array, TrivialConstructor) {
 //      EXPECT_NE(chars[1], 0);
 //    }
   }
+
+  {
+    Array<char> chars = heapArray<char>(32, 'x');
+    for (char c : chars) EXPECT_EQ('x', c);
+  }
 }
 
 TEST(Array, ComplexConstructor) {
@@ -122,7 +127,6 @@ TEST(Array, ComplexConstructor) {
   }
   EXPECT_EQ(0, TestObject::count);
 }
-
 TEST(Array, ThrowingConstructor) {
   TestObject::count = 0;
   TestObject::throwAt = 16;

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -322,6 +322,15 @@ template <typename T, typename Iterator> Array<T> heapArray(Iterator begin, Iter
 template <typename T> Array<T> heapArray(std::initializer_list<T> init);
 // Allocate a heap array containing a copy of the given content.
 
+template <typename T, typename = EnableIf<KJ_HAS_TRIVIAL_CONSTRUCTOR(T)>>
+inline Array<T> heapArray(size_t size, T t) {
+  // Allocate array pre-filled with t.
+  // TODO: implement for complex T types without creating `size` instances first.
+  Array<T> array = heapArray<T>(size);
+  array.asPtr().fill(t);
+  return array;
+}
+
 template <typename T, typename Container>
 Array<T> heapArrayFromIterable(Container&& a) { return heapArray<T>(a.begin(), a.end()); }
 template <typename T>


### PR DESCRIPTION
For trivial types, heapArray returns unitialized memory, which could be a security issue.
While the implementation is possible for non-trivial types, it is less of an issue and will probably be seldom used.

As an alternative I could suggest `heapZeroArray()` and provide only zero-initialized heap arrays.