### PR TITLE
kj::arrayPtr<T>(T &t) creates a single-element array pointer

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -1023,6 +1023,22 @@ KJ_TEST("arrayPtr()") {
   KJ_EXPECT(ptr.size() == 1024);
 }
 
+KJ_TEST("single item arrayPtr()") {
+  byte b = 42;
+  KJ_EXPECT(arrayPtr(b).size() == 1);
+  KJ_EXPECT(arrayPtr(b).begin() == &b);
+
+  // test an object
+  struct SomeObject {
+    int64_t i;
+    double d;
+  };
+  SomeObject obj = {42, 3.1415};
+  kj::arrayPtr(obj).asBytes().fill(0);
+  KJ_EXPECT(obj.i == 0);
+  KJ_EXPECT(obj.d == 0);
+}
+
 KJ_TEST("memzero<T>()") {
   // memzero() works for primitive types
   int64_t x = 42;

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2033,6 +2033,12 @@ inline constexpr ArrayPtr<T> arrayPtr(T* begin KJ_LIFETIMEBOUND, T* end KJ_LIFET
   return ArrayPtr<T>(begin, end);
 }
 
+template <typename T>
+inline constexpr ArrayPtr<T> arrayPtr(T& t KJ_LIFETIMEBOUND) {
+  // Construct ArrayPtr pointing to a single object instance.
+  return arrayPtr(&t, 1);
+}
+
 template <typename T, size_t s>
 inline constexpr ArrayPtr<T> arrayPtr(T (&arr)[s]) {
   // Use this function to construct ArrayPtrs without writing out the type name.


### PR DESCRIPTION
This is a common operation when dealing with IO.