### PR TITLE
[nfc] Clean up recursive header dependencies

### DIFF
--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "layout.h"
-#include "pointer-helpers.h"
 #include "orphan.h"
 #include "list.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
@@ -31,6 +30,9 @@
 CAPNP_BEGIN_HEADER
 
 namespace capnp {
+namespace _ {
+  class PointerBuilder;
+}
 
 class StructSchema;
 class ListSchema;

--- a/c++/src/capnp/capability-test.c++
+++ b/c++/src/capnp/capability-test.c++
@@ -35,6 +35,7 @@
 #include "test-util.h"
 #include <kj/debug.h>
 #include <kj/compat/gtest.h>
+#include <capnp/message.h>
 
 namespace capnp {
 namespace _ {

--- a/c++/src/capnp/compat/json-rpc.c++
+++ b/c++/src/capnp/compat/json-rpc.c++
@@ -22,6 +22,7 @@
 #include "json-rpc.h"
 #include <kj/compat/http.h>
 #include <capnp/compat/json-rpc.capnp.h>
+#include <capnp/message.h>
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -21,6 +21,7 @@
 
 #include "json.h"
 #include <capnp/test-util.h>
+#include <capnp/message.h>
 #include <capnp/compat/json.capnp.h>
 #include <capnp/compat/json-test.capnp.h>
 #include <kj/debug.h>

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #include "json.h"
+#include <capnp/message.h>
 #include <capnp/orphan.h>
 #include <kj/debug.h>
 #include <kj/function.h>

--- a/c++/src/capnp/compat/json.capnp.h
+++ b/c++/src/capnp/compat/json.capnp.h
@@ -5,9 +5,6 @@
 
 #include <capnp/generated-header-support.h>
 #include <kj/windows-sanity.h>
-#if !CAPNP_LITE
-#include <capnp/capability.h>
-#endif  // !CAPNP_LITE
 
 #ifndef CAPNP_VERSION
 #error "CAPNP_VERSION is not defined, is capnp/generated-header-support.h missing?"

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -37,6 +37,7 @@
 #include <kj/vector.h>
 #include <kj/io.h>
 #include <kj/miniposix.h>
+#include <kj/filesystem.h>
 #include <kj/debug.h>
 #include "../message.h"
 #include <kj/main.h>

--- a/c++/src/capnp/compiler/error-reporter.h
+++ b/c++/src/capnp/compiler/error-reporter.h
@@ -23,11 +23,14 @@
 
 #include <capnp/common.h>
 #include <kj/string.h>
-#include <kj/exception.h>
 #include <kj/vector.h>
-#include <kj/filesystem.h>
 
 CAPNP_BEGIN_HEADER
+
+namespace kj {
+  class ReadableDirectory;
+  class PathPtr;
+}
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/generics.h
+++ b/c++/src/capnp/compiler/generics.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#include <capnp/orphan.h>
-#include <capnp/compiler/grammar.capnp.h>
-#include <capnp/schema.capnp.h>
-#include <capnp/dynamic.h>
+#include <capnp/common.h>
+#include <kj/debug.h>
+#include <kj/refcount.h>
 #include <kj/vector.h>
-#include <kj/one-of.h>
 #include "error-reporter.h"
 #include "resolver.h"
 

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -20,8 +20,10 @@
 // THE SOFTWARE.
 
 #include "module-loader.h"
+#include "compiler.h"
 #include "lexer.h"
 #include "parser.h"
+#include <kj/filesystem.h>
 #include <kj/vector.h>
 #include <kj/mutex.h>
 #include <kj/debug.h>

--- a/c++/src/capnp/compiler/module-loader.h
+++ b/c++/src/capnp/compiler/module-loader.h
@@ -21,17 +21,18 @@
 
 #pragma once
 
-#include "compiler.h"
-#include "error-reporter.h"
-#include <kj/memory.h>
-#include <kj/array.h>
-#include <kj/string.h>
-#include <kj/filesystem.h>
+#include <capnp/common.h>
 
 CAPNP_BEGIN_HEADER
+namespace kj {
+class ReadableDirectory;
+class PathPtr;
+}
 
 namespace capnp {
 namespace compiler {
+class GlobalErrorReporter;
+class Module;
 
 class ModuleLoader {
 public:

--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -20,12 +20,12 @@
 // THE SOFTWARE.
 
 #include "node-translator.h"
+#include "generics.h"
 #include "parser.h"      // only for generateGroupId() and expressionString()
 #include <capnp/serialize.h>
 #include <kj/debug.h>
 #include <kj/arena.h>
 #include <kj/encoding.h>
-#include <set>
 #include <map>
 #include <stdlib.h>
 #include <capnp/stream.capnp.h>

--- a/c++/src/capnp/compiler/node-translator.h
+++ b/c++/src/capnp/compiler/node-translator.h
@@ -26,17 +26,17 @@
 #include <capnp/schema.capnp.h>
 #include <capnp/dynamic.h>
 #include <kj/vector.h>
-#include <kj/one-of.h>
 #include "error-reporter.h"
 #include "resolver.h"
-#include "generics.h"
-#include <map>
 
 CAPNP_BEGIN_HEADER
 
 namespace capnp {
 namespace compiler {
 
+struct ImplicitParams;
+class BrandScope;
+class BrandedDecl;
 class NodeTranslator {
   // Translates one node in the schema from AST form to final schema form.  A "node" is anything
   // that has a unique ID, such as structs, enums, constants, and annotations, but not fields,

--- a/c++/src/capnp/compiler/resolver.h
+++ b/c++/src/capnp/compiler/resolver.h
@@ -23,12 +23,14 @@
 
 #include <capnp/compiler/grammar.capnp.h>
 #include <capnp/schema.capnp.h>
-#include <capnp/schema.h>
 #include <kj/one-of.h>
 
 CAPNP_BEGIN_HEADER
 
 namespace capnp {
+class Type;
+class Schema;
+
 namespace compiler {
 
 class Resolver {

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -34,7 +34,6 @@
 
 #include "schema.h"
 #include "layout.h"
-#include "message.h"
 #include "any.h"
 #include "capability.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`

--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -31,7 +31,6 @@
 #include "any.h"
 #include <kj/string.h>
 #include <kj/string-tree.h>
-#include <kj/hash.h>
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -25,6 +25,7 @@
 #include <kj/memory.h>
 #include <kj/mutex.h>
 #include <kj/debug.h>
+#include "pointer-helpers.h"
 #include <kj/vector.h>
 #include "common.h"
 #include "layout.h"

--- a/c++/src/capnp/pointer-helpers.h
+++ b/c++/src/capnp/pointer-helpers.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "layout.h"
-#include "list.h"
+#include "orphan.h"
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -26,6 +26,7 @@
 #include "schema.h"
 #include "serialize.h"
 #include <kj/debug.h>
+#include <kj/function.h>
 #include <kj/string-tree.h>
 #include <kj/compat/gtest.h>
 #include <capnp/rpc.capnp.h>

--- a/c++/src/capnp/schema-loader-test.c++
+++ b/c++/src/capnp/schema-loader-test.c++
@@ -24,6 +24,7 @@
 #include "schema-loader.h"
 #include <kj/compat/gtest.h>
 #include "test-util.h"
+#include <capnp/message.h>
 #include <kj/debug.h>
 
 namespace capnp {

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -34,6 +34,7 @@
 #include "serialize.h"
 #include <kj/debug.h>
 #include <kj/io.h>
+#include <kj/one-of.h>
 
 namespace capnp {
 

--- a/c++/src/capnp/serialize-text.c++
+++ b/c++/src/capnp/serialize-text.c++
@@ -23,6 +23,8 @@
 
 #include <kj/debug.h>
 
+#include <capnp/message.h>
+#include "schema.h"
 #include "pretty-print.h"
 #include "compiler/lexer.capnp.h"
 #include "compiler/lexer.h"

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <capnp/test.capnp.h>
-#include <iostream>
+#include <initializer_list>
 #include <capnp/blob.h>
 #include <kj/compat/gtest.h>
 

--- a/c++/src/kj/arena.h
+++ b/c++/src/kj/arena.h
@@ -23,11 +23,11 @@
 
 #include "memory.h"
 #include "array.h"
-#include "string.h"
 
 KJ_BEGIN_HEADER
 
 namespace kj {
+class StringPtr;
 
 class Arena {
   // A class which allows several objects to be allocated in contiguous chunks of memory, then

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -32,7 +32,7 @@
 #endif
 
 #if _MSC_VER
-#include <intrin.h>
+#include <intrin.h>  // _ReturnAddress
 #endif
 
 #include <kj/list.h>

--- a/c++/src/kj/async-io-internal.h
+++ b/c++/src/kj/async-io-internal.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#include "string.h"
 #include "vector.h"
 #include "async-io.h"
 #include <stdint.h>
-#include "one-of.h"
 #include "cidr.h"
 
 KJ_BEGIN_HEADER
@@ -34,6 +32,9 @@ struct sockaddr;
 struct sockaddr_un;
 
 namespace kj {
+
+class StringPtr;
+
 namespace _ {  // private
 
 // =======================================================================================

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -28,9 +28,12 @@
 #include <inttypes.h>
 #include <limits>
 #include <pthread.h>
-#include <map>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#if !KJ_USE_KQUEUE
+#include <map>
+#endif
 
 #if KJ_USE_EPOLL
 #include <sys/epoll.h>

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -27,7 +27,6 @@
 
 #include "async.h"
 #include "timer.h"
-#include <kj/vector.h>
 #include <kj/io.h>
 #include <signal.h>
 

--- a/c++/src/kj/cidr.h
+++ b/c++/src/kj/cidr.h
@@ -31,6 +31,9 @@ struct sockaddr;
 
 namespace kj {
 
+class String;
+class StringPtr;
+
 class CidrRange {
 public:
   CidrRange(StringPtr pattern);

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -115,8 +115,12 @@ KJ_BEGIN_HEADER
 #endif
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
+#if _MSC_VER < 1920
 #include <intrin.h>  // __popcnt
+#else
+#include <intrin0.h>  // __popcnt
+#endif
 #endif
 
 // =======================================================================================

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -83,7 +83,7 @@
 #endif
 
 #if _MSC_VER
-#include <intrin.h>
+#include <intrin.h>  // _ReturnAddress
 #endif
 
 #if KJ_HAS_COMPILER_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)

--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -306,12 +306,7 @@ protected:
   }
 };
 
-#if _MSC_VER && _MSC_VER < 1910 && !defined(__clang__)
-// TODO(msvc): MSVC 2015 can't initialize a constexpr's vtable correctly.
-const MmapDisposer mmapDisposer = MmapDisposer();
-#else
 constexpr MmapDisposer mmapDisposer = MmapDisposer();
-#endif
 
 void* win32Mmap(HANDLE handle, MmapRange range, DWORD pageProtect, DWORD access) {
   HANDLE mappingHandle;

--- a/c++/src/kj/main.h
+++ b/c++/src/kj/main.h
@@ -25,7 +25,6 @@
 
 #include "array.h"
 #include "string.h"
-#include "vector.h"
 #include "function.h"
 
 KJ_BEGIN_HEADER

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -22,6 +22,7 @@
 #include "kj/common.h"
 #include "kj/string.h"
 #include "kj/test.h"
+#include "function.h"
 #include "memory.h"
 #include <signal.h>
 #include <kj/compat/gtest.h>

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -22,7 +22,9 @@
 #pragma once
 
 #include "common.h"
-#include <atomic>
+#ifdef KJ_DEBUG
+#include <atomic>  // std::atomic for KJ_ASSERT_PTR_COUNTERS
+#endif
 
 KJ_BEGIN_HEADER
 

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -21,12 +21,10 @@
 
 #pragma once
 
-#include "debug.h"
 #include "memory.h"
 #include <inttypes.h>
 #include "time.h"
 #include "source-location.h"
-#include "one-of.h"
 
 KJ_BEGIN_HEADER
 

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -23,12 +23,8 @@
 
 #include "memory.h"
 
-#if _MSC_VER
-#if _MSC_VER < 1910
-#include <intrin.h>
-#else
-#include <intrin0.h>
-#endif
+#if _MSC_VER && !defined(__clang__)
+#include <intrin0.h> // _InterlockedXX
 #endif
 
 KJ_BEGIN_HEADER

--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -28,11 +28,7 @@
 
 #if _MSC_VER
 // Need _ReadWriteBarrier
-#if _MSC_VER < 1910
-#include <intrin.h>
-#else
 #include <intrin0.h>
-#endif
 #endif
 
 #if KJ_DEBUG_TABLE_IMPL

--- a/c++/src/kj/test-helpers.c++
+++ b/c++/src/kj/test-helpers.c++
@@ -23,6 +23,7 @@
 #define _GNU_SOURCE
 #endif
 
+#include "function.h"
 #include "test.h"
 
 #include <string.h>

--- a/c++/src/kj/test-test.c++
+++ b/c++/src/kj/test-test.c++
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #include "common.h"
+#include "function.h"
 #include "test.h"
 #include <cstdlib>
 #include <stdexcept>

--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -27,6 +27,7 @@
 
 #include "test.h"
 #include "main.h"
+#include <kj/glob-filter.h>
 #include "io.h"
 #include "miniposix.h"
 #include <stdlib.h>

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -22,14 +22,16 @@
 #pragma once
 
 #include <kj/debug.h>
-#include <kj/glob-filter.h>
-#include <kj/vector.h>
-#include <kj/function.h>
 #include <kj/windows-sanity.h>  // work-around macro conflict with `ERROR`
 
 KJ_BEGIN_HEADER
 
 namespace kj {
+template<typename T>
+class Function;
+
+template<typename T>
+class FunctionParam;
 
 class TestRunner;
 

--- a/c++/src/kj/units-test.c++
+++ b/c++/src/kj/units-test.c++
@@ -21,7 +21,6 @@
 
 #include "units.h"
 #include <kj/compat/gtest.h>
-#include <iostream>
 
 namespace kj {
 namespace {


### PR DESCRIPTION
This should slightly improve compile speeds, especially under MSVC. To keep this change small this primarily affects headers, which should already allow us to eliminate many superfluous recursive includes.

- Limit usage of intrin.h for MSVC, this is generally heavy
- Drop some support for MSVC versions older than VS 2017 Update 9 (MSVC_VER 1916). We likely don't support this version anyway based on coroutines/C++20 support, but dropping more _MSC_VER checks can be done in another PR.

Further potential to reduce recursive includes exists by refactoring async code so that coroutines are not always included, as well as isolating usage of large libc++ headers like \<set\> and \<atomic\>. I experimented with those and based on looking at preprocessed source code sizes in a more rigorous way this leads to larger improvements in include sizes, but the advantage in compile time is harder to evaluate.

This will likely require some include changes downstream which are still Work-In-Progress, but this should be final and ready for review.