### PR TITLE
enable -Wsuggest-override

### DIFF
--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -2,8 +2,9 @@ common --noenable_bzlmod
 common --enable_platform_specific_config
 
 build:unix --cxxopt='-std=c++20' --host_cxxopt='-std=c++20' --force_pic --verbose_failures
-build:unix --cxxopt='-Wall' --host_cxxopt='-Wall'
-build:unix --cxxopt='-Wextra' --host_cxxopt='-Wextra'
+build:unix --cxxopt='-Wall'
+build:unix --cxxopt='-Wextra'
+build:unix --cxxopt='-Wsuggest-override'
 build:unix --cxxopt='-Wno-strict-aliasing' --host_cxxopt='-Wno-strict-aliasing'
 build:unix --cxxopt='-Wno-sign-compare' --host_cxxopt='-Wno-sign-compare'
 build:unix --cxxopt='-Wno-unused-parameter' --host_cxxopt='-Wno-unused-parameter'

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -147,7 +147,7 @@ else()
   #   recognize as safe.
   # * sign-compare: Low S/N ratio.
   # * unused-parameter: Low S/N ratio.
-  add_compile_options(-Wall -Wextra -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter)
+  add_compile_options(-Wall -Wextra -Wsuggest-override -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter)
 
   if(DEFINED CMAKE_CXX_EXTENSIONS AND NOT CMAKE_CXX_EXTENSIONS)
     message(SEND_ERROR "Cap'n Proto requires compiler-specific extensions (e.g., -std=gnu++20). Please leave CMAKE_CXX_EXTENSIONS undefined or ON.")

--- a/c++/Makefile.ekam
+++ b/c++/Makefile.ekam
@@ -6,7 +6,7 @@ ifeq ($(CXX),clang++)
   # Clang's verbose diagnostics don't play nice with the Ekam Eclipse plugin's error parsing,
   # so disable them.  Also enable some useful Clang warnings (dunno if GCC supports them, and don't
   # care).
-  EXTRA_FLAG=-fno-caret-diagnostics -Wglobal-constructors -Wextra-semi -Werror=return-type
+  EXTRA_FLAG=-fno-caret-diagnostics -Wglobal-constructors -Wextra-semi -Wsuggest-override -Werror=return-type
 #  EXTRA_FLAG=-fno-caret-diagnostics -Weverything -Wno-c++98-compat -Wno-shadow -Wno-c++98-compat-pedantic -Wno-padded -Wno-weak-vtables -Wno-gnu -Wno-unused-parameter -Wno-sign-conversion -Wno-undef -Wno-shorten-64-to-32 -Wno-conversion -Wno-unreachable-code -Wno-non-virtual-dtor
 else
   EXTRA_FLAG=

--- a/c++/ekam-build.sh
+++ b/c++/ekam-build.sh
@@ -50,7 +50,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-CLANG_CXXFLAGS="-std=c++20 -stdlib=libc++ -pthread -Wall -Wextra -Werror -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -Wimplicit-fallthrough -Wno-error=unused-command-line-argument -Wno-missing-field-initializers -DKJ_HEADER_WARNINGS -DCAPNP_HEADER_WARNINGS -DKJ_HAS_OPENSSL -DKJ_HAS_LIBDL -DKJ_HAS_ZLIB -DKJ_BENCHMARK_MALLOC"
+CLANG_CXXFLAGS="-std=c++20 -stdlib=libc++ -pthread -Wall -Wextra -Wsuggest-override -Werror -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -Wimplicit-fallthrough -Wno-error=unused-command-line-argument -Wno-missing-field-initializers -DKJ_HEADER_WARNINGS -DCAPNP_HEADER_WARNINGS -DKJ_HAS_OPENSSL -DKJ_HAS_LIBDL -DKJ_HAS_ZLIB -DKJ_BENCHMARK_MALLOC"
 
 export CXX=${CXX:-clang++}
 export CC=${CC:-clang}

--- a/c++/samples/calculator-client.c++
+++ b/c++/samples/calculator-client.c++
@@ -32,7 +32,7 @@ class PowerFunction final: public Calculator::Function::Server {
   // the server.  The server will then be able to make calls back to the client.
 
 public:
-  kj::Promise<void> call(CallContext context) {
+  kj::Promise<void> call(CallContext context) override {
     auto params = context.getParams().getParams();
     KJ_REQUIRE(params.size() == 2, "Wrong number of parameters.");
     context.getResults().setValue(pow(params[0], params[1]));

--- a/c++/samples/calculator-server.c++
+++ b/c++/samples/calculator-server.c++
@@ -97,7 +97,7 @@ class ValueImpl final: public Calculator::Value::Server {
 public:
   ValueImpl(double value): value(value) {}
 
-  kj::Promise<void> read(ReadContext context) {
+  kj::Promise<void> read(ReadContext context) override {
     context.getResults().setValue(value);
     return kj::READY_NOW;
   }
@@ -116,7 +116,7 @@ public:
     this->body.setRoot(body);
   }
 
-  kj::Promise<void> call(CallContext context) {
+  kj::Promise<void> call(CallContext context) override {
     auto params = context.getParams().getParams();
     KJ_REQUIRE(params.size() == paramCount, "Wrong number of parameters.");
 
@@ -141,7 +141,7 @@ class OperatorImpl final: public Calculator::Function::Server {
 public:
   OperatorImpl(Calculator::Operator op): op(op) {}
 
-  kj::Promise<void> call(CallContext context) {
+  kj::Promise<void> call(CallContext context) override {
     auto params = context.getParams().getParams();
     KJ_REQUIRE(params.size() == 2, "Wrong number of parameters.");
 

--- a/c++/src/capnp/capability-test.c++
+++ b/c++/src/capnp/capability-test.c++
@@ -492,7 +492,7 @@ public:
   int& callCount;
 
   kj::Promise<void> call(InterfaceSchema::Method method,
-                         CallContext<DynamicStruct, DynamicStruct> context) {
+                         CallContext<DynamicStruct, DynamicStruct> context) override {
     auto methodName = method.getProto().getName();
     if (methodName == "foo") {
       ++callCount;
@@ -566,7 +566,7 @@ public:
   int& callCount;
 
   kj::Promise<void> call(InterfaceSchema::Method method,
-                         CallContext<DynamicStruct, DynamicStruct> context) {
+                         CallContext<DynamicStruct, DynamicStruct> context) override {
     auto methodName = method.getProto().getName();
     if (methodName == "foo") {
       ++callCount;
@@ -626,7 +626,7 @@ public:
   int& callCount;
 
   kj::Promise<void> call(InterfaceSchema::Method method,
-                         CallContext<DynamicStruct, DynamicStruct> context) {
+                         CallContext<DynamicStruct, DynamicStruct> context) override {
     auto methodName = method.getProto().getName();
     if (methodName == "getCap") {
       ++callCount;
@@ -719,7 +719,7 @@ public:
   int& callCount;
 
   kj::Promise<void> call(InterfaceSchema::Method method,
-                         CallContext<DynamicStruct, DynamicStruct> context) {
+                         CallContext<DynamicStruct, DynamicStruct> context) override {
     auto methodName = method.getProto().getName();
     if (methodName == "foo") {
       ++callCount;
@@ -1070,7 +1070,7 @@ public:
   }
 
 protected:
-  kj::Promise<void> bar(BarContext context) {
+  kj::Promise<void> bar(BarContext context) override {
     ++callCount;
     return kj::READY_NOW;
   }

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -525,11 +525,11 @@ public:
       : context(kj::mv(contextParam)),
         results(context->getResults(MessageSize { 0, 0 })) {}
 
-  kj::Own<PipelineHook> addRef() {
+  kj::Own<PipelineHook> addRef() override {
     return kj::addRef(*this);
   }
 
-  kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) {
+  kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
     return results.getPipelinedCap(ops);
   }
 

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -502,7 +502,7 @@ public:
 
   kj::Promise<void> request(
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
-      kj::AsyncInputStream& requestBody, Response& response) {
+      kj::AsyncInputStream& requestBody, Response& response) override {
     kj::HttpHeaders respHeaders(headerTable);
     respHeaders.add("X-Foo", "bar");
     fulfiller->fulfill(response.acceptWebSocket(respHeaders));
@@ -631,7 +631,7 @@ public:
 
   kj::Promise<void> request(
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
-      kj::AsyncInputStream& requestBody, Response& response) {
+      kj::AsyncInputStream& requestBody, Response& response) override {
     called = true;
     return kj::NEVER_DONE;
   }

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -919,12 +919,13 @@ R"({
 
 class PrefixAdder: public JsonCodec::Handler<capnp::Text> {
 public:
-  void encode(const JsonCodec& codec, capnp::Text::Reader input, JsonValue::Builder output) const {
+  void encode(const JsonCodec& codec, capnp::Text::Reader input, 
+              JsonValue::Builder output) const override {
     output.setString(kj::str("add-prefix-", input));
   }
 
   Orphan<capnp::Text> decode(const JsonCodec& codec, JsonValue::Reader input,
-                             Orphanage orphanage) const {
+                             Orphanage orphanage) const override {
     return orphanage.newOrphanCopy(capnp::Text::Reader(input.getString().slice(11)));
   }
 };

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -904,24 +904,26 @@ static constexpr uint64_t JSON_HEX_ANNOTATION_ID = 0xf061e22f0ae5c7b5ull;
 
 class JsonCodec::Base64Handler final: public JsonCodec::Handler<capnp::Data> {
 public:
-  void encode(const JsonCodec& codec, capnp::Data::Reader input, JsonValue::Builder output) const {
+  void encode(const JsonCodec& codec, capnp::Data::Reader input,
+              JsonValue::Builder output) const override {
     output.setString(kj::encodeBase64(input));
   }
 
   Orphan<capnp::Data> decode(const JsonCodec& codec, JsonValue::Reader input,
-                             Orphanage orphanage) const {
+                             Orphanage orphanage) const override {
     return orphanage.newOrphanCopy(capnp::Data::Reader(kj::decodeBase64(input.getString())));
   }
 };
 
 class JsonCodec::HexHandler final: public JsonCodec::Handler<capnp::Data> {
 public:
-  void encode(const JsonCodec& codec, capnp::Data::Reader input, JsonValue::Builder output) const {
+  void encode(const JsonCodec& codec, capnp::Data::Reader input,
+              JsonValue::Builder output) const override {
     output.setString(kj::encodeHex(input));
   }
 
   Orphan<capnp::Data> decode(const JsonCodec& codec, JsonValue::Reader input,
-                             Orphanage orphanage) const {
+                             Orphanage orphanage) const override {
     return orphanage.newOrphanCopy(capnp::Data::Reader(kj::decodeHex(input.getString())));
   }
 };

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -984,7 +984,7 @@ private:
       }
     }
 
-    void onRecoverableException(kj::Exception&& e) {
+    void onRecoverableException(kj::Exception&& e) override {
       // Only capture the first exception, on the assumption that later exceptions are probably
       // just cascading problems.
       if (exception == kj::none) {

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -494,7 +494,7 @@ private:
 
 class TestBootstrapFactory: public BootstrapFactory<rpc::twoparty::VatId> {
 public:
-  Capability::Client createFor(rpc::twoparty::VatId::Reader clientId) {
+  Capability::Client createFor(rpc::twoparty::VatId::Reader clientId) override {
     called = true;
     EXPECT_EQ(rpc::twoparty::Side::CLIENT, clientId.getSide());
     return kj::heap<TestAuthenticatedBootstrapImpl>(clientId);

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -303,7 +303,7 @@ public:
     fulfiller->fulfill();
   }
 
-  kj::Promise<void> foo(FooContext context) {
+  kj::Promise<void> foo(FooContext context) override {
     return impl.foo(context);
   }
 

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -1050,8 +1050,8 @@ public:
   uint64_t getOffset() { return offset; }
   void seek(uint64_t newOffset) { offset = newOffset; }
 
-  Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes);
-  Maybe<uint64_t> tryGetLength();
+  Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+  Maybe<uint64_t> tryGetLength() override;
 
   // (pumpTo() is not actually overridden here, but AsyncStreamFd's tryPumpFrom() will detect when
   // the source is a file.)
@@ -1080,9 +1080,9 @@ public:
   uint64_t getOffset() { return offset; }
   void seek(uint64_t newOffset) { offset = newOffset; }
 
-  Promise<void> write(const void* buffer, size_t size);
-  Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces);
-  Promise<void> whenWriteDisconnected();
+  Promise<void> write(const void* buffer, size_t size) override;
+  Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
+  Promise<void> whenWriteDisconnected() override;
 
 private:
   const File& file;

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -657,7 +657,7 @@ private:
   }
 #endif
 
-  void disposeImpl(void* pointer) const {
+  void disposeImpl(void* pointer) const override {
     _::FiberStack* stack = reinterpret_cast<_::FiberStack*>(pointer);
     KJ_DEFER(delete stack);
 

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -689,10 +689,10 @@ public:
   virtual void fulfill(T&& value) = 0;
   // Fulfill the promise with the given value.
 
-  virtual void reject(Exception&& exception) = 0;
+  virtual void reject(Exception&& exception) override = 0;
   // Reject the promise with an error.
 
-  virtual bool isWaiting() = 0;
+  virtual bool isWaiting() override = 0;
   // Returns true if the promise is still unfulfilled and someone is potentially waiting for it.
   // Returns false if fulfill()/reject() has already been called *or* if the promise to be
   // fulfilled has been discarded and therefore the result will never be used anyway.
@@ -713,8 +713,8 @@ public:
   // Call with zero parameters.  The parameter is a dummy that only exists so that subclasses don't
   // have to specialize for <void>.
 
-  virtual void reject(Exception&& exception) = 0;
-  virtual bool isWaiting() = 0;
+  void reject(Exception&& exception) override = 0;
+  bool isWaiting() override = 0;
 
   template <typename Func>
   bool rejectIfThrows(Func&& func);

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1873,7 +1873,7 @@ class WebSocketErrorCatcher : public WebSocketErrorHandler {
 public:
   kj::Vector<kj::WebSocket::ProtocolError> errors;
 
-  kj::Exception handleWebSocketProtocolError(kj::WebSocket::ProtocolError protocolError) {
+  kj::Exception handleWebSocketProtocolError(kj::WebSocket::ProtocolError protocolError) override {
     errors.add(kj::mv(protocolError));
     return KJ_EXCEPTION(FAILED, protocolError.description);
   }

--- a/c++/src/kj/compat/tls.h
+++ b/c++/src/kj/compat/tls.h
@@ -123,12 +123,12 @@ public:
   ~TlsContext() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(TlsContext);
 
-  kj::Promise<kj::Own<kj::AsyncIoStream>> wrapServer(kj::Own<kj::AsyncIoStream> stream);
+  kj::Promise<kj::Own<kj::AsyncIoStream>> wrapServer(kj::Own<kj::AsyncIoStream> stream) override;
   // Upgrade a regular network stream to TLS and begin the initial handshake as the server. The
   // returned promise resolves when the handshake has completed successfully.
 
   kj::Promise<kj::Own<kj::AsyncIoStream>> wrapClient(
-      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname);
+      kj::Own<kj::AsyncIoStream> stream, kj::StringPtr expectedServerHostname) override;
   // Upgrade a regular network stream to TLS and begin the initial handshake as a client. The
   // returned promise resolves when the handshake has completed successfully, including validating
   // the server's certificate.
@@ -139,23 +139,23 @@ public:
   // 2. The server's certificate is validated against this hostname. If validation fails, the
   //    promise returned by wrapClient() will be broken; you'll never get a stream.
 
-  kj::Promise<kj::AuthenticatedStream> wrapServer(kj::AuthenticatedStream stream);
+  kj::Promise<kj::AuthenticatedStream> wrapServer(kj::AuthenticatedStream stream) override;
   kj::Promise<kj::AuthenticatedStream> wrapClient(
-      kj::AuthenticatedStream stream, kj::StringPtr expectedServerHostname);
+      kj::AuthenticatedStream stream, kj::StringPtr expectedServerHostname) override;
   // Like wrapServer() and wrapClient(), but also produces information about the peer's
   // certificate (if any). The returned `peerIdentity` will be a `TlsPeerIdentity`.
 
-  kj::Own<kj::ConnectionReceiver> wrapPort(kj::Own<kj::ConnectionReceiver> port);
+  kj::Own<kj::ConnectionReceiver> wrapPort(kj::Own<kj::ConnectionReceiver> port) override;
   // Upgrade a ConnectionReceiver to one that automatically upgrades all accepted connections to
   // TLS (acting as the server).
 
   kj::Own<kj::NetworkAddress> wrapAddress(
-      kj::Own<kj::NetworkAddress> address, kj::StringPtr expectedServerHostname);
+      kj::Own<kj::NetworkAddress> address, kj::StringPtr expectedServerHostname) override;
   // Upgrade a NetworkAddress to one that automatically upgrades all connections to TLS, acting
   // as the client when `connect()` is called or the server if `listen()` is called.
   // `connect()` will athenticate the server as `expectedServerHostname`.
 
-  kj::Own<kj::Network> wrapNetwork(kj::Network& network);
+  kj::Own<kj::Network> wrapNetwork(kj::Network& network) override;
   // Upgrade a Network to one that automatically upgrades all connections to TLS. The network will
   // only accept addresses of the form "hostname" and "hostname:port" (it does not accept raw IP
   // addresses). It will automatically use SNI and verify certificates based on these hostnames.

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -256,7 +256,7 @@ static MmapRange getMmapRange(uint64_t offset, uint64_t size) {
 class MmapDisposer: public ArrayDisposer {
 protected:
   void disposeImpl(void* firstElement, size_t elementSize, size_t elementCount,
-                   size_t capacity, void (*destroyElement)(void*)) const {
+                   size_t capacity, void (*destroyElement)(void*)) const override {
     auto range = getMmapRange(reinterpret_cast<uintptr_t>(firstElement),
                               elementSize * elementCount);
     KJ_SYSCALL(munmap(reinterpret_cast<byte*>(range.offset), range.size)) { break; }

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -382,7 +382,7 @@ KJ_DECLARE_NON_POLYMORPHIC(IncompleteTemplate<T, U>)
 struct IncompleteDisposer: public Disposer {
   mutable void* sawPtr = nullptr;
 
-  virtual void disposeImpl(void* pointer) const {
+  void disposeImpl(void* pointer) const override {
     sawPtr = pointer;
   }
 };

--- a/c++/src/kj/test-helpers.c++
+++ b/c++/src/kj/test-helpers.c++
@@ -70,7 +70,7 @@ public:
                         Maybe<StringPtr> message)
       : type(type), message(message) {}
 
-  virtual void onFatalException(Exception&& exception) {
+  void onFatalException(Exception&& exception) override {
     KJ_IF_SOME(expectedType, type) {
       if (exception.getType() != expectedType) {
         KJ_LOG(ERROR, "threw exception of wrong type", exception, expectedType);

--- a/c++/src/kj/thread-test.c++
+++ b/c++/src/kj/thread-test.c++
@@ -91,7 +91,7 @@ public:
   CapturingExceptionCallback(String& target): target(target) {}
 
   void logMessage(LogSeverity severity, const char* file, int line, int contextDepth,
-                  String&& text) {
+                  String&& text) override {
     target = kj::mv(text);
   }
 

--- a/c++/src/kj/timer.h
+++ b/c++/src/kj/timer.h
@@ -50,7 +50,7 @@ class Timer: public MonotonicClock {
   // `systemPreciseMonotonicClock()` directly in this case.
 
 public:
-  virtual TimePoint now() const = 0;
+  virtual TimePoint now() const override = 0;
   // Returns the current value of a clock that moves steadily forward, independent of any
   // changes in the wall clock. The value is updated every time the event loop waits,
   // and is constant in-between waits.

--- a/super-test.sh
+++ b/super-test.sh
@@ -348,7 +348,7 @@ done
 # sign-compare warnings than probably all other warnings combined and I've never seen it flag a
 # real problem. Disable unused parameters because it's stupidly noisy and never a real problem.
 # Enable expensive release-gating tests.
-export CXXFLAGS="-O2 -DDEBUG -Wall -Wextra -Werror -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -DCAPNP_EXPENSIVE_TESTS=1 ${CPP_FEATURES}"
+export CXXFLAGS="-O2 -DDEBUG -Wall -Wextra -Werror -Wsuggest-override -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -DCAPNP_EXPENSIVE_TESTS=1 ${CPP_FEATURES}"
 export LIBS="$EXTRA_LIBS"
 
 if [ "${CXX:-}" != "g++-5" ]; then


### PR DESCRIPTION
Having override annotations in place greatly helps with API
refactorings. I also believe this is a commonly accepted coding
practice.