### PR TITLE
Website: Add link to RPC Tracer

### DIFF
--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -47,6 +47,7 @@ new languages.
 * [Wireshark Dissector Plugin](https://github.com/kaos/wireshark-plugins) by [@kaos](https://github.com/kaos)
 * [VS Code Syntax Highlighter](https://marketplace.visualstudio.com/items?itemName=xmonader.vscode-capnp) by [@xmonader](https://github.com/xmonader)
 * [IntelliJ Syntax Highlighter](https://github.com/xmonader/sercapnp) by [@xmonader](https://github.com/xmonader)
+* [RPC Tracer](https://github.com/toyota-digital-cockpit-pf/capnp-trace) by [@t-kondo-tmc](https://github.com/t-kondo-tmc)
 
 ## Contribute Your Own!
 


### PR DESCRIPTION
Hi, thank you for the project.

I'd like to propose adding link to [Cap'n Proto RPC Tracer](https://github.com/toyota-digital-cockpit-pf/capnp-trace) in Tools section.

[Cap'n Proto RPC Tracer](https://github.com/toyota-digital-cockpit-pf/capnp-trace) can trace Cap'n Proto RPC like `strace` command.
Roughly speaking, this tool sniffs Unix Domain Socket communication by `ptrace` and `process_vm_readv`,
and deserialize it with `capnp::SchemaLoader`.
I believe this tool can be useful for Cap'n Proto users.