### PR TITLE
Support comparators for ArrayPtr and refactor StringPtr to use them internally.

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1928,6 +1928,30 @@ public:
     return true;
   }
 
+  inline bool operator<(const ArrayPtr& other) const {
+    size_t comparisonSize = kj::min(size_, other.size_);
+    if constexpr (isSameType<RemoveConst<T>, char>() || isSameType<RemoveConst<T>, unsigned char>()) {
+      int ret = memcmp(ptr, other.ptr, comparisonSize * sizeof(T));
+      if (ret != 0) {
+        return ret < 0;
+      }
+    } else {
+      for (size_t i = 0; i < comparisonSize; i++) {
+        bool ret = ptr[i] == other.ptr[i];
+        if (!ret) {
+          return ptr[i] < other.ptr[i];
+        }
+      }
+    }
+    // arrays are equal up to comparisonSize
+    return size_ <  other.size_;
+  }
+
+  inline bool operator<=(const ArrayPtr& other) const { return !(other < *this); }
+  inline bool operator>=(const ArrayPtr& other) const { return other <= *this; }
+  // Note that only strongly ordered types are currently supported
+  inline bool operator> (const ArrayPtr& other) const { return other < *this; }
+
   template <typename... Attachments>
   Array<T> attach(Attachments&&... attachments) const KJ_WARN_UNUSED_RESULT;
   // Like Array<T>::attach(), but also promotes an ArrayPtr to an Array. Generally the attachment
@@ -1940,10 +1964,10 @@ public:
   // Syntax sugar for invoking U::from.
   // Used to chain conversion calls rather than wrap with function.
 
-  inline void fill(T t) { 
+  inline void fill(T t) {
     // Fill the area by copying t over every element.
 
-    for (size_t i = 0; i < size_; i++) { ptr[i] = t; } 
+    for (size_t i = 0; i < size_; i++) { ptr[i] = t; }
     // All modern compilers are smart enough to optimize this loop for simple T's.
     // libc++ std::fill doesn't have memset specialization either.
   }
@@ -1955,7 +1979,7 @@ public:
     KJ_IREQUIRE(!intersects(other), "copy memory area must not overlap");
     T* __restrict__ dst = begin();
     const T* __restrict__ src = other.begin();
-    for (size_t s = size_, i = 0; i < s; i++) { dst[i] = src[i]; } 
+    for (size_t s = size_, i = 0; i < s; i++) { dst[i] = src[i]; }
   }
 
 private:
@@ -2209,7 +2233,7 @@ struct ByteLiteral {
   constexpr size_t size() const { return N - 1; }
   constexpr const kj::byte* begin() const { return data; }
   kj::byte data[N-1]; // do not store 0-terminator
-}; 
+};
 
 template<>
 struct ByteLiteral<1ul> {

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -721,15 +721,11 @@ inline constexpr ArrayPtr<const char> StringPtr::asArray() const {
 }
 
 inline bool StringPtr::operator==(const StringPtr& other) const {
-  return content.size() == other.content.size() &&
-      memcmp(content.begin(), other.content.begin(), content.size() - 1) == 0;
+  return content == other.content;
 }
 
-inline bool StringPtr::operator<(const StringPtr& other) const {
-  bool shorter = content.size() < other.content.size();
-  int cmp = memcmp(content.begin(), other.content.begin(),
-                   shorter ? content.size() : other.content.size());
-  return cmp < 0 || (cmp == 0 && shorter);
+inline bool StringPtr::operator< (const StringPtr& other) const {
+  return content < other.content;
 }
 
 inline StringPtr StringPtr::slice(size_t start) const {


### PR DESCRIPTION
ArrayPtr comparators  are implemented by implementing `operator<` and `operator==`.

This was chosen over `operator<=>` or spaceship as that generally requires the `compare` header which was deemed to include too much of stdlib and thus make compilation times less under our control.
