### PR TITLE
Allow reserved address ranges to be explicitly allowlisted in network filters.

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1154,7 +1154,7 @@ KJ_TEST("NetworkFilter") {
   _::NetworkFilter base;
 
   KJ_EXPECT(allowed4(base, "8.8.8.8"));
-  KJ_EXPECT(!allowed4(base, "240.1.2.3"));
+  KJ_EXPECT(allowed4(base, "240.1.2.3"));
 
   {
     _::NetworkFilter filter({"public"}, {}, base);
@@ -1250,6 +1250,24 @@ KJ_TEST("NetworkFilter") {
 
     KJ_EXPECT(allowed6(filter, "2400:cb00:2048:1::c629:d7a2"));
     KJ_EXPECT(!allowed6(filter, "fc00::1234"));
+    KJ_EXPECT(allowed6(filter, "::1"));
+    KJ_EXPECT(allowed6(filter, "::"));
+  }
+
+  // Reserved ranges can be explicitly allowed.
+  {
+    _::NetworkFilter filter({"public", "private", "240.0.0.0/4"}, {}, base);
+
+    KJ_EXPECT(allowed4(filter, "8.8.8.8"));
+    KJ_EXPECT(allowed4(filter, "240.1.2.3"));
+
+    KJ_EXPECT(allowed4(filter, "192.168.0.1"));
+    KJ_EXPECT(allowed4(filter, "10.1.2.3"));
+    KJ_EXPECT(allowed4(filter, "127.0.0.1"));
+    KJ_EXPECT(allowed4(filter, "0.0.0.0"));
+
+    KJ_EXPECT(allowed6(filter, "2400:cb00:2048:1::c629:d7a2"));
+    KJ_EXPECT(allowed6(filter, "fc00::1234"));
     KJ_EXPECT(allowed6(filter, "::1"));
     KJ_EXPECT(allowed6(filter, "::"));
   }


### PR DESCRIPTION
Some people use these address ranges -- especially 240.0.0.0/4 -- as private networks. Is this wise? I dunno. Here's a blog post with extended discussion:

https://blog.benjojo.co.uk/post/class-e-addresses-in-the-real-world

KJ previously totally disallowed use of these ranges. With this change, they are now allowed, but not considered part of any of the named groups (public/private/network/local) -- you have to allow them explicitly.

Note that this also means that these addresses will now be allowed by the default network when no filter has been applied. I think this is OK because if you haven't appplied a filter at all you presumably trust your addresses.