### PR TITLE
any.c++ memcmp == 0 -> ArrayPtr ==

### DIFF
--- a/c++/src/capnp/any.c++
+++ b/c++/src/capnp/any.c++
@@ -92,11 +92,7 @@ Equality AnyStruct::Reader::equals(AnyStruct::Reader right) const {
     -- dataSizeR;
   }
 
-  if(dataSizeL != dataSizeR) {
-    return Equality::NOT_EQUAL;
-  }
-
-  if(0 != memcmp(dataL.begin(), dataR.begin(), dataSizeL)) {
+  if(dataL.first(dataSizeL) != dataR.first(dataSizeR)) {
     return Equality::NOT_EQUAL;
   }
 
@@ -180,7 +176,7 @@ Equality AnyList::Reader::equals(AnyList::Reader right) const {
         cmpSize -= 1;
       }
 
-      if (memcmp(getRawBytes().begin(), right.getRawBytes().begin(), cmpSize) == 0) {
+      if (getRawBytes().first(cmpSize) == right.getRawBytes().first(cmpSize)) {
         return Equality::EQUAL;
       } else {
         return Equality::NOT_EQUAL;


### PR DESCRIPTION
These two cases are tested in `any-test.c++:307: legacy test: Any/Equals`.