### PR TITLE
capnpc-c++.c++: memcmp == 0 -> arrayptr ==

### DIFF
--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -472,7 +472,7 @@ private:
       }
     }
 
-    if (result.size() == 4 && memcmp(result.begin(), "NULL", 4) == 0) {
+    if (result == "NULL"_kjb) {
       // NULL probably collides with a macro.
       result.add('_');
     }


### PR DESCRIPTION
This change is tested by compilation failures when it is implemented incorrectly.