### PR TITLE
load-module.c++ memcmp == 0 -> ArrayPtr equality

### DIFF
--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -79,7 +79,7 @@ struct FileKey {
     // check the content.
     auto mapping1 = KJ_ASSERT_NONNULL(file).mmap(0, size);
     auto mapping2 = KJ_ASSERT_NONNULL(other.file).mmap(0, size);
-    if (memcmp(mapping1.begin(), mapping2.begin(), size) != 0) return false;
+    if (mapping1 != mapping2) return false;
 
     if (path == other.path) {
       // Exactly the same content was mapped at exactly the same path relative to two different


### PR DESCRIPTION
This is in the compiler and isn't a tested case, I think this small change is fine, however if we want a more tested compiler we'd need to invest in a proper framework for that.