### PR TITLE
Set name for anonymous virtual memory areas allocated for fiber stacks.

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1416,7 +1416,7 @@ struct FiberStack::Impl {
       KJ_SYSCALL(munmap(stackMapping, allocSize)) { break; }
     });
 
-#ifdef __linux__
+#if __linux__
 #if defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
     // Try to name the virtual memory area for debugging purposes. This may fail if the kernel was
     // not configured with the CONFIG_ANON_VMA_NAME option.

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -49,7 +49,7 @@
 #include <deque>
 #include <atomic>
 
-#ifdef __linux__
+#if __linux__
 #include <sys/prctl.h>
 #endif
 

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1420,7 +1420,7 @@ struct FiberStack::Impl {
 #if defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
     // Try to name the virtual memory area for debugging purposes. This may fail if the kernel was
     // not configured with the CONFIG_ANON_VMA_NAME option.
-    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, stackMapping, allocSize, "capnp_stack");
+    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, stackMapping, allocSize, "kj_fiber_stack");
 #endif
 #endif
 


### PR DESCRIPTION
This attaches a name to the relevant entries in /proc/<pid>/smaps.