### PR TITLE
Various RPC refactoring and cleanup

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -1171,7 +1171,7 @@ kj::Promise<void*> CapabilityServerSetBase::getLocalServerInternal(Capability::C
   }
 
   // Try to unwrap that.
-  if (hook->getBrand() == &LocalClient::BRAND) {
+  if (hook->isBrand(&LocalClient::BRAND)) {
     KJ_IF_SOME(promise, kj::downcast<LocalClient>(*hook).getLocalServer(*this)) {
       // This is definitely a member of our set and will resolve to non-null. We just have to wait
       // for any existing streaming calls to complete.

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -743,10 +743,10 @@ public:
   virtual AnyPointer::Pipeline sendForPipeline() = 0;
   // Send a call for pipelining purposes only.
 
-  const void* getBrand() { return brand; }
-  // Returns a void* that identifies who made this request.  This can be used by an RPC adapter to
-  // discover when tail call is going to be sent over its own connection and therefore can be
-  // optimized into a remote tail call.
+  inline bool isBrand(const void* other) { return brand == other; }
+  // Checks if this RequestHook's brand, as passed to the constructor, matches the given pointer.
+  // This can be used by an RPC adapter to discover when tail call is going to be sent over its own
+  // connection and therefore can be optimized into a remote tail call.
 
   template <typename T, typename U>
   inline static kj::Own<RequestHook> from(Request<T, U>&& request) {
@@ -832,20 +832,21 @@ public:
   virtual kj::Own<ClientHook> addRef() = 0;
   // Return a new reference to the same capability.
 
-  const void* getBrand() { return brand; }
-  // Returns a void* that identifies who made this client.  This can be used by an RPC adapter to
-  // discover when a capability it needs to marshal is one that it created in the first place, and
-  // therefore it can transfer the capability without proxying.
+  inline bool isBrand(const void* other) { return brand == other; }
+  // Checks if this ClientHooks's brand, as passed to the constructor, matches the given pointer.
+  // This can be used by an RPC adapter to discover when a capability it needs to marshal is one
+  // that it created in the first place, and therefore it can transfer the capability without
+  // proxying.
 
   static const uint NULL_CAPABILITY_BRAND;
   static const uint BROKEN_CAPABILITY_BRAND;
   // Values are irrelevant; used for pointers.
 
-  inline bool isNull() { return getBrand() == &NULL_CAPABILITY_BRAND; }
+  inline bool isNull() { return isBrand(&NULL_CAPABILITY_BRAND); }
   // Returns true if the capability was created as a result of assigning a Client to null or by
   // reading a null pointer out of a Cap'n Proto message.
 
-  inline bool isError() { return getBrand() == &BROKEN_CAPABILITY_BRAND; }
+  inline bool isError() { return isBrand(&BROKEN_CAPABILITY_BRAND); }
   // Returns true if the capability was created by newBrokenCap().
 
   virtual kj::Maybe<int> getFd() = 0;

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -732,6 +732,8 @@ class RequestHook {
   // Hook interface implemented by RPC system representing a request being built.
 
 public:
+  RequestHook(const void* brand = nullptr): brand(brand) {}
+
   virtual RemotePromise<AnyPointer> send() = 0;
   // Send the call and return a promise for the result.
 
@@ -741,7 +743,7 @@ public:
   virtual AnyPointer::Pipeline sendForPipeline() = 0;
   // Send a call for pipelining purposes only.
 
-  virtual const void* getBrand() = 0;
+  const void* getBrand() { return brand; }
   // Returns a void* that identifies who made this request.  This can be used by an RPC adapter to
   // discover when tail call is going to be sent over its own connection and therefore can be
   // optimized into a remote tail call.
@@ -750,6 +752,9 @@ public:
   inline static kj::Own<RequestHook> from(Request<T, U>&& request) {
     return kj::mv(request.hook);
   }
+
+private:
+  const void* brand;
 };
 
 class ResponseHook {
@@ -772,7 +777,7 @@ public:
 
 class ClientHook {
 public:
-  ClientHook();
+  ClientHook(const void* brand = nullptr);
 
   using CallHints = Capability::Client::CallHints;
 
@@ -827,7 +832,7 @@ public:
   virtual kj::Own<ClientHook> addRef() = 0;
   // Return a new reference to the same capability.
 
-  virtual const void* getBrand() = 0;
+  const void* getBrand() { return brand; }
   // Returns a void* that identifies who made this client.  This can be used by an RPC adapter to
   // discover when a capability it needs to marshal is one that it created in the first place, and
   // therefore it can transfer the capability without proxying.
@@ -848,6 +853,9 @@ public:
   // non-null, then Capability::Client::getFd() waits for resolution and tries again.
 
   static kj::Own<ClientHook> from(Capability::Client client) { return kj::mv(client.hook); }
+
+private:
+  const void* brand;
 };
 
 class RevocableClientHook: public ClientHook {

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -156,7 +156,8 @@ private:
 class MembraneRequestHook final: public RequestHook {
 public:
   MembraneRequestHook(kj::Own<RequestHook>&& inner, kj::Own<MembranePolicy>&& policy, bool reverse)
-      : inner(kj::mv(inner)), policy(kj::mv(policy)),
+      : RequestHook(&MEMBRANE_BRAND),
+        inner(kj::mv(inner)), policy(kj::mv(policy)),
         reverse(reverse), capTable(*this->policy, reverse) {}
 
   static Request<AnyPointer, AnyPointer> wrap(
@@ -234,10 +235,6 @@ public:
   AnyPointer::Pipeline sendForPipeline() override {
     return AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(
         PipelineHook::from(inner->sendForPipeline()), policy->addRef(), reverse));
-  }
-
-  const void* getBrand() override {
-    return MEMBRANE_BRAND;
   }
 
 private:
@@ -330,7 +327,8 @@ private:
 class MembraneHook final: public ClientHook, public kj::Refcounted {
 public:
   MembraneHook(kj::Own<ClientHook>&& inner, kj::Own<MembranePolicy>&& policyParam, bool reverse)
-      : inner(kj::mv(inner)), policy(kj::mv(policyParam)), reverse(reverse) {
+      : ClientHook(MEMBRANE_BRAND), inner(kj::mv(inner)), policy(kj::mv(policyParam)),
+        reverse(reverse) {
     KJ_IF_SOME(r, policy->onRevoked()) {
       revocationTask = r.eagerlyEvaluate([this](kj::Exception&& exception) {
         // Since `inner` will be overwritten here and could even be destroyed, it's important that
@@ -526,10 +524,6 @@ public:
 
   kj::Own<ClientHook> addRef() override {
     return kj::addRef(*this);
-  }
-
-  const void* getBrand() override {
-    return MEMBRANE_BRAND;
   }
 
   kj::Maybe<int> getFd() override {

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -164,7 +164,7 @@ public:
       Request<AnyPointer, AnyPointer>&& inner, MembranePolicy& policy, bool reverse) {
     AnyPointer::Builder builder = inner;
     auto innerHook = RequestHook::from(kj::mv(inner));
-    if (innerHook->getBrand() == MEMBRANE_BRAND) {
+    if (innerHook->isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneRequestHook>(*innerHook);
       if (otherMembrane.policy.get() == &policy && otherMembrane.reverse == !reverse) {
         // Request that passed across the membrane one way is now passing back the other way.
@@ -181,7 +181,7 @@ public:
 
   static kj::Own<RequestHook> wrap(
       kj::Own<RequestHook>&& inner, MembranePolicy& policy, bool reverse) {
-    if (inner->getBrand() == MEMBRANE_BRAND) {
+    if (inner->isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneRequestHook>(*inner);
       if (otherMembrane.policy.get() == &policy && otherMembrane.reverse == !reverse) {
         // Request that passed across the membrane one way is now passing back the other way.
@@ -347,7 +347,7 @@ public:
   }
 
   static kj::Own<ClientHook> wrap(ClientHook& cap, MembranePolicy& policy, bool reverse) {
-    if (cap.getBrand() == MEMBRANE_BRAND) {
+    if (cap.isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneHook>(cap);
       auto& rootPolicy = policy.rootPolicy();
       if (&otherMembrane.policy->rootPolicy() == &rootPolicy &&
@@ -377,7 +377,7 @@ public:
   }
 
   static kj::Own<ClientHook> wrap(kj::Own<ClientHook> cap, MembranePolicy& policy, bool reverse) {
-    if (cap->getBrand() == MEMBRANE_BRAND) {
+    if (cap->isBrand(MEMBRANE_BRAND)) {
       auto& otherMembrane = kj::downcast<MembraneHook>(*cap);
       auto& rootPolicy = policy.rootPolicy();
       if (&otherMembrane.policy->rootPolicy() == &rootPolicy &&

--- a/c++/src/capnp/reconnect.c++
+++ b/c++/src/capnp/reconnect.c++
@@ -69,10 +69,6 @@ public:
     return kj::addRef(*this);
   }
 
-  const void* getBrand() override {
-    return nullptr;
-  }
-
   kj::Maybe<int> getFd() override {
     // It's not safe to return current->getFd() because normally callers wouldn't expect the FD to
     // change or go away over time, but this one could whenever we reconnect. If there's a use
@@ -137,10 +133,6 @@ private:
     AnyPointer::Pipeline sendForPipeline() override {
       // TODO(bug): This definitely fails to detect disconnects; see comment in send().
       return inner->sendForPipeline();
-    }
-
-    const void* getBrand() override {
-      return nullptr;
     }
 
   private:

--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -97,6 +97,8 @@ private:
   Capability::Client baseRestore(AnyStruct::Reader vatId, AnyPointer::Reader objectId);
   void baseSetFlowLimit(size_t words);
 
+  class RpcConnectionState;
+
   template <typename>
   friend class capnp::RpcSystem;
 };

--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -99,6 +99,15 @@ private:
 
   class RpcConnectionState;
 
+  static void dropConnection(Impl& impl,
+      VatNetworkBase::Connection& connection, kj::Promise<void> shutdownTask);
+  // Called when RpcConnectionState becomes disconnected and so should be removed from the map of
+  // known connections.
+  //
+  // TODO(cleanup): This is defined as a static method with `Impl&` passed in because the caller
+  //   is defined before `Impl` in rpc.c++. We can't have the caller hold a pointer to
+  //   `RpcSystemBase` instead because it is movable.
+
   template <typename>
   friend class capnp::RpcSystem;
 };

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -746,7 +746,8 @@ private:
   class RpcClient: public ClientHook, public kj::Refcounted {
   public:
     RpcClient(RpcConnectionState& connectionState)
-        : connectionState(kj::addRef(connectionState)) {}
+        : ClientHook(&connectionState),
+          connectionState(kj::addRef(connectionState)) {}
 
     ~RpcClient() noexcept(false) {
       KJ_IF_SOME(f, this->flowController) {
@@ -847,9 +848,6 @@ private:
 
     kj::Own<ClientHook> addRef() override {
       return kj::addRef(*this);
-    }
-    const void* getBrand() override {
-      return connectionState.get();
     }
 
     kj::Own<RpcConnectionState> connectionState;
@@ -1591,9 +1589,6 @@ private:
     kj::Own<ClientHook> addRef() override {
       return kj::addRef(*this);
     }
-    const void* getBrand() override {
-      return nullptr;
-    }
     kj::Maybe<int> getFd() override {
       return inner->getFd();
     }
@@ -1764,7 +1759,8 @@ private:
   public:
     RpcRequest(RpcConnectionState& connectionState, VatNetworkBase::Connection& connection,
                kj::Maybe<MessageSize> sizeHint, kj::Own<RpcClient>&& target)
-        : connectionState(kj::addRef(connectionState)),
+        : RequestHook(&connectionState),
+          connectionState(kj::addRef(connectionState)),
           target(kj::mv(target)),
           message(connection.newOutgoingMessage(
               firstSegmentSize(sizeHint, messageSizeHint<rpc::Call>() +
@@ -1920,10 +1916,6 @@ private:
       }
 
       return TailInfo { questionId, kj::mv(promise), kj::mv(pipeline) };
-    }
-
-    const void* getBrand() override {
-      return connectionState.get();
     }
 
   private:

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -345,9 +345,12 @@ private:
   std::unordered_map<Id, T> high;
 };
 
+}  // namespace
+
 // =======================================================================================
 
-class RpcConnectionState final: public kj::TaskSet::ErrorHandler, public kj::Refcounted {
+class RpcSystemBase::RpcConnectionState final
+    : public kj::TaskSet::ErrorHandler, public kj::Refcounted {
 public:
   struct DisconnectInfo {
     kj::Promise<void> shutdownPromise;
@@ -3545,8 +3548,6 @@ private:
   // ---------------------------------------------------------------------------
   // Level 2
 };
-
-}  // namespace
 
 class RpcSystemBase::Impl final: private BootstrapFactoryBase, private kj::TaskSet::ErrorHandler {
 public:

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -2230,7 +2230,7 @@ private:
   };
 
   kj::Maybe<RpcClient&> unwrapIfSameConnection(ClientHook& hook) {
-    if (hook.getBrand() == brand.get()) {
+    if (hook.isBrand(brand.get())) {
       RpcClient& result = kj::downcast<RpcClient>(hook);
       if (result.isOnConnection(*this)) {
         return result;
@@ -2240,7 +2240,7 @@ private:
   }
 
   kj::Maybe<RpcRequest&> unwrapIfSameConnection(RequestHook& hook) {
-    if (hook.getBrand() == brand.get()) {
+    if (hook.isBrand(brand.get())) {
       RpcRequest& result = kj::downcast<RpcRequest>(hook);
       if (result.isOnConnection(*this)) {
         return result;

--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -102,6 +102,11 @@ struct HashCoder {
     }
   }
 
+  template <typename T>
+  uint operator*(const Own<T>& ptr) const {
+    return operator*(ptr.get());
+  }
+
   template <typename T, typename = decltype(instance<const HashCoder&>() * instance<const T&>())>
   uint operator*(ArrayPtr<T> arr) const;
   template <typename T, typename = decltype(instance<const HashCoder&>() * instance<const T&>())>


### PR DESCRIPTION
Just a series of small cleanups and refactors, mostly of `rpc.c++`, some of them leading up to three-party handoff although no actual 3PH logic is implemented yet.

Be sure to read each commit separately.