### PR TITLE
Rework promise continuations to reduce amount of templated functions, code size

### DIFF
--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -2844,8 +2844,8 @@ private:
         co_return;
       }
 
-      // TODO(perf): We add an evalLater() here so that anything we needed to do in reaction to
-      //   the previous message has a chance to complete before the next message is handled. In
+      // TODO(perf): We add a yield() here so that anything we needed to do in reaction to the
+      //   previous message has a chance to complete before the next message is handled. In
       //   particular, without this, I observed an ordering problem: I saw a case where a `Return`
       //   message was followed by a `Resolve` message, but the `PromiseClient` associated with the
       //   `Resolve` had its `resolve()` method invoked _before_ any `PromiseClient`s associated
@@ -2854,12 +2854,8 @@ private:
       //   other. This is probably really a bug in the way `Return`s are handled -- apparently,
       //   resolution of `PromiseClient`s based on returned capabilities does not occur in a
       //   depth-first way, when it should. If we could fix that then we can probably remove this
-      //   `evalLater()`. However, the `evalLater()` is not that bad and solves the problem...
-      // TODO(cleanup): As an extra optimization here I'm calling yield() directly since
-      //   evalLater(func) reduces to yield().then(func) and we don't need the .then(). yield()
-      //   itself does zero allocation which is nice. Maybe we should make it public? It's a much
-      //   better API for coroutines.
-      co_await kj::_::yield();  // instead of: co_await kj::evalLater([]() {});
+      //   `yield()`. However, the `yield()` is not that bad and solves the problem...
+      co_await kj::yield();
     }
   }
 

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -263,7 +263,7 @@ KJ_TEST("Coroutines can be canceled while suspended") {
 
   auto coro = [&](kj::Promise<int> promise) -> kj::Promise<void> {
     Counter counter1(wind, unwind);
-    co_await kj::evalLater([](){});
+    co_await kj::yield();
     Counter counter2(wind, unwind);
     co_await promise;
   };

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1482,12 +1482,12 @@ inline Promise<T> constPromise() {
 
 template <typename Func>
 inline PromiseForResult<Func, void> evalLater(Func&& func) {
-  return _::yield().then(kj::fwd<Func>(func), _::PropagateException());
+  return _::yield().then(kj::fwd<Func>(func));
 }
 
 template <typename Func>
 inline PromiseForResult<Func, void> evalLast(Func&& func) {
-  return _::yieldHarder().then(kj::fwd<Func>(func), _::PropagateException());
+  return _::yieldHarder().then(kj::fwd<Func>(func));
 }
 
 template <typename Func>

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1482,12 +1482,12 @@ inline Promise<T> constPromise() {
 
 template <typename Func>
 inline PromiseForResult<Func, void> evalLater(Func&& func) {
-  return _::yield().then(kj::fwd<Func>(func));
+  return yield().then(kj::fwd<Func>(func));
 }
 
 template <typename Func>
 inline PromiseForResult<Func, void> evalLast(Func&& func) {
-  return _::yieldHarder().then(kj::fwd<Func>(func));
+  return yieldUntilQueueEmpty().then(kj::fwd<Func>(func));
 }
 
 template <typename Func>

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -235,8 +235,6 @@ void detach(kj::Promise<void>&& promise);
 void waitImpl(_::OwnPromiseNode&& node, _::ExceptionOrValue& result, WaitScope& waitScope,
               SourceLocation location);
 bool pollImpl(_::PromiseNode& node, WaitScope& waitScope, SourceLocation location);
-Promise<void> yield();
-Promise<void> yieldHarder();
 OwnPromiseNode readyNow();
 OwnPromiseNode neverDone();
 

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -1061,7 +1061,7 @@ TEST(Async, TaskSetOnEmpty) {
 
   auto paf = newPromiseAndFulfiller<void>();
   tasks.add(kj::mv(paf.promise));
-  tasks.add(evalLater([]() {}));
+  tasks.add(yield());
 
   KJ_EXPECT(!tasks.isEmpty());
 
@@ -1160,13 +1160,13 @@ TEST(Async, EagerlyEvaluate) {
   Promise<void> promise = Promise<void>(READY_NOW).then([&]() {
     called = true;
   });
-  evalLater([]() {}).wait(waitScope);
+  yield().wait(waitScope);
 
   EXPECT_FALSE(called);
 
   promise = promise.eagerlyEvaluate(nullptr);
 
-  evalLater([]() {}).wait(waitScope);
+  yield().wait(waitScope);
 
   EXPECT_TRUE(called);
 }
@@ -1190,7 +1190,7 @@ TEST(Async, Detach) {
   EXPECT_FALSE(ran2);
   EXPECT_FALSE(ran3);
 
-  evalLater([]() {}).wait(waitScope);
+  yield().wait(waitScope);
 
   EXPECT_FALSE(ran1);
   EXPECT_TRUE(ran2);
@@ -1219,7 +1219,7 @@ TEST(Async, SetRunnable) {
   EXPECT_EQ(0, port.callCount);
 
   {
-    auto promise = evalLater([]() {}).eagerlyEvaluate(nullptr);
+    auto promise = yield().eagerlyEvaluate(nullptr);
 
     EXPECT_TRUE(port.runnable);
     loop.run(1);
@@ -1236,7 +1236,7 @@ TEST(Async, SetRunnable) {
     auto promise = paf.promise.then([]() {}).eagerlyEvaluate(nullptr);
     EXPECT_FALSE(port.runnable);
 
-    auto promise2 = evalLater([]() {}).eagerlyEvaluate(nullptr);
+    auto promise2 = yield().eagerlyEvaluate(nullptr);
     paf.fulfiller->fulfill();
 
     EXPECT_TRUE(port.runnable);

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -1168,7 +1168,7 @@ KJ_TEST("UnixEventPoll::getPollableFd() for external waiting") {
 
     KJ_EXPECT(!portIsReady());
 
-    auto promise = kj::evalLater([]() {}).eagerlyEvaluate(nullptr);
+    auto promise = yield().eagerlyEvaluate(nullptr);
 
     KJ_EXPECT(portIsReady());
     KJ_ASSERT(promise.poll(ws));

--- a/c++/src/kj/async-win32-test.c++
+++ b/c++/src/kj/async-win32-test.c++
@@ -66,11 +66,11 @@ KJ_TEST("Win32IocpEventPort I/O operations") {
 
   KJ_EXPECT(!done);
 
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
 
   KJ_EXPECT(!done);
 
@@ -125,11 +125,11 @@ KJ_TEST("Win32IocpEventPort timer") {
 
   KJ_EXPECT(!done);
 
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
-  evalLater([]() {}).wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
+  yield().wait(waitScope);
 
   KJ_EXPECT(!done);
 

--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -558,7 +558,7 @@ KJ_TEST("call own thread's executor") {
 
   KJ_EXPECT_THROW_MESSAGE(
       "can't call executeSync() on own thread's executor with a promise-returning function",
-      executor.executeSync([]() { return kj::evalLater([]() {}); }));
+      executor.executeSync([]() { return kj::yield(); }));
 
   {
     uint i = executor.executeAsync([]() {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -367,7 +367,7 @@ TaskSet::~TaskSet() noexcept(false) {
 }
 
 void TaskSet::add(Promise<void>&& promise) {
-  auto task = _::appendPromise<Task>(_::PromiseNode::from(kj::mv(promise)), *this);
+  auto task = _::PromiseDisposer::appendPromise<Task>(_::PromiseNode::from(kj::mv(promise)), *this);
   KJ_IF_SOME(head, tasks) {
     head->prev = &task->next;
     task->next = kj::mv(tasks);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -462,6 +462,14 @@ PromiseForResult<Func, void> evalLast(Func&& func) KJ_WARN_UNUSED_RESULT;
 // callback enqueues new events, then latter callbacks will not execute until those events are
 // drained.
 
+Promise<void> yield();
+// Like `eval()`, but without a function to be evaluated. Useful for yielding control temporarily
+// to serialize actions or schedule other actions for a later time using promise continuations.
+
+Promise<void> yieldUntilQueueEmpty();
+// Like `evalLast()`, but without a function to be evaluated. Useful for yielding control until the
+// event queue is otherwise completely empty and the thread is about to suspend waiting for I/O.
+
 ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space);
 kj::String getAsyncTrace();
 // If the event loop is currently running in this thread, get a trace back through the promise

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -196,8 +196,11 @@ public:
 
   inline Promise(decltype(nullptr)) {}
 
-  template <typename Func, typename ErrorFunc = _::PropagateException>
-  PromiseForResult<Func, T> then(Func&& func, ErrorFunc&& errorHandler = _::PropagateException(),
+  template <typename Func>
+  PromiseForResult<Func, T> then(Func&& func) KJ_WARN_UNUSED_RESULT;
+
+  template <typename Func, typename ErrorFunc>
+  PromiseForResult<Func, T> then(Func&& func, ErrorFunc&& errorHandler,
                                  SourceLocation location = {}) KJ_WARN_UNUSED_RESULT;
   // Register a continuation function to be executed when the promise completes.  The continuation
   // (`func`) takes the promised value (an rvalue of type `T`) as its parameter.  The continuation


### PR DESCRIPTION
**Rationale**
This PR introduces a series of patches related to promises that are intended to reduce code size and compile times.
Investigating the slow compile time of `kj/compat/http.c++` led me to look at the generated object file – it turns out that it defines ~15,000 symbols in ~8,000 lines on Darwin when optimization/inlining is disabled (< 5,000 symbols with -O1 enabled). This is believed to be a major driver of its slow compile time and code size. Looking at the generated object symbol names with [bloaty](https://github.com/google/bloaty) showed that many symbols are functions of the templated `TransformPromiseNode` class in `kj/promise.h`. This class is used in promise continuations (among other things), causing dozens of templated functions to be defined with every `then()` call.

**Implementation**
This PR includes several changes to reduce the number of templated functions being generated. This is divided into several self-contained patches to make it easier to understand, and in case we decide to only land a subset of changes. I plan to squash the individual commits before merging Note that I have no background in implementing async library code – this may include trivial mistakes. Open to suggestions on how to make this easier to maintain considering the duplication of `TransformPromiseNode` and `then()`.

**Results**
Compile time and code size are measured on the bazel kj-http library target since it uses promise continuations extensively. The number of symbols is for http.c++ alone.
Number of symbols (O0): 15243 => 14580
Code size (O0): 6.16MB  => 5.78MB
Code size (O1): 1.68MB  => 1.57MB
Code size (O1 + debug): 16.71MB  => 14.93MB

Compile time is a bit harder to quantify, but I observed an improvement from 5.69s => 5.25s user time on http.c++ (best of 3 runs, measured on M1 Mac).

**Discussion**
Compile time and code size are improved for kj-http, even if inlining is enabled and especially when debug information is present. Smaller gains are expected in downstream projects too based on promise continuation usage.
Similar improvements are expected to be possible by rewriting `kj::Own`, which also leads to many templated functions being generated. However, this is unlikely to be worth prioritizing; for now this represents a proof-of-concept for reducing the amount of templated functions.