### PR TITLE
Improve hashCode().

### DIFF
--- a/c++/src/kj/table-test.c++
+++ b/c++/src/kj/table-test.c++
@@ -278,7 +278,7 @@ public:
     return a == b;
   }
   uint hashCode(uint i) const {
-    return i;
+    return kj::hashCode(i);
   }
 };
 
@@ -327,8 +327,11 @@ public:
     return a.i == b;
   }
   uint hashCode(uint i) const {
-    return i;
+    return inner.hashCode(i);
   }
+
+private:
+  IntHasher inner;
 };
 
 KJ_TEST("double-index table") {
@@ -405,7 +408,7 @@ public:
     return a == b;
   }
   uint hashCode(uint i) const {
-    return i;
+    return kj::hashCode(i);
   }
 };
 
@@ -1337,7 +1340,7 @@ public:
   }
 
   uint hashCode(size_t size) const {
-    return size;
+    return kj::hashCode(size);
   }
 };
 

--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -893,7 +893,10 @@ inline size_t probeHash(const kj::Array<HashBucket>& buckets, size_t i) {
 
 kj::Array<HashBucket> rehash(kj::ArrayPtr<const HashBucket> oldBuckets, size_t targetSize);
 
-uint chooseBucket(uint hash, uint count);
+inline uint chooseBucket(uint hash, uint count) {
+  KJ_IASSERT(kj::popCount(count) == 1, "hash bucket count must be power of two!");
+  return hash & (count - 1);
+}
 
 }  // namespace _ (private)
 


### PR DESCRIPTION
Previously, `hashCode()` merely needed to return a value that was likely to be unique. When the input was already a 32-bit integer, it was acceptable to just return exactly the input value. However, this meant that the distribution of hashes wasn't necessarily uniform. To compensate for this, the hashtable implementation would use prime-number bucket counts. This, however, made computing the correct bucket expensive, as it required an integer division operation.

After this change, `hashCode()` is expected to return a uniform distribution. Thus, hashtables can have power-of-two size, avoiding the integer division. This improves performance in our string-keyed hashtable benchmark by 10%. The integer-keyed benchmark is slower, due to the need to spend more cycles computing hashes, but integer keys are already very fast anyway and most real-world hash tables tend to be string-keyed.

This also improves the behavior of open addressing with linear probing (which KJ's hashtable uses). Previously, if you inserted many sequential keys into a hash table, they would occupy consecutive buckets, creating a large range of buckets that were full. If you then tried to insert a non-sequential key that happened to hash somewhere into the range of occupied buckets, the hashtable wolud have to scan all the way to the end of the range to find an appropriate slot for the new key. Cap'n Proto's RPC tables tended to have this problem in particular.