### PR TITLE
[nfc] Convert remaining evalLater() calls to yield where possible

### DIFF
--- a/c++/src/capnp/capability-test.c++
+++ b/c++/src/capnp/capability-test.c++
@@ -306,8 +306,8 @@ TEST(Capability, AsyncCancelation) {
       returned = true;
     }).eagerlyEvaluate(nullptr);
   }
-  kj::evalLater([]() {}).wait(waitScope);
-  kj::evalLater([]() {}).wait(waitScope);
+  kj::yield().wait(waitScope);
+  kj::yield().wait(waitScope);
 
   // We can detect that the method was canceled because it will drop the cap.
   EXPECT_FALSE(destroyed);
@@ -1040,10 +1040,10 @@ TEST(Capability, CapabilityServerSet) {
     KJ_EXPECT(e.getDescription().endsWith("foo"), e.getDescription());
   });
 
-  kj::evalLater([](){}).wait(waitScope);
-  kj::evalLater([](){}).wait(waitScope);
-  kj::evalLater([](){}).wait(waitScope);
-  kj::evalLater([](){}).wait(waitScope);
+  kj::yield().wait(waitScope);
+  kj::yield().wait(waitScope);
+  kj::yield().wait(waitScope);
+  kj::yield().wait(waitScope);
 
   EXPECT_FALSE(resolved1);
   EXPECT_FALSE(resolved2);

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -654,17 +654,17 @@ TEST(Rpc, Release) {
 
   handle1 = nullptr;
 
-  for (uint i = 0; i < 16; i++) kj::evalLater([]() {}).wait(context.waitScope);
+  for (uint i = 0; i < 16; i++) kj::yield().wait(context.waitScope);
   EXPECT_EQ(1, context.restorer.handleCount);
 
   handle2 = nullptr;
 
-  for (uint i = 0; i < 16; i++) kj::evalLater([]() {}).wait(context.waitScope);
+  for (uint i = 0; i < 16; i++) kj::yield().wait(context.waitScope);
   EXPECT_EQ(1, context.restorer.handleCount);
 
   promise = nullptr;
 
-  for (uint i = 0; i < 16; i++) kj::evalLater([]() {}).wait(context.waitScope);
+  for (uint i = 0; i < 16; i++) kj::yield().wait(context.waitScope);
   EXPECT_EQ(0, context.restorer.handleCount);
 }
 
@@ -684,16 +684,16 @@ TEST(Rpc, ReleaseOnCancel) {
 
     // If the server receives cancellation too early, it won't even return a capability in the
     // results, it will just return "canceled". We want to emulate the case where the return message
-    // and the cancel (finish) message cross paths. It turns out that exactly two evalLater()s get
-    // us there.
+    // and the cancel (finish) message cross paths. It turns out that exactly two yield()s get us
+    // there.
     //
     // TODO(cleanup): This is fragile, but I'm not sure how else to write it without a ton
     //   of scaffolding.
-    kj::evalLater([]() {}).wait(context.waitScope);
-    kj::evalLater([]() {}).wait(context.waitScope);
+    kj::yield().wait(context.waitScope);
+    kj::yield().wait(context.waitScope);
   }
 
-  for (uint i = 0; i < 16; i++) kj::evalLater([]() {}).wait(context.waitScope);
+  for (uint i = 0; i < 16; i++) kj::yield().wait(context.waitScope);
   EXPECT_EQ(0, context.restorer.handleCount);
 }
 
@@ -865,12 +865,12 @@ TEST(Rpc, Cancellation) {
       returned = true;
     }).eagerlyEvaluate(nullptr);
   }
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
 
   // We can detect that the method was canceled because it will drop the cap.
   EXPECT_FALSE(destroyed);
@@ -1257,14 +1257,14 @@ TEST(Rpc, CallBrokenPromise) {
     kj::throwRecoverableException(kj::mv(e));
   }).eagerlyEvaluate(nullptr);
 
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
 
   EXPECT_FALSE(returned);
 
@@ -1273,14 +1273,14 @@ TEST(Rpc, CallBrokenPromise) {
   expectPromiseThrows(kj::mv(req), context.waitScope);
   EXPECT_TRUE(returned);
 
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
-  kj::evalLater([]() {}).wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
+  kj::yield().wait(context.waitScope);
 
   // Verify that we're still connected (there were no protocol errors).
   getCallSequence(client, 1).wait(context.waitScope);

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -3517,9 +3517,9 @@ private:
         // Disembargo is delivered to a promise capability.
         auto promise = target->whenResolved()
             .then([]() {
-          // We also need to insert an evalLast() here to make sure that any pending calls towards
-          // this cap have had time to find their way through the event loop.
-          return kj::evalLast([]() {});
+          // We also need to insert yieldUntilQueueEmpty() here to make sure that any pending calls
+          // towards this cap have had time to find their way through the event loop.
+          return kj::yieldUntilQueueEmpty();
         });
 
         tasks.add(promise.then([this, embargoId, target = kj::mv(target)]() mutable {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -196,10 +196,6 @@ private:
   void* traceAddr;
 };
 
-struct DummyFunctor {
-  void operator()() {};
-};
-
 }  // namespace
 
 // =======================================================================================
@@ -2854,7 +2850,7 @@ Promise<void> yield() {
       output.as<_::Void>() = _::Void();
     }
     void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
-      builder.add(reinterpret_cast<void*>(&kj::evalLater<DummyFunctor>));
+      builder.add(reinterpret_cast<void*>(&kj::yield));
     }
   };
 
@@ -2874,7 +2870,7 @@ Promise<void> yieldUntilQueueEmpty() {
       output.as<_::Void>() = _::Void();
     }
     void tracePromise(_::TraceBuilder& builder, bool stopAtNextEvent) override {
-      builder.add(reinterpret_cast<void*>(&kj::evalLast<DummyFunctor>));
+      builder.add(reinterpret_cast<void*>(&kj::yieldUntilQueueEmpty));
     }
   };
 


### PR DESCRIPTION
That should actually cover the remaining evalLater()/evalLast() calls that can be simplified, please correct me if I'm wrong.