### PR TITLE
RPC: Implement idle hints and other refactoring

### DIFF
--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -59,6 +59,7 @@ public:
     virtual kj::Promise<void> shutdown() = 0;
     virtual AnyStruct::Reader baseGetPeerVatId() = 0;
     virtual kj::Own<RpcFlowController> newStream() = 0;
+    virtual void setIdle(bool idle) = 0;
   };
   virtual kj::Maybe<kj::Own<Connection>> baseConnect(AnyStruct::Reader vatId) = 0;
   virtual kj::Promise<kj::Own<Connection>> baseAccept() = 0;

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -396,6 +396,7 @@ TEST(TwoPartyNetwork, Abort) {
   hostId.setSide(rpc::twoparty::Side::SERVER);
 
   auto conn = KJ_ASSERT_NONNULL(network.connect(hostId));
+  conn->setIdle(false);
 
   {
     // Send an invalid message (Return to non-existent question).

--- a/c++/src/capnp/rpc-twoparty.h
+++ b/c++/src/capnp/rpc-twoparty.h
@@ -119,6 +119,10 @@ private:
   bool solSndbufUnimplemented = false;
   // Whether stream.getsockopt(SO_SNDBUF) has been observed to throw UNIMPLEMENTED.
 
+  bool idle = true;
+  // Only used to catch RpcSystem bugs. Starts true because RpcSystem should call setIdle(false)
+  // right away.
+
   kj::Canceler readCanceler;
   kj::Maybe<kj::Exception> readCancelReason;
   // Used to propagate write errors into (permanent) read errors.
@@ -173,6 +177,7 @@ private:
   kj::Own<OutgoingRpcMessage> newOutgoingMessage(uint firstSegmentWordSize) override;
   kj::Promise<kj::Maybe<kj::Own<IncomingRpcMessage>>> receiveIncomingMessage() override;
   kj::Promise<void> shutdown() override;
+  void setIdle(bool idle) override;
 
   // implements WindowGetter ---------------------------------------------------
 

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -3586,10 +3586,9 @@ private:
         KJ_FAIL_REQUIRE("Unimplemented Disembargo type.", disembargo) { return; }
     }
   }
-
-  // ---------------------------------------------------------------------------
-  // Level 2
 };
+
+// =======================================================================================
 
 class RpcSystemBase::Impl final: private BootstrapFactoryBase, private kj::TaskSet::ErrorHandler {
 public:

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -415,11 +415,12 @@ KJ_TEST("Can trace through coroutines") {
   // Get an async trace when the promise is fulfilled. We eagerlyEvaluate() to make sure the
   // continuation executes while the event loop is running.
   paf.promise = paf.promise.then([]() {
-    auto trace = getAsyncTrace();
+    void* scratch[16];
+    auto trace = getAsyncTrace(scratch);
     // We expect one entry for waitImpl(), one for the coroutine, and one for this continuation.
     // When building in debug mode with CMake, I observed this count can be 2. The missing frame is
     // probably this continuation. Let's just expect a range.
-    auto count = countLines(trace);
+    auto count = trace.size();
     KJ_EXPECT(0 < count && count <= 3);
   }).eagerlyEvaluate(nullptr);
 

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -156,6 +156,11 @@ public:
 
   void logMessage(LogSeverity severity, const char* file, int line, int contextDepth,
                   String&& text) override {
+    if (text.contains("To symbolize stack traces, install it in your $PATH")) {
+      // Ignore warning about LLVM_SYMBOLIZER not being available.
+      return;
+    }
+
     this->text += "log message: ";
     text = str(file, ":", line, ":+", contextDepth, ": ", severity, ": ", mv(text));
     this->text.append(text.begin(), text.end());

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -80,6 +80,7 @@
 
 #if KJ_HAS_LIBDL
 #include "dlfcn.h"
+#include <sys/wait.h>
 #endif
 
 #if _MSC_VER
@@ -226,6 +227,161 @@ ArrayPtr<void* const> getStackTrace(ArrayPtr<void*> space, uint ignoreCount,
 }  // namespace
 #endif
 
+#if KJ_HAS_LIBDL
+
+namespace {
+
+// A simple subprocess wrapper with in/out pipes.
+struct Subprocess {
+  // Execute command with a shell.
+  static kj::Maybe<Subprocess> exec(const char* argv[]) noexcept {
+    // Since this is used during error handling we do not to try to free resources in
+    // case of errors.
+
+    int in[2]{}; // process stdin pipe
+    int out[2]{}; // process stdout pipe
+
+    if (pipe(in)) {
+      KJ_LOG(ERROR, "can't allocate in pipe", strerror(errno));
+      return kj::none;
+    }
+    if (pipe(out)){
+      KJ_LOG(ERROR, "can't allocate out pipe", strerror(errno));
+      return kj::none;
+    }
+
+    auto pid = fork();
+    if (pid > 0) {
+      // parent
+      close(in[0]);
+      close(out[1]);
+      return Subprocess({ .pid = pid, .in = in[1], .out = out[0] });
+    } else {
+      // child
+      close(in[1]);
+      close(out[0]);
+
+      // redirect stdin
+      close(0);
+      if(dup(in[0]) < 0) {
+        _exit(2 * errno);
+      }
+
+      // redirect stdout
+      close(1);
+      if(dup(out[1]) < 0) {
+        _exit(3 * errno);
+      }
+
+      KJ_SYSCALL_HANDLE_ERRORS(execvp(argv[0], const_cast<char**>(argv))) {
+        case ENOENT:
+          _exit(2);
+        default:
+          KJ_FAIL_SYSCALL("execvp", error);
+      }
+      _exit(1);
+    }
+  }
+
+  int closeAndWait() {
+    close(in);
+    close(out);
+    int status;
+    waitpid(pid, &status, 0);
+    return status;
+  }
+
+  int pid;
+  int in;
+  int out;
+};
+
+String stringifyStackTraceWithLlvm(ArrayPtr<void* const> trace) {
+  const char* llvmSymbolizer = getenv("LLVM_SYMBOLIZER");
+  if (llvmSymbolizer == nullptr) {
+    llvmSymbolizer = "llvm-symbolizer";
+  }
+
+  const char* argv[] = {
+    llvmSymbolizer,
+    "--relativenames",
+    nullptr
+  };
+
+  bool disableSigpipeOnce KJ_UNUSED = []() {
+    // Just in case for some reason SIGPIPE is not already disabled in this process, disable it
+    // now, otherwise the below will fail in the case that llvm-symbolizer is not found. Note
+    // that if the process creates a kj::UnixEventPort, then SIGPIPE will already be disabled.
+    signal(SIGPIPE, SIG_IGN);
+    return false;
+  }();
+
+  KJ_IF_SOME(subprocess, Subprocess::exec(argv)) {
+    // write addresses as "CODE <file_name> <hex_address>" lines.
+    auto addrs = strArray(KJ_MAP(addr, trace) {
+      Dl_info info;
+      if (dladdr(addr, &info)) {
+        uintptr_t offset = reinterpret_cast<uintptr_t>(addr) -
+                            reinterpret_cast<uintptr_t>(info.dli_fbase);
+        return kj::str("CODE ", info.dli_fname, " 0x", reinterpret_cast<void*>(offset));
+      } else {
+        return kj::str("CODE 0x", reinterpret_cast<void*>(addr));
+      }
+    }, "\n");
+    if (write(subprocess.in, addrs.cStr(), addrs.size()) != addrs.size()) {
+      // Ignore EPIPE, which means the process exited early. We'll deal with it below, presumably.
+      if (errno != EPIPE) {
+        KJ_LOG(ERROR, "write error", strerror(errno));
+        return nullptr;
+      }
+    }
+    close(subprocess.in);
+
+    // read result
+    auto out = fdopen(subprocess.out, "r");
+    if (!out) {
+      KJ_LOG(ERROR, "fdopen error", strerror(errno));
+      return nullptr;
+    }
+
+    kj::String lines[256];
+    size_t i = 0;
+    for (char line[512]{}; fgets(line, sizeof(line), out) != nullptr;) {
+      if (i < kj::size(lines)) {
+        lines[i++] = kj::str(line);
+      }
+    }
+    int status = subprocess.closeAndWait();
+    if (WIFEXITED(status)) {
+      if (WEXITSTATUS(status) != 0) {
+        if (WEXITSTATUS(status) == 2) {
+          static bool logged = false;
+          if (!logged) {
+            KJ_LOG(WARNING, kj::str(llvmSymbolizer, " was not found. "
+                "To symbolize stack traces, install it in your $PATH or set $LLVM_SYMBOLIZER to the "
+                "location of the binary. When running tests under bazel, use "
+                "`--test_env=LLVM_SYMBOLIZER=<path>`."));
+            logged = true;
+          }
+        } else {
+          KJ_LOG(ERROR, "bad exit code", WEXITSTATUS(status));
+        }
+        return nullptr;
+      }
+    } else {
+      KJ_LOG(ERROR, "bad exit status", status);
+      return nullptr;
+    }
+    return kj::str("\n", kj::strArray(kj::arrayPtr(lines, i), ""));
+  } else {
+    return kj::str("\nerror starting llvm-symbolizer");
+  }
+}
+
+} // namespace
+
+#endif
+
 ArrayPtr<void* const> getStackTrace(ArrayPtr<void*> space, uint ignoreCount) {
   if (getExceptionCallback().stackTraceMode() == ExceptionCallback::StackTraceMode::NONE) {
     return nullptr;
@@ -266,7 +422,10 @@ String stringifyStackTrace(ArrayPtr<void* const> trace) {
     return nullptr;
   }
 
-#if KJ_USE_WIN32_DBGHELP && _MSC_VER
+#if KJ_HAS_LIBDL
+  return stringifyStackTraceWithLlvm(trace);
+
+#elif KJ_USE_WIN32_DBGHELP && _MSC_VER
 
   // Try to get file/line using SymGetLineFromAddr64(). We don't bother if we aren't on MSVC since
   // this requires MSVC debug info.


### PR DESCRIPTION
The last (main) commit of this PR adds an API by which the RpcSystem will inform the VatNetwork when a connection is "idle", meaning it has no active calls or capabilities on it in either direction.

This gives us a reasonable way to shut down connections that are "done", which will enable us to switch over to a connection-per-session approach rather than our current connection-per-destination approach. This will in turn be important to make three-party handoff work well.