### PR TITLE
Fixes for group assignment in dynamic API and BufferInputStreamWrapper::tryRead

### DIFF
--- a/c++/src/capnp/dynamic-test.c++
+++ b/c++/src/capnp/dynamic-test.c++
@@ -492,6 +492,25 @@ TEST(DynamicApi, BuilderAssign) {
   listValue.set(0, 123);
 }
 
+TEST(DynamicApi, SetGroup) {
+  MallocMessageBuilder srcBuilder;
+  MallocMessageBuilder dstBuilder;
+  
+  auto srcRoot = srcBuilder.initRoot<TestInterleavedGroups>();
+  auto srcGroup = srcRoot.initGroup1();
+  srcGroup.setFoo(10);
+  srcGroup.initCorge().setPlugh("howdy");
+  
+  auto dstRoot = dstBuilder.initRoot<DynamicStruct>(Schema::from<TestInterleavedGroups>());
+  dstRoot.set("group1", srcGroup.asReader());
+  
+  auto dstGroup = dstRoot.get("group1").as<DynamicStruct>();
+  
+  EXPECT_EQ(10u, dstGroup.get("foo").as<uint32_t>());
+  EXPECT_ANY_THROW(dstGroup.get("qux"));
+  EXPECT_EQ("howdy", dstGroup.get("corge").as<DynamicStruct>().get("plugh").as<Text>());
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp

--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -662,7 +662,7 @@ void DynamicStruct::Builder::set(StructSchema::Field field, const DynamicValue::
         }
       }
 	  
-	  return;
+      return;
     }
   }
 

--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -661,6 +661,8 @@ void DynamicStruct::Builder::set(StructSchema::Field field, const DynamicValue::
           dst.set(field, src.get(field));
         }
       }
+	  
+	  return;
     }
   }
 

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -81,6 +81,7 @@ using ::capnproto_test::capnp::test::TestUnionDefaults;
 using ::capnproto_test::capnp::test::TestNestedTypes;
 using ::capnproto_test::capnp::test::TestUsing;
 using ::capnproto_test::capnp::test::TestListDefaults;
+using ::capnproto_test::capnp::test::TestInterleavedGroups;
 
 void initTestMessage(TestAllTypes::Builder builder);
 void initTestMessage(TestDefaults::Builder builder);

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -153,7 +153,7 @@ size_t BufferedInputStreamWrapper::tryRead(void* dst, size_t minBytes, size_t ma
 
     if (maxBytes <= buffer.size()) {
       // Read the next buffer-full.
-      size_t n = inner.read(buffer.begin(), minBytes, buffer.size());
+      size_t n = inner.tryRead(buffer.begin(), minBytes, buffer.size());
       size_t fromSecondBuffer = std::min(n, maxBytes);
       memcpy(dst, buffer.begin(), fromSecondBuffer);
       bufferAvailable = buffer.slice(fromSecondBuffer, n);
@@ -161,7 +161,7 @@ size_t BufferedInputStreamWrapper::tryRead(void* dst, size_t minBytes, size_t ma
     } else {
       // Forward large read to the underlying stream.
       bufferAvailable = nullptr;
-      return fromFirstBuffer + inner.read(dst, minBytes, maxBytes);
+      return fromFirstBuffer + inner.tryRead(dst, minBytes, maxBytes);
     }
   }
 }


### PR DESCRIPTION
This fixes #1980 and #2067 and adds a test case that would have fired on #2067. Based on master because I still work on v1 and didn't want to port it forward and back again.