### PR TITLE
Make WebSocket::disconnect() synchronous and fix some obscure promise ordering bugs

### DIFF
--- a/c++/compile_flags.txt
+++ b/c++/compile_flags.txt
@@ -3,7 +3,6 @@
 -Itmp
 -isystem/usr/local/include
 -isystem/usr/include/x86_64-linux-gnu
--isystem/usr/include
 -DKJ_HEADER_WARNINGS
 -DCAPNP_HEADER_WARNINGS
 -DCAPNP_DEBUG_TYPES

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -544,11 +544,10 @@ void runWebSocketBasicTestCase(
   }
 
   {
-    auto promise = serverWs.disconnect();
+    serverWs.disconnect();
     auto receivePromise = clientWs.receive();
     KJ_EXPECT(receivePromise.poll(waitScope));
     KJ_EXPECT_THROW(DISCONNECTED, receivePromise.wait(waitScope));
-    promise.wait(waitScope);
   }
 }
 

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -78,9 +78,8 @@ public:
     KJ_IF_SOME(e, error) {
       onEnd->reject(kj::mv(*e));
     } else KJ_IF_SOME(ws, webSocket) {
-      onEnd->fulfill(kj::evalNow([&]() {
-        return ws.disconnect().attach(kj::mv(ownWebSocket));
-      }));
+      ws.disconnect();
+      onEnd->fulfill(kj::READY_NOW);
     } else {
       // cancel() was called -- we assume no one is waiting on the fulfiller
     }
@@ -215,9 +214,8 @@ public:
     return req.send().ignoreResult();
   }
 
-  kj::Promise<void> disconnect() override {
+  void disconnect() override {
     out = kj::none;
-    return kj::READY_NOW;
   }
 
   void abort() override {

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -6541,8 +6541,8 @@ KJ_TEST("HttpServer handles disconnected exception for clients disconnecting aft
       int writeId = writeCount++;
       if (writeId == 0) {
         // Allow first write (headers) to succeed.
-        auto promise = inner.write(buffer);
-        inner.shutdownWrite();
+        auto promise = inner.write(buffer)
+            .then([this]() { inner.shutdownWrite(); });
         return promise;
       } else if (writeId == 1) {
         // Fail subsequent write (body) with a disconnected exception.


### PR DESCRIPTION
I was just sort of messing around with promise ordering, trying to use depth-first scheduling in more cases, and it revealed some bugs.

In a big of a yak shave, I ended up changing `WebSocket::disconnect()` to be synchronous, which I've wanted to do for a while.