### PR TITLE
[nfc] Replace std::min/max with kj::min/max

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -27,7 +27,6 @@
 #include <kj/refcount.h>
 #include <kj/debug.h>
 #include <kj/vector.h>
-#include <map>
 #include "generated-header-support.h"
 
 namespace capnp {

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -35,7 +35,6 @@
 #include <kj/filesystem.h>
 #include "../schema-loader.h"
 #include "../dynamic.h"
-#include <unordered_map>
 #include <unordered_set>
 #include <map>
 #include <set>

--- a/c++/src/capnp/compiler/capnpc-capnp.c++
+++ b/c++/src/capnp/compiler/capnpc-capnp.c++
@@ -35,7 +35,6 @@
 #include "../schema-loader.h"
 #include "../dynamic.h"
 #include <kj/miniposix.h>
-#include <unordered_map>
 #include <kj/main.h>
 #include <algorithm>
 #include <map>

--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -765,7 +765,7 @@ private:
     // lists are sorted by ordinal.
     auto fields = structNode.getFields();
     auto replacementFields = replacement.getFields();
-    uint count = std::min(fields.size(), replacementFields.size());
+    uint count = kj::min(fields.size(), replacementFields.size());
 
     if (replacementFields.size() > fields.size()) {
       replacementIsNewer();
@@ -907,7 +907,7 @@ private:
       replacementIsOlder();
     }
 
-    uint count = std::min(methods.size(), replacementMethods.size());
+    uint count = kj::min(methods.size(), replacementMethods.size());
 
     for (uint i = 0; i < count; i++) {
       checkCompatibility(methods[i], replacementMethods[i]);

--- a/c++/src/capnp/schema-parser-test.c++
+++ b/c++/src/capnp/schema-parser-test.c++
@@ -25,7 +25,6 @@
 #include <kj/compat/gtest.h>
 #include "test-util.h"
 #include <kj/debug.h>
-#include <map>
 
 namespace capnp {
 namespace {

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -7896,7 +7896,6 @@ private:
     httpOutput.writeHeaders(headers.serializeResponse(
         statusCode, statusText, connectionHeadersArray));
 
-    kj::Own<kj::AsyncOutputStream> bodyStream;
     if (isHeadRequest) {
       // Ignore entity-body.
       httpOutput.finishBody();

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -30,7 +30,6 @@
 #include "io.h"
 #include "debug.h"
 #include "miniposix.h"
-#include <algorithm>
 #include <errno.h>
 #include "vector.h"
 
@@ -61,7 +60,7 @@ size_t InputStream::read(ArrayPtr<byte> buffer, size_t minBytes) {
 void InputStream::skip(size_t bytes) {
   byte scratch[8192]{};
   while (bytes > 0) {
-    size_t amount = std::min(bytes, sizeof(scratch));
+    size_t amount = kj::min(bytes, sizeof(scratch));
     read(arrayPtr(scratch).first(amount));
     bytes -= amount;
   }
@@ -139,7 +138,7 @@ size_t BufferedInputStreamWrapper::tryRead(ArrayPtr<byte> dst, size_t minBytes) 
   size_t maxBytes = dst.size();
   if (minBytes <= bufferAvailable.size()) {
     // Serve from current buffer.
-    size_t n = std::min(bufferAvailable.size(), maxBytes);
+    size_t n = kj::min(bufferAvailable.size(), maxBytes);
     memcpy(dst.begin(), bufferAvailable.begin(), n);
     bufferAvailable = bufferAvailable.slice(n);
     return n;
@@ -154,7 +153,7 @@ size_t BufferedInputStreamWrapper::tryRead(ArrayPtr<byte> dst, size_t minBytes) 
     if (maxBytes <= buffer.size()) {
       // Read the next buffer-full.
       size_t n = inner.read(buffer, minBytes);
-      size_t fromSecondBuffer = std::min(n, maxBytes);
+      size_t fromSecondBuffer = kj::min(n, maxBytes);
       memcpy(dst.begin(), buffer.begin(), fromSecondBuffer);
       bufferAvailable = buffer.slice(fromSecondBuffer, n);
       return fromFirstBuffer + fromSecondBuffer;
@@ -248,7 +247,7 @@ ArrayPtr<const byte> ArrayInputStream::tryGetReadBuffer() {
 }
 
 size_t ArrayInputStream::tryRead(ArrayPtr<byte> dst, size_t minBytes) {
-  size_t n = std::min(dst.size(), array.size());
+  size_t n = kj::min(dst.size(), array.size());
   memcpy(dst.begin(), array.begin(), n);
   array = array.slice(n);
   return n;

--- a/c++/src/kj/time.c++
+++ b/c++/src/kj/time.c++
@@ -26,7 +26,6 @@
 
 #include "time.h"
 #include "debug.h"
-#include <set>
 
 #if _WIN32
 #include <windows.h>

--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -146,7 +146,7 @@ void TimerImpl::advanceTo(TimePoint newTime) {
   // This workaround is to avoid the assert triggering on these machines.
   // See also https://github.com/capnproto/capnproto/issues/1693
 #if __APPLE__ && (defined(__x86_64__) || defined(__POWERPC__))
-  time = std::max(time, newTime);
+  time = kj::max(time, newTime);
 #else
   KJ_REQUIRE(newTime >= time, "can't advance backwards in time") { return; }
   time = newTime;


### PR DESCRIPTION
This is more consistent and allows us to eliminate the large <algorithm> header in some places. I am assuming that both of these are functionally equivalent.
\- Drop unused AsyncOutputStream in http.c++
\- Clean up a few unused STL headers

\- I needed this for a downstream change to add _LIBCPP_REMOVE_TRANSITIVE_INCLUDES there, c++/src/kj/timer.c++ should either be including <algorithm> or not using std::max