### PR TITLE
Delete some deprecated stuff

### DIFF
--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -65,11 +65,6 @@ public:
   virtual kj::Promise<kj::Own<Connection>> baseAccept() = 0;
 };
 
-class SturdyRefRestorerBase {
-public:
-  virtual Capability::Client baseRestore(AnyPointer::Reader ref) = 0;
-};
-
 class BootstrapFactoryBase {
   // Non-template version of BootstrapFactory.  Ignore this class; see BootstrapFactory in rpc.h.
 public:
@@ -82,7 +77,6 @@ class RpcSystemBase {
 public:
   RpcSystemBase(VatNetworkBase& network, kj::Maybe<Capability::Client> bootstrapInterface);
   RpcSystemBase(VatNetworkBase& network, BootstrapFactoryBase& bootstrapFactory);
-  RpcSystemBase(VatNetworkBase& network, SturdyRefRestorerBase& restorer);
   RpcSystemBase(RpcSystemBase&& other) noexcept;
   ~RpcSystemBase() noexcept(false);
 
@@ -95,7 +89,6 @@ private:
   kj::Own<Impl> impl;
 
   Capability::Client baseBootstrap(AnyStruct::Reader vatId);
-  Capability::Client baseRestore(AnyStruct::Reader vatId, AnyPointer::Reader objectId);
   void baseSetFlowLimit(size_t words);
 
   class RpcConnectionState;

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -59,34 +59,6 @@ namespace capnp {
 namespace _ {
 namespace {
 
-class TestRestorer final: public SturdyRefRestorer<test::TestSturdyRefObjectId> {
-public:
-  TestRestorer(int& callCount, int& handleCount)
-      : callCount(callCount), handleCount(handleCount) {}
-
-  Capability::Client restore(test::TestSturdyRefObjectId::Reader objectId) override {
-    switch (objectId.getTag()) {
-      case test::TestSturdyRefObjectId::Tag::TEST_INTERFACE:
-        return kj::heap<TestInterfaceImpl>(callCount);
-      case test::TestSturdyRefObjectId::Tag::TEST_EXTENDS:
-        return Capability::Client(newBrokenCap("No TestExtends implemented."));
-      case test::TestSturdyRefObjectId::Tag::TEST_PIPELINE:
-        return kj::heap<TestPipelineImpl>(callCount);
-      case test::TestSturdyRefObjectId::Tag::TEST_TAIL_CALLEE:
-        return kj::heap<TestTailCalleeImpl>(callCount);
-      case test::TestSturdyRefObjectId::Tag::TEST_TAIL_CALLER:
-        return kj::heap<TestTailCallerImpl>(callCount);
-      case test::TestSturdyRefObjectId::Tag::TEST_MORE_STUFF:
-        return kj::heap<TestMoreStuffImpl>(callCount, handleCount);
-    }
-    KJ_UNREACHABLE;
-  }
-
-private:
-  int& callCount;
-  int& handleCount;
-};
-
 class TestMonotonicClock final: public kj::MonotonicClock {
 public:
   kj::TimePoint now() const override {
@@ -105,26 +77,20 @@ kj::AsyncIoProvider::PipeThread runServer(kj::AsyncIoProvider& ioProvider,
       [&callCount, &handleCount](
        kj::AsyncIoProvider& ioProvider, kj::AsyncIoStream& stream, kj::WaitScope& waitScope) {
     TwoPartyVatNetwork network(stream, rpc::twoparty::Side::SERVER);
-    TestRestorer restorer(callCount, handleCount);
-    auto server = makeRpcServer(network, restorer);
+    auto server = makeRpcServer(network, kj::heap<TestInterfaceImpl>(callCount, handleCount));
     network.onDisconnect().wait(waitScope);
   });
 }
 
-Capability::Client getPersistentCap(RpcSystem<rpc::twoparty::VatId>& client,
-                                    rpc::twoparty::Side side,
-                                    test::TestSturdyRefObjectId::Tag tag) {
+test::TestInterface::Client getBootstrap(RpcSystem<rpc::twoparty::VatId>& client,
+                                         rpc::twoparty::Side side) {
   // Create the VatId.
   MallocMessageBuilder hostIdMessage(8);
   auto hostId = hostIdMessage.initRoot<rpc::twoparty::VatId>();
   hostId.setSide(side);
 
-  // Create the SturdyRefObjectId.
-  MallocMessageBuilder objectIdMessage(8);
-  objectIdMessage.initRoot<test::TestSturdyRefObjectId>().setTag(tag);
-
   // Connect to the remote capability.
-  return client.restore(hostId, objectIdMessage.getRoot<AnyPointer>());
+  return client.bootstrap(hostId).castAs<test::TestInterface>();
 }
 
 TEST(TwoPartyNetwork, Basic) {
@@ -142,8 +108,7 @@ TEST(TwoPartyNetwork, Basic) {
   KJ_EXPECT(network.getOutgoingMessageWaitTime() == 0 * kj::SECONDS);
 
   // Request the particular capability from the server.
-  auto client = getPersistentCap(rpcClient, rpc::twoparty::Side::SERVER,
-      test::TestSturdyRefObjectId::Tag::TEST_INTERFACE).castAs<test::TestInterface>();
+  auto client = getBootstrap(rpcClient, rpc::twoparty::Side::SERVER);
   clock.increment(1 * kj::SECONDS);
 
   KJ_EXPECT(network.getCurrentQueueCount() == 1);
@@ -246,8 +211,8 @@ TEST(TwoPartyNetwork, Pipelining) {
 
   {
     // Request the particular capability from the server.
-    auto client = getPersistentCap(rpcClient, rpc::twoparty::Side::SERVER,
-        test::TestSturdyRefObjectId::Tag::TEST_PIPELINE).castAs<test::TestPipeline>();
+    auto client = getBootstrap(rpcClient, rpc::twoparty::Side::SERVER)
+        .getTestPipelineRequest().send().getCap();
 
     {
       // Use the capability.
@@ -338,8 +303,8 @@ TEST(TwoPartyNetwork, Release) {
   auto rpcClient = makeRpcClient(network);
 
   // Request the particular capability from the server.
-  auto client = getPersistentCap(rpcClient, rpc::twoparty::Side::SERVER,
-      test::TestSturdyRefObjectId::Tag::TEST_MORE_STUFF).castAs<test::TestMoreStuff>();
+  auto client = getBootstrap(rpcClient, rpc::twoparty::Side::SERVER)
+      .getTestMoreStuffRequest().send().getCap();
 
   auto handle1 = client.getHandleRequest().send().wait(ioContext.waitScope).getHandle();
   auto promise = client.getHandleRequest().send();
@@ -452,8 +417,8 @@ TEST(TwoPartyNetwork, HugeMessage) {
   TwoPartyVatNetwork network(*serverThread.pipe, rpc::twoparty::Side::CLIENT);
   auto rpcClient = makeRpcClient(network);
 
-  auto client = getPersistentCap(rpcClient, rpc::twoparty::Side::SERVER,
-      test::TestSturdyRefObjectId::Tag::TEST_MORE_STUFF).castAs<test::TestMoreStuff>();
+  auto client = getBootstrap(rpcClient, rpc::twoparty::Side::SERVER)
+      .getTestMoreStuffRequest().send().getCap();
 
   // Oversized request fails.
   {

--- a/c++/src/capnp/rpc.capnp
+++ b/c++/src/capnp/rpc.capnp
@@ -311,7 +311,7 @@ struct Bootstrap {
   # containing the restored capability.
 
   deprecatedObjectId @1 :AnyPointer;
-  # ** DEPRECATED **
+  # ** OBSOLETE **
   #
   # A Vat may export multiple bootstrap interfaces. In this case, `deprecatedObjectId` specifies
   # which one to return. If this pointer is null, then the default bootstrap interface is returned.
@@ -319,6 +319,8 @@ struct Bootstrap {
   # As of version 0.5, use of this field is deprecated. If a service wants to export multiple
   # bootstrap interfaces, it should instead define a single bootstrap interface that has methods
   # that return each of the other interfaces.
+  #
+  # As of version 2.0, this field is no longer implemented at all.
   #
   # **History**
   #

--- a/c++/src/capnp/schema-test.c++
+++ b/c++/src/capnp/schema-test.c++
@@ -236,18 +236,6 @@ TEST(Schema, Lists) {
     EXPECT_EQ(schema::Type::ENUM, inner.whichElementType());
     EXPECT_TRUE(inner.getEnumElementType() == Schema::from<TestEnum>());
   }
-
-  {
-    auto context = Schema::from<TestAllTypes>();
-    auto type = context.getFieldByName("enumList").getProto().getSlot().getType();
-
-    ListSchema schema = ListSchema::of(type.getList().getElementType(), context);
-    EXPECT_EQ(schema::Type::ENUM, schema.whichElementType());
-    EXPECT_TRUE(schema.getEnumElementType() == Schema::from<TestEnum>());
-    EXPECT_NONFATAL_FAILURE(schema.getStructElementType());
-    EXPECT_NONFATAL_FAILURE(schema.getInterfaceElementType());
-    EXPECT_NONFATAL_FAILURE(schema.getListElementType());
-  }
 }
 
 TEST(Schema, UnnamedUnion) {

--- a/c++/src/capnp/schema.c++
+++ b/c++/src/capnp/schema.c++
@@ -759,51 +759,6 @@ ListSchema ListSchema::of(schema::Type::Which primitiveType) {
   return ListSchema(primitiveType);
 }
 
-ListSchema ListSchema::of(schema::Type::Reader elementType, Schema context) {
-  // This method is deprecated because it can only be implemented in terms of other deprecated
-  // methods. Temporarily disable warnings for those other deprecated methods.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-  switch (elementType.which()) {
-    case schema::Type::VOID:
-    case schema::Type::BOOL:
-    case schema::Type::INT8:
-    case schema::Type::INT16:
-    case schema::Type::INT32:
-    case schema::Type::INT64:
-    case schema::Type::UINT8:
-    case schema::Type::UINT16:
-    case schema::Type::UINT32:
-    case schema::Type::UINT64:
-    case schema::Type::FLOAT32:
-    case schema::Type::FLOAT64:
-    case schema::Type::TEXT:
-    case schema::Type::DATA:
-      return of(elementType.which());
-
-    case schema::Type::STRUCT:
-      return of(context.getDependency(elementType.getStruct().getTypeId()).asStruct());
-
-    case schema::Type::ENUM:
-      return of(context.getDependency(elementType.getEnum().getTypeId()).asEnum());
-
-    case schema::Type::INTERFACE:
-      return of(context.getDependency(elementType.getInterface().getTypeId()).asInterface());
-
-    case schema::Type::LIST:
-      return of(of(elementType.getList().getElementType(), context));
-
-    case schema::Type::ANY_POINTER:
-      KJ_FAIL_REQUIRE("List(AnyPointer) not supported.");
-      return ListSchema();
-  }
-
-  // Unknown type is acceptable.
-  return ListSchema(elementType.which());
-#pragma GCC diagnostic pop
-}
-
 // =======================================================================================
 
 StructSchema Type::asStruct() const {

--- a/c++/src/capnp/schema.h
+++ b/c++/src/capnp/schema.h
@@ -747,16 +747,6 @@ public:
   static ListSchema of(Type elementType);
   // Construct the schema for a list of the given type.
 
-  static ListSchema of(schema::Type::Reader elementType, Schema context)
-      CAPNP_DEPRECATED("Does not handle generics correctly.");
-  // DEPRECATED: This method cannot correctly account for generic type parameter bindings that
-  //   may apply to the input type. Instead of using this method, use a method of the Schema API
-  //   that corresponds to the exact kind of dependency. For example, to get a field type, use
-  //   StructSchema::Field::getType().
-  //
-  // Construct from an element type schema.  Requires a context which can handle getDependency()
-  // requests for any type ID found in the schema.
-
   Type getElementType() const;
 
   inline schema::Type::Which whichElementType() const;

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -890,7 +890,8 @@ void checkDynamicTestMessageAllZero(DynamicStruct::Reader reader) {
 
 #if !CAPNP_LITE
 
-TestInterfaceImpl::TestInterfaceImpl(int& callCount): callCount(callCount) {}
+TestInterfaceImpl::TestInterfaceImpl(int& callCount, kj::Maybe<int&> handleCount)
+    : callCount(callCount), handleCount(handleCount) {}
 
 kj::Promise<void> TestInterfaceImpl::foo(FooContext context) {
   ++callCount;
@@ -909,6 +910,24 @@ kj::Promise<void> TestInterfaceImpl::baz(BazContext context) {
   context.releaseParams();
   EXPECT_ANY_THROW(context.getParams());
 
+  return kj::READY_NOW;
+}
+
+kj::Promise<void> TestInterfaceImpl::getTestPipeline(GetTestPipelineContext context) {
+  context.getResults().setCap(kj::heap<TestPipelineImpl>(callCount));
+  return kj::READY_NOW;
+}
+kj::Promise<void> TestInterfaceImpl::getTestTailCallee(GetTestTailCalleeContext context) {
+  context.getResults().setCap(kj::heap<TestTailCalleeImpl>(callCount));
+  return kj::READY_NOW;
+}
+kj::Promise<void> TestInterfaceImpl::getTestTailCaller(GetTestTailCallerContext context) {
+  context.getResults().setCap(kj::heap<TestTailCallerImpl>(callCount));
+  return kj::READY_NOW;
+}
+kj::Promise<void> TestInterfaceImpl::getTestMoreStuff(GetTestMoreStuffContext context) {
+  context.getResults().setCap(
+      kj::heap<TestMoreStuffImpl>(callCount, KJ_REQUIRE_NONNULL(handleCount)));
   return kj::READY_NOW;
 }
 

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -184,14 +184,20 @@ void checkList(T reader, std::initializer_list<ReaderFor<Element>> expected) {
 
 class TestInterfaceImpl final: public test::TestInterface::Server {
 public:
-  TestInterfaceImpl(int& callCount);
+  TestInterfaceImpl(int& callCount, kj::Maybe<int&> handleCount = kj::none);
 
   kj::Promise<void> foo(FooContext context) override;
 
   kj::Promise<void> baz(BazContext context) override;
 
+  kj::Promise<void> getTestPipeline(GetTestPipelineContext context) override;
+  kj::Promise<void> getTestTailCallee(GetTestTailCalleeContext context) override;
+  kj::Promise<void> getTestTailCaller(GetTestTailCallerContext context) override;
+  kj::Promise<void> getTestMoreStuff(GetTestMoreStuffContext context) override;
+
 private:
   int& callCount;
+  kj::Maybe<int&> handleCount;
 };
 
 class TestExtendsImpl final: public test::TestExtends2::Server {

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -790,6 +790,11 @@ interface TestInterface {
   foo @0 (i :UInt32, j :Bool) -> (x :Text);
   bar @1 () -> ();
   baz @2 (s: TestAllTypes);
+
+  getTestPipeline @3 () -> (cap :TestPipeline);
+  getTestTailCallee @4 () -> (cap :TestTailCallee);
+  getTestTailCaller @5 () -> (cap :TestTailCaller);
+  getTestMoreStuff @6 () -> (cap :TestMoreStuff);
 }
 
 interface TestExtends extends(TestInterface) {
@@ -939,25 +944,8 @@ interface TestAuthenticatedBootstrap(VatId) {
   getCallerId @0 () -> (caller :VatId);
 }
 
-struct TestSturdyRef {
-  hostId @0 :TestSturdyRefHostId;
-  objectId @1 :AnyPointer;
-}
-
 struct TestSturdyRefHostId {
   host @0 :Text;
-}
-
-struct TestSturdyRefObjectId {
-  tag @0 :Tag;
-  enum Tag {
-    testInterface @0;
-    testExtends @1;
-    testPipeline @2;
-    testTailCallee @3;
-    testTailCaller @4;
-    testMoreStuff @5;
-  }
 }
 
 struct TestProvisionId {}


### PR DESCRIPTION
Just deleting some APIs that have been marked deprecated for a long time (and updating tests that were still using said APIs).