### PR TITLE
[RFC] Backport v1.x fixes to v2

### DIFF
--- a/c++/src/capnp/blob.h
+++ b/c++/src/capnp/blob.h
@@ -79,7 +79,9 @@ public:
   inline Reader(const StringPtr& value): StringPtr(value) {}
 
 #if KJ_COMPILER_SUPPORTS_STL_STRING_INTEROP
-  template <typename T, typename = decltype(kj::instance<T>().c_str())>
+  template <
+    typename T,
+    typename = kj::EnableIf<kj::canConvert<decltype(kj::instance<T>().c_str()), const char*>()>>
   inline Reader(const T& t): StringPtr(t) {}
   // Allow implicit conversion from any class that has a c_str() method (namely, std::string).
   // We use a template trick to detect std::string in order to avoid including the header for

--- a/c++/src/capnp/compat/std-iterator.h
+++ b/c++/src/capnp/compat/std-iterator.h
@@ -39,7 +39,7 @@ struct iterator_traits<capnp::_::IndexingIterator<Container, Element>> {
   using value_type = Element;
   using difference_type	= int;
   using pointer = Element*;
-  using reference = Element&;
+  using reference = Element;
 };
 
 }  // namespace std

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -23,6 +23,11 @@
 #define _GNU_SOURCE
 #endif
 
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+// Request 64-bit off_t and ino_t, otherwise this code will break when either value exceeds 2^32.
+#endif
+
 #if _WIN32
 #include <kj/win32-api-version.h>
 #endif

--- a/c++/src/capnp/dynamic-test.c++
+++ b/c++/src/capnp/dynamic-test.c++
@@ -492,6 +492,25 @@ TEST(DynamicApi, BuilderAssign) {
   listValue.set(0, 123);
 }
 
+TEST(DynamicApi, SetGroup) {
+  MallocMessageBuilder srcBuilder;
+  MallocMessageBuilder dstBuilder;
+
+  auto srcRoot = srcBuilder.initRoot<TestInterleavedGroups>();
+  auto srcGroup = srcRoot.initGroup1();
+  srcGroup.setFoo(10);
+  srcGroup.initCorge().setPlugh("howdy");
+
+  auto dstRoot = dstBuilder.initRoot<DynamicStruct>(Schema::from<TestInterleavedGroups>());
+  dstRoot.set("group1", srcGroup.asReader());
+
+  auto dstGroup = dstRoot.get("group1").as<DynamicStruct>();
+
+  EXPECT_EQ(10u, dstGroup.get("foo").as<uint32_t>());
+  EXPECT_ANY_THROW(dstGroup.get("qux"));
+  EXPECT_EQ("howdy", dstGroup.get("corge").as<DynamicStruct>().get("plugh").as<Text>());
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp

--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -661,6 +661,8 @@ void DynamicStruct::Builder::set(StructSchema::Field field, const DynamicValue::
           dst.set(field, src.get(field));
         }
       }
+
+      return;
     }
   }
 

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -81,6 +81,7 @@ using ::capnproto_test::capnp::test::TestUnionDefaults;
 using ::capnproto_test::capnp::test::TestNestedTypes;
 using ::capnproto_test::capnp::test::TestUsing;
 using ::capnproto_test::capnp::test::TestListDefaults;
+using ::capnproto_test::capnp::test::TestInterleavedGroups;
 
 void initTestMessage(TestAllTypes::Builder builder);
 void initTestMessage(TestDefaults::Builder builder);

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -3278,7 +3278,7 @@ kj::String fillWriteBuffer(int fd) {
   // Fill up the write buffer of the given FD and return the contents written. We need to use the
   // raw syscalls to do this because KJ doesn't have a way to know how many bytes made it into the
   // socket buffer.
-  auto huge = bigString(2'000'000);
+  auto huge = bigString(4'200'000);
 
   size_t pos = 0;
   for (;;) {

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -352,6 +352,10 @@ public:
     *length = socklen;
   }
 
+  Maybe<void*> getWin32Handle() const {
+    return reinterpret_cast<void*>(fd);
+  }
+
 private:
   Own<Win32EventPort::IoObserver> observer;
 

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -169,6 +169,10 @@ public:
   virtual kj::Maybe<int> getFd() const { return kj::none; }
   // Get the underlying Unix file descriptor, if any. Returns kj::none if this object actually
   // isn't wrapping a file descriptor.
+
+  virtual Maybe<void*> getWin32Handle() const { return nullptr; }
+  // Get the underlying Win32 HANDLE, if any. Returns nullptr if this object actually isn't
+  // wrapping a handle.
 };
 
 class NullStream final: public AsyncIoStream {

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -170,7 +170,7 @@ public:
   // Get the underlying Unix file descriptor, if any. Returns kj::none if this object actually
   // isn't wrapping a file descriptor.
 
-  virtual Maybe<void*> getWin32Handle() const { return nullptr; }
+  virtual kj::Maybe<void*> getWin32Handle() const { return kj::none; }
   // Get the underlying Win32 HANDLE, if any. Returns nullptr if this object actually isn't
   // wrapping a handle.
 };

--- a/c++/src/kj/cidr.c++
+++ b/c++/src/kj/cidr.c++
@@ -41,6 +41,10 @@
 #include <arpa/inet.h>
 #endif
 
+#if __FreeBSD__
+#include <netinet/in.h>
+#endif
+
 namespace kj {
 
 CidrRange::CidrRange(StringPtr pattern) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -321,10 +321,11 @@ KJ_NORETURN(void unreachable());
 
 }  // namespace _ (private)
 
-#ifdef KJ_DEBUG
 #if _MSC_VER && !defined(__clang__) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
 #define KJ_MSVC_TRADITIONAL_CPP 1
 #endif
+
+#ifdef KJ_DEBUG
 #if KJ_MSVC_TRADITIONAL_CPP
 #define KJ_IREQUIRE(condition, ...) \
     if (KJ_LIKELY(condition)); else ::kj::_::inlineRequireFailure( \

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -19,6 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+// Request 64-bit off_t and ino_t, otherwise this code will break when either value exceeds 2^32.
+#endif
+
 #include "debug.h"
 #include "filesystem.h"
 #include "string.h"

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -1706,7 +1706,14 @@ private:
             pwdStat.st_dev == dotStat.st_dev) {
           return kj::mv(result);
         } else {
-          KJ_LOG(WARNING, "PWD environment variable doesn't match current directory", pwd);
+          // It appears PWD doesn't actually point at the current directory. In practice, only
+          // shells tend to update PWD. Other programs, like build tools, may do `chdir()` without
+          // actually updating PWD to match. Arguably they are buggy, but realistically we have to
+          // live with them. So, we will treat an incorrect PWD the same as an absent PWD, and fall
+          // back to using the current directory's canonical path.
+          //
+          // We used to log a WARNING here but it was deemed too noisy, so we changed it to INFO.
+          KJ_LOG(INFO, "PWD environment variable doesn't match current directory", pwd);
         }
       }
     }

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -152,7 +152,7 @@ size_t BufferedInputStreamWrapper::tryRead(ArrayPtr<byte> dst, size_t minBytes) 
 
     if (maxBytes <= buffer.size()) {
       // Read the next buffer-full.
-      size_t n = inner.read(buffer, minBytes);
+      size_t n = inner.tryRead(buffer, minBytes);
       size_t fromSecondBuffer = kj::min(n, maxBytes);
       memcpy(dst.begin(), buffer.begin(), fromSecondBuffer);
       bufferAvailable = buffer.slice(fromSecondBuffer, n);
@@ -160,7 +160,7 @@ size_t BufferedInputStreamWrapper::tryRead(ArrayPtr<byte> dst, size_t minBytes) 
     } else {
       // Forward large read to the underlying stream.
       bufferAvailable = nullptr;
-      return fromFirstBuffer + inner.read(dst, minBytes);
+      return fromFirstBuffer + inner.tryRead(dst, minBytes);
     }
   }
 }

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -380,9 +380,57 @@ KJ_TEST("float stringification and parsing is not locale-dependent") {
   }
 }
 
-KJ_TEST("ConstString") {
+KJ_TEST("ConstString literal operator") {
   kj::ConstString theString = "it's a const string!"_kjc;
   KJ_EXPECT(theString == "it's a const string!");
+}
+
+KJ_TEST("ConstString promotion") {
+  kj::StringPtr theString = "it's a const string!";
+  kj::ConstString constString = theString.attach();
+  KJ_EXPECT(constString == "it's a const string!");
+}
+
+struct DestructionOrderRecorder {
+  DestructionOrderRecorder(uint& counter, uint& recordTo)
+    : counter(counter), recordTo(recordTo) {}
+  ~DestructionOrderRecorder() {
+    recordTo = ++counter;
+  }
+
+  uint& counter;
+  uint& recordTo;
+};
+
+KJ_TEST("ConstString attachment lifetimes") {
+  uint counter = 0;
+  uint destroyed1 = 0;
+  uint destroyed2 = 0;
+  uint destroyed3 = 0;
+
+  auto obj1 = kj::heap<DestructionOrderRecorder>(counter, destroyed1);
+  auto obj2 = kj::heap<DestructionOrderRecorder>(counter, destroyed2);
+  auto obj3 = kj::heap<DestructionOrderRecorder>(counter, destroyed3);
+
+  StringPtr theString = "it's a string!";
+  const char* ptr = theString.begin();
+
+  ConstString combined = theString.attach(kj::mv(obj1), kj::mv(obj2), kj::mv(obj3));
+
+  KJ_EXPECT(combined.begin() == ptr);
+
+  KJ_EXPECT(obj1.get() == nullptr);
+  KJ_EXPECT(obj2.get() == nullptr);
+  KJ_EXPECT(obj3.get() == nullptr);
+  KJ_EXPECT(destroyed1 == 0);
+  KJ_EXPECT(destroyed2 == 0);
+  KJ_EXPECT(destroyed3 == 0);
+
+  combined = nullptr;
+
+  KJ_EXPECT(destroyed1 == 1, destroyed1);
+  KJ_EXPECT(destroyed2 == 2, destroyed2);
+  KJ_EXPECT(destroyed3 == 3, destroyed3);
 }
 
 KJ_TEST("StringPtr find") {

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -100,7 +100,7 @@ public:
 #if KJ_COMPILER_SUPPORTS_STL_STRING_INTEROP
   template <
     typename T,
-    typename = decltype(instance<T>().c_str()),
+    typename = EnableIf<canConvert<decltype(instance<T>().c_str()), const char*>()>,
     typename = decltype(instance<T>().size())>
   inline StringPtr(const T& t KJ_LIFETIMEBOUND): StringPtr(t.c_str(), t.size()) {}
   // Allow implicit conversion from any class that has a c_str() and a size() method (namely, std::string).
@@ -108,7 +108,7 @@ public:
   // those who don't want it.
   template <
     typename T,
-    typename = decltype(instance<T>().c_str()),
+    typename = EnableIf<canConvert<decltype(instance<T>().c_str()), const char*>()>,
     typename = decltype(instance<T>().size())>
   inline operator T() const { return {cStr(), size()}; }
   // Allow implicit conversion to any class that has a c_str() method and a size() method (namely, std::string).

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -751,7 +751,7 @@ inline ConstString StringPtr::attach() const {
 
 template <typename... Attachments>
 inline ConstString StringPtr::attach(Attachments&&... attachments) const {
-  return ConstString { .content = content.attach(kj::fwd<Attachments>(attachments)...) };
+  return ConstString { content.attach(kj::fwd<Attachments>(attachments)...) };
 }
 
 inline String::operator ArrayPtr<char>() {


### PR DESCRIPTION
I was curious if the v2 branch was missing any important changes that were contributed to the master branch and reviewed all code changes present on master but not on v2 – turns out that this largely consists of smaller changes that are not very relevant to downstream projects, so there's **no need to prioritize** porting them. I still wanted to track them here so we don't lose them. I'm not sure if cherry-picking the changes individually is even the right approach for this, but this should include all relevant code changes as of writing. 2a9ba4eca3253a3e53ac91b6aefaa7e0f9475474 which fixes compilation errors for recent compilers is not included as we already resolved that differently.

Cherry-picked commits:
9da0b118049cbf017935ac20a04a9aa5bbc54514
2d41340e102607d4478b7b79d0dcfe5fdd7f67be
2ed5cdcb6c67fd885401b204fb7b6cace8aadf74
12b49cca010fde10d1ee8109c813a9eabe1cb43e
2754d74e3eea68413936c4ab546d9a0923c6bb35
58e509db5473fab6acba3c74a2be648f05ce934e
0eea6f1a5095c16225a6f22e3cd534d017a52957
5303d8776ab8b1dd883957dffe3a304dc44d6e01
7ad12031f05ff7d36bcdd41b8baeec0b33bfcf4a
3dc31dbca86e561249e7c2a0ca366514523d9a91
