### PR TITLE
kj::Rc and kj::Arc escape hatches

### DIFF
--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -210,7 +210,8 @@ public:
   inline T* operator->() { return own.get(); }
   inline const T* operator->() const { return own.get(); }
 
-  // do not expose * to avoid dangling references
+  inline T* get() { return own.get(); }
+  inline const T* get() const { return own.get(); }
 
 private:
   Rc(T* t) : own(t, *t) { }
@@ -490,7 +491,8 @@ public:
   inline T* operator->() { return own.get(); }
   inline const T* operator->() const { return own.get(); }
 
-  // do not expose * to avoid dangling references
+  inline T* get() { return own.get(); }
+  inline const T* get() const { return own.get(); }
 
 private:
   Arc(T* t) : own(t, *t) { }


### PR DESCRIPTION
T* get() 
People have asked for it, and it makes migrating easier. The only danger is using addRef(T&) again, but that is on the implementer to carefully analyze the usage.