### PR TITLE
3PH part 3: Basic three-party handoff of capabilities

### DIFF
--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -530,9 +530,14 @@ namespace _ {
   };
 };
 
-template <typename Reader, typename>
+template <typename Reader, typename T>
 kj::Own<kj::Decay<Reader>> clone(Reader&& reader) {
-  auto size = reader.totalSize();
+  MessageSize size;
+  if constexpr(kj::isSameType<T, AnyPointer>()) {
+    size = reader.targetSize();
+  } else {
+    size = reader.totalSize();
+  }
   auto buffer = kj::heapArray<capnp::word>(size.wordCount + 1);
   memset(buffer.asBytes().begin(), 0, buffer.asBytes().size());
   if (size.capCount == 0) {

--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -123,6 +123,10 @@ private:
   //   is defined before `Impl` in rpc.c++. We can't have the caller hold a pointer to
   //   `RpcSystemBase` instead because it is movable.
 
+  static RpcConnectionState& getConnectionState(Impl& impl,
+      kj::Own<VatNetworkBase::Connection> connection);
+  // Get the RpcConnectionState associated with the given connection, creating it if necessary.
+
   template <typename>
   friend class capnp::RpcSystem;
 };

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -959,6 +959,11 @@ private:
       // returned reference is dropped. Note that `addRef()`s on the returned reference do NOT have
       // to hold open the Provide; the Provide can be held open by an attachment on the ref itself.
       //
+      // If this function returns *without* filling in `contact` (i.e. `contact.isNull()`), then
+      // this indicates that the return value is actually a redirect (not the vine). The caller
+      // will have to start over writing a descriptor for this new capability instead.
+      // TODO(cleanup): This is is an ugly API, consider making it better.
+      //
       // The default implementation of this method is appropriate most of the time. It is
       // overridded for the specific case of `DeferredThirdPartyClient`.
 
@@ -972,7 +977,13 @@ private:
       auto otherMsg = provider.newOutgoingMessage(messageSizeHint<rpc::Provide>() + 32);
       auto provide = otherMsg->getBody().initAs<rpc::Message>().initProvide();
       provide.setQuestionId(questionId);
-      writeTarget(provide.initTarget());
+      KJ_IF_SOME(redirect, writeTarget(provide.initTarget())) {
+        // Oops, this capability was redirected. This *shouldn't* happen since the immediate
+        // caller of writeThirdPartyDescriptor() would have already followed redirects, but as it
+        // happens, if we simply return the redirect here (without filling in `contact`), we are
+        // honoring our contract.
+        return kj::mv(redirect);
+      }
       recipient.introduceTo(provider, contact, provide.initRecipient());
       otherMsg->send();
 
@@ -981,9 +992,10 @@ private:
 
     // implements ClientHook -----------------------------------------
 
-    Request<AnyPointer, AnyPointer> newCall(
+    virtual Request<AnyPointer, AnyPointer> newCall(
         uint64_t interfaceId, uint16_t methodId, kj::Maybe<MessageSize> sizeHint,
         CallHints hints) override {
+      // NOTE: Some subclasses (PromiseClient, DeferredThirdPartyClient) further override this.
       return newCallNoIntercept(interfaceId, methodId, sizeHint, hints);
     }
 
@@ -1008,8 +1020,10 @@ private:
       return Request<AnyPointer, AnyPointer>(root, kj::mv(request));
     }
 
-    VoidPromiseAndPipeline call(uint64_t interfaceId, uint16_t methodId,
-                                kj::Own<CallContextHook>&& context, CallHints hints) override {
+    virtual VoidPromiseAndPipeline call(
+        uint64_t interfaceId, uint16_t methodId,
+        kj::Own<CallContextHook>&& context, CallHints hints) override {
+      // NOTE: Some subclasses (PromiseClient, DeferredThirdPartyClient) further override this.
       return callNoIntercept(interfaceId, methodId, kj::mv(context), hints);
     }
 
@@ -1457,6 +1471,191 @@ private:
     }
   };
 
+  class DeferredThirdPartyClient: public RpcClient {
+    // Client constructed from a ThirdPartyCapDescriptor which we have not actually accepted yet.
+    // We don't actually attempt to send an `Accept` message to the third party until the
+    // application attempts to use the capability. This way, if we merely end up forwarding the
+    // cap to another party without using it at all, we don't need to form our own connection to
+    // the host of the capability.
+
+  public:
+    DeferredThirdPartyClient(RpcConnectionState& connectionState,
+        kj::Own<AnyPointer::Reader> contact, kj::Own<RpcClient> vine)
+        : RpcClient(connectionState), state(Deferred {kj::mv(contact), kj::mv(vine)}) {}
+
+
+    kj::Maybe<ExportId> writeDescriptor(rpc::CapDescriptor::Builder descriptor,
+                                        kj::Vector<int>& fds) override {
+      KJ_SWITCH_ONEOF(state) {
+        KJ_CASE_ONEOF(deferred, Deferred) {
+          // A ThirdPartyCapDescriptor was sent to us, and we are sending it *back* over the same
+          // connection we received it from.
+          //
+          // The easiest way to handle this is to send back the vine, which after all points to
+          // the capability that the other side originally sent us.
+          return deferred.vine->writeDescriptor(descriptor, fds);
+        }
+        KJ_CASE_ONEOF(cap, kj::Own<ClientHook>) {
+          return connectionState->writeDescriptor(*cap, descriptor, fds);
+        }
+      }
+      KJ_UNREACHABLE;
+    }
+
+    kj::Maybe<kj::Own<ClientHook>> writeTarget(
+        rpc::MessageTarget::Builder target) override {
+      // Someone is addressing a message to this capability. We probably need to accept it and
+      // have them address the accepted capability instead.
+      return connectionState->writeTarget(ensureAccepted(), target);
+    }
+
+    kj::Own<ClientHook> getInnermostClient() override {
+      // getInnermostClient() is used as part of the tribble 4-way race condition.
+      //
+      // That is: Say there's a promise on the export table. It resolves, and it resolves to
+      // *this* capability. If there are calls in-flight to that promise, where do we forward
+      // them to? Similarly, if a disembargo is received, where do we forward it to?
+
+      KJ_SWITCH_ONEOF(state) {
+        KJ_CASE_ONEOF(deferred, Deferred) {
+          // At present, `getInnermostClient()` is only actually called when sending the capability
+          // back on the same connection it came from. Well, in that case, we just use the vine.
+          //
+          // TODO(now): When implementing embargos for three-party handoff, presumably
+          //   getInnermostClient() needs to change somehow.
+          return deferred.vine->addRef();
+        }
+        KJ_CASE_ONEOF(cap, kj::Own<ClientHook>) {
+          // Since we already accepted the capability, the accepted version now counts as the
+          // innermost client.
+          return connectionState->getInnermostClient(*cap);
+        }
+      }
+      KJ_UNREACHABLE;
+    }
+
+    // NOTE: We don't need to implement adoptFlowController() since flow controllers are tied to
+    //   specific connections, so presumably the old flow controller won't be able to be adopted
+    //   by the new capability on the new connection anyway. Additionally, it just makes sense to
+    //   recompute the flow from scratch since the new connection probably has different latency
+    //   and throughput.
+
+    kj::Own<ClientHook> writeThirdPartyDescriptor(
+          VatNetworkBase::Connection& provider,
+          VatNetworkBase::Connection& recipient,
+          AnyPointer::Builder contact) override {
+      if (state.is<Deferred>() &&
+          provider.canForwardThirdPartyToContact(*state.get<Deferred>().contact, recipient)) {
+        // We have not accepted this capability yet, and the VatNetwork supports forwarding it!
+        // We can get away without accepting the capability.
+        auto& deferred = state.get<Deferred>();
+        provider.forwardThirdPartyToContact(*deferred.contact, recipient, contact);
+        return deferred.vine->addRef();
+      } else {
+        // Either:
+        // a. We already accepted this cap, so we should treat this as a normal three-party handoff
+        //    and hand off the cap we accepted. (Actually, this doesn't happen in practice because
+        //    the caller would already have resolved to the inner capability in this case.)
+        // b. The VatNetwork won't allow forwarding, so we must accept the cap first, and then,
+        //    again, hand off the accepted cap.
+        auto& hook = ensureAccepted();
+        KJ_IF_SOME(rpcHook, connectionState->unwrapIfSameNetwork(hook)) {
+          KJ_SWITCH_ONEOF(rpcHook.connectionState->connection) {
+            KJ_CASE_ONEOF(connected, Connected) {
+              // Common case: the accepted capability is on its own connection, which we're still
+              // connected to.
+              return rpcHook.writeThirdPartyDescriptor(*connected.connection, recipient, contact);
+            }
+            KJ_CASE_ONEOF(error, Disconnected) {
+              // We accepted the capability but the connection we accepted it on is now dead.
+              // Don't fill in `contact` and just return a broken cap.
+              return newBrokenCap(kj::cp(error));
+            }
+          }
+          KJ_UNREACHABLE;
+        } else {
+          // Apparently, when we accepted the capability, it turned out to be a self-introduction
+          // and now we're left with a capability pointing into our own vat. We need to return
+          // that instead.
+          return hook.addRef();
+        }
+      }
+    }
+
+    // implements ClientHook -----------------------------------------
+
+    Request<AnyPointer, AnyPointer> newCall(
+        uint64_t interfaceId, uint16_t methodId, kj::Maybe<MessageSize> sizeHint,
+        CallHints hints) override {
+      // If we receive a call, then we should immediately accept the capability in order to
+      // dispatch it. (Note that if we didn't override this, then writeTarget() would eventually
+      // be called and would accept the capability there, but at that point we've already
+      // constructed the requst and would have to redirect it, requiring a copy.)
+      return ensureAccepted().newCall(interfaceId, methodId, sizeHint, hints);
+    }
+
+    VoidPromiseAndPipeline call(uint64_t interfaceId, uint16_t methodId,
+                                kj::Own<CallContextHook>&& context, CallHints hints) override {
+      // Same here, when we receive a call we always accept the capability immediately.
+      return ensureAccepted().call(interfaceId, methodId, kj::mv(context), hints);
+    }
+
+    kj::Maybe<ClientHook&> getResolved() override {
+      // This is tricky: Although whenMoreResolved() triggers accept, getResolved() shouldn't,
+      // because lots of stuff calls getResolved() optimistically and it doesn't necessarily mean
+      // the caller wants to use the capability.
+      KJ_SWITCH_ONEOF(state) {
+        KJ_CASE_ONEOF(deferred, Deferred) {
+          return kj::none;
+        }
+        KJ_CASE_ONEOF(cap, kj::Own<ClientHook>) {
+          return cap->getResolved();
+        }
+      }
+      KJ_UNREACHABLE;
+    }
+
+    kj::Maybe<kj::Promise<kj::Own<ClientHook>>> whenMoreResolved() override {
+      // Someone (locally) is waiting for this capability to resolve. We had better actually
+      // accept it.
+      //
+      // Note that this will *always* return non-null, because accepting a capability always
+      // ends up returning a promise cap of some sort. (Even when introduced-to-self, we need to
+      // wait for the `Provite` message to show up.)
+      return ensureAccepted().whenMoreResolved();
+    }
+
+    kj::Maybe<int> getFd() override {
+      // This is free to return null if `whenMoreResolved()` would return non-null, which it
+      // always will.
+      return kj::none;
+    }
+
+  private:
+    struct Deferred {
+      kj::Own<AnyPointer::Reader> contact;
+      kj::Own<RpcClient> vine;
+    };
+
+    kj::OneOf<Deferred, kj::Own<ClientHook>> state;
+
+    ClientHook& ensureAccepted() {
+      // Call when this capability is actually used locally. If it's the first use, the Accept
+      // message will be sent to actually accept it.
+
+      KJ_SWITCH_ONEOF(state) {
+        KJ_CASE_ONEOF(deferred, Deferred) {
+          return *state.init<kj::Own<ClientHook>>(
+              connectionState->acceptThirdParty(*deferred.contact, kj::mv(deferred.vine)));
+        }
+        KJ_CASE_ONEOF(cap, kj::Own<ClientHook>) {
+          return *cap;
+        }
+      }
+      KJ_UNREACHABLE;
+    }
+  };
+
   kj::Maybe<ExportId> writeDescriptor(ClientHook& cap, rpc::CapDescriptor::Builder descriptor,
                                       kj::Vector<int>& fds) {
     // Write a descriptor for the given capability.
@@ -1488,7 +1687,25 @@ private:
 
             auto tph = descriptor.initThirdPartyHosted();
 
-            auto vine = rpcInner.writeThirdPartyDescriptor(otherConn, conn, tph.initId());
+            auto id = tph.initId();
+            auto vine = rpcInner.writeThirdPartyDescriptor(otherConn, conn, id);
+
+            if (id.isNull()) {
+              // writeThirdPartyDescriptor() ended up deciding that it's not pointing at a
+              // third party after all, oops. This is unusual, but DeferredThirdPartyClient has
+              // some edge cases where this happens.
+
+              // Unfortunately, this will leave a hole in the message. This should be rare.
+              // TODO(perf): Since we're removing the last object allocated, the segment ought
+              //   to be able to reclaim the memory, but this doesn't appear to be implemented
+              //   at present. Fix that?
+              descriptor.disownThirdPartyHosted();
+              descriptor.setNone();
+
+              // Recursively apply to the client returned by `writeThirdPartyDescriptor()` (which
+              // is not actually a vine in this case).
+              return writeDescriptor(*vine, descriptor, fds);
+            }
 
             // We always have to add a new export to the table to use as the "vine"; we cannot
             // share an existing export pointing to the same capability. The reason is, the vine
@@ -1694,7 +1911,7 @@ private:
   // =====================================================================================
   // Interpreting CapDescriptor
 
-  kj::Own<ClientHook> import(ImportId importId, bool isPromise, kj::Maybe<kj::OwnFd> fd) {
+  kj::Own<RpcClient> import(ImportId importId, bool isPromise, kj::Maybe<kj::OwnFd> fd) {
     // Receive a new import.
 
     auto& import = imports.findOrCreate(importId);
@@ -1874,18 +2091,25 @@ private:
 
       case rpc::CapDescriptor::THIRD_PARTY_HOSTED: {
         // We need to connect to a third party to accept this capability.
-        //
-        // TODO(now): Defer sending the Accept until the capability is actually invoked. This way,
-        //   if the capability is merely forwarded on without being used locally, and the
-        //   VatNetwork supports forwarding, we can avoid a redundant connection.
-
-        auto& state = KJ_ASSERT_NONNULL(connection.tryGet<Connected>());
 
         auto tph = descriptor.getThirdPartyHosted();
 
         // Import the vine first so that we're sure to drop it if anything goes wrong.
         auto vine = import(tph.getVineId(), false, kj::mv(fd));
 
+        return kj::refcounted<DeferredThirdPartyClient>(
+            *this, capnp::clone(tph.getId()), kj::mv(vine));
+      }
+
+      default:
+        KJ_FAIL_REQUIRE("unknown CapDescriptor type");
+        return newBrokenCap("unknown CapDescriptor type");
+    }
+  }
+
+  kj::Own<ClientHook> acceptThirdParty(AnyPointer::Reader contact, kj::Own<RpcClient> vine) {
+    KJ_SWITCH_ONEOF(connection) {
+      KJ_CASE_ONEOF(state, Connected) {
         // Allocate temporary message to hold ThirdPartyCompletion. Unfortunately we need a temp
         // message here because we can't allocate the actual outgoing message until we have a
         // connection object.
@@ -1896,7 +2120,7 @@ private:
         auto completion = message.getRoot<AnyPointer>();
 
         // Call connectToIntroduced() and get the other connection state.
-        KJ_IF_SOME(ownOtherConn, state.connection->connectToIntroduced(tph.getId(), completion)) {
+        KJ_IF_SOME(ownOtherConn, state.connection->connectToIntroduced(contact, completion)) {
           RpcConnectionState& other = getConnectionState(state.rpcSystem, kj::mv(ownOtherConn));
 
           other.setNotIdle();
@@ -1943,11 +2167,11 @@ private:
           }));
         }
       }
-
-      default:
-        KJ_FAIL_REQUIRE("unknown CapDescriptor type");
-        return newBrokenCap("unknown CapDescriptor type");
+      KJ_CASE_ONEOF(error, Disconnected) {
+        return newBrokenCap(kj::cp(error));
+      }
     }
+    KJ_UNREACHABLE;
   }
 
   kj::Array<kj::Maybe<kj::Own<ClientHook>>> receiveCaps(List<rpc::CapDescriptor>::Reader capTable,

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -1906,8 +1906,13 @@ private:
         } else {
           // We've been introduced to ourselves. A corresponding `Provide` message will come
           // directly to us via another connection.
-          // TODO(now): implement this
-          KJ_UNIMPLEMENTED("introduction to self");
+          return newLocalPromiseClient(state.connection->completeThirdParty(completion)
+              .then([](kj::Rc<kj::Refcounted> holder) mutable {
+            // TODO(now): Await embargo if needed.
+
+            return kj::mv(KJ_ASSERT_NONNULL(
+                holder.downcast<ThirdPartyExchangeValue>()->value.tryGet<kj::Own<ClientHook>>()));
+          }));
         }
       }
 

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -960,6 +960,10 @@ struct TestThirdPartyToAwait {
 struct TestThirdPartyToContact {
   path @0 :TestSturdyRefHostId;
   token @1 :UInt64;
+
+  sentBy @2 :Text;
+  # Host who sent this, used to verify we didn't just forward by copying the contact, we used
+  # forwardThirdPartyToContact() to rewrite it.
 }
 struct TestJoinResult {}
 

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -948,9 +948,16 @@ struct TestSturdyRefHostId {
   host @0 :Text;
 }
 
-struct TestThirdPartyCompletion {}
-struct TestThirdPartyToAwait {}
-struct TestThirdPartyToContact {}
+struct TestThirdPartyCompletion {
+  token @0 :UInt64;
+}
+struct TestThirdPartyToAwait {
+  token @0 :UInt64;
+}
+struct TestThirdPartyToContact {
+  path @0 :TestSturdyRefHostId;
+  token @1 :UInt64;
+}
 struct TestJoinResult {}
 
 struct TestNameAnnotation $Cxx.name("RenamedStruct") {

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -946,6 +946,9 @@ interface TestAuthenticatedBootstrap(VatId) {
 
 struct TestSturdyRefHostId {
   host @0 :Text;
+
+  unique @1 :Bool = false;
+  # Set true (in rpc-test) to open a new connection even if one already exists.
 }
 
 struct TestThirdPartyCompletion {


### PR DESCRIPTION
This does not implement embargoes, so e-order may be violated.

As a reminder, none of this is enabled unless the VatNetwork implements new methods, so merging this won't impact existing users.