### PR TITLE
3PH part4: Embargoes for capabilities

### DIFF
--- a/c++/src/capnp/rpc.capnp
+++ b/c++/src/capnp/rpc.capnp
@@ -1080,6 +1080,17 @@ struct CapDescriptor {
     # `senderPromise` is received multiple times, only one `Resolve` is sent to cover all of
     # them.  If `senderPromise` is released before the `Resolve` is sent, the sender (of this
     # `CapDescriptor`) may choose not to send the `Resolve` at all.
+    #
+    # `senderPromise` must not refer to an export for which `Resolve` was already sent in the past.
+    # The reason for this is that the receiver may no longer have a record of that past `Resolve`.
+    # In fact, it's extremely likely that when the receiver received the `Resolve`, it promptly
+    # released the promise from its import table, since it updated all references to the new taget.
+    # This means that if the old promise's export ID were sent again here, the receiver wouldn't
+    # know anything about it and wouldn't know that it's already resolved.
+    #
+    # In order to avoid the above case, if the sender detects that promise A is resolving to
+    # promise B, but promise B has already previously resolved to C, then the sender should simply
+    # resolve promise A directly to C.
 
     receiverHosted @3 :ImportId;
     # A capability (or promise) previously exported by the receiver (imported by the sender).

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -787,7 +787,7 @@ struct TestListOfAny {
 }
 
 interface TestInterface {
-  foo @0 (i :UInt32, j :Bool) -> (x :Text);
+  foo @0 (i :UInt32, j :Bool, expectedCallCount :Int32 = -1) -> (x :Text);
   bar @1 () -> ();
   baz @2 (s: TestAllTypes);
 
@@ -866,7 +866,7 @@ interface TestMoreStuff extends(TestCallOrder) {
   hold @3 (cap :TestInterface) -> ();
   # Returns immediately but holds on to the capability.
 
-  callHeld @4 () -> (s: Text);
+  callHeld @4 (expectedCallCount :Int32 = -1) -> (s: Text);
   # Calls the capability previously held using `hold` (and keeps holding it).
 
   getHeld @5 () -> (cap :TestInterface);


### PR DESCRIPTION
This builds on #2121 by doing some refactoring and then implementing embargoes, so e-order is preserved through a handoff.

(This PR's merge target is set to #2121.)