### PR TITLE
make kj::string* methods constexpr

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -159,12 +159,12 @@ public:
     return ArrayPtr<T>(ptr, size_);
   }
 
-  inline size_t size() const { return size_; }
-  inline T& operator[](size_t index) KJ_LIFETIMEBOUND {
+  inline constexpr size_t size() const { return size_; }
+  inline constexpr T& operator[](size_t index) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(index < size_, "Out-of-bounds Array access.");
     return ptr[index];
   }
-  inline const T& operator[](size_t index) const KJ_LIFETIMEBOUND {
+  inline constexpr const T& operator[](size_t index) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(index < size_, "Out-of-bounds Array access.");
     return ptr[index];
   }

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1838,7 +1838,7 @@ public:
   }
 
   inline constexpr size_t size() const { return size_; }
-  inline const T& operator[](size_t index) const {
+  inline constexpr const T& operator[](size_t index) const {
     KJ_IREQUIRE(index < size_, "Out-of-bounds ArrayPtr access.");
     return ptr[index];
   }
@@ -1847,40 +1847,40 @@ public:
     return ptr[index];
   }
 
-  inline T* begin() { return ptr; }
-  inline T* end() { return ptr + size_; }
-  inline T& front() { return *ptr; }
-  inline T& back() { return *(ptr + size_ - 1); }
+  inline constexpr T* begin() { return ptr; }
+  inline constexpr T* end() { return ptr + size_; }
+  inline constexpr T& front() { return *ptr; }
+  inline constexpr T& back() { return *(ptr + size_ - 1); }
   inline constexpr const T* begin() const { return ptr; }
   inline constexpr const T* end() const { return ptr + size_; }
-  inline const T& front() const { return *ptr; }
-  inline const T& back() const { return *(ptr + size_ - 1); }
+  inline constexpr const T& front() const { return *ptr; }
+  inline constexpr const T& back() const { return *(ptr + size_ - 1); }
 
-  inline ArrayPtr<const T> slice(size_t start, size_t end) const {
+  inline constexpr ArrayPtr<const T> slice(size_t start, size_t end) const {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds ArrayPtr::slice().");
     return ArrayPtr<const T>(ptr + start, end - start);
   }
-  inline ArrayPtr slice(size_t start, size_t end) {
+  inline constexpr ArrayPtr slice(size_t start, size_t end) {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds ArrayPtr::slice().");
     return ArrayPtr(ptr + start, end - start);
   }
-  inline ArrayPtr<const T> slice(size_t start) const {
+  inline constexpr ArrayPtr<const T> slice(size_t start) const {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().");
     return ArrayPtr<const T>(ptr + start, size_ - start);
   }
-  inline ArrayPtr slice(size_t start) {
+  inline constexpr ArrayPtr slice(size_t start) {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().");
     return ArrayPtr(ptr + start, size_ - start);
   }
-  inline bool startsWith(const ArrayPtr<const T>& other) const {
+  inline constexpr bool startsWith(const ArrayPtr<const T>& other) const {
     return other.size() <= size_ && slice(0, other.size()) == other;
   }
-  inline bool endsWith(const ArrayPtr<const T>& other) const {
+  inline constexpr bool endsWith(const ArrayPtr<const T>& other) const {
     return other.size() <= size_ && slice(size_ - other.size(), size_) == other;
   }
 
-  inline ArrayPtr first(size_t count) { return slice(0, count); }
-  inline ArrayPtr<const T> first(size_t count) const { return slice(0, count); }
+  inline constexpr ArrayPtr first(size_t count) { return slice(0, count); }
+  inline constexpr ArrayPtr<const T> first(size_t count) const { return slice(0, count); }
 
   inline Maybe<size_t> findFirst(const T& match) const {
     for (size_t i = 0; i < size_; i++) {
@@ -1910,14 +1910,16 @@ public:
     return { reinterpret_cast<PropagateConst<T, char>*>(ptr), size_ * sizeof(T) };
   }
 
-  inline bool operator==(decltype(nullptr)) const { return size_ == 0; }
+  inline constexpr bool operator==(decltype(nullptr)) const { return size_ == 0; }
 
-  inline bool operator==(const ArrayPtr& other) const {
+  inline constexpr bool operator==(const ArrayPtr& other) const {
     if (size_ != other.size_) return false;
+#if __has_feature(cxx_constexpr_string_builtins)
     if (isIntegral<RemoveConst<T>>()) {
       if (size_ == 0) return true;
-      return memcmp(ptr, other.ptr, size_ * sizeof(T)) == 0;
+      return __builtin_memcmp(ptr, other.ptr, size_ * sizeof(T)) == 0;
     }
+#endif
     for (size_t i = 0; i < size_; i++) {
       if (ptr[i] != other[i]) return false;
     }
@@ -1925,7 +1927,7 @@ public:
   }
 
   template <typename U>
-  inline bool operator==(const ArrayPtr<U>& other) const {
+  inline constexpr bool operator==(const ArrayPtr<U>& other) const {
     if (size_ != other.size()) return false;
     for (size_t i = 0; i < size_; i++) {
       if (ptr[i] != other[i]) return false;

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -503,6 +503,19 @@ KJ_TEST("as<Std>") {
   KJ_EXPECT(stdPtr == "bar");
 }
 
+// Supports constexpr
+constexpr const StringPtr HELLO_WORLD = "hello world"_kj;
+static_assert(HELLO_WORLD.size() == 11);
+static_assert(HELLO_WORLD.startsWith("hello"_kj));
+static_assert(HELLO_WORLD.endsWith("world"_kj));
+static_assert(HELLO_WORLD[0] == *"h");
+static_assert(HELLO_WORLD.asArray().size() == 11);
+static_assert(HELLO_WORLD.first(2).size() == 2);
+static_assert(HELLO_WORLD.slice(5).size() == 6);
+static_assert(StringPtr().size() == 0);
+static_assert(StringPtr(nullptr).size() == 0);
+static_assert(StringPtr(HELLO_WORLD.begin(), HELLO_WORLD.size()).size() == 11);
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -72,10 +72,10 @@ namespace kj {
 
 class StringPtr {
 public:
-  inline StringPtr(): content("", 1) {}
-  inline StringPtr(decltype(nullptr)): content("", 1) {}
+  inline constexpr StringPtr(): content("", 1) {}
+  inline constexpr StringPtr(decltype(nullptr)): content("", 1) {}
   inline StringPtr(const char* value KJ_LIFETIMEBOUND): content(value, strlen(value) + 1) {}
-  inline StringPtr(const char* value KJ_LIFETIMEBOUND, size_t size): content(value, size + 1) {
+  inline constexpr StringPtr(const char* value KJ_LIFETIMEBOUND, size_t size): content(value, size + 1) {
     KJ_IREQUIRE(value[size] == '\0', "StringPtr must be NUL-terminated.");
   }
   inline StringPtr(const char* begin KJ_LIFETIMEBOUND, const char* end KJ_LIFETIMEBOUND): StringPtr(begin, end - begin) {}
@@ -118,38 +118,38 @@ public:
 
   inline constexpr operator ArrayPtr<const char>() const;
   inline constexpr ArrayPtr<const char> asArray() const;
-  inline ArrayPtr<const byte> asBytes() const { return asArray().asBytes(); }
+  inline constexpr ArrayPtr<const byte> asBytes() const { return asArray().asBytes(); }
   // Result does not include NUL terminator.
 
-  inline const char* cStr() const { return content.begin(); }
+  inline constexpr const char* cStr() const { return content.begin(); }
   // Returns NUL-terminated string.
 
-  inline size_t size() const { return content.size() - 1; }
+  inline constexpr size_t size() const { return content.size() - 1; }
   // Result does not include NUL terminator.
 
-  inline char operator[](size_t index) const { return content[index]; }
+  inline constexpr char operator[](size_t index) const { return content[index]; }
 
   inline constexpr const char* begin() const { return content.begin(); }
   inline constexpr const char* end() const { return content.end() - 1; }
 
   inline constexpr bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
 
-  inline bool operator==(const StringPtr& other) const;
+  inline constexpr bool operator==(const StringPtr& other) const;
   inline bool operator< (const StringPtr& other) const;
   inline bool operator> (const StringPtr& other) const { return other < *this; }
   inline bool operator<=(const StringPtr& other) const { return !(other < *this); }
   inline bool operator>=(const StringPtr& other) const { return !(*this < other); }
 
-  inline StringPtr slice(size_t start) const;
-  inline ArrayPtr<const char> slice(size_t start, size_t end) const;
+  inline constexpr StringPtr slice(size_t start) const;
+  inline constexpr ArrayPtr<const char> slice(size_t start, size_t end) const;
   // A string slice is only NUL-terminated if it is a suffix, so slice() has a one-parameter
   // version that assumes end = size().
 
-  inline ArrayPtr<const char> first(size_t count) const;
+  inline constexpr ArrayPtr<const char> first(size_t count) const;
   // Return string prefix.
 
-  inline bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
-  inline bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
+  inline constexpr bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
+  inline constexpr bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
 
   inline Maybe<size_t> findFirst(char c) const { return asArray().findFirst(c); }
   inline Maybe<size_t> findLast(char c) const { return asArray().findLast(c); }
@@ -249,12 +249,12 @@ public:
   inline explicit String(Array<char> buffer);
   // Does not copy.  Requires `buffer` ends with `\0`.
 
-  inline operator ArrayPtr<char>() KJ_LIFETIMEBOUND;
-  inline operator ArrayPtr<const char>() const KJ_LIFETIMEBOUND;
-  inline ArrayPtr<char> asArray() KJ_LIFETIMEBOUND;
-  inline ArrayPtr<const char> asArray() const KJ_LIFETIMEBOUND;
-  inline ArrayPtr<byte> asBytes() KJ_LIFETIMEBOUND { return asArray().asBytes(); }
-  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asArray().asBytes(); }
+  inline constexpr operator ArrayPtr<char>() KJ_LIFETIMEBOUND;
+  inline constexpr operator ArrayPtr<const char>() const KJ_LIFETIMEBOUND;
+  inline constexpr ArrayPtr<char> asArray() KJ_LIFETIMEBOUND;
+  inline constexpr ArrayPtr<const char> asArray() const KJ_LIFETIMEBOUND;
+  inline constexpr ArrayPtr<byte> asBytes() KJ_LIFETIMEBOUND { return asArray().asBytes(); }
+  inline constexpr ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asArray().asBytes(); }
   // Result does not include NUL terminator.
 
   inline StringPtr asPtr() const KJ_LIFETIMEBOUND {
@@ -266,20 +266,20 @@ public:
   // Disowns the backing array (which includes the NUL terminator) and returns it. The String value
   // is clobbered (as if moved away).
 
-  inline const char* cStr() const KJ_LIFETIMEBOUND;
+  inline constexpr const char* cStr() const KJ_LIFETIMEBOUND;
 
-  inline size_t size() const;
+  inline constexpr size_t size() const;
   // Result does not include NUL terminator.
 
-  inline char operator[](size_t index) const;
-  inline char& operator[](size_t index) KJ_LIFETIMEBOUND;
+  inline constexpr char operator[](size_t index) const;
+  inline constexpr char& operator[](size_t index) KJ_LIFETIMEBOUND;
 
-  inline char* begin() KJ_LIFETIMEBOUND;
-  inline char* end() KJ_LIFETIMEBOUND;
-  inline const char* begin() const KJ_LIFETIMEBOUND;
-  inline const char* end() const KJ_LIFETIMEBOUND;
+  inline constexpr char* begin() KJ_LIFETIMEBOUND;
+  inline constexpr char* end() KJ_LIFETIMEBOUND;
+  inline constexpr const char* begin() const KJ_LIFETIMEBOUND;
+  inline constexpr const char* end() const KJ_LIFETIMEBOUND;
 
-  inline bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
+  inline constexpr bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
 
   inline bool operator==(const StringPtr& other) const { return StringPtr(*this) == other; }
   inline bool operator< (const StringPtr& other) const { return StringPtr(*this) <  other; }
@@ -302,8 +302,8 @@ public:
   inline bool operator<=(const ConstString& other) const { return StringPtr(*this) <= StringPtr(other); }
   inline bool operator>=(const ConstString& other) const { return StringPtr(*this) >= StringPtr(other); }
 
-  inline bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
-  inline bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
+  inline constexpr bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
+  inline constexpr bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
 
   Maybe<size_t> find(const StringPtr& other) const { return asPtr().find(other); }
   // Return the index at which other appears in this string.
@@ -358,9 +358,9 @@ public:
   inline explicit ConstString(String&& string): content(string.releaseArray()) {}
   // Does not copy. Ownership is transferred.
 
-  inline operator ArrayPtr<const char>() const KJ_LIFETIMEBOUND;
-  inline ArrayPtr<const char> asArray() const KJ_LIFETIMEBOUND;
-  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asArray().asBytes(); }
+  inline constexpr operator ArrayPtr<const char>() const KJ_LIFETIMEBOUND;
+  inline constexpr ArrayPtr<const char> asArray() const KJ_LIFETIMEBOUND;
+  inline constexpr ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asArray().asBytes(); }
   // Result does not include NUL terminator.
 
   inline StringPtr asPtr() const KJ_LIFETIMEBOUND {
@@ -372,18 +372,18 @@ public:
   // Disowns the backing array (which includes the NUL terminator) and returns it. The ConstString value
   // is clobbered (as if moved away).
 
-  inline const char* cStr() const KJ_LIFETIMEBOUND;
+  inline constexpr const char* cStr() const KJ_LIFETIMEBOUND;
 
-  inline size_t size() const;
+  inline constexpr size_t size() const;
   // Result does not include NUL terminator.
 
-  inline char operator[](size_t index) const;
-  inline char& operator[](size_t index) KJ_LIFETIMEBOUND;
+  inline constexpr char operator[](size_t index) const;
+  inline constexpr char& operator[](size_t index) KJ_LIFETIMEBOUND;
 
-  inline const char* begin() const KJ_LIFETIMEBOUND;
-  inline const char* end() const KJ_LIFETIMEBOUND;
+  inline constexpr const char* begin() const KJ_LIFETIMEBOUND;
+  inline constexpr const char* end() const KJ_LIFETIMEBOUND;
 
-  inline bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
+  inline constexpr bool operator==(decltype(nullptr)) const { return content.size() <= 1; }
 
   inline bool operator==(const StringPtr& other) const { return StringPtr(*this) == other; }
   inline bool operator< (const StringPtr& other) const { return StringPtr(*this) <  other; }
@@ -406,8 +406,8 @@ public:
   // comparisons between two strings are ambiguous. (Clang turns this into a warning,
   // -Wambiguous-reversed-operator, due to the stupidity...)
 
-  inline bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
-  inline bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
+  inline constexpr bool startsWith(const StringPtr& other) const { return asArray().startsWith(other);}
+  inline constexpr bool endsWith(const StringPtr& other) const { return asArray().endsWith(other); }
 
   Maybe<size_t> find(const StringPtr& other) const { return asPtr().find(other); }
   // Return the index at which other appears in this string.
@@ -720,7 +720,7 @@ inline constexpr ArrayPtr<const char> StringPtr::asArray() const {
   return ArrayPtr<const char>(content.begin(), content.size() - 1);
 }
 
-inline bool StringPtr::operator==(const StringPtr& other) const {
+inline constexpr bool StringPtr::operator==(const StringPtr& other) const {
   return content == other.content;
 }
 
@@ -728,13 +728,13 @@ inline bool StringPtr::operator< (const StringPtr& other) const {
   return content < other.content;
 }
 
-inline StringPtr StringPtr::slice(size_t start) const {
+inline constexpr StringPtr StringPtr::slice(size_t start) const {
   return StringPtr(content.slice(start, content.size()));
 }
-inline ArrayPtr<const char> StringPtr::slice(size_t start, size_t end) const {
+inline constexpr ArrayPtr<const char> StringPtr::slice(size_t start, size_t end) const {
   return content.slice(start, end);
 }
-inline ArrayPtr<const char> StringPtr::first(size_t count) const { return slice(0, count); }
+inline constexpr ArrayPtr<const char> StringPtr::first(size_t count) const { return slice(0, count); }
 
 inline LiteralStringConst::operator ConstString() const {
   return ConstString(begin(), size(), NullArrayDisposer::instance);
@@ -750,42 +750,42 @@ inline ConstString StringPtr::attach(Attachments&&... attachments) const {
   return ConstString { content.attach(kj::fwd<Attachments>(attachments)...) };
 }
 
-inline String::operator ArrayPtr<char>() {
+inline constexpr String::operator ArrayPtr<char>() {
   return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
 }
-inline String::operator ArrayPtr<const char>() const {
+inline constexpr String::operator ArrayPtr<const char>() const {
   return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
-inline ConstString::operator ArrayPtr<const char>() const {
+inline constexpr ConstString::operator ArrayPtr<const char>() const {
   return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
 
-inline ArrayPtr<char> String::asArray() {
+inline constexpr ArrayPtr<char> String::asArray() {
   return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
 }
-inline ArrayPtr<const char> String::asArray() const {
+inline constexpr ArrayPtr<const char> String::asArray() const {
   return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
-inline ArrayPtr<const char> ConstString::asArray() const {
+inline constexpr ArrayPtr<const char> ConstString::asArray() const {
   return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
 }
 
-inline const char* String::cStr() const { return content == nullptr ? "" : content.begin(); }
-inline const char* ConstString::cStr() const { return content == nullptr ? "" : content.begin(); }
+inline constexpr const char* String::cStr() const { return content == nullptr ? "" : content.begin(); }
+inline constexpr const char* ConstString::cStr() const { return content == nullptr ? "" : content.begin(); }
 
-inline size_t String::size() const { return content == nullptr ? 0 : content.size() - 1; }
-inline size_t ConstString::size() const { return content == nullptr ? 0 : content.size() - 1; }
+inline constexpr size_t String::size() const { return content == nullptr ? 0 : content.size() - 1; }
+inline constexpr size_t ConstString::size() const { return content == nullptr ? 0 : content.size() - 1; }
 
-inline char String::operator[](size_t index) const { return content[index]; }
-inline char& String::operator[](size_t index) { return content[index]; }
-inline char ConstString::operator[](size_t index) const { return content[index]; }
+inline constexpr char String::operator[](size_t index) const { return content[index]; }
+inline constexpr char& String::operator[](size_t index) { return content[index]; }
+inline constexpr char ConstString::operator[](size_t index) const { return content[index]; }
 
-inline char* String::begin() { return content == nullptr ? nullptr : content.begin(); }
-inline char* String::end() { return content == nullptr ? nullptr : content.end() - 1; }
-inline const char* String::begin() const { return content == nullptr ? nullptr : content.begin(); }
-inline const char* String::end() const { return content == nullptr ? nullptr : content.end() - 1; }
-inline const char* ConstString::begin() const { return content == nullptr ? nullptr : content.begin(); }
-inline const char* ConstString::end() const { return content == nullptr ? nullptr : content.end() - 1; }
+inline constexpr char* String::begin() { return content == nullptr ? nullptr : content.begin(); }
+inline constexpr char* String::end() { return content == nullptr ? nullptr : content.end() - 1; }
+inline constexpr const char* String::begin() const { return content == nullptr ? nullptr : content.begin(); }
+inline constexpr const char* String::end() const { return content == nullptr ? nullptr : content.end() - 1; }
+inline constexpr const char* ConstString::begin() const { return content == nullptr ? nullptr : content.begin(); }
+inline constexpr const char* ConstString::end() const { return content == nullptr ? nullptr : content.end() - 1; }
 
 inline String::String(char* value, size_t size, const ArrayDisposer& disposer)
     : content(value, size + 1, disposer) {


### PR DESCRIPTION
This pull-request adds `constexpr` qualifier to kj::string* methods just like `std::string_view` and other string classes have. The goal of adding `constexpr` is to add support for evaluating the value of the expression on the runtime and as a result, improve the performance. Prior to this change, any function that calls the changed methods in this pull-request, can't add a `constexpr` qualifier due to the lack of support.