### PR TITLE
add missing newline in RpcDumper output for Return messages

### DIFF
--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -153,7 +153,7 @@ public:
             auto results = content.getAs<DynamicStruct>(schema.asStruct());
 
             return kj::str(name, "->", partnerName, ": return ", ret.getAnswerId(), ": ", results,
-                           " caps:[", kj::strArray(capTable, ", "), "]");
+                           " caps:[", kj::strArray(capTable, ", "), "]\n");
           } else if (schema.getProto().isInterface()) {
             content.getAs<DynamicCapability>(schema.asInterface());
             return kj::str(name, "->", partnerName, "(", ret.getAnswerId(), "): return cap ",


### PR DESCRIPTION
Before:
```console
$ ./c++/src/capnp/capnp-heavy-tests -f rpc-test.c++:1259
[ TEST ] rpc-test.c++:1259: don't embargo null capability
alice->bob(0): bootstrap
alice->bob: call 1: (promisedAnswer = (questionId = 0, transform = [])) <- TestInterface.getTestMoreStuff() caps:[]
alice->bob: (finish = (questionId = 0, releaseResultCaps = true, requireEarlyCancellationWorkaround = false))
alice->bob: call 2: (promisedAnswer = (questionId = 1, transform = [(getPointerField = 0)])) <- TestMoreStuff.getNull() caps:[]
alice->bob: call 3: (promisedAnswer = (questionId = 2, transform = [(getPointerField = 0)])) <- TestCallOrder.getCallSequence(expected = 0) caps:[]
bob->alice(0): return cap (senderHosted = 0, attachedFd = 255)
bob->alice: return 1: (cap = <external capability>) caps:[(senderHosted = 1, attachedFd = 255)]alice->bob: (finish = (questionId = 1, releaseResultCaps = false, requireEarlyCancellationWorkaround = false))
bob->alice: return 2: () caps:[]bob->alice: (return = (answerId = 3, releaseParamCaps = false, exception = (reason = "Pipeline call on a request that returned no capabilities or was already closed.", obsoleteIsCallersFault = false, obsoleteDurability = 0, type = failed), noFinishNeeded = false))
alice->bob: (finish = (questionId = 3, releaseResultCaps = false, requireEarlyCancellationWorkaround = false))
alice->bob: call 0: (importedCap = 1) <- TestCallOrder.getCallSequence(expected = 0) caps:[]
bob->alice: return 0: (n = 0) caps:[]alice->bob: (release = (id = 1, referenceCount = 1))
bob->alice: (abort = (reason = "RpcSystem was destroyed.", obsoleteIsCallersFault = false, obsoleteDurability = 0, type = disconnected))
```

After:
```console
$ ./c++/src/capnp/capnp-heavy-tests -f rpc-test.c++:1259
[ TEST ] rpc-test.c++:1259: don't embargo null capability
alice->bob(0): bootstrap
alice->bob: call 1: (promisedAnswer = (questionId = 0, transform = [])) <- TestInterface.getTestMoreStuff() caps:[]
alice->bob: (finish = (questionId = 0, releaseResultCaps = true, requireEarlyCancellationWorkaround = false))
alice->bob: call 2: (promisedAnswer = (questionId = 1, transform = [(getPointerField = 0)])) <- TestMoreStuff.getNull() caps:[]
alice->bob: call 3: (promisedAnswer = (questionId = 2, transform = [(getPointerField = 0)])) <- TestCallOrder.getCallSequence(expected = 0) caps:[]
bob->alice(0): return cap (senderHosted = 0, attachedFd = 255)
bob->alice: return 1: (cap = <external capability>) caps:[(senderHosted = 1, attachedFd = 255)]
alice->bob: (finish = (questionId = 1, releaseResultCaps = false, requireEarlyCancellationWorkaround = false))
bob->alice: return 2: () caps:[]
bob->alice: (return = (answerId = 3, releaseParamCaps = false, exception = (reason = "Pipeline call on a request that returned no capabilities or was already closed.", obsoleteIsCallersFault = false, obsoleteDurability = 0, type = failed), noFinishNeeded = false))
alice->bob: (finish = (questionId = 3, releaseResultCaps = false, requireEarlyCancellationWorkaround = false))
alice->bob: call 0: (importedCap = 1) <- TestCallOrder.getCallSequence(expected = 0) caps:[]
bob->alice: return 0: (n = 0) caps:[]
alice->bob: (release = (id = 1, referenceCount = 1))
bob->alice: (abort = (reason = "RpcSystem was destroyed.", obsoleteIsCallersFault = false, obsoleteDurability = 0, type = disconnected))
[ PASS ] rpc-test.c++:1259: don't embargo null capability (1300 μs)
1 test(s) passed 
```