### PR TITLE
[nfc] extracting bazel capnp_gen rule

### DIFF
--- a/c++/src/capnp/capnp_gen.bzl
+++ b/c++/src/capnp/capnp_gen.bzl
@@ -1,0 +1,82 @@
+"""Support rule to invoke capnp compiler."""
+
+capnp_provider = provider("Capnproto Provider", fields = {
+    "includes": "includes for this target (transitive)",
+    "inputs": "src + data for the target",
+    "src_prefix": "src_prefix of the target",
+})
+
+def _workspace_path(label, path):
+    if label.workspace_root == "":
+        return path
+    return label.workspace_root + "/" + path
+
+def _capnp_gen_impl(ctx):
+    label = ctx.label
+    src_prefix = _workspace_path(label, ctx.attr.src_prefix) if ctx.attr.src_prefix != "" else ""
+    includes = []
+
+    inputs = ctx.files.srcs + ctx.files.data
+    for dep_target in ctx.attr.deps:
+        includes += dep_target[capnp_provider].includes
+        inputs += dep_target[capnp_provider].inputs
+
+    if src_prefix != "":
+        includes.append(src_prefix)
+
+    system_include = ctx.files._capnp_system[0].dirname.removesuffix("/capnp")
+
+    gen_dir = ctx.var["GENDIR"]
+    out_dir = gen_dir
+    if src_prefix != "":
+        out_dir = out_dir + "/" + src_prefix
+
+    cc_out = "-o%s:%s" % (ctx.executable.capnpc_plugin.path, out_dir)
+    args = ctx.actions.args()
+    args.add_all(["compile", "--verbose", cc_out])
+    args.add_all(["-I" + inc for inc in includes])
+    args.add_all(["-I", system_include])
+
+    if src_prefix == "":
+        # guess src_prefix for generated files
+        for src in ctx.files.srcs:
+            if src.path.startswith(gen_dir):
+                src_prefix = gen_dir
+                break
+
+    if src_prefix != "":
+        args.add_all(["--src-prefix", src_prefix])
+
+    args.add_all([s for s in ctx.files.srcs])
+
+    ctx.actions.run(
+        inputs = inputs + ctx.files.capnpc_plugin + ctx.files._capnpc_capnp + ctx.files._capnp_system,
+        outputs = ctx.outputs.outs,
+        executable = ctx.executable._capnpc,
+        arguments = [args],
+        mnemonic = "GenCapnp",
+    )
+
+    return [
+        capnp_provider(
+            includes = includes,
+            inputs = inputs,
+            src_prefix = src_prefix,
+        ),
+    ]
+
+capnp_gen = rule(
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = [capnp_provider]),
+        "data": attr.label_list(allow_files = True),
+        "outs": attr.output_list(),
+        "src_prefix": attr.string(),
+        "capnpc_plugin": attr.label(executable = True, allow_single_file = True, cfg = "exec", mandatory = True),
+        "_capnpc": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "@capnp-cpp//src/capnp:capnp_tool"),
+        "_capnpc_capnp": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "@capnp-cpp//src/capnp:capnpc-capnp"),
+        "_capnp_system": attr.label(default = "@capnp-cpp//src/capnp:capnp_system_library"),
+    },
+    output_to_genfiles = True,
+    implementation = _capnp_gen_impl,
+)

--- a/c++/src/capnp/cc_capnp_library.bzl
+++ b/c++/src/capnp/cc_capnp_library.bzl
@@ -1,85 +1,8 @@
 """Bazel rule to compile .capnp files into c++."""
+load(":capnp_gen.bzl", "capnp_gen", _capnp_provider = "capnp_provider")
 
-capnp_provider = provider("Capnproto Provider", fields = {
-    "includes": "includes for this target (transitive)",
-    "inputs": "src + data for the target",
-    "src_prefix": "src_prefix of the target",
-})
-
-def _workspace_path(label, path):
-    if label.workspace_root == "":
-        return path
-    return label.workspace_root + "/" + path
-
-def _capnp_gen_impl(ctx):
-    label = ctx.label
-    src_prefix = _workspace_path(label, ctx.attr.src_prefix) if ctx.attr.src_prefix != "" else ""
-    includes = []
-
-    inputs = ctx.files.srcs + ctx.files.data
-    for dep_target in ctx.attr.deps:
-        includes += dep_target[capnp_provider].includes
-        inputs += dep_target[capnp_provider].inputs
-
-    if src_prefix != "":
-        includes.append(src_prefix)
-
-    system_include = ctx.files._capnp_system[0].dirname.removesuffix("/capnp")
-
-    gen_dir = ctx.var["GENDIR"]
-    out_dir = gen_dir
-    if src_prefix != "":
-        out_dir = out_dir + "/" + src_prefix
-
-    cc_out = "-o%s:%s" % (ctx.executable._capnpc_cxx.path, out_dir)
-    args = ctx.actions.args()
-    args.add_all(["compile", "--verbose", cc_out])
-    args.add_all(["-I" + inc for inc in includes])
-    args.add_all(["-I", system_include])
-
-    if src_prefix == "":
-        # guess src_prefix for generated files
-        for src in ctx.files.srcs:
-            if src.path.startswith(gen_dir):
-                src_prefix = gen_dir
-                break
-
-    if src_prefix != "":
-        args.add_all(["--src-prefix", src_prefix])
-
-    args.add_all([s for s in ctx.files.srcs])
-
-    ctx.actions.run(
-        inputs = inputs + ctx.files._capnpc_cxx + ctx.files._capnpc_capnp + ctx.files._capnp_system,
-        outputs = ctx.outputs.outs,
-        executable = ctx.executable._capnpc,
-        arguments = [args],
-        mnemonic = "GenCapnp",
-    )
-
-    return [
-        capnp_provider(
-            includes = includes,
-            inputs = inputs,
-            src_prefix = src_prefix,
-        ),
-    ]
-
-_capnp_gen = rule(
-    attrs = {
-        "srcs": attr.label_list(allow_files = True),
-        "deps": attr.label_list(providers = [capnp_provider]),
-        "data": attr.label_list(allow_files = True),
-        "outs": attr.output_list(),
-        "src_prefix": attr.string(),
-        "_capnpc": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "@capnp-cpp//src/capnp:capnp_tool"),
-        "_capnpc_cxx": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "@capnp-cpp//src/capnp:capnpc-c++"),
-        "_capnpc_capnp": attr.label(executable = True, allow_single_file = True, cfg = "exec", default = "@capnp-cpp//src/capnp:capnpc-capnp"),
-        "_capnp_system": attr.label(default = "@capnp-cpp//src/capnp:capnp_system_library"),
-    },
-    output_to_genfiles = True,
-    implementation = _capnp_gen_impl,
-)
+# re-export for backward compatibility
+capnp_provider = _capnp_provider
 
 def cc_capnp_library(
         name,
@@ -108,7 +31,7 @@ def cc_capnp_library(
     hdrs = [s + ".h" for s in srcs]
     srcs_cpp = [s + ".c++" for s in srcs]
 
-    _capnp_gen(
+    capnp_gen(
         name = name + "_gen",
         srcs = srcs,
         deps = [s + "_gen" for s in deps],
@@ -116,6 +39,7 @@ def cc_capnp_library(
         outs = hdrs + srcs_cpp,
         src_prefix = src_prefix,
         visibility = visibility,
+        capnpc_plugin = "@capnp-cpp//src/capnp:capnpc-c++",
         target_compatible_with = target_compatible_with,
     )
     native.cc_library(


### PR DESCRIPTION
Rust and js rules basically copy it and are not compatible with each other. By having reusable implementation not only language rules are simpler, but they will also support language-independent deps because they will share provider.

No functional change at all, just a copy-paste + attr rename