### PR TITLE
Check if atomic intrinsics are implemented by libatomic

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -111,6 +111,21 @@ if(NOT CAPNP_LITE)
   install(FILES ${capnp-rpc_headers} ${capnp-rpc_schemas} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
 endif()
 
+# From CMake upstream: Some atomic instructions are implemented using
+# libatomic on some platforms.
+include(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+int main()
+{
+  std::atomic<long long>(0).load();
+  return 0;
+}
+" HAVE_CXX_ATOMICS_WITHOUT_LIB)
+if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+  target_link_libraries(capnp PUBLIC atomic)
+endif()
+
 # capnp-json ========================================================================
 
 set(capnp-json_sources


### PR DESCRIPTION
By testing whether a simple atomic-enabled C++ source (taken from CMake: /Source/Checks/cm_cxx_atomic.cxx) builds, determine whether an extra `-latomic' linkage is needed (if not implemented by built-in compiler intrinsics, something like GCC would use what they call a "library fallback", i.e., libatomic). [^1]

On an i486-target system, building the aforementioned source would return the following error (with g++ 13.2.0):

ld: /tmp/cccsCQSO.o: in function `main':
test.cxx:(.text+0xaa): undefined reference to `__atomic_load_8'
collect2: error: ld returned 1 exit status

Whereas on platforms with atomics implemented by built-in compiler intrinsics, the source would build successfully. Use this mechanism to determine if the said extra linkage is needed.

[^1]: https://gcc.gnu.org/onlinedocs/libstdc++/manual/ext_concurrency_impl.html