### PR TITLE
Fix non-monotonic time on all Mac machines

### DIFF
--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -110,11 +110,11 @@ Maybe<uint64_t> TimerImpl::timeoutToNextEvent(TimePoint start, Duration unit, ui
 }
 
 void TimerImpl::advanceTo(TimePoint newTime) {
-  // On Macs running an Intel processor, it has been observed that clock_gettime 
+  // On Macs, it has been observed that clock_gettime 
   // may return non monotonic time, even when CLOCK_MONOTONIC is used.
-  // This workaround is to avoid the assert triggering on these machines.
+  // This workaround is to avoid the assert triggering if this happens.
   // See also https://github.com/capnproto/capnproto/issues/1693
-#if __APPLE__ && (defined(__x86_64__) || defined(__POWERPC__))
+#if __APPLE__
   time = std::max(time, newTime);
 #else
   KJ_REQUIRE(newTime >= time, "can't advance backwards in time") { return; }


### PR DESCRIPTION
The issue was originally observed only on Macs with intel processor, and it was believed to affect only those. However the issue has been observed on a Mac with M2 processor, thus the need to relax the preprocessor directive.