### PR TITLE
Make kj::encodeHex() go brrrrr

### DIFF
--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -371,9 +371,12 @@ static Maybe<uint> tryFromOctDigit(char c) {
 }  // namespace
 
 String encodeHex(ArrayPtr<const byte> input) {
-  return strArray(KJ_MAP(b, input) {
-    return heapArray<char>({HEX_DIGITS[b/16], HEX_DIGITS[b%16]});
-  }, "");
+  auto result = heapString(input.size() * 2);
+  for (auto i: kj::indices(input)) {
+    result[i*2] = HEX_DIGITS[input[i] / 16];
+    result[i*2+1] = HEX_DIGITS[input[i] % 16];
+  }
+  return result;
 }
 
 EncodingResult<Array<byte>> decodeHex(ArrayPtr<const char> text) {


### PR DESCRIPTION
Optimize `kj::encodeHex()` by allocating the string up front to avoid allocating memory for every input byte. This drastically improves performance, even when optimization is enabled. A number of downstream tests that include large text files benefit from this.
It is trivial to get another performance improvement by looking up a byte at a time in a larger lookup table but this is "good enough" for our needs.