### PR TITLE
Add kj::yieldUntilWouldSleep() and EventLoopLocal

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1347,7 +1347,7 @@ protected:
 private:
   enum { WAITING, RUNNING, CANCELED, FINISHED } state;
 
-  _::PromiseNode* currentInner = nullptr;
+  OwnPromiseNode* currentInner = nullptr;
   OnReadyEvent onReadyEvent;
   Own<FiberStack> stack;
   _::ExceptionOrValue& result;

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -175,6 +175,9 @@ public:
   // Enqueues this event to happen after all other events have run to completion and there is
   // really nothing left to do except wait for I/O.
 
+  void armWhenWouldSleep();
+  // Enqueues this event to a separate queue of events which should be promoted
+
   bool isNext();
   // True if the Event has been armed and is next in line to be fired. This can be used after
   // calling PromiseNode::onReady(event) to determine if a promise being waited is immediately

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1729,12 +1729,12 @@ void FiberBase::onReady(_::Event* event) noexcept {
 
 void FiberBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
   if (stopAtNextEvent) return;
-  currentInner->tracePromise(builder, false);
+  currentInner->get()->tracePromise(builder, false);
   stack->trace(builder);
 }
 
 void FiberBase::traceEvent(TraceBuilder& builder) {
-  currentInner->tracePromise(builder, true);
+  currentInner->get()->tracePromise(builder, true);
   stack->trace(builder);
   onReadyEvent.traceEvent(builder);
 }
@@ -2009,7 +2009,7 @@ void waitImpl(_::OwnPromiseNode&& node, _::ExceptionOrValue& result, WaitScope& 
     node->setSelfPointer(&node);
     node->onReady(&fiber);
 
-    fiber.currentInner = node;
+    fiber.currentInner = &node;
     KJ_DEFER(fiber.currentInner = nullptr);
 
     // Switch to the main stack to run the event loop.

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1223,6 +1223,10 @@ public:
   // Note that this is only needed for cross-thread scheduling. To schedule code to run later in
   // the current thread, use `kj::evalLater()`, which will be more efficient.
 
+  void cancelAllDetached();
+  // Same as WaitScope::cancelAllDetached(). Sometimes it's easier to call on the EventLoop. (A
+  // WaitScope still must exist, i.e., this EventLoop must be current.)
+
 private:
   kj::Maybe<EventPort&> port;
   // If null, this thread doesn't receive I/O events from the OS. It can potentially receive


### PR DESCRIPTION
This goes further than kj::yieldUntilQueueEmpty() by also making sure the OS-level I/O queue (e.g. `epoll`) is empty.

Also in this PR: EventLoopLocal, which is like thread_local but attached to the current EventLoop.

Hint: These are things needed for implementing green threads.