### PR TITLE
Fix warning: cmake_minimum_required() should be called prior to this top-level project()

### DIFF
--- a/c++/samples/CMakeLists.txt
+++ b/c++/samples/CMakeLists.txt
@@ -16,8 +16,8 @@
 #      cmake ../c++/samples
 #      cmake --build .
 
-project("Cap'n Proto Samples" CXX)
 cmake_minimum_required(VERSION 3.1)
+project("Cap'n Proto Samples" CXX)
 
 find_package(CapnProto CONFIG REQUIRED)
 


### PR DESCRIPTION
As per the CMake document, we should call the cmake_minimum_required() command at the beginning of the top-level CMakeLists.txt file even before calling the project() command.