### PR TITLE
[build][perf][capnpc] Move function definition in generated capnp files out of headers

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -141,6 +141,10 @@ cc_binary(
     srcs = [
         "compiler/capnpc-c++.c++",
     ],
+    defines = select({
+        "//src/capnp:capnp_no_inline_accessors_true": ["CAPNP_NO_INLINE_ACCESSORS"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":capnpc",

--- a/c++/src/capnp/configure.bzl
+++ b/c++/src/capnp/configure.bzl
@@ -4,6 +4,13 @@ def capnp_configure():
     """Generates set of flag, settings for capnp configuration.
     """
 
+    # Define some methods for generated capnp code in source file instead of header, reducing
+    # header parsing overhead but reducing inlining opportunities. Recommended for debug builds.
+    bool_flag(
+        name = "capnp_no_inline_accessors",
+        build_setting_default = False,
+    )
+
     # Generate rust capnp libraries
     bool_flag(
         name = "gen_rust",
@@ -11,6 +18,11 @@ def capnp_configure():
     )
 
     # Settings to use in select() expressions
+    native.config_setting(
+        name = "capnp_no_inline_accessors_true",
+        flag_values = {"capnp_no_inline_accessors": "True"},
+        visibility = ["//visibility:public"],
+    )
     native.config_setting(
         name = "gen_rust_true",
         flag_values = {"gen_rust": "True"},


### PR DESCRIPTION
**Motivation**
For downstream projects, parsing capnproto headers is a major factor in slow compile times. This is mediated by capnproto definitions being compiled to classes with many sub-classes and functions, including templated ones; defining sub-classes which can't be forward declared; and relying on recursively including generated headers. Based on compiler profiling, parsing generated capnp headers is disproportionately more expensive than parsing other headers; I assume having many small functions plays a role here. On many downstream source files that include capnp headers, the compiler spends more time parsing capnp headers than doing anything else, including codegen.

**Proposed change**
capnpc-c++ translates capnp files to a C++ source and header file. Most class methods are first declared as inline methods in the header and then defined later in the header. Defining methods in the header allows the compiler to inline them, but contributes to compile time overhead. With this change, non-templated functions will be declared as non-inline and moved to the generated source file instead of the header. This results in massive improvements in include size and compile times.
I have regenerated the bootstrap capnp files here, which serve as an example of how the changes look like.

**Results**
To get a somewhat representative picture of the build performance impact I tested this on both small tests and larger source files. On a small downstream test file including large capnp headers as part of the test framework, this change reduces the include size (i.e. size of the preprocessed source file with all includes resolved) by **24%** (4.95MB => 3.66MB) and compile time by **46% (2.85s => 1.54s)**. There are many tests where this applies. On a large-ish downstream file including even more capnp code, include size shrinks **27%** (10.23MB => 7.46MB) and compile time **43% (6.58s => 3.77s)**. 
On workerd api/crypto/impl.c++, smaller improvements of 8% for include size (6.72MB => 6.16MB) and 22% for compile time (3.29s => 2.58s) can be observed. Similarly io/io-context.c++ sees improvements of 9% (6.07MB => 5.52MB) and 23% (3.87s => 2.98s), respectively. The smaller improvement for workerd reflects that it relies less on multiple inheritance of capnproto structures, and has some more header parsing overhead from JSG/V8.
These numbers are for -O0 -g0, the impact is inevitably smaller when optimization is enabled. I'm happy to elaborate on the build performance impact out-of-band.

**Limitations**
- There is a **binary size regression** since the compiler will need to generate code for every capnp function moved to the source file instead of only those that are included elsewhere. On an internal binary used to run tests, the debug binary size increases by 7%. However, this effect all but vanishes when enabling optimization, using ffunction-sections/gc-sections, and/or reducing the level of debug information, suggesting that this is caused by code that is not actually being used and the debug information being generated for it. Release binaries for the full runtime see a much smaller impact (~0.2%).
- It is conceivable that this makes the performance of binaries using capnp worse as the compiler will have fewer opportunities for inlining. I'd imagine that this overhead will generally be low as "hot" code is unlikely to repeatedly call generated code for capnp structures. Additionally, the compiler should still be able to perform inlining when thinLTO is enabled.
- This PR is not aiming to be exhaustive in moving code outside of generated headers – to keep the size of this change reasonable, I'm not attempting to move functions generated in makeInterfaceText and makeMethodText. Based on limited testing this change set already achieves most of the potential speedup here.
- As with any larger code generator change getting things wrong here can easily cause compile / linker errors or simply subtle changes to formatting, so this will require a close review. I have created a downstream branch under the same name to try this, all builds are passing there so this looks relatively stable.
- If this change is considered to have negative side effects, making it configurable as an opt-in option would still speed up local development and boost developer productivity.