### PR TITLE
Fix useSystemTrustStore behaviour in Windows

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -204,6 +204,9 @@ if(WITH_OPENSSL)
 
     target_compile_definitions(kj-tls PRIVATE KJ_HAS_OPENSSL)
     target_link_libraries(kj-tls PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    if(WIN32)
+      target_link_libraries(kj-tls PUBLIC crypt32)
+    endif()
 
     # Ensure the library has a version set to match autotools build
     set_target_properties(kj-tls PROPERTIES VERSION ${VERSION})

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -11,6 +11,12 @@ cc_library(
         "tls.h",
     ],
     include_prefix = "kj/compat",
+    linkopts = select({
+        "@platforms//os:windows": [
+            "Crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         "//src/kj:use_openssl": [],
         "//conditions:default": ["@platforms//:incompatible"],


### PR DESCRIPTION
Under windows SSL_CTX_set_default_verify_paths doesn't populate the trusted ca store with all the trusted CAs. This commit should fix the error.