### PR TITLE
kj::FdOutputStream::write: Split writes for macOS in case byte count exceeds INT_MAX

### DIFF
--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -31,6 +31,7 @@
 #include "debug.h"
 #include "miniposix.h"
 #include <algorithm>
+#include <numeric>
 #include <errno.h>
 #include "vector.h"
 
@@ -362,7 +363,11 @@ void FdOutputStream::write(const void* buffer, size_t size) {
 
   while (size > 0) {
     miniposix::ssize_t n;
+#if __APPLE__
+    KJ_SYSCALL(n = miniposix::write(fd, pos, std::min<size_t> (size, macosMaxBytes)), fd);
+#else
     KJ_SYSCALL(n = miniposix::write(fd, pos, size), fd);
+#endif
     KJ_ASSERT(n > 0, "write() returned zero.");
     pos += n;
     size -= n;
@@ -377,11 +382,47 @@ void FdOutputStream::write(ArrayPtr<const ArrayPtr<const byte>> pieces) {
   OutputStream::write(pieces);
 
 #else
+
   const size_t iovmax = miniposix::iovMax();
   while (pieces.size() > iovmax) {
     write(pieces.slice(0, iovmax));
     pieces = pieces.slice(iovmax, pieces.size());
   }
+
+#if __APPLE__
+  // According to newer macOS manpages write and writev don't accept buffers bigger than INT_MAX bytes.
+  // Therefore slicing of the input might be required in case the sum of the bytes exceeds the threshold
+  const auto bytesSum = std::accumulate (pieces.begin(), pieces.end(), size_t (0), [] (auto sum, auto& piece) { return sum + piece.size(); });
+
+  if (bytesSum > macosMaxBytes)
+  {
+    Vector<Vector<ArrayPtr<const byte>>> sizeLimitedPieces;
+    sizeLimitedPieces.add (Vector<ArrayPtr<const byte>>());
+
+    auto currentBytesRemaining = macosMaxBytes;
+    for (auto piece : pieces)
+    {
+      while (piece.size() > currentBytesRemaining)
+      {
+        sizeLimitedPieces.back().add (piece.slice (0, currentBytesRemaining));
+        piece = piece.slice (currentBytesRemaining, piece.size());
+        currentBytesRemaining = macosMaxBytes;
+        sizeLimitedPieces.add (Vector<ArrayPtr<const byte>>());
+      }
+
+      if (piece.size() > 0)
+      {
+        currentBytesRemaining -= piece.size();
+        sizeLimitedPieces.back().add (std::move (piece));
+      }
+    }
+
+    for (auto& p : sizeLimitedPieces)
+      write (p);
+
+    return;
+  }
+#endif
 
   KJ_STACK_ARRAY(struct iovec, iov, pieces.size(), 16, 128);
 

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -26,6 +26,7 @@
 #include "array.h"
 #include "exception.h"
 #include <stdint.h>
+#include <climits>
 
 KJ_BEGIN_HEADER
 
@@ -342,6 +343,11 @@ public:
 private:
   int fd;
   AutoCloseFd autoclose;
+
+#if __APPLE__
+  static constexpr ssize_t macosMaxBytes = INT_MAX;
+  // According to newer macOS manpages write and writev don't accept buffers bigger than INT_MAX bytes
+#endif
 };
 
 // =======================================================================================


### PR DESCRIPTION
Fix for the issue discussed in https://github.com/capnproto/capnproto/issues/2187

I decided to allocate a temporary Vector in case the size exceeded the limit as I don't consider it a performance issue in case that much data is written out. I tried to match the style of the existing implementation but feel free to remark if you feel that the code doesn't match your preferred style.