### PR TITLE
Silence compiler warning about missing override identifier

### DIFF
--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -352,7 +352,7 @@ public:
     *length = socklen;
   }
 
-  Maybe<void*> getWin32Handle() const {
+  Maybe<void*> getWin32Handle() const override {
     return reinterpret_cast<void*>(fd);
   }
 


### PR DESCRIPTION
Silences the following compiler warning:

```
src/kj/async-io-win32.c++(355,16): warning: 'getWin32Handle' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
```