### PR TITLE
Check for `AI_V4MAPPED` before usage

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -378,7 +378,11 @@ bool systemSupportsAddress(StringPtr addr, StringPtr service = nullptr) {
   struct addrinfo hints;
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = 0;
+#if !defined(AI_V4MAPPED)
+  hints.ai_flags = AI_ADDRCONFIG;
+#else
   hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG;
+#endif
   hints.ai_protocol = 0;
   hints.ai_canonname = nullptr;
   hints.ai_addr = nullptr;

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1237,7 +1237,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
       struct addrinfo hints;
       memset(&hints, 0, sizeof(hints));
       hints.ai_family = AF_UNSPEC;
-#if __BIONIC__
+#if __BIONIC__ || !defined(AI_V4MAPPED)
       // AI_V4MAPPED causes getaddrinfo() to fail on Bionic libc (Android).
       hints.ai_flags = AI_ADDRCONFIG;
 #else


### PR DESCRIPTION
On certain systems, such as NetBSD, the `AI_V4MAPPED` flag is not defined in the `netdb.h` header.

See: https://man.netbsd.org/getaddrinfo.3

Should be ported to the `master` and `release-1.0.*` branches.

Fixes https://github.com/capnproto/capnproto/issues/2201.