### PR TITLE
Improve FD handling: Add KJ_SYSCALL_FD and rename AutoCloseFd

### DIFF
--- a/c++/src/capnp/compat/websocket-rpc.c++
+++ b/c++/src/capnp/compat/websocket-rpc.c++
@@ -30,7 +30,7 @@ WebSocketMessageStream::WebSocketMessageStream(kj::WebSocket& socket)
   {};
 
 kj::Promise<kj::Maybe<MessageReaderAndFds>> WebSocketMessageStream::tryReadMessage(
-    kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+    kj::ArrayPtr<kj::OwnFd> fdSpace,
     ReaderOptions options, kj::ArrayPtr<word> scratchSpace) {
   return socket.receive(options.traversalLimitInWords * sizeof(word))
       .then([options](auto msg) -> kj::Promise<kj::Maybe<MessageReaderAndFds>> {

--- a/c++/src/capnp/compat/websocket-rpc.h
+++ b/c++/src/capnp/compat/websocket-rpc.h
@@ -37,7 +37,7 @@ public:
 
   // Implements MessageStream
   kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+      kj::ArrayPtr<kj::OwnFd> fdSpace,
       ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr) override;
   kj::Promise<void> writeMessage(
       kj::ArrayPtr<const int> fds,

--- a/c++/src/capnp/compiler/parser.c++
+++ b/c++/src/capnp/compiler/parser.c++
@@ -27,6 +27,7 @@
 #include "type-id.h"
 #include <capnp/dynamic.h>
 #include <kj/debug.h>
+#include <kj/io.h>
 #include <kj/encoding.h>
 #if !_MSC_VER
 #include <unistd.h>
@@ -57,9 +58,7 @@ uint64_t generateRandomId() {
   KJ_ASSERT(CryptGenRandom(handle, sizeof(result), reinterpret_cast<BYTE*>(&result)));
 
 #else
-  int fd;
-  KJ_SYSCALL(fd = open("/dev/urandom", O_RDONLY));
-  KJ_DEFER(close(fd));
+  auto fd = KJ_SYSCALL_FD(open("/dev/urandom", O_RDONLY));
 
   ssize_t n;
   KJ_SYSCALL(n = read(fd, &result, sizeof(result)), "/dev/urandom");

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -507,11 +507,11 @@ KJ_TEST("send FD over RPC") {
 
   int pipeFds[2]{};
   KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
-  kj::AutoCloseFd in1(pipeFds[0]);
-  kj::AutoCloseFd out1(pipeFds[1]);
+  kj::OwnFd in1(pipeFds[0]);
+  kj::OwnFd out1(pipeFds[1]);
   KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
-  kj::AutoCloseFd in2(pipeFds[0]);
-  kj::AutoCloseFd out2(pipeFds[1]);
+  kj::OwnFd in2(pipeFds[0]);
+  kj::OwnFd out2(pipeFds[1]);
 
   capnp::RemotePromise<test::TestMoreStuff::WriteToFdResults> promise = nullptr;
   {
@@ -554,11 +554,11 @@ KJ_TEST("FD per message limit") {
 
   int pipeFds[2]{};
   KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
-  kj::AutoCloseFd in1(pipeFds[0]);
-  kj::AutoCloseFd out1(pipeFds[1]);
+  kj::OwnFd in1(pipeFds[0]);
+  kj::OwnFd out1(pipeFds[1]);
   KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
-  kj::AutoCloseFd in2(pipeFds[0]);
-  kj::AutoCloseFd out2(pipeFds[1]);
+  kj::OwnFd in2(pipeFds[0]);
+  kj::OwnFd out2(pipeFds[1]);
 
   capnp::RemotePromise<test::TestMoreStuff::WriteToFdResults> promise = nullptr;
   {

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -983,7 +983,7 @@ private:
 
   public:
     ImportClient(RpcConnectionState& connectionState, ImportId importId,
-                 kj::Maybe<kj::AutoCloseFd> fd)
+                 kj::Maybe<kj::OwnFd> fd)
         : RpcClient(connectionState), importId(importId), fd(kj::mv(fd)) {}
 
     ~ImportClient() noexcept(false) {
@@ -1011,7 +1011,7 @@ private:
       });
     }
 
-    void setFdIfMissing(kj::Maybe<kj::AutoCloseFd> newFd) {
+    void setFdIfMissing(kj::Maybe<kj::OwnFd> newFd) {
       if (fd == kj::none) {
         fd = kj::mv(newFd);
       }
@@ -1054,7 +1054,7 @@ private:
 
   private:
     ImportId importId;
-    kj::Maybe<kj::AutoCloseFd> fd;
+    kj::Maybe<kj::OwnFd> fd;
 
     uint remoteRefcount = 0;
     // Number of times we've received this import from the peer.
@@ -1605,7 +1605,7 @@ private:
   // =====================================================================================
   // Interpreting CapDescriptor
 
-  kj::Own<ClientHook> import(ImportId importId, bool isPromise, kj::Maybe<kj::AutoCloseFd> fd) {
+  kj::Own<ClientHook> import(ImportId importId, bool isPromise, kj::Maybe<kj::OwnFd> fd) {
     // Receive a new import.
 
     auto& import = imports.findOrCreate(importId);
@@ -1739,9 +1739,9 @@ private:
   };
 
   kj::Maybe<kj::Own<ClientHook>> receiveCap(rpc::CapDescriptor::Reader descriptor,
-                                            kj::ArrayPtr<kj::AutoCloseFd> fds) {
+                                            kj::ArrayPtr<kj::OwnFd> fds) {
     uint fdIndex = descriptor.getAttachedFd();
-    kj::Maybe<kj::AutoCloseFd> fd;
+    kj::Maybe<kj::OwnFd> fd;
     if (fdIndex < fds.size() && fds[fdIndex] != nullptr) {
       fd = kj::mv(fds[fdIndex]);
     }
@@ -1794,7 +1794,7 @@ private:
   }
 
   kj::Array<kj::Maybe<kj::Own<ClientHook>>> receiveCaps(List<rpc::CapDescriptor>::Reader capTable,
-                                                        kj::ArrayPtr<kj::AutoCloseFd> fds) {
+                                                        kj::ArrayPtr<kj::OwnFd> fds) {
     auto result = kj::heapArrayBuilder<kj::Maybe<kj::Own<ClientHook>>>(capTable.size());
     for (auto cap: capTable) {
       result.add(receiveCap(cap, fds));

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -26,7 +26,7 @@
 
 CAPNP_BEGIN_HEADER
 
-namespace kj { class AutoCloseFd; }
+namespace kj { class OwnFd; }
 
 namespace capnp {
 
@@ -213,13 +213,13 @@ public:
   // Get the message body, to be interpreted by the caller.  (The standard RPC implementation
   // interprets it as a Message as defined in rpc.capnp.)
 
-  virtual kj::ArrayPtr<kj::AutoCloseFd> getAttachedFds() { return nullptr; }
+  virtual kj::ArrayPtr<kj::OwnFd> getAttachedFds() { return nullptr; }
   // If the transport supports attached file descriptors and some were attached to this message,
   // returns them. Otherwise returns an empty array. It is intended that the caller will move the
   // FDs out of this table when they are consumed, possibly leaving behind a null slot. Callers
   // should be careful to check if an FD was already consumed by comparing the slot with `nullptr`.
   // (We don't use Maybe here because moving from a Maybe doesn't make it null, so it would only
-  // add confusion. Moving from an AutoCloseFd does in fact make it null.)
+  // add confusion. Moving from an OwnFd does in fact make it null.)
 
   virtual size_t sizeInWords() = 0;
   // Get the total size of the message, for flow control purposes. Although the caller could

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -26,7 +26,10 @@
 
 CAPNP_BEGIN_HEADER
 
-namespace kj { class OwnFd; }
+namespace kj {
+  class OwnFd;
+  using AutoCloseFd = OwnFd;
+}
 
 namespace capnp {
 

--- a/c++/src/capnp/serialize-async.h
+++ b/c++/src/capnp/serialize-async.h
@@ -31,7 +31,7 @@ namespace capnp {
 
 struct MessageReaderAndFds {
   kj::Own<MessageReader> reader;
-  kj::ArrayPtr<kj::AutoCloseFd> fds;
+  kj::ArrayPtr<kj::OwnFd> fds;
 };
 
 struct MessageAndFds {
@@ -44,7 +44,7 @@ class MessageStream {
   // the functionality above.
 public:
   virtual kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+      kj::ArrayPtr<kj::OwnFd> fdSpace,
       ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr) = 0;
   // Read a message that may also have file descriptors attached, e.g. from a Unix socket with
   // SCM_RIGHTS. Returns null on EOF.
@@ -57,7 +57,7 @@ public:
   // Equivalent to the above with fdSpace = nullptr.
 
   kj::Promise<MessageReaderAndFds> readMessage(
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+      kj::ArrayPtr<kj::OwnFd> fdSpace,
       ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr);
   kj::Promise<kj::Own<MessageReader>> readMessage(
       ReaderOptions options = ReaderOptions(),
@@ -114,7 +114,7 @@ public:
 
   // Implements MessageStream
   kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+      kj::ArrayPtr<kj::OwnFd> fdSpace,
       ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr) override;
   kj::Promise<void> writeMessage(
       kj::ArrayPtr<const int> fds,
@@ -139,7 +139,7 @@ public:
 
   // Implements MessageStream
   kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+      kj::ArrayPtr<kj::OwnFd> fdSpace,
       ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr) override;
   kj::Promise<void> writeMessage(
       kj::ArrayPtr<const int> fds,
@@ -180,7 +180,7 @@ public:
 
   // Implements MessageStream
   kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+      kj::ArrayPtr<kj::OwnFd> fdSpace,
       ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr) override;
   kj::Promise<void> writeMessage(
       kj::ArrayPtr<const int> fds,
@@ -209,25 +209,25 @@ private:
   // Pointer to the location in `buffer` where unused buffer space begins, i.e. immediately after
   // the last byte read.
 
-  kj::Vector<kj::AutoCloseFd> leftoverFds;
+  kj::Vector<kj::OwnFd> leftoverFds;
   // FDs which were accidentally read too early. These are always connected to the last message
   // in the buffer, since the OS would not have allowed us to read past that point.
 
   bool hasOutstandingShortLivedMessage = false;
 
   kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessageImpl(
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace, size_t fdsSoFar,
+      kj::ArrayPtr<kj::OwnFd> fdSpace, size_t fdsSoFar,
       ReaderOptions options, kj::ArrayPtr<word> scratchSpace);
 
   kj::Promise<kj::Maybe<MessageReaderAndFds>> readEntireMessage(
       kj::ArrayPtr<const byte> prefix, size_t expectedSizeInWords,
-      kj::ArrayPtr<kj::AutoCloseFd> fdSpace, size_t fdsSoFar,
+      kj::ArrayPtr<kj::OwnFd> fdSpace, size_t fdsSoFar,
       ReaderOptions options);
   // Given a message prefix and expected size of the whole message, read the entire message into
   // a single array and return it.
 
   kj::Promise<kj::AsyncCapabilityStream::ReadResult> tryReadWithFds(
-      void* buffer, size_t minBytes, size_t maxBytes, kj::AutoCloseFd* fdBuffer, size_t maxFds);
+      void* buffer, size_t minBytes, size_t maxBytes, kj::OwnFd* fdBuffer, size_t maxFds);
   // Executes AsyncCapabilityStream::tryReadWithFds() on the underlying stream, or falls back to
   // AsyncIoStream::tryRead() if it's not a capability stream.
 
@@ -265,11 +265,11 @@ kj::Promise<void> writeMessage(kj::AsyncOutputStream& output, MessageBuilder& bu
 // `AsyncCapabilityMessageStream(stream).foo(...)`.
 
 kj::Promise<MessageReaderAndFds> readMessage(
-    kj::AsyncCapabilityStream& input, kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+    kj::AsyncCapabilityStream& input, kj::ArrayPtr<kj::OwnFd> fdSpace,
     ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr);
 
 kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
-    kj::AsyncCapabilityStream& input, kj::ArrayPtr<kj::AutoCloseFd> fdSpace,
+    kj::AsyncCapabilityStream& input, kj::ArrayPtr<kj::OwnFd> fdSpace,
     ReaderOptions options = ReaderOptions(), kj::ArrayPtr<word> scratchSpace = nullptr);
 
 kj::Promise<void> writeMessage(kj::AsyncCapabilityStream& output, kj::ArrayPtr<const int> fds,

--- a/c++/src/capnp/serialize-packed.c++
+++ b/c++/src/capnp/serialize-packed.c++
@@ -449,7 +449,7 @@ PackedFdMessageReader::PackedFdMessageReader(
                           options, scratchSpace) {}
 
 PackedFdMessageReader::PackedFdMessageReader(
-    kj::AutoCloseFd fd, ReaderOptions options, kj::ArrayPtr<word> scratchSpace)
+    kj::OwnFd fd, ReaderOptions options, kj::ArrayPtr<word> scratchSpace)
     : FdInputStream(kj::mv(fd)),
       BufferedInputStreamWrapper(static_cast<FdInputStream&>(*this)),
       PackedMessageReader(static_cast<BufferedInputStreamWrapper&>(*this),

--- a/c++/src/capnp/serialize-packed.h
+++ b/c++/src/capnp/serialize-packed.h
@@ -79,7 +79,7 @@ public:
   // Note that if you want to reuse the descriptor after the reader is destroyed, you'll need to
   // seek it, since otherwise the position is unspecified.
 
-  PackedFdMessageReader(kj::AutoCloseFd fd, ReaderOptions options = ReaderOptions(),
+  PackedFdMessageReader(kj::OwnFd fd, ReaderOptions options = ReaderOptions(),
                         kj::ArrayPtr<word> scratchSpace = nullptr);
   // Read a message from a file descriptor, taking ownership of the descriptor.
 

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -406,7 +406,7 @@ TEST(Serialize, FileDescriptors) {
 #else
   char filename[] = "/tmp/capnproto-serialize-test-XXXXXX";
 #endif
-  kj::AutoCloseFd tmpfile(mkstemp(filename));
+  kj::OwnFd tmpfile(mkstemp(filename));
   ASSERT_GE(tmpfile.get(), 0);
 
 #if !_WIN32

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -181,7 +181,7 @@ public:
       : FdInputStream(fd), InputStreamMessageReader(*this, options, scratchSpace) {}
   // Read message from a file descriptor, without taking ownership of the descriptor.
 
-  StreamFdMessageReader(kj::AutoCloseFd fd, ReaderOptions options = ReaderOptions(),
+  StreamFdMessageReader(kj::OwnFd fd, ReaderOptions options = ReaderOptions(),
                         kj::ArrayPtr<word> scratchSpace = nullptr)
       : FdInputStream(kj::mv(fd)), InputStreamMessageReader(*this, options, scratchSpace) {}
   // Read a message from a file descriptor, taking ownership of the descriptor.

--- a/c++/src/capnp/test-util.c++
+++ b/c++/src/capnp/test-util.c++
@@ -1194,8 +1194,8 @@ kj::Promise<void> TestMoreStuffImpl::writeToFd(WriteToFdContext context) {
 
   int pair[2]{};
   KJ_SYSCALL(kj::miniposix::pipe(pair));
-  kj::AutoCloseFd in(pair[0]);
-  kj::AutoCloseFd out(pair[1]);
+  kj::OwnFd in(pair[0]);
+  kj::OwnFd out(pair[1]);
 
   kj::FdOutputStream(kj::mv(out)).write("baz"_kjb);
   context.getResults().setFdCap3(kj::heap<TestFdCap>(kj::mv(in)));

--- a/c++/src/capnp/test-util.h
+++ b/c++/src/capnp/test-util.h
@@ -324,12 +324,12 @@ class TestFdCap final: public test::TestInterface::Server {
   // Implementation of TestInterface that wraps a file descriptor.
 
 public:
-  TestFdCap(kj::AutoCloseFd fd): fd(kj::mv(fd)) {}
+  TestFdCap(kj::OwnFd fd): fd(kj::mv(fd)) {}
 
   kj::Maybe<int> getFd() override { return fd.get(); }
 
 private:
-  kj::AutoCloseFd fd;
+  kj::OwnFd fd;
 };
 
 class TestStreamingImpl final: public test::TestStreaming::Server {

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -962,9 +962,7 @@ bool isMsgTruncBroken() {
   // Detect if the kernel fails to set MSG_TRUNC on recvmsg(). This seems to be the case at least
   // when running an arm64 binary under qemu.
 
-  int fd;
-  KJ_SYSCALL(fd = socket(AF_INET, SOCK_DGRAM, 0));
-  KJ_DEFER(close(fd));
+  auto fd = KJ_SYSCALL_FD(socket(AF_INET, SOCK_DGRAM, 0));
 
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
@@ -1172,9 +1170,7 @@ TEST(AsyncIo, AbstractUnixSocket) {
   Own<ConnectionReceiver> listener = addr->listen();
   // chdir proves no filesystem dependence. Test fails for regular unix socket
   // but passes for abstract unix socket.
-  int originalDirFd;
-  KJ_SYSCALL(originalDirFd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC));
-  KJ_DEFER(close(originalDirFd));
+  auto originalDirFd = KJ_SYSCALL_FD(open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC));
   KJ_SYSCALL(chdir("/"));
   KJ_DEFER(KJ_SYSCALL(fchdir(originalDirFd)));
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -515,9 +515,7 @@ private:
             // by default.
             // TODO(perf): Should we add an ownership-releasing version of writeWithFds()?
             for (auto i: kj::zeroTo(capCount)) {
-              int duped;
-              KJ_SYSCALL(duped = dup(fds[i]));
-              fdBuffer[i] = kj::AutoCloseFd(duped);
+              fdBuffer[i] = KJ_SYSCALL_FD(dup(fds[i]));
             }
             fdBuffer += capCount;
             maxFds -= capCount;
@@ -1021,9 +1019,7 @@ private:
             // by default.
             // TODO(perf): Should we add an ownership-releasing version of writeWithFds()?
             for (auto i: kj::zeroTo(count)) {
-              int duped;
-              KJ_SYSCALL(duped = dup(fds[i]));
-              fdBuffer[i] = kj::AutoCloseFd(duped);
+              fdBuffer[i] = KJ_SYSCALL_FD(dup(fds[i]));
             }
             capBuffer = fdBuffer.slice(count, fdBuffer.size());
             readSoFar.capCount += count;

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -517,7 +517,7 @@ private:
             for (auto i: kj::zeroTo(capCount)) {
               int duped;
               KJ_SYSCALL(duped = dup(fds[i]));
-              fdBuffer[i] = kj::AutoCloseFd(fds[i]);
+              fdBuffer[i] = kj::AutoCloseFd(duped);
             }
             fdBuffer += capCount;
             maxFds -= capCount;

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -39,7 +39,7 @@ class AutoCloseHandle;
 class UnixEventPort;
 #endif
 
-class AutoCloseFd;
+class OwnFd;
 class NetworkAddress;
 class AsyncOutputStream;
 class AsyncIoStream;
@@ -239,7 +239,7 @@ public:
                                      ArrayPtr<const int> fds) = 0;
   Promise<void> writeWithFds(ArrayPtr<const byte> data,
                              ArrayPtr<const ArrayPtr<const byte>> moreData,
-                             ArrayPtr<const AutoCloseFd> fds);
+                             ArrayPtr<const OwnFd> fds);
   // Write some data to the stream with some file descriptors attached to it.
   //
   // The maximum number of FDs that can be sent at a time is usually subject to an OS-imposed
@@ -252,7 +252,7 @@ public:
   };
 
   virtual Promise<ReadResult> tryReadWithFds(void* buffer, size_t minBytes, size_t maxBytes,
-                                             AutoCloseFd* fdBuffer, size_t maxFds) = 0;
+                                             OwnFd* fdBuffer, size_t maxFds) = 0;
   // Read data from the stream that may have file descriptors attached. Any attached descriptors
   // will be placed in `fdBuffer`. If multiple bundles of FDs are encountered in the course of
   // reading the amount of data requested by minBytes/maxBytes, then they will be concatenated. If
@@ -281,8 +281,8 @@ public:
   Promise<void> sendStream(Own<AsyncCapabilityStream> stream);
   // Transfer a single stream.
 
-  Promise<AutoCloseFd> receiveFd();
-  Promise<Maybe<AutoCloseFd>> tryReceiveFd();
+  Promise<OwnFd> receiveFd();
+  Promise<Maybe<OwnFd>> tryReceiveFd();
   Promise<void> sendFd(int fd);
   // Transfer a single raw file descriptor.
 };
@@ -837,7 +837,7 @@ public:
   // explicitly).
 #else
   typedef int Fd;
-  typedef AutoCloseFd OwnFd;
+  typedef OwnFd OwnFd;
   // On Unix, any arbitrary file descriptor is supported.
 #endif
 
@@ -917,7 +917,7 @@ public:
   Own<ConnectionReceiver> wrapListenSocketFd(OwnFd&& fd, uint flags = 0);
   Own<DatagramPort> wrapDatagramSocketFd(OwnFd&& fd, NetworkFilter& filter, uint flags = 0);
   Own<DatagramPort> wrapDatagramSocketFd(OwnFd&& fd, uint flags = 0);
-  // Convenience wrappers which transfer ownership via AutoCloseFd (Unix) or AutoCloseHandle
+  // Convenience wrappers which transfer ownership via OwnFd (Unix) or AutoCloseHandle
   // (Windows). TAKE_OWNERSHIP will be implicitly added to `flags`.
 };
 

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -40,6 +40,7 @@ class UnixEventPort;
 #endif
 
 class OwnFd;
+using AutoCloseFd = OwnFd;
 class NetworkAddress;
 class AsyncOutputStream;
 class AsyncIoStream;
@@ -835,9 +836,13 @@ public:
   // On Windows, the `fd` parameter to each of these methods must be a SOCKET, and must have the
   // flag WSA_FLAG_OVERLAPPED (which socket() uses by default, but WSASocket() wants you to specify
   // explicitly).
+  //
+  // TODO(cleanup): This alias was created when `kj::OwnFd` was called `kj::AutoCloseFd`. Later
+  //   `AutoCloseFd` itself was renamed `OwnFd`, which means this alias now shadows `kj::OwnFd`,
+  //   which is a little weird.
 #else
   typedef int Fd;
-  typedef OwnFd OwnFd;
+  typedef kj::OwnFd OwnFd;
   // On Unix, any arbitrary file descriptor is supported.
 #endif
 

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -367,7 +367,7 @@ TEST(AsyncUnixTest, ReadObserver) {
 
   int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
-  kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
+  kj::OwnFd infd(pipefds[0]), outfd(pipefds[1]);
 
   UnixEventPort::FdObserver observer(port, infd, UnixEventPort::FdObserver::OBSERVE_READ);
 
@@ -463,7 +463,7 @@ TEST(AsyncUnixTest, ReadObserverAndSignals) {
 
   int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
-  kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
+  kj::OwnFd infd(pipefds[0]), outfd(pipefds[1]);
 
   UnixEventPort::FdObserver observer(port, infd, UnixEventPort::FdObserver::OBSERVE_READ);
 
@@ -560,7 +560,7 @@ TEST(AsyncUnixTest, WriteObserver) {
 
   int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
-  kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
+  kj::OwnFd infd(pipefds[0]), outfd(pipefds[1]);
   setNonblocking(outfd);
   setNonblocking(infd);
 
@@ -940,7 +940,7 @@ KJ_TEST("UnixEventPort whenWriteDisconnected()") {
 
   int fds_[2]{};
   KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds_));
-  kj::AutoCloseFd fds[2] = { kj::AutoCloseFd(fds_[0]), kj::AutoCloseFd(fds_[1]) };
+  kj::OwnFd fds[2] = { kj::OwnFd(fds_[0]), kj::OwnFd(fds_[1]) };
 
   UnixEventPort::FdObserver observer(port, fds[0], UnixEventPort::FdObserver::OBSERVE_READ);
 
@@ -986,7 +986,7 @@ KJ_TEST("UnixEventPort FdObserver(..., flags=0)::whenWriteDisconnected()") {
 
   int pipefds[2]{};
   KJ_SYSCALL(pipe(pipefds));
-  kj::AutoCloseFd infd(pipefds[0]), outfd(pipefds[1]);
+  kj::OwnFd infd(pipefds[0]), outfd(pipefds[1]);
 
   UnixEventPort::FdObserver observer(port, outfd, 0);
 
@@ -1134,8 +1134,8 @@ KJ_TEST("UnixEventPoll::getPollableFd() for external waiting") {
   {
     int pair[2]{};
     KJ_SYSCALL(pipe(pair));
-    kj::AutoCloseFd in(pair[0]);
-    kj::AutoCloseFd out(pair[1]);
+    kj::OwnFd in(pair[0]);
+    kj::OwnFd out(pair[1]);
 
     kj::UnixEventPort::FdObserver observer(port, in, kj::UnixEventPort::FdObserver::OBSERVE_READ);
     auto promise = observer.whenBecomesReadable();
@@ -1312,8 +1312,8 @@ KJ_TEST("yieldUntilWouldSleep") {
   {
     int pair[2]{};
     KJ_SYSCALL(pipe(pair));
-    kj::AutoCloseFd in(pair[0]);
-    kj::AutoCloseFd out(pair[1]);
+    kj::OwnFd in(pair[0]);
+    kj::OwnFd out(pair[1]);
 
     kj::UnixEventPort::FdObserver observer(port, in, kj::UnixEventPort::FdObserver::OBSERVE_READ);
     auto promise = observer.whenBecomesReadable();

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -1253,8 +1253,8 @@ UnixEventPort::UnixEventPort()
   // Allocate a pipe to which we'll write a byte in order to wake this thread.
   int fds[2];
   KJ_SYSCALL(pipe(fds));
-  wakePipeIn = kj::AutoCloseFd(fds[0]);
-  wakePipeOut = kj::AutoCloseFd(fds[1]);
+  wakePipeIn = kj::OwnFd(fds[0]);
+  wakePipeOut = kj::OwnFd(fds[1]);
   KJ_SYSCALL(fcntl(wakePipeIn, F_SETFD, FD_CLOEXEC));
   KJ_SYSCALL(fcntl(wakePipeOut, F_SETFD, FD_CLOEXEC));
 #else

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -259,9 +259,9 @@ private:
 
 #if KJ_USE_EPOLL
   sigset_t originalMask;
-  AutoCloseFd epollFd;
-  AutoCloseFd eventFd;   // Used for cross-thread wakeups.
-  kj::Maybe<AutoCloseFd> timerFd;   // Used if preparePollableFdForSleep() is ever called.
+  OwnFd epollFd;
+  OwnFd eventFd;   // Used for cross-thread wakeups.
+  kj::Maybe<OwnFd> timerFd;   // Used if preparePollableFdForSleep() is ever called.
 
   bool sleeping = false;  // Was preparePollableFdForSleep() called?
   bool runnable = false;  // Last value passed to setRunnable().
@@ -269,7 +269,7 @@ private:
 
   bool processEpollEvents(struct epoll_event events[], int n);
 #elif KJ_USE_KQUEUE
-  AutoCloseFd kqueueFd;
+  OwnFd kqueueFd;
 
   bool doKqueueWait(struct timespec* timeout);
 #else
@@ -279,8 +279,8 @@ private:
   FdObserver** observersTail = &observersHead;
 
 #if KJ_USE_PIPE_FOR_WAKEUP
-  AutoCloseFd wakePipeIn;
-  AutoCloseFd wakePipeOut;
+  OwnFd wakePipeIn;
+  OwnFd wakePipeOut;
 #else
   unsigned long long threadId;  // actually pthread_t
 #endif

--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -90,15 +90,15 @@
 //   would have caused an exception to be thrown.
 //
 // * `KJ_SYSCALL_FD(code, ...)` provides shorthand for the common case that the syscall returns
-//   a file descriptor and you want to wrap that file descirptor in `kj::AutoCloseFd`.
+//   a file descriptor and you want to wrap that file descirptor in `kj::OwnFd`.
 //   `KJ_SYSCALL_FD` is like `KJ_SYSCALL`, but:
 //     * The syscall must return a file descriptor.
-//     * The whole macro evaluates to a `kj::AutoCloseFd`.
+//     * The whole macro evaluates to a `kj::OwnFd`.
 //     * It cannot have a recovery block.
 //
 //   Example:
 //
-//       kj::AutoCloseFd fd = KJ_SYSCALL_FD(open(filename, O_RDONLY), filename);
+//       kj::OwnFd fd = KJ_SYSCALL_FD(open(filename, O_RDONLY), filename);
 //
 // * `KJ_CONTEXT(...)`:  Notes additional contextual information relevant to any exceptions thrown
 //   from within the current scope.  That is, until control exits the block in which KJ_CONTEXT()
@@ -373,7 +373,7 @@ namespace kj {
   ([&]{ \
     int _kj_fd; \
     KJ_SYSCALL(_kj_fd = __VA_ARGS__); \
-    return kj::AutoCloseFd(_kj_fd); \
+    return kj::OwnFd(_kj_fd); \
   }())
 
 #else
@@ -382,7 +382,7 @@ namespace kj {
   ({ \
     int _kj_fd; \
     KJ_SYSCALL(_kj_fd = __VA_ARGS__); \
-    (kj::AutoCloseFd(_kj_fd)); \
+    (kj::OwnFd(_kj_fd)); \
   })
 
 #endif

--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -387,6 +387,8 @@ namespace kj {
 
 #endif
 
+// TODO(someday): Add KJ_WIN32_HANDLE(), similar to KJ_SYSCALL_FD().
+
 #define KJ_ASSERT KJ_REQUIRE
 #define KJ_FAIL_ASSERT KJ_FAIL_REQUIRE
 #define KJ_ASSERT_NONNULL KJ_REQUIRE_NONNULL

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -232,14 +232,14 @@ ArrayPtr<void* const> getStackTrace(ArrayPtr<void*> space, uint ignoreCount,
 namespace {
 
 struct PipePair {
-  kj::AutoCloseFd readEnd;
-  kj::AutoCloseFd writeEnd;
+  kj::OwnFd readEnd;
+  kj::OwnFd writeEnd;
 };
 
 PipePair raiiPipe() {
   int fds[2];
   KJ_SYSCALL(pipe(fds));
-  return PipePair { AutoCloseFd(fds[0]), AutoCloseFd(fds[1]) };
+  return PipePair { OwnFd(fds[0]), OwnFd(fds[1]) };
 }
 
 // A simple subprocess wrapper with in/out pipes.
@@ -283,8 +283,8 @@ struct Subprocess {
   }
 
   pid_t pid;
-  kj::AutoCloseFd in;
-  kj::AutoCloseFd out;
+  kj::OwnFd in;
+  kj::OwnFd out;
 };
 
 String stringifyStackTraceWithLlvm(ArrayPtr<void* const> trace) {

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -217,10 +217,9 @@ bool isWine() { return false; }
 static Own<File> newTempFile() {
   const char* tmpDir = getenv("TEST_TMPDIR");
   auto filename = str(tmpDir != nullptr ? tmpDir : VAR_TMP, "/kj-filesystem-test.XXXXXX");
-  int fd;
-  KJ_SYSCALL(fd = mkstemp(filename.begin()));
+  auto fd = KJ_SYSCALL_FD(mkstemp(filename.begin()));
   KJ_DEFER(KJ_SYSCALL(unlink(filename.cStr())));
-  return newDiskFile(AutoCloseFd(fd));
+  return newDiskFile(kj::mv(fd));
 }
 
 class TempDir {
@@ -234,9 +233,8 @@ public:
   }
 
   Own<Directory> get() {
-    int fd;
-    KJ_SYSCALL(fd = open(filename.cStr(), O_RDONLY));
-    return newDiskDirectory(AutoCloseFd(fd));
+    auto fd = KJ_SYSCALL_FD(open(filename.cStr(), O_RDONLY));
+    return newDiskDirectory(kj::mv(fd));
   }
 
   ~TempDir() noexcept(false) {

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -281,8 +281,8 @@ public:
   // OsHandle ------------------------------------------------------------------
 
   AutoCloseFd clone() const {
-    int fd2;
 #ifdef F_DUPFD_CLOEXEC
+    int fd2;
     KJ_SYSCALL_HANDLE_ERRORS(fd2 = fcntl(fd, F_DUPFD_CLOEXEC, 3)) {
       case EINVAL:
       case EOPNOTSUPP:
@@ -296,8 +296,7 @@ public:
     }
 #endif
 
-    KJ_SYSCALL(fd2 = ::dup(fd));
-    AutoCloseFd result(fd2);
+    auto result = KJ_SYSCALL_FD(::dup(fd));
     setCloexec(result);
     return result;
   }
@@ -1676,9 +1675,7 @@ private:
   Path currentPath;
 
   static AutoCloseFd openDir(const char* dir) {
-    int newFd;
-    KJ_SYSCALL(newFd = open(dir, O_RDONLY | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY));
-    AutoCloseFd result(newFd);
+    auto result = KJ_SYSCALL_FD(open(dir, O_RDONLY | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY));
 #ifndef O_CLOEXEC
     setCloexec(result);
 #endif

--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -276,11 +276,11 @@ class DiskHandle {
   // it. Ugly, but works.
 
 public:
-  DiskHandle(AutoCloseFd&& fd): fd(kj::mv(fd)) {}
+  DiskHandle(OwnFd&& fd): fd(kj::mv(fd)) {}
 
   // OsHandle ------------------------------------------------------------------
 
-  AutoCloseFd clone() const {
+  OwnFd clone() const {
 #ifdef F_DUPFD_CLOEXEC
     int fd2;
     KJ_SYSCALL_HANDLE_ERRORS(fd2 = fcntl(fd, F_DUPFD_CLOEXEC, 3)) {
@@ -292,7 +292,7 @@ public:
         KJ_FAIL_SYSCALL("fnctl(fd, F_DUPFD_CLOEXEC, 3)", error) { break; }
         break;
     } else {
-      return AutoCloseFd(fd2);
+      return OwnFd(fd2);
     }
 #endif
 
@@ -305,7 +305,7 @@ public:
     return fd.get();
   }
 
-  void setFd(AutoCloseFd newFd) {
+  void setFd(OwnFd newFd) {
     // Used for one hack in DiskFilesystem's constructor...
     fd = kj::mv(newFd);
   }
@@ -770,7 +770,7 @@ public:
         KJ_FAIL_SYSCALL("openat(fd, path, O_RDONLY)", error, path) { return kj::none; }
     }
 
-    kj::AutoCloseFd result(newFd);
+    kj::OwnFd result(newFd);
 #ifndef O_CLOEXEC
     setCloexec(result);
 #endif
@@ -778,7 +778,7 @@ public:
     return newDiskReadableFile(kj::mv(result));
   }
 
-  Maybe<AutoCloseFd> tryOpenSubdirInternal(PathPtr path) const {
+  Maybe<OwnFd> tryOpenSubdirInternal(PathPtr path) const {
     int newFd;
     KJ_SYSCALL_HANDLE_ERRORS(newFd = openat(
         fd, path.toString().cStr(), O_RDONLY | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY)) {
@@ -796,7 +796,7 @@ public:
         KJ_FAIL_SYSCALL("openat(fd, path, O_DIRECTORY)", error, path) { return kj::none; }
     }
 
-    kj::AutoCloseFd result(newFd);
+    kj::OwnFd result(newFd);
 #ifndef O_CLOEXEC
     setCloexec(result);
 #endif
@@ -993,7 +993,7 @@ public:
     }
   }
 
-  Maybe<AutoCloseFd> tryOpenFileInternal(PathPtr path, WriteMode mode, bool append) const {
+  Maybe<OwnFd> tryOpenFileInternal(PathPtr path, WriteMode mode, bool append) const {
     uint flags = O_RDWR | MAYBE_O_CLOEXEC;
     mode_t acl = 0666;
     if (has(mode, WriteMode::CREATE)) {
@@ -1062,7 +1062,7 @@ public:
         KJ_FAIL_SYSCALL("openat(fd, path, O_RDWR | ...)", error, path) { return kj::none; }
     }
 
-    kj::AutoCloseFd result(newFd);
+    kj::OwnFd result(newFd);
 #ifndef O_CLOEXEC
     setCloexec(result);
 #endif
@@ -1328,7 +1328,7 @@ public:
       return newFd_ = openat(fd, candidatePath.cStr(),
                              O_RDWR | O_CREAT | O_EXCL | MAYBE_O_CLOEXEC, acl);
     });
-    AutoCloseFd newFd(newFd_);
+    OwnFd newFd(newFd_);
 #ifndef O_CLOEXEC
     setCloexec(newFd);
 #endif
@@ -1353,7 +1353,7 @@ public:
         KJ_FAIL_SYSCALL("open(O_TMPFILE)", error) { break; }
         break;
     } else {
-      AutoCloseFd newFd(newFd_);
+      OwnFd newFd(newFd_);
 #ifndef O_CLOEXEC
       setCloexec(newFd);
 #endif
@@ -1365,7 +1365,7 @@ public:
         [&](StringPtr path) {
       return newFd_ = openat(fd, path.cStr(), O_RDWR | O_CREAT | O_EXCL | MAYBE_O_CLOEXEC, 0600);
     });
-    AutoCloseFd newFd(newFd_);
+    OwnFd newFd(newFd_);
 #ifndef O_CLOEXEC
     setCloexec(newFd);
 #endif
@@ -1402,7 +1402,7 @@ public:
         return heap<BrokenReplacer<Directory>>(newInMemoryDirectory(nullClock()));
     }
 
-    AutoCloseFd subdirFd(subdirFd_);
+    OwnFd subdirFd(subdirFd_);
 #ifndef O_CLOEXEC
     setCloexec(subdirFd);
 #endif
@@ -1474,7 +1474,7 @@ public:
   }
 
 protected:
-  AutoCloseFd fd;
+  OwnFd fd;
 };
 
 #define FSNODE_METHODS(classname)                                   \
@@ -1490,7 +1490,7 @@ protected:
 
 class DiskReadableFile final: public ReadableFile, public DiskHandle {
 public:
-  DiskReadableFile(AutoCloseFd&& fd): DiskHandle(kj::mv(fd)) {}
+  DiskReadableFile(OwnFd&& fd): DiskHandle(kj::mv(fd)) {}
 
   FSNODE_METHODS(DiskReadableFile);
 
@@ -1507,7 +1507,7 @@ public:
 
 class DiskAppendableFile final: public AppendableFile, public DiskHandle, public FdOutputStream {
 public:
-  DiskAppendableFile(AutoCloseFd&& fd)
+  DiskAppendableFile(OwnFd&& fd)
       : DiskHandle(kj::mv(fd)),
         FdOutputStream(DiskHandle::fd.get()) {}
 
@@ -1523,7 +1523,7 @@ public:
 
 class DiskFile final: public File, public DiskHandle {
 public:
-  DiskFile(AutoCloseFd&& fd): DiskHandle(kj::mv(fd)) {}
+  DiskFile(OwnFd&& fd): DiskHandle(kj::mv(fd)) {}
 
   FSNODE_METHODS(DiskFile);
 
@@ -1561,7 +1561,7 @@ public:
 
 class DiskReadableDirectory final: public ReadableDirectory, public DiskHandle {
 public:
-  DiskReadableDirectory(AutoCloseFd&& fd): DiskHandle(kj::mv(fd)) {}
+  DiskReadableDirectory(OwnFd&& fd): DiskHandle(kj::mv(fd)) {}
 
   FSNODE_METHODS(DiskReadableDirectory);
 
@@ -1582,7 +1582,7 @@ public:
 
 class DiskDirectory final: public Directory, public DiskHandle {
 public:
-  DiskDirectory(AutoCloseFd&& fd): DiskHandle(kj::mv(fd)) {}
+  DiskDirectory(OwnFd&& fd): DiskHandle(kj::mv(fd)) {}
 
   FSNODE_METHODS(DiskDirectory);
 
@@ -1674,7 +1674,7 @@ private:
   DiskDirectory current;
   Path currentPath;
 
-  static AutoCloseFd openDir(const char* dir) {
+  static OwnFd openDir(const char* dir) {
     auto result = KJ_SYSCALL_FD(open(dir, O_RDONLY | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY));
 #ifndef O_CLOEXEC
     setCloexec(result);
@@ -1742,19 +1742,19 @@ private:
 
 } // namespace
 
-Own<ReadableFile> newDiskReadableFile(kj::AutoCloseFd fd) {
+Own<ReadableFile> newDiskReadableFile(kj::OwnFd fd) {
   return heap<DiskReadableFile>(kj::mv(fd));
 }
-Own<AppendableFile> newDiskAppendableFile(kj::AutoCloseFd fd) {
+Own<AppendableFile> newDiskAppendableFile(kj::OwnFd fd) {
   return heap<DiskAppendableFile>(kj::mv(fd));
 }
-Own<File> newDiskFile(kj::AutoCloseFd fd) {
+Own<File> newDiskFile(kj::OwnFd fd) {
   return heap<DiskFile>(kj::mv(fd));
 }
-Own<ReadableDirectory> newDiskReadableDirectory(kj::AutoCloseFd fd) {
+Own<ReadableDirectory> newDiskReadableDirectory(kj::OwnFd fd) {
   return heap<DiskReadableDirectory>(kj::mv(fd));
 }
-Own<Directory> newDiskDirectory(kj::AutoCloseFd fd) {
+Own<Directory> newDiskDirectory(kj::OwnFd fd) {
   return heap<DiskDirectory>(kj::mv(fd));
 }
 

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -1807,7 +1807,7 @@ public:
   }
 
 private:
-  
+
   Own<const File> file;
 };
 
@@ -1839,9 +1839,7 @@ const InMemoryFileFactory& defaultInMemoryFileFactory() {
 #if __linux__
 
 Own<File> newMemfdFile(uint flags) {
-  int fd;
-  KJ_SYSCALL(fd = memfd_create("kj-memfd", flags | MFD_CLOEXEC));
-  return newDiskFile(AutoCloseFd(fd));
+  return newDiskFile(KJ_SYSCALL_FD(memfd_create("kj-memfd", flags | MFD_CLOEXEC)));
 }
 
 const InMemoryFileFactory& memfdInMemoryFileFactory() {

--- a/c++/src/kj/filesystem.h
+++ b/c++/src/kj/filesystem.h
@@ -981,7 +981,7 @@ Own<AppendableFile> newFileAppender(Own<const File> inner);
 #if _WIN32
 typedef AutoCloseHandle OsFileHandle;
 #else
-typedef AutoCloseFd OsFileHandle;
+typedef OwnFd OsFileHandle;
 #endif
 
 Own<ReadableFile> newDiskReadableFile(OsFileHandle fd);

--- a/c++/src/kj/io-test.c++
+++ b/c++/src/kj/io-test.c++
@@ -38,8 +38,8 @@ TEST(Io, WriteVec) {
   int fds[2]{};
   KJ_SYSCALL(miniposix::pipe(fds));
 
-  FdInputStream in((AutoCloseFd(fds[0])));
-  FdOutputStream out((AutoCloseFd(fds[1])));
+  FdInputStream in((OwnFd(fds[0])));
+  FdOutputStream out((OwnFd(fds[1])));
 
   ArrayPtr<const byte> pieces[5] = {
     arrayPtr(implicitCast<const byte*>(nullptr), 0),
@@ -56,10 +56,10 @@ TEST(Io, WriteVec) {
   EXPECT_EQ("foobar"_kjb, arrayPtr(buf));
 }
 
-KJ_TEST("stringify AutoCloseFd") {
+KJ_TEST("stringify OwnFd") {
   int fds[2]{};
   KJ_SYSCALL(miniposix::pipe(fds));
-  AutoCloseFd in(fds[0]), out(fds[1]);
+  OwnFd in(fds[0]), out(fds[1]);
 
   KJ_EXPECT(kj::str(in) == kj::str(fds[0]), in, fds[0]);
 }

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -327,7 +327,7 @@ void VectorOutputStream::grow(size_t minSize) {
 
 // =======================================================================================
 
-AutoCloseFd::~AutoCloseFd() noexcept(false) {
+OwnFd::~OwnFd() noexcept(false) {
   if (fd >= 0) {
     // Don't use SYSCALL() here because close() should not be repeated on EINTR.
     if (miniposix::close(fd) < 0) {

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -365,6 +365,8 @@ class AutoCloseHandle {
   //
   // If your code is not exception-safe, you should not use AutoCloseHandle.  In this case you will
   // have to call close() yourself and handle errors appropriately.
+  //
+  // TODO(cleanup): Rename this to OwnWin32Handle.
 
 public:
   inline AutoCloseHandle(): handle((void*)-1) {}

--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -306,6 +306,10 @@ private:
   int fd;
 };
 
+using AutoCloseFd = OwnFd;
+// Historically, this class was called `kj::AutoCloseFd`. For now we define this alias for
+// backwards-compatibility.
+
 inline auto KJ_STRINGIFY(const OwnFd& fd)
     -> decltype(kj::toCharSequence(implicitCast<int>(fd))) {
   return kj::toCharSequence(implicitCast<int>(fd));

--- a/kjdoc/tour.md
+++ b/kjdoc/tour.md
@@ -376,7 +376,7 @@ KJ includes special variants of its assertion macros that convert traditional C 
 
 ```c++
 // For a syscall returning a file descriptor, use KJ_SYSCALL_FD.
-kj::AutoCloseFd fd = KJ_SYSCALL_FD(
+kj::OwnFd fd = KJ_SYSCALL_FD(
     open(filename, O_RDONLY), "couldn't open the document", filename);
 
 // For a syscall returning anything else, use KJ_SYSCALL.
@@ -402,7 +402,7 @@ KJ_SYSCALL_HANDLE_ERRORS(fd = open(filename, O_RDONLY)) {
     KJ_FAIL_SYSCALL("open()", error, "couldn't open the document", filename);
 } else {
   // The `else` clause runs if the system call succeeded.
-  return kj::AutoCloseFd(fd);
+  return kj::OwnFd(fd);
 }
 ```
 
@@ -1030,7 +1030,7 @@ Although most complex KJ applications use async I/O, sometimes you want somethin
 
 `kj/io.h` provides some more basic, synchronous streaming interfaces, like `kj::InputStream` and `kj::OutputStream`. Implementations are provided on top of file descriptors and Windows `HANDLE`s.
 
-Additionally, the important utility class `kj::AutoCloseFd` (and `kj::AutoCloseHandle` for Windows) can be found here. This is an RAII wrapper around a file descriptor (or `HANDLE`), which you will likely want to use any time you are manipulating raw file descriptors (or `HANDLE`s) in KJ code.
+Additionally, the important utility class `kj::OwnFd` (and `kj::AutoCloseHandle` for Windows) can be found here. This is an RAII wrapper around a file descriptor (or `HANDLE`), which you will likely want to use any time you are manipulating raw file descriptors (or `HANDLE`s) in KJ code.
 
 ### Filesystem
 


### PR DESCRIPTION
This pattern is very common in KJ code:

```
int fd_;
KJ_SYSCALL(fd_ = open(...));
kj::AutoCloseFd fd(fd_);
```

Now it can be written as:

```
auto fd = KJ_SYSCALL_FD(open(...));
```

I've wanted this for like ten years but never got around to writing it.

Additionally, I've renamed `AutoCloseFd` to `OwnFd`, with a backwards-compatibility alias. This is another thing I've wanted to do for ten years; the old name was terrible. I think I didn't realize how widely it would be used at the time I first named the class.

I've verified this PR doesn't break the Workers Runtime builds, although I also plan to update them.