### PR TITLE
[bazel] Add support for header parsing

### DIFF
--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -116,6 +116,8 @@ cc_library(
         "//conditions:default": ["async-unix.h"],
     }),
     include_prefix = "kj",
+    # Disable header parsing based on async-inl.h
+    features = ["-parse_headers"],
     linkopts = select({
         "@platforms//os:windows": [
             "Ws2_32.lib",


### PR DESCRIPTION
This allows us to use the bazel header parsing check. capnproto appears to already be compliant, just need to disable it for async-inl.h.