### PR TITLE
filesystem-disk-unix.c++: add a missing header for Apple

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -53,6 +53,10 @@
 #include <sys/sendfile.h>
 #endif
 
+#if __APPLE__
+#include <sys/stdio.h> // renameat
+#endif
+
 namespace kj {
 namespace {
 


### PR DESCRIPTION
This fixes a build error due to undeclared `renameat`.