### PR TITLE
Add Executor::newPromiseAndCrossThreadFulfiller()

### DIFF
--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -834,6 +834,9 @@ PromiseCrossThreadFulfillerPair<T> newPromiseAndCrossThreadFulfiller();
 // not just the one that called this method. Note that the Promise is still tied to the calling
 // thread's event loop and *cannot* be used from another thread -- only the PromiseFulfiller is
 // cross-thread.
+//
+// There is also a member function of the same name on the Executor class. This function here is
+// equivalent to writing: `getCurrentThreadExecutor().newPromiseAndCrossThreadfulfiller()`.
 
 // =======================================================================================
 // Canceler
@@ -1092,6 +1095,17 @@ public:
   //
   // As with `executeAsync()`, `func` is always destroyed on the requesting thread, after the
   // executor thread has signaled completion. The return value is transferred between threads.
+
+  template <typename T>
+  PromiseCrossThreadFulfillerPair<T> newPromiseAndCrossThreadFulfiller() const;
+  // Like `newPromiseAndCrossThreadFulfiller()`, but the Promise is tied to the event loop
+  // associated with this Executor. This allows the caller to construct Promises associated with
+  // other threads. The caller will have to arrange to move the constructed Promise to its home
+  // thread somehow in order to await or cancel (destroy) it.
+  //
+  // It is not an error to create a promise and cross-thread-fulfiller pair on an Executor whose
+  // event loop has already exited. However, the only thing you can do with the promise is destroy
+  // it. Fulfilling or rejecting it via the fulfiller is a no-op.
 
 private:
   struct Impl;

--- a/c++/src/kj/test-helpers.c++
+++ b/c++/src/kj/test-helpers.c++
@@ -123,7 +123,7 @@ bool expectFatalThrow(kj::Maybe<Exception::Type> type, kj::Maybe<StringPtr> mess
     KJ_FAIL_EXPECT("subprocess crashed without throwing exception", WTERMSIG(status));
     return false;
   } else {
-    KJ_FAIL_EXPECT("subprocess neither excited nor crashed?", status);
+    KJ_FAIL_EXPECT("subprocess neither exited nor crashed?", status);
     return false;
   }
 #endif


### PR DESCRIPTION
Currently, `newPromiseAndCrossThreadFulfiller()` can only create Promises associated with the calling thread's event loop. This is the overwhelmingly common use case for CrossThreadPromiseFulfillers.

Recently, while working on the ability to `co_await` Rust Futures across an FFI boundary, I encountered a case where it would be helpful to create Promises associated with a different thread's event loop.

To elaborate on the use case:
- Rust Futures have a `poll()` function which drives the Future to make some forward progress.
- The caller of `poll()` must pass a reference to a Waker object to `poll()`. Let's call this Waker the "initial Waker". It lives on the stack of the thread which calls `poll()`.
- Waker is an abstract interface, with any number of actual implementations.
- If the Future is not yet ready, it stores a clone of the initial Waker somewhere, and arranges to call `Waker::wake()` asynchronously on the clone when it thinks it can next make forward progress. Let's call this second Waker the "cloned Waker".
- Rust may call `Waker::wake()` on the cloned Waker from any thread.
- So, when awaiting Futures from KJ, CrossThreadPromiseFulfiller serves as a good implementation for the cloned Waker. The associated Promise can be arranged to fire an Event which calls `Future::poll()`.
- But creating a CrossThreadPromiseFulfiller has some overhead -- memory allocations, and a slow-path toward fulfilling the Promise. So ideally, we won't create the CrossThreadPromiseFulfiller unless we know we actually need it -- that is, when Rust tries to clone the initial Waker.
- The only problem: a Rust Future may clone the Waker from a different thread, as long as it does so before the call to `poll()` on the main thread returns. For this reason, it would be helpful to be able to call `newPromiseAndCrossThreadFulfiller()` from any thread.

This commit adds an `Executor::newPromiseAndCrossThreadFulfiller()` member function, which allows for the above use case. It's a very narrow use case, and unlikely to be commonly useful. But, the Rust API allows it, so I need to handle it.

~~One final note: the new function is a bit more dangerous than the existing `newPromiseAndCrossThreadFulfiller()` free function. This is because, if your code fails to transfer the created Promise back to its "home" thread before that thread exits, your process _will_ crash when the fulfiller tries to fulfill/reject the Promise (and if you destroy the fulfiller, it implicitly rejects the Promise). In the Rust use case delineated above, that synchronization naturally occurs because the Waker can only be cloned during the main thread's call to `poll()`.~~

This change exposed a footgun: callers needed to arrange to move the promise back to its native event loop before that event loop exited, or else they risk UB. To make this situation safer, the XThreadPaf now holds a strong reference to the Executor, and fulfilling such a Promise after its event loop has exited is now a no-op.