### PR TITLE
Silence log: "capability was revoked  (RevocableServer was destroyed)"

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -921,6 +921,9 @@ kj::Own<ClientHook> Capability::Client::makeRevocableLocalClient(Capability::Ser
       kj::Own<Capability::Server>(&server, kj::NullDisposer::instance), true /* revocable */);
   return result;
 }
+bool Capability::Client::isLocalClientShared(ClientHook& hook) {
+  return kj::downcast<LocalClient>(hook).isShared();
+}
 void Capability::Client::revokeLocalClientIfShared(ClientHook& hook) {
   if (kj::downcast<LocalClient>(hook).isShared()) {
     revokeLocalClient(hook);

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -302,6 +302,7 @@ private:
 
   static kj::Own<ClientHook> makeLocalClient(kj::Own<Capability::Server>&& server);
   static kj::Own<ClientHook> makeRevocableLocalClient(Capability::Server& server);
+  static bool isLocalClientShared(ClientHook& hook);
   static void revokeLocalClientIfShared(ClientHook& hook);
   static void revokeLocalClient(ClientHook& hook);
   static void revokeLocalClient(ClientHook& hook, kj::Exception&& reason);
@@ -590,6 +591,9 @@ public:
   KJ_DISALLOW_COPY(RevocableServer);
 
   typename T::Client getClient();
+
+  bool isInUse();
+  // Returns whether the capability returned by getClient() still has references outstanding.
 
   void revoke();
   void revoke(kj::Exception&& reason);
@@ -1227,6 +1231,11 @@ RevocableServer<T>::~RevocableServer() noexcept(false) {
 template <typename T>
 typename T::Client RevocableServer<T>::getClient() {
   return typename T::Client(hook->addRef());
+}
+
+template <typename T>
+bool RevocableServer<T>::isInUse() {
+  return Capability::Client::isLocalClientShared(*hook);
 }
 
 template <typename T>


### PR DESCRIPTION
Unfortunately I don't understand how this could be happening but I'm pretty sure it's benign. See comment for the full story.

This is currently the most prolific error log in production.