### PR TITLE
Website: Update link to RPC Tracer

### DIFF
--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -48,7 +48,7 @@ new languages.
 * [Wireshark Dissector Plugin](https://github.com/kaos/wireshark-plugins) by [@kaos](https://github.com/kaos)
 * [VS Code Syntax Highlighter](https://marketplace.visualstudio.com/items?itemName=xmonader.vscode-capnp) by [@xmonader](https://github.com/xmonader)
 * [IntelliJ Syntax Highlighter](https://github.com/xmonader/sercapnp) by [@xmonader](https://github.com/xmonader)
-* [RPC Tracer](https://github.com/toyota-digital-cockpit-pf/capnp-trace) by [@t-kondo-tmc](https://github.com/t-kondo-tmc)
+* [RPC Tracer](https://github.com/Toyota/capnp-trace) by [@t-kondo-tmc](https://github.com/t-kondo-tmc)
 * [Flow-IPC](https://github.com/Flow-IPC) (shared memory IPC transport in C++) by [Akamai](https://www.akamai.com) / [@ygoldfeld](https://github.com/ygoldfeld)
 
 ## Contribute Your Own!


### PR DESCRIPTION
Hi, thank you for the project.

I'd like to propose updating [the link to RPC Tracer in Tools section](https://capnproto.org/otherlang.html#:~:text=by%20%40xmonader-,RPC%20Tracer,-by%20%40t%2Dkondo).

When I've added the link in #2054 , the repository was hosted in [toyota-digital-cockpit-pf](https://github.com/toyota-digital-cockpit-pf/) organization.
But now, I can use [Toyota](https://github.com/Toyota) organization and transfer the repository into it.

This modification is not mandatory because GitHub redirects the access to legacy URL automatically.
However just I want to clean it up.