### PR TITLE
Add Arc::disown() and Arc::reown()

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -303,4 +303,22 @@ KJ_TEST("Arc Own interop") {
   EXPECT_TRUE(b);
 }
 
+KJ_TEST("Arc disown / reown") {
+  bool b = false;
+  AtomicSetTrueInDestructor* ptr = nullptr;
+
+  {
+    kj::Arc<AtomicSetTrueInDestructor> ref = kj::arc<AtomicSetTrueInDestructor>(&b);
+    ptr = ref.disown();
+  }
+
+  KJ_EXPECT(b == false);
+
+  {
+    auto ref = kj::Arc<AtomicSetTrueInDestructor>::reown(ptr);
+  }
+
+  KJ_EXPECT(b == true);
+}
+
 }  // namespace kj

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -472,6 +472,18 @@ public:
     }
   }
 
+  // Surrenders ownership of the underlying object to the caller. Unlike Own<T>::disown(), there
+  // is no need for the caller to prove they know how to dispose of the object, because the object
+  // is its own Disposer.
+  T* disown() {
+    return own.disown(own.get());
+  }
+
+  // Assume ownership of an object without incrementing its refcount. Opposite of disown().
+  static Arc reown(T* ptr) {
+    return Arc(ptr);
+  }
+
   Arc& operator=(decltype(nullptr)) {
     own = nullptr;
     return *this;


### PR DESCRIPTION
These two functions allow the user to release and later reacquire ownership of a kj::Arc<T>. This is useful for transporting an Arc across an FFI boundary, where we might only be able to pass a raw pointer.

I'm using this in a downstream PR, https://github.com/cloudflare/workerd/pull/3280, to avoid a nasty hack.