### PR TITLE
Cleanup KJ_IF_MAYBE / Maybe(nullptr) stragglers

### DIFF
--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -404,7 +404,7 @@ kj::Maybe<kj::Own<const T>> atomicAddRefWeak(const T& object) {
   if (refcounted->addRefWeakInternal()) {
     return kj::Own<const T>(&object, *refcounted);
   } else {
-    return nullptr;
+    return kj::none;
   }
 }
 

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -690,7 +690,7 @@ public:
   inline Maybe<Bounded<maxN - otherValue, T>> trySubtract(BoundedConst<otherValue>) const {
     // Subtract a number, calling func() if the result would underflow.
     if (value < otherValue) {
-      return nullptr;
+      return kj::none;
     } else {
       return Bounded<maxN - otherValue, T>(value - otherValue, unsafe);
     }

--- a/doc/cxx.md
+++ b/doc/cxx.md
@@ -584,9 +584,9 @@ void dynamicPrintValue(DynamicValue::Reader value) {
     }
     case DynamicValue::ENUM: {
       auto enumValue = value.as<DynamicEnum>();
-      KJ_IF_MAYBE(enumerant, enumValue.getEnumerant()) {
+      KJ_IF_SOME(enumerant, enumValue.getEnumerant()) {
         std::cout <<
-            enumerant->getProto().getName().cStr();
+            enumerant.getProto().getName().cStr();
       } else {
         // Unknown enum value; output raw number.
         std::cout << enumValue.getRaw();

--- a/kjdoc/tour.md
+++ b/kjdoc/tour.md
@@ -210,31 +210,28 @@ When constructing very large, complex strings -- for example, when writing a cod
 
 `kj::Maybe<T>` is either `nullptr`, or contains a `T`. In KJ-based code, nullable values should always be expressed using `kj::Maybe`. Primitive pointers should never be null. Use `kj::Maybe<T&>` instead of `T*` to express that the pointer/reference can be null.
 
-In order to dereference a `kj::Maybe`, you must use the `KJ_IF_MAYBE` macro, which behaves like an `if` statement.
+In order to dereference a `kj::Maybe`, you must use the `KJ_IF_SOME` macro, which behaves like an `if` statement.
 
 ```c++
 kj::Maybe<int> maybeI = 123;
 kj::Maybe<int> maybeJ = nullptr;
 
-KJ_IF_MAYBE(i, maybeI) {
+KJ_IF_SOME(i, maybeI) {
   // This block will execute, with `i` being a
-  // pointer into `maybeI`'s value. In a better world,
-  // `i` would be a reference rather than a pointer,
-  // but we couldn't find a way to trick the compiler
-  // into that.
-  KJ_ASSERT(*i == 123);
+  // reference to `maybeI`'s value.
+  KJ_ASSERT(i == 123);
 } else {
   KJ_FAIL_ASSERT("can't get here");
 }
 
-KJ_IF_MAYBE(j, maybeJ) {
+KJ_IF_SOME(j, maybeJ) {
   KJ_FAIL_ASSERT("can't get here");
 } else {
   // This block will execute.
 }
 ```
 
-Note that `KJ_IF_MAYBE` forces you to think about the null case. This differs from `std::optional`, which can be dereferenced using `*`, resulting in undefined behavior if the value is null.
+Note that `KJ_IF_SOME` forces you to think about the null case. This differs from `std::optional`, which can be dereferenced using `*`, resulting in undefined behavior if the value is null.
 
 Similarly, `map()` and `orDefault()` allow transforming and retrieving the stored value in a safe manner without complex control flows.
 
@@ -249,8 +246,7 @@ void handle(kj::OneOf<int, kj::String> value) {
   KJ_SWITCH_ONEOF(value) {
     KJ_CASE_ONEOF(i, int) {
       // Note that `i` is an lvalue reference to the content
-      // of the OneOf. This differs from `KJ_IF_MAYBE` where
-      // the variable is a pointer.
+      // of the OneOf, similar to `KJ_IF_SOME`.
       handleInt(i);
     }
     KJ_CASE_ONEOF(s, kj::String) {
@@ -431,7 +427,7 @@ kj::throwFatalException(kj::mv(e));
 kj::Maybe<kj::Exception> maybeException = kj::runCatchingExceptions([&]() {
   doSomething();
 });
-KJ_IF_MAYBE(e, maybeException) {
+KJ_IF_SOME(e, maybeException) {
   // handle exception
 }
 ```


### PR DESCRIPTION
Using the KJ_IF_MAYBE macro and using `nullptr` to mean an empty Maybe are deprecated. This cleans up a few last places we have them.