### PR TITLE
Reject unfulfilled promises on WaiterQueue destruction.

### DIFF
--- a/c++/src/kj/async-queue.h
+++ b/c++/src/kj/async-queue.h
@@ -41,6 +41,14 @@ public:
   WaiterQueue() = default;
   KJ_DISALLOW_COPY_AND_MOVE(WaiterQueue);
 
+  ~WaiterQueue() noexcept(false) {
+    while (!empty()) {
+      reject(KJ_EXCEPTION(FAILED, "WaiterQueue destroyed while some promises returned by wait()"
+        " are still outstanding. This is undefined behavior. You must cancel all promises before"
+        " destroying the WaiterQueue."));
+    }
+  }
+
   Promise<T> wait() {
     return newAdaptedPromise<T, Node>(queue);
   }


### PR DESCRIPTION
When a `WaiterQueue` is destroyed with unfulfilled promises, these promises become "dangling". I.e. waiting on them will hang indefinitely. This PR changes that by rejecting all unfulfilled promises remaining in the queue.