### PR TITLE
Add Thread::getCpuTime() to read another thread's CPU usage.

### DIFF
--- a/c++/src/kj/thread-test.c++
+++ b/c++/src/kj/thread-test.c++
@@ -21,6 +21,7 @@
 
 #include "thread.h"
 #include "test.h"
+#include "mutex.h"
 #include <atomic>
 
 #if _WIN32
@@ -119,6 +120,61 @@ KJ_TEST("threads pick up exception callback initializer") {
   });
   KJ_EXPECT(context.captured == "foobar", context.captured);
 }
+
+#if !__APPLE__  // Mac doesn't implement pthread_getcpuclockid().
+static kj::Duration threadCpuNow() {
+#if _WIN32
+  FILETIME creationTime;
+  FILETIME exitTime;
+  FILETIME kernelTime;
+  FILETIME userTime;
+
+  KJ_WIN32(GetThreadTimes(GetCurrentThread(), &creationTime, &exitTime, &kernelTime, &userTime));
+
+  // FILETIME is a 64-bit integer split into two 32-bit pieces, with a base unit of 100ns.
+  int64_t utime = (static_cast<uint64_t>(userTime.dwHighDateTime) << 32) | userTime.dwLowDateTime;
+  int64_t ktime = (static_cast<uint64_t>(kernelTime.dwHighDateTime) << 32) | kernelTime.dwLowDateTime;
+  return (utime + ktime) * 100 * kj::NANOSECONDS;
+#else
+  struct timespec ts;
+  KJ_SYSCALL(clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts));
+  return ts.tv_sec * kj::SECONDS + ts.tv_nsec * kj::NANOSECONDS;
+#endif
+}
+
+KJ_TEST("Thread::getCpuTime()") {
+  enum State { INIT, RUNNING, DONE, EXIT };
+  MutexGuarded<State> state(INIT);
+  auto waitForState = [&](State expected) {
+    state.when([&](State s) { return s == expected; }, [](State) {});
+  };
+
+  Thread thread([&]() {
+    waitForState(RUNNING);
+    while (threadCpuNow() < 10 * MILLISECONDS) {}
+    *state.lockExclusive() = DONE;
+    waitForState(EXIT);
+  });
+
+  // CPU time should start at zero.
+  KJ_EXPECT(thread.getCpuTime() <= 5 * MILLISECONDS);
+
+  // Signal thread to start running, and wait for it to finish.
+  *state.lockExclusive() = RUNNING;
+  waitForState(DONE);
+
+  // Now CPU time should reflect that the thread burned 10ms.
+  KJ_EXPECT(thread.getCpuTime() >= 10 * MILLISECONDS);
+
+  // The thread should have gone to sleep basically immediately after hitting 10ms but we'll give
+  // it a wide margin for error to avoid flakes.
+  KJ_EXPECT(thread.getCpuTime() < 100 * MILLISECONDS);
+
+  // Signal the thread to exit. Note that getCpuTime() may fail if called after the thread exit,
+  // hence why we had to delay it.
+  *state.lockExclusive() = EXIT;
+}
+#endif  // !__APPLE__
 
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/thread.h
+++ b/c++/src/kj/thread.h
@@ -24,6 +24,7 @@
 #include "common.h"
 #include "function.h"
 #include "exception.h"
+#include "time.h"
 
 KJ_BEGIN_HEADER
 
@@ -47,6 +48,13 @@ public:
 
   void detach();
   // Don't join the thread in ~Thread().
+
+#if !__APPLE__  // Mac doesn't implement pthread_getcpuclockid().
+  kj::Duration getCpuTime() const;
+  // Get the total CPU time consumed by the thread.
+  //
+  // This may fail if the thread has already exited.
+#endif  // !__APPLE__
 
 private:
   struct ThreadState {


### PR DESCRIPTION
(Blind-coded the Windows version, let's see if it works in CI...)