### PR TITLE
Fix crash scenario in TaskSet::trace

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2545,7 +2545,7 @@ void ForkBranchBase::onReady(Event* event) noexcept {
 void ForkBranchBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
   if (stopAtNextEvent) return;
 
-  if (hub.get() != nullptr) {
+  if (hub.get() != nullptr && hub->inner.get() != nullptr) {
     hub->inner->tracePromise(builder, false);
   }
 


### PR DESCRIPTION
Without the change in `async.c++`, the newly added test would throw when `TaskSet::trace()` gets called:
```
[ TEST ] async-test.c++:1227: TaskSet::trace() on forked promise                                                                                                                                                                                        
kj/_virtual_includes/kj/kj/memory.h:433: failed: expected ptr != nullptr; null Own<> dereference                                                                                                                                                        
stack: <redacted>

kj::_::inlineRequireFailure(char const*, int, char const*, char const*, char const*)                                                                                                                                                                    
src/kj/common.c++:36:7                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                        
kj::Own<kj::_::PromiseNode, kj::_::PromiseDisposer>::operator->()                                                                                                                                                                                       
bazel-out/k8-dbg/bin/src/kj/_virtual_includes/kj/kj/memory.h:433:28                                                                                                                                                                                     
                                                                                                                                                                                                                                                        
kj::_::ForkBranchBase::tracePromise(kj::_::TraceBuilder&, bool)                                                                                                                                                                                         
src/kj/async.c++:2549:5                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                        
kj::_::TransformPromiseNodeBase::tracePromise(kj::_::TraceBuilder&, bool)                                                                                                                                                                               
src/kj/async.c++:2484:17                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                        
kj::TaskSet::Task::trace()                                                                                                                                                                                                                              
src/kj/async.c++:313:11                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                        
kj::TaskSet::trace()                                                                                                                                                                                                                                    
src/kj/async.c++:382:24                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                        
kj::(anonymous namespace)::TestCase1227::run()                                                                                                                                                                                                          
src/kj/async-test.c++:1255:22                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                        
kj::TestRunner::run()::'lambda'()::operator()() const                                                                                                                                                                                                   
src/kj/test.c++:264:11                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                        
kj::Maybe<kj::Exception> kj::runCatchingExceptions<kj::TestRunner::run()::'lambda'()>(kj::TestRunner::run()::'lambda'()&&)                                                                                                                              
bazel-out/k8-dbg/bin/src/kj/_virtual_includes/kj/kj/exception.h:366:5                                                                                                                                                                                   
                                                                                                                                                                                                                                                        
[ FAIL ] async-test.c++:1227: TaskSet::trace() on forked promise (48197 μs)
```