### PR TITLE
Platform-dependent fix for root permissions error

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -1675,7 +1675,25 @@ private:
   Path currentPath;
 
   static OwnFd openDir(const char* dir) {
-    auto result = KJ_SYSCALL_FD(open(dir, O_RDONLY | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY));
+    int fd;
+    KJ_SYSCALL_HANDLE_ERRORS(fd = open(dir, O_RDONLY | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY)) {
+      case EACCES:
+        // If we don't have read permission, fall back to O_PATH if available
+#ifdef O_PATH
+        {
+          auto result = KJ_SYSCALL_FD(open(dir, O_PATH | MAYBE_O_CLOEXEC | MAYBE_O_DIRECTORY));
+#ifndef O_CLOEXEC
+          setCloexec(result);
+#endif
+          return result;
+        }
+	KJ_FALLTHROUGH;
+#endif
+      default:
+        KJ_FAIL_SYSCALL("open(dir, O_RDONLY)", error, dir);
+    }
+
+    auto result = OwnFd(fd);
 #ifndef O_CLOEXEC
     setCloexec(result);
 #endif


### PR DESCRIPTION
At least Linux (including Android) and FreeBSD provide an extension for `open`, [O_PATH](https://man7.org/linux/man-pages/man2/open.2.html#:~:text=O_PATH%20(since%20Linux%202.6.39)), that is essentially an inode-only reference; it avoids potential permission issues. When available, replacing O_RDONLY with it in DiskFilesystem's openDir appears to be compatible with capnproto's use case.

When compiling for Android API >= 30 (for memfd_create), testing on an Android device passes all tests except the DiskDirectory hard linking test (https://github.com/capnproto/capnproto/blob/20af9fe2de10a2e7f621a212351d20860cc32a0d/c%2B%2B/src/kj/filesystem-disk-test.c%2B%2B#L605) , which is not allowed on Android. (Could only test on Android without fibers, as some parts of libucontext will fail.)

Fixes https://github.com/capnproto/capnproto/issues/1768 .