### PR TITLE
Remove KJ_LIFETIMEBOUND from StringPtr constructor.

### DIFF
--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -80,7 +80,7 @@ public:
   }
   inline constexpr StringPtr(const char* begin KJ_LIFETIMEBOUND, const char* end KJ_LIFETIMEBOUND): StringPtr(begin, end - begin) {}
   inline constexpr StringPtr(String&& value KJ_LIFETIMEBOUND) : StringPtr(value) {}
-  inline constexpr StringPtr(const String& value KJ_LIFETIMEBOUND);
+  inline constexpr StringPtr(const String& value);
   inline constexpr StringPtr(const ConstString& value KJ_LIFETIMEBOUND);
   StringPtr& operator=(String&& value) = delete;
   inline StringPtr& operator=(decltype(nullptr)) {


### PR DESCRIPTION
KJ_LIFETIMEBOUND causes false alarms when compiling with clang 21.

For example in workerd:

```
bazel-out/k8-dbg/bin/external/workerd/src/workerd/io/_virtual_includes/io/workerd/api/streams/../basics.h:36:14: error: initializing pointer member 'type' with the stack address of parameter 'ownType' [-Werror,-Wdangling-field]
   36 |       : type(ownType),
      |              ^~~~~~~
bazel-out/k8-dbg/bin/external/workerd/src/workerd/io/_virtual_includes/io/workerd/api/streams/../basics.h:198:17: note: pointer member declared here
  198 |   kj::StringPtr type;
      |                 ^
```