### PR TITLE
Support large ws messages over capnp

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -1049,9 +1049,9 @@ public:
     ByteStreamFactory streamFactory2;
     kj::HttpHeaderTable::Builder tableBuilder;
     HttpOverCapnpFactory clientFactory(streamFactory1, tableBuilder,
-                                       TEST_PEER_OPTIMIZATION_LEVEL);
+                                       HttpOverCapnpFactory::LEVEL_2);
     HttpOverCapnpFactory serverFactory(streamFactory2, tableBuilder,
-                                       TEST_PEER_OPTIMIZATION_LEVEL);
+                                       HttpOverCapnpFactory::LEVEL_2);
     auto headerTable = tableBuilder.build();
     auto donePaf = kj::newPromiseAndFulfiller<void>();
     auto back = serverFactory.kjToCapnp(kj::heap<DummyWebSocketAccepter>(

--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -84,6 +84,12 @@ interface HttpService {
     #
     # Client -> Server WebSocket frames will be sent via method calls on `upSocket`, while
     # Server -> Client will be sent as calls to `downSocket`.
+
+    startOptimizedWebSocket @2 (headers :List(HttpHeader), upStream :ByteStream)
+                            -> (downStream :ByteStream);
+    # Server calls this method when the request is a valid WebSocket handshake and it wishes to
+    # accept it as a WebSocket but optimized pumping should be enabled, this is useful to enable
+    # pumping large messages back and forth over http-over-capnp.
   }
 
   interface ConnectClientRequestContext {


### PR DESCRIPTION
* Still in draft stage, gotta make sure all internal tests are passing before actual review.
* This should be mostly close to the final implementation.
* For now this explicitly does not handle WS with extension headers.