### PR TITLE
kj::Arc::addRef() const version

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -321,4 +321,12 @@ KJ_TEST("Arc disown / reown") {
   KJ_EXPECT(b == true);
 }
 
+
+KJ_TEST("Arc<const T>") {
+  bool b = false;
+
+  const kj::Arc<AtomicSetTrueInDestructor> ref1 = kj::arc<AtomicSetTrueInDestructor>(&b);
+  kj::Arc<const AtomicSetTrueInDestructor> ref2 = ref1.addRef();
+}
+
 }  // namespace kj

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -472,6 +472,15 @@ public:
     }
   }
 
+  kj::Arc<const T> addRef() const {
+    const T* refcounted = own.get();
+    if (refcounted != nullptr) {
+      return AtomicRefcounted::addRcRefInternal(refcounted);
+    } else {
+      return kj::Arc<T>();
+    }
+  }
+  
   // Surrenders ownership of the underlying object to the caller. Unlike Own<T>::disown(), there
   // is no need for the caller to prove they know how to dispose of the object, because the object
   // is its own Disposer.


### PR DESCRIPTION
const in KJ means here "thread-safe", expose the const version of addRef.