### PR TITLE
defining arrayptr-based AsyncInputStream methods

### DIFF
--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -61,6 +61,16 @@ public:
 
   Promise<void> read(void* buffer, size_t bytes);
 
+  Promise<size_t> read(ArrayPtr<byte> buffer, size_t minBytes) { 
+    return read(buffer.begin(), minBytes, buffer.size()); 
+  }
+  Promise<size_t> tryRead(ArrayPtr<byte> buffer, size_t minBytes) {
+    return tryRead(buffer.begin(), minBytes, buffer.size()); 
+  }
+  Promise<void> read(ArrayPtr<byte> buffer) {
+    return read(buffer.begin(), buffer.size());
+  }
+
   virtual Maybe<uint64_t> tryGetLength();
   // Get the remaining number of bytes that will be produced by this stream, if known.
   //


### PR DESCRIPTION
This is part 1 of N of async input stream refactoring. Previously I tried to do everything at once but ultimately wasn't successful given the complexity of managing 2 downstreams.

This time I am picking a more gradual approach that will let me migrate clients first and then implementations.