### PR TITLE
Expose socketpair creation in async-io

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1987,28 +1987,18 @@ public:
   }
 
   TwoWayPipe newTwoWayPipe() override {
-    int fds[2];
-    int type = SOCK_STREAM;
-#if __linux__ && !__BIONIC__
-    type |= SOCK_NONBLOCK | SOCK_CLOEXEC;
-#endif
-    KJ_SYSCALL(socketpair(AF_UNIX, type, 0, fds));
+    auto socketpair = newOsSocketpair();
     return TwoWayPipe { {
-      lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS),
-      lowLevel.wrapSocketFd(fds[1], NEW_FD_FLAGS)
+      lowLevel.wrapSocketFd(kj::mv(socketpair.fds[0]), NEW_FD_FLAGS),
+      lowLevel.wrapSocketFd(kj::mv(socketpair.fds[1]), NEW_FD_FLAGS)
     } };
   }
 
   CapabilityPipe newCapabilityPipe() override {
-    int fds[2];
-    int type = SOCK_STREAM;
-#if __linux__ && !__BIONIC__
-    type |= SOCK_NONBLOCK | SOCK_CLOEXEC;
-#endif
-    KJ_SYSCALL(socketpair(AF_UNIX, type, 0, fds));
+    auto socketpair = newOsSocketpair();
     return CapabilityPipe { {
-      lowLevel.wrapUnixSocketFd(fds[0], NEW_FD_FLAGS),
-      lowLevel.wrapUnixSocketFd(fds[1], NEW_FD_FLAGS)
+      lowLevel.wrapUnixSocketFd(kj::mv(socketpair.fds[0]), NEW_FD_FLAGS),
+      lowLevel.wrapUnixSocketFd(kj::mv(socketpair.fds[1]), NEW_FD_FLAGS)
     } };
   }
 
@@ -2018,23 +2008,15 @@ public:
 
   PipeThread newPipeThread(
       Function<void(AsyncIoProvider&, AsyncIoStream&, WaitScope&)> startFunc) override {
-    int fds[2];
-    int type = SOCK_STREAM;
-#if __linux__ && !__BIONIC__
-    type |= SOCK_NONBLOCK | SOCK_CLOEXEC;
-#endif
-    KJ_SYSCALL(socketpair(AF_UNIX, type, 0, fds));
+    auto socketpair = newOsSocketpair();
 
-    int threadFd = fds[1];
-    KJ_ON_SCOPE_FAILURE(close(threadFd));
-
-    auto pipe = lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS);
-
-    auto thread = heap<Thread>([threadFd,startFunc=kj::mv(startFunc)]() mutable {
-      LowLevelAsyncIoProviderImpl lowLevel;
-      auto stream = lowLevel.wrapSocketFd(threadFd, NEW_FD_FLAGS);
+    auto pipe = lowLevel.wrapSocketFd(kj::mv(socketpair.fds[0]), NEW_FD_FLAGS);
+    auto thread = heap<Thread>([threadFd=kj::mv(socketpair.fds[1]),startFunc=kj::mv(startFunc)]() mutable {
+      LowLevelAsyncIoProviderImpl lowLevelImpl;
+      LowLevelAsyncIoProvider& lowLevel = lowLevelImpl;
+      auto stream = lowLevel.wrapSocketFd(kj::mv(threadFd), NEW_FD_FLAGS);
       AsyncIoProviderImpl ioProvider(lowLevel);
-      startFunc(ioProvider, *stream, lowLevel.getWaitScope());
+      startFunc(ioProvider, *stream, lowLevelImpl.getWaitScope());
     });
 
     return { kj::mv(thread), kj::mv(pipe) };
@@ -2048,6 +2030,17 @@ private:
 };
 
 }  // namespace
+
+Socketpair newOsSocketpair() {
+  LowLevelAsyncIoProvider::Fd socketpairFds[2];
+  int type = SOCK_STREAM;
+#if __linux__ && !__BIONIC__
+  type |= SOCK_NONBLOCK | SOCK_CLOEXEC;
+#endif
+  KJ_SYSCALL(socketpair(AF_UNIX, type, 0, socketpairFds));
+  return Socketpair{{LowLevelAsyncIoProvider::OwnFd{socketpairFds[0]}, 
+                     LowLevelAsyncIoProvider::OwnFd{socketpairFds[1]}}};
+}
 
 Own<AsyncIoProvider> newAsyncIoProvider(LowLevelAsyncIoProvider& lowLevel) {
   return kj::heap<AsyncIoProviderImpl>(lowLevel);

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -95,8 +95,6 @@ int win32Socketpair(SOCKET socks[2]) {
 
   // Note: This function is called from some Cap'n Proto unit tests, despite not having a public
   //   header declaration.
-  // TODO(cleanup): Consider putting this somewhere public? Note that since it depends on Winsock,
-  //   it needs to be in the kj-async library.
 
   initWinsockOnce();
 
@@ -1123,20 +1121,18 @@ public:
       : lowLevel(lowLevel), network(lowLevel) {}
 
   OneWayPipe newOneWayPipe() override {
-    SOCKET fds[2];
-    KJ_WINSOCK(_::win32Socketpair(fds));
-    auto in = lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS);
-    auto out = lowLevel.wrapOutputFd(fds[1], NEW_FD_FLAGS);
+    auto socketpair = newOsSocketpair();
+    auto in = lowLevel.wrapSocketFd(kj::mv(socketpair.fds[0]), NEW_FD_FLAGS);
+    auto out = lowLevel.wrapOutputFd(kj::mv(socketpair.fds[1]), NEW_FD_FLAGS);
     in->shutdownWrite();
     return { kj::mv(in), kj::mv(out) };
   }
 
   TwoWayPipe newTwoWayPipe() override {
-    SOCKET fds[2];
-    KJ_WINSOCK(_::win32Socketpair(fds));
+    auto socketpair = newOsSocketpair();
     return TwoWayPipe { {
-      lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS),
-      lowLevel.wrapSocketFd(fds[1], NEW_FD_FLAGS)
+      lowLevel.wrapSocketFd(kj::mv(socketpair.fds[0]), NEW_FD_FLAGS),
+      lowLevel.wrapSocketFd(kj::mv(socketpair.fds[1]), NEW_FD_FLAGS)
     } };
   }
 
@@ -1146,19 +1142,16 @@ public:
 
   PipeThread newPipeThread(
       Function<void(AsyncIoProvider&, AsyncIoStream&, WaitScope&)> startFunc) override {
-    SOCKET fds[2];
-    KJ_WINSOCK(_::win32Socketpair(fds));
+    auto socketpair = newOsSocketpair();
 
-    int threadFd = fds[1];
-    KJ_ON_SCOPE_FAILURE(closesocket(threadFd));
+    auto pipe = lowLevel.wrapSocketFd(kj::mv(socketpair.fds[0]), NEW_FD_FLAGS);
 
-    auto pipe = lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS);
-
-    auto thread = heap<Thread>([threadFd,startFunc=kj::mv(startFunc)]() mutable {
-      LowLevelAsyncIoProviderImpl lowLevel;
-      auto stream = lowLevel.wrapSocketFd(threadFd, NEW_FD_FLAGS);
+    auto thread = heap<Thread>([threadFd=kj::mv(socketpair.fds[1]),startFunc=kj::mv(startFunc)]() mutable {
+      LowLevelAsyncIoProviderImpl lowLevelImpl;
+      LowLevelAsyncIoProvider& lowLevel = lowLevelImpl;
+      auto stream = lowLevel.wrapSocketFd(kj::mv(threadFd), NEW_FD_FLAGS);
       AsyncIoProviderImpl ioProvider(lowLevel);
-      startFunc(ioProvider, *stream, lowLevel.getWaitScope());
+      startFunc(ioProvider, *stream, lowLevelImpl.getWaitScope());
     });
 
     return { kj::mv(thread), kj::mv(pipe) };
@@ -1172,6 +1165,13 @@ private:
 };
 
 }  // namespace
+
+Socketpair newOsSocketpair() {
+  LowLevelAsyncIoProvider::Fd socketpairFds[2];
+  KJ_WINSOCK(_::win32Socketpair(socketpairFds));
+  return Socketpair{{LowLevelAsyncIoProvider::OwnFd{reinterpret_cast<void*>(socketpairFds[0])}, 
+                     LowLevelAsyncIoProvider::OwnFd{reinterpret_cast<void*>(socketpairFds[1])}}};
+}
 
 Own<AsyncIoProvider> newAsyncIoProvider(LowLevelAsyncIoProvider& lowLevel) {
   return kj::heap<AsyncIoProviderImpl>(lowLevel);

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -904,6 +904,16 @@ public:
   // (Windows). TAKE_OWNERSHIP will be implicitly added to `flags`.
 };
 
+template <typename T> struct Socketpair_ { T fds[2]; };
+using Socketpair = Socketpair_<LowLevelAsyncIoProvider::OwnFd>;
+// We use a template to work around the fact that LowLevelAsyncIoProvider::OwnFd
+// is an incomplete type, without having to include the io.h header.
+
+Socketpair newOsSocketpair();
+// Creates a socket pair, using socketpair(2) on Unix-like systems.
+// On Windows, which doesn't have a built-in socketpair(), a loopback
+// TCP connection is used.
+
 Own<AsyncIoProvider> newAsyncIoProvider(LowLevelAsyncIoProvider& lowLevel);
 // Make a new AsyncIoProvider wrapping a `LowLevelAsyncIoProvider`.
 


### PR DESCRIPTION
AsyncIoProvider has a "newPipeThread" function that spawns a thread that can be communicated with through the returned pipe.

Users can't always change the way threads in their application are spawned, so "newPipeThread" can't always be used. In those cases, it is better to give users access to the lower-level tools and let them create the pipe themselves.

By exposing newSocketpair(), it is fairly easy to setup cross-thread communication.