### PR TITLE
nit: use _kj and _kjb where possible

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -110,16 +110,16 @@ struct JsonCodec::Impl {
     escaped.add('"');
     for (char c: chars) {
       switch (c) {
-        case '\"': escaped.addAll(kj::StringPtr("\\\"")); break;
-        case '\\': escaped.addAll(kj::StringPtr("\\\\")); break;
-        case '\b': escaped.addAll(kj::StringPtr("\\b")); break;
-        case '\f': escaped.addAll(kj::StringPtr("\\f")); break;
-        case '\n': escaped.addAll(kj::StringPtr("\\n")); break;
-        case '\r': escaped.addAll(kj::StringPtr("\\r")); break;
-        case '\t': escaped.addAll(kj::StringPtr("\\t")); break;
+        case '\"': escaped.addAll("\\\""_kj); break;
+        case '\\': escaped.addAll("\\\\"_kj); break;
+        case '\b': escaped.addAll("\\b"_kj); break;
+        case '\f': escaped.addAll("\\f"_kj); break;
+        case '\n': escaped.addAll("\\n"_kj); break;
+        case '\r': escaped.addAll("\\r"_kj); break;
+        case '\t': escaped.addAll("\\t"_kj); break;
         default:
           if (static_cast<uint8_t>(c) < 0x20) {
-            escaped.addAll(kj::StringPtr("\\u00"));
+            escaped.addAll("\\u00"_kj);
             uint8_t c2 = c;
             escaped.add(HEXDIGITS[c2 / 16]);
             escaped.add(HEXDIGITS[c2 % 16]);
@@ -652,9 +652,9 @@ public:
     KJ_REQUIRE(!input.exhausted(), "JSON message ends prematurely.");
 
     switch (input.nextChar()) {
-      case 'n': input.consume(kj::StringPtr("null"));  output.setNull();         break;
-      case 'f': input.consume(kj::StringPtr("false")); output.setBoolean(false); break;
-      case 't': input.consume(kj::StringPtr("true"));  output.setBoolean(true);  break;
+      case 'n': input.consume("null"_kj);  output.setNull();         break;
+      case 'f': input.consume("false"_kj); output.setBoolean(false); break;
+      case 't': input.consume("true"_kj);  output.setBoolean(true);  break;
       case '"': parseString(output); break;
       case '[': parseArray(output);  break;
       case '{': parseObject(output); break;

--- a/c++/src/kj/compat/brotli-test.c++
+++ b/c++/src/kj/compat/brotli-test.c++
@@ -359,10 +359,7 @@ KJ_TEST("async brotli compression") {
     MockAsyncOutputStream rawOutput;
     BrotliAsyncOutputStream brotli(rawOutput);
 
-    ArrayPtr<const byte> pieces[] = {
-      kj::StringPtr("foo").asBytes(),
-      kj::StringPtr("bar").asBytes(),
-    };
+    ArrayPtr<const byte> pieces[] = { "foo"_kjb, "bar"_kjb };
     brotli.write(pieces).wait(io.waitScope);
     brotli.end().wait(io.waitScope);
 

--- a/c++/src/kj/compat/gzip-test.c++
+++ b/c++/src/kj/compat/gzip-test.c++
@@ -318,10 +318,7 @@ KJ_TEST("async gzip compression") {
     MockAsyncOutputStream rawOutput;
     GzipAsyncOutputStream gzip(rawOutput);
 
-    ArrayPtr<const byte> pieces[] = {
-      kj::StringPtr("foo").asBytes(),
-      kj::StringPtr("bar").asBytes(),
-    };
+    ArrayPtr<const byte> pieces[] = { "foo"_kjb, "bar"_kjb };
     gzip.write(pieces).wait(io.waitScope);
     gzip.end().wait(io.waitScope);
 

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1715,7 +1715,7 @@ KJ_TEST("WebSocket core protocol") {
   auto clientTask = client->send(kj::StringPtr("hello"))
       .then([&]() { return client->send(mediumString); })
       .then([&]() { return client->send(bigString); })
-      .then([&]() { return client->send(kj::StringPtr("world").asBytes()); })
+      .then([&]() { return client->send("world"_kjb); })
       .then([&]() { return client->close(1234, "bored"); })
       .then([&]() { KJ_EXPECT(client->sentByteCount() == 90307)});
 

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1057,13 +1057,13 @@ bool HttpHeaders::parseHeaders(char* ptr, char* end) {
 kj::String HttpHeaders::serializeRequest(
     HttpMethod method, kj::StringPtr url,
     kj::ArrayPtr<const kj::StringPtr> connectionHeaders) const {
-  return serialize(kj::toCharSequence(method), url, kj::StringPtr("HTTP/1.1"), connectionHeaders);
+  return serialize(kj::toCharSequence(method), url, "HTTP/1.1"_kj, connectionHeaders);
 }
 
 kj::String HttpHeaders::serializeConnectRequest(
     kj::StringPtr authority,
     kj::ArrayPtr<const kj::StringPtr> connectionHeaders) const {
-  return serialize("CONNECT"_kj, authority, kj::StringPtr("HTTP/1.1"), connectionHeaders);
+  return serialize("CONNECT"_kj, authority, "HTTP/1.1"_kj, connectionHeaders);
 }
 
 kj::String HttpHeaders::serializeResponse(
@@ -1071,7 +1071,7 @@ kj::String HttpHeaders::serializeResponse(
     kj::ArrayPtr<const kj::StringPtr> connectionHeaders) const {
   auto statusCodeStr = kj::toCharSequence(statusCode);
 
-  return serialize(kj::StringPtr("HTTP/1.1"), statusCodeStr, statusText, connectionHeaders);
+  return serialize("HTTP/1.1"_kj, statusCodeStr, statusText, connectionHeaders);
 }
 
 kj::String HttpHeaders::serialize(kj::ArrayPtr<const char> word1,

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2566,7 +2566,7 @@ public:
     auto parts = kj::heapArray<ArrayPtr<const byte>>(3);
     parts[0] = header.asBytes();
     parts[1] = buffer;
-    parts[2] = kj::StringPtr("\r\n").asBytes();
+    parts[2] = "\r\n"_kjb;
 
     auto promise = getInner().writeBodyData(parts.asPtr());
     return promise.attach(kj::mv(header), kj::mv(parts));
@@ -2584,7 +2584,7 @@ public:
     for (auto& piece: pieces) {
       partsBuilder.add(piece);
     }
-    partsBuilder.add(kj::StringPtr("\r\n").asBytes());
+    partsBuilder.add("\r\n"_kjb);
 
     auto parts = partsBuilder.finish();
     auto promise = getInner().writeBodyData(parts.asPtr());

--- a/c++/src/kj/compat/readiness-io-test.c++
+++ b/c++/src/kj/compat/readiness-io-test.c++
@@ -34,7 +34,7 @@ KJ_TEST("readiness IO: write small") {
   auto readPromise = pipe.in->read(buf, 3, 4);
 
   ReadyOutputStreamWrapper out(*pipe.out);
-  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write(kj::StringPtr("foo").asBytes())) == 3);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write("foo"_kjb)) == 3);
 
   KJ_ASSERT(readPromise.wait(io.waitScope) == 3);
   buf[3] = '\0';
@@ -49,7 +49,7 @@ KJ_TEST("readiness IO: write many odd") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_SOME(n, out.write(kj::StringPtr("bar").asBytes())) {
+    KJ_IF_SOME(n, out.write("bar"_kjb)) {
       totalWritten += n;
       if (n < 3) {
         break;
@@ -75,7 +75,7 @@ KJ_TEST("readiness IO: write even") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_SOME(n, out.write(kj::StringPtr("ba").asBytes())) {
+    KJ_IF_SOME(n, out.write("ba"_kjb)) {
       totalWritten += n;
       if (n < 2) {
         KJ_FAIL_ASSERT("pipe buffer is not divisible by 2? really?");
@@ -102,13 +102,13 @@ KJ_TEST("readiness IO: write while corked") {
 
   ReadyOutputStreamWrapper out(*pipe.out);
   auto cork = out.cork();
-  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write(kj::StringPtr("foo").asBytes())) == 3);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write("foo"_kjb)) == 3);
 
   // Data hasn't been written yet.
   KJ_ASSERT(!readPromise.poll(io.waitScope));
 
   // Write some more, and observe it still isn't flushed out yet.
-  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write(kj::StringPtr("bar").asBytes())) == 3);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write("bar"_kjb)) == 3);
   KJ_ASSERT(!readPromise.poll(io.waitScope));
 
   // After reenabling pumping, the full read should succeed.
@@ -133,7 +133,7 @@ KJ_TEST("readiness IO: write many odd while corked") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_SOME(n, out.write(kj::StringPtr("bar").asBytes())) {
+    KJ_IF_SOME(n, out.write("bar"_kjb)) {
       totalWritten += n;
       if (n < 3) {
         break;
@@ -151,7 +151,7 @@ KJ_TEST("readiness IO: write many odd while corked") {
   }
 
   // Eager pumping should still be corked.
-  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write(kj::StringPtr("bar").asBytes())) == 3);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write("bar"_kjb)) == 3);
   auto readPromise = pipe.in->read(buf.begin(), 3, buf.size());
   KJ_ASSERT(!readPromise.poll(io.waitScope));
 }
@@ -165,7 +165,7 @@ KJ_TEST("readiness IO: write many even while corked") {
 
   size_t totalWritten = 0;
   for (;;) {
-    KJ_IF_SOME(n, out.write(kj::StringPtr("ba").asBytes())) {
+    KJ_IF_SOME(n, out.write("ba"_kjb)) {
       totalWritten += n;
       if (n < 2) {
         KJ_FAIL_ASSERT("pipe buffer is not divisible by 2? really?");
@@ -183,7 +183,7 @@ KJ_TEST("readiness IO: write many even while corked") {
   }
 
   // Eager pumping should still be corked.
-  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write(kj::StringPtr("ba").asBytes())) == 2);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(out.write("ba"_kjb)) == 2);
   auto readPromise = pipe.in->read(buf.begin(), 2, buf.size());
   KJ_ASSERT(!readPromise.poll(io.waitScope));
 }

--- a/c++/src/kj/compat/url.c++
+++ b/c++/src/kj/compat/url.c++
@@ -427,7 +427,7 @@ String Url::toString(Context context) const {
 
   if (context != HTTP_REQUEST) {
     chars.addAll(scheme);
-    chars.addAll(StringPtr("://"));
+    chars.addAll("://"_kj);
 
     if (context == REMOTE_HREF) {
       KJ_IF_SOME(user, userInfo) {
@@ -451,7 +451,7 @@ String Url::toString(Context context) const {
       chars.addAll(host);
     } else {
       KJ_FAIL_REQUIRE("invalid hostname when stringifying URL", host) {
-        chars.addAll(StringPtr("invalid-host"));
+        chars.addAll("invalid-host"_kj);
         break;
       }
     }

--- a/c++/src/kj/encoding-test.c++
+++ b/c++/src/kj/encoding-test.c++
@@ -415,13 +415,13 @@ KJ_TEST("C escape encoding/decoding") {
 
 KJ_TEST("base64 encoding/decoding") {
   {
-    auto encoded = encodeBase64(StringPtr("").asBytes(), false);
+    auto encoded = encodeBase64(""_kjb, false);
     KJ_EXPECT(encoded == "", encoded, encoded.size());
     KJ_EXPECT(heapString(decodeBase64(encoded.asArray()).asChars()) == "");
   }
 
   {
-    auto encoded = encodeBase64(StringPtr("foo").asBytes(), false);
+    auto encoded = encodeBase64("foo"_kjb, false);
     KJ_EXPECT(encoded == "Zm9v", encoded, encoded.size());
     auto decoded = decodeBase64(encoded.asArray());
     KJ_EXPECT(!decoded.hadErrors);
@@ -429,13 +429,13 @@ KJ_TEST("base64 encoding/decoding") {
   }
 
   {
-    auto encoded = encodeBase64(StringPtr("quux").asBytes(), false);
+    auto encoded = encodeBase64("quux"_kjb, false);
     KJ_EXPECT(encoded == "cXV1eA==", encoded, encoded.size());
     KJ_EXPECT(heapString(decodeBase64(encoded.asArray()).asChars()) == "quux");
   }
 
   {
-    auto encoded = encodeBase64(StringPtr("corge").asBytes(), false);
+    auto encoded = encodeBase64("corge"_kjb, false);
     KJ_EXPECT(encoded == "Y29yZ2U=", encoded);
     auto decoded = decodeBase64(encoded.asArray());
     KJ_EXPECT(!decoded.hadErrors);
@@ -468,7 +468,7 @@ KJ_TEST("base64 encoding/decoding") {
   KJ_EXPECT(decodeBase64("ab=c").hadErrors);
 
   {
-    auto encoded = encodeBase64(StringPtr("corge").asBytes(), true);
+    auto encoded = encodeBase64("corge"_kjb, true);
     KJ_EXPECT(encoded == "Y29yZ2U=\n", encoded);
   }
 
@@ -505,21 +505,21 @@ KJ_TEST("base64 encoding/decoding") {
 KJ_TEST("base64 url encoding") {
   {
     // Handles empty.
-    auto encoded = encodeBase64Url(StringPtr("").asBytes());
+    auto encoded = encodeBase64Url(""_kjb);
     KJ_EXPECT(encoded == "", encoded, encoded.size());
   }
 
   {
     // Handles paddingless encoding.
-    auto encoded = encodeBase64Url(StringPtr("foo").asBytes());
+    auto encoded = encodeBase64Url("foo"_kjb);
     KJ_EXPECT(encoded == "Zm9v", encoded, encoded.size());
   }
 
   {
     // Handles padded encoding.
-    auto encoded1 = encodeBase64Url(StringPtr("quux").asBytes());
+    auto encoded1 = encodeBase64Url("quux"_kjb);
     KJ_EXPECT(encoded1 == "cXV1eA", encoded1, encoded1.size());
-    auto encoded2 = encodeBase64Url(StringPtr("corge").asBytes());
+    auto encoded2 = encodeBase64Url("corge"_kjb);
     KJ_EXPECT(encoded2 == "Y29yZ2U", encoded2, encoded2.size());
   }
 

--- a/c++/src/kj/encoding.c++
+++ b/c++/src/kj/encoding.c++
@@ -546,16 +546,16 @@ String encodeCEscapeImpl(ArrayPtr<const byte> bytes, bool isBinary) {
 
   for (byte b: bytes) {
     switch (b) {
-      case '\a': escaped.addAll(StringPtr("\\a")); break;
-      case '\b': escaped.addAll(StringPtr("\\b")); break;
-      case '\f': escaped.addAll(StringPtr("\\f")); break;
-      case '\n': escaped.addAll(StringPtr("\\n")); break;
-      case '\r': escaped.addAll(StringPtr("\\r")); break;
-      case '\t': escaped.addAll(StringPtr("\\t")); break;
-      case '\v': escaped.addAll(StringPtr("\\v")); break;
-      case '\'': escaped.addAll(StringPtr("\\\'")); break;
-      case '\"': escaped.addAll(StringPtr("\\\"")); break;
-      case '\\': escaped.addAll(StringPtr("\\\\")); break;
+      case '\a': escaped.addAll("\\a"_kj); break;
+      case '\b': escaped.addAll("\\b"_kj); break;
+      case '\f': escaped.addAll("\\f"_kj); break;
+      case '\n': escaped.addAll("\\n"_kj); break;
+      case '\r': escaped.addAll("\\r"_kj); break;
+      case '\t': escaped.addAll("\\t"_kj); break;
+      case '\v': escaped.addAll("\\v"_kj); break;
+      case '\'': escaped.addAll("\\\'"_kj); break;
+      case '\"': escaped.addAll("\\\""_kj); break;
+      case '\\': escaped.addAll("\\\\"_kj); break;
       default:
         if (b < 0x20 || b == 0x7f || (isBinary && b > 0x7f)) {
           // Use octal escape, not hex, because hex escapes technically have no length limit and

--- a/c++/src/kj/filesystem-disk-test.c++
+++ b/c++/src/kj/filesystem-disk-test.c++
@@ -293,13 +293,13 @@ KJ_TEST("DiskFile") {
   file->writeAll("foo");
   KJ_EXPECT(file->readAllText() == "foo");
 
-  file->write(3, StringPtr("bar").asBytes());
+  file->write(3, "bar"_kjb);
   KJ_EXPECT(file->readAllText() == "foobar");
 
-  file->write(3, StringPtr("baz").asBytes());
+  file->write(3, "baz"_kjb);
   KJ_EXPECT(file->readAllText() == "foobaz");
 
-  file->write(9, StringPtr("qux").asBytes());
+  file->write(9, "qux"_kjb);
   KJ_EXPECT(file->readAllText() == kj::StringPtr("foobaz\0\0\0qux", 12));
 
   file->truncate(6);
@@ -344,12 +344,12 @@ KJ_TEST("DiskFile") {
     KJ_EXPECT(kj::str(writableMapping->get().first(6).asChars()) == "fDobaz");
     KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "Foobaz");
 
-    file->write(0, StringPtr("qux").asBytes());
+    file->write(0, "qux"_kjb);
     KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "quxbaz");
     KJ_EXPECT(kj::str(writableMapping->get().first(6).asChars()) == "quxbaz");
     KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "Foobaz");
 
-    file->write(12, StringPtr("corge").asBytes());
+    file->write(12, "corge"_kjb);
     KJ_EXPECT(kj::str(mapping.slice(12, 17).asChars()) == "corge");
 
 #if !_WIN32 && !__CYGWIN__  // Windows doesn't allow the file size to change while mapped.
@@ -482,7 +482,7 @@ KJ_TEST("DiskDirectory") {
   KJ_EXPECT(dir->openFile(Path({"corge", "grault"}))->readAllText() == "garply");
 
   dir->openFile(Path({"corge", "grault"}), WriteMode::CREATE | WriteMode::MODIFY)
-     ->write(0, StringPtr("rag").asBytes());
+     ->write(0, "rag"_kjb);
   KJ_EXPECT(dir->openFile(Path({"corge", "grault"}))->readAllText() == "ragply");
 
   KJ_EXPECT(dir->openSubdir(Path("corge"))->listNames().size() == 1);
@@ -883,7 +883,7 @@ KJ_TEST("DiskFile holes") {
 #endif
 
   file->writeAll("foobar");
-  file->write(1 << 20, StringPtr("foobar").asBytes());
+  file->write(1 << 20, "foobar"_kjb);
 
   // Some filesystems, like BTRFS, report zero `spaceUsed` until synced.
   file->datasync();

--- a/c++/src/kj/filesystem-test.c++
+++ b/c++/src/kj/filesystem-test.c++
@@ -303,15 +303,15 @@ KJ_TEST("InMemoryFile") {
   clock.expectChanged(*file);
   KJ_EXPECT(file->readAllText() == "foo");
 
-  file->write(3, StringPtr("bar").asBytes());
+  file->write(3, "bar"_kjb);
   clock.expectChanged(*file);
   KJ_EXPECT(file->readAllText() == "foobar");
 
-  file->write(3, StringPtr("baz").asBytes());
+  file->write(3, "baz"_kjb);
   clock.expectChanged(*file);
   KJ_EXPECT(file->readAllText() == "foobaz");
 
-  file->write(9, StringPtr("qux").asBytes());
+  file->write(9, "qux"_kjb);
   clock.expectChanged(*file);
   KJ_EXPECT(file->readAllText() == kj::StringPtr("foobaz\0\0\0qux", 12));
 
@@ -341,12 +341,12 @@ KJ_TEST("InMemoryFile") {
     KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "foobaz");
     clock.expectUnchanged(*file);
 
-    file->write(0, StringPtr("qux").asBytes());
+    file->write(0, "qux"_kjb);
     clock.expectChanged(*file);
     KJ_EXPECT(kj::str(mapping.first(6).asChars()) == "quxbaz");
     KJ_EXPECT(kj::str(privateMapping.first(6).asChars()) == "foobaz");
 
-    file->write(12, StringPtr("corge").asBytes());
+    file->write(12, "corge"_kjb);
     KJ_EXPECT(kj::str(mapping.slice(12, 17).asChars()) == "corge");
 
     // Can shrink.
@@ -553,7 +553,7 @@ KJ_TEST("InMemoryDirectory") {
   KJ_EXPECT(dir->openFile(Path({"corge", "grault"}))->readAllText() == "garply");
 
   dir->openFile(Path({"corge", "grault"}), WriteMode::CREATE | WriteMode::MODIFY)
-     ->write(0, StringPtr("rag").asBytes());
+     ->write(0, "rag"_kjb);
   KJ_EXPECT(dir->openFile(Path({"corge", "grault"}))->readAllText() == "ragply");
   clock.expectUnchanged(*dir);
 

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -687,25 +687,25 @@ void MainBuilder::MainImpl::printHelp(StringPtr programName) {
       }
     }
   } else {
-    text.addAll(StringPtr(" <command> [<arg>...]"));
+    text.addAll(" <command> [<arg>...]"_kj);
   }
-  text.addAll(StringPtr("\n\n"));
+  text.addAll("\n\n"_kj);
 
   wrapText(text, "", impl->briefDescription);
 
   if (!impl->subCommands.empty()) {
-    text.addAll(StringPtr("\nCommands:\n"));
+    text.addAll("\nCommands:\n"_kj);
     size_t maxLen = 0;
     for (auto& command: impl->subCommands) {
       maxLen = kj::max(maxLen, command.first.size());
     }
     for (auto& command: impl->subCommands) {
-      text.addAll(StringPtr("  "));
+      text.addAll("  "_kj);
       text.addAll(command.first);
       for (size_t i = command.first.size(); i < maxLen; i++) {
         text.add(' ');
       }
-      text.addAll(StringPtr("  "));
+      text.addAll("  "_kj);
       text.addAll(command.second.helpText);
       text.add('\n');
     }
@@ -714,16 +714,16 @@ void MainBuilder::MainImpl::printHelp(StringPtr programName) {
   }
 
   if (!sortedOptions.empty()) {
-    text.addAll(StringPtr("\nOptions:\n"));
+    text.addAll("\nOptions:\n"_kj);
 
     for (auto opt: sortedOptions) {
-      text.addAll(StringPtr("    "));
+      text.addAll("    "_kj);
       bool isFirst = true;
       for (auto& name: opt->names) {
         if (isFirst) {
           isFirst = false;
         } else {
-          text.addAll(StringPtr(", "));
+          text.addAll(", "_kj);
         }
         if (name.isLong) {
           text.addAll(str("--", name.longName));
@@ -741,7 +741,7 @@ void MainBuilder::MainImpl::printHelp(StringPtr programName) {
       wrapText(text, "        ", opt->helpText);
     }
 
-    text.addAll(StringPtr("    --help\n        Display this help text and exit.\n"));
+    text.addAll("    --help\n        Display this help text and exit.\n"_kj);
   }
 
   if (impl->extendedDescription.size() > 0) {

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -69,183 +69,183 @@ TEST(String, Nullptr) {
 }
 
 TEST(String, StartsEndsWith) {
-  EXPECT_TRUE(StringPtr("foobar").startsWith("foo"));
-  EXPECT_FALSE(StringPtr("foobar").startsWith("bar"));
-  EXPECT_FALSE(StringPtr("foobar").endsWith("foo"));
-  EXPECT_TRUE(StringPtr("foobar").endsWith("bar"));
+  EXPECT_TRUE("foobar"_kj.startsWith("foo"));
+  EXPECT_FALSE("foobar"_kj.startsWith("bar"));
+  EXPECT_FALSE("foobar"_kj.endsWith("foo"));
+  EXPECT_TRUE("foobar"_kj.endsWith("bar"));
 
-  EXPECT_FALSE(StringPtr("fo").startsWith("foo"));
-  EXPECT_FALSE(StringPtr("fo").endsWith("foo"));
+  EXPECT_FALSE("fo"_kj.startsWith("foo"));
+  EXPECT_FALSE("fo"_kj.endsWith("foo"));
 
-  EXPECT_TRUE(StringPtr("foobar").startsWith(""));
-  EXPECT_TRUE(StringPtr("foobar").endsWith(""));
+  EXPECT_TRUE("foobar"_kj.startsWith(""));
+  EXPECT_TRUE("foobar"_kj.endsWith(""));
 }
 
 TEST(String, parseAs) {
-  EXPECT_EQ(StringPtr("0").parseAs<double>(), 0.0);
-  EXPECT_EQ(StringPtr("0.0").parseAs<double>(), 0.0);
-  EXPECT_EQ(StringPtr("1").parseAs<double>(), 1.0);
-  EXPECT_EQ(StringPtr("1.0").parseAs<double>(), 1.0);
-  EXPECT_EQ(StringPtr("1e100").parseAs<double>(), 1e100);
-  EXPECT_EQ(StringPtr("inf").parseAs<double>(), inf());
-  EXPECT_EQ(StringPtr("infinity").parseAs<double>(), inf());
-  EXPECT_EQ(StringPtr("INF").parseAs<double>(), inf());
-  EXPECT_EQ(StringPtr("INFINITY").parseAs<double>(), inf());
-  EXPECT_EQ(StringPtr("1e100000").parseAs<double>(), inf());
-  EXPECT_EQ(StringPtr("-inf").parseAs<double>(), -inf());
-  EXPECT_EQ(StringPtr("-infinity").parseAs<double>(), -inf());
-  EXPECT_EQ(StringPtr("-INF").parseAs<double>(), -inf());
-  EXPECT_EQ(StringPtr("-INFINITY").parseAs<double>(), -inf());
-  EXPECT_EQ(StringPtr("-1e100000").parseAs<double>(), -inf());
-  EXPECT_TRUE(isNaN(StringPtr("nan").parseAs<double>()));
-  EXPECT_TRUE(isNaN(StringPtr("NAN").parseAs<double>()));
-  EXPECT_TRUE(isNaN(StringPtr("NaN").parseAs<double>()));
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("").parseAs<double>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("a").parseAs<double>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("1a").parseAs<double>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("+-1").parseAs<double>());
+  EXPECT_EQ("0"_kj.parseAs<double>(), 0.0);
+  EXPECT_EQ("0.0"_kj.parseAs<double>(), 0.0);
+  EXPECT_EQ("1"_kj.parseAs<double>(), 1.0);
+  EXPECT_EQ("1.0"_kj.parseAs<double>(), 1.0);
+  EXPECT_EQ("1e100"_kj.parseAs<double>(), 1e100);
+  EXPECT_EQ("inf"_kj.parseAs<double>(), inf());
+  EXPECT_EQ("infinity"_kj.parseAs<double>(), inf());
+  EXPECT_EQ("INF"_kj.parseAs<double>(), inf());
+  EXPECT_EQ("INFINITY"_kj.parseAs<double>(), inf());
+  EXPECT_EQ("1e100000"_kj.parseAs<double>(), inf());
+  EXPECT_EQ("-inf"_kj.parseAs<double>(), -inf());
+  EXPECT_EQ("-infinity"_kj.parseAs<double>(), -inf());
+  EXPECT_EQ("-INF"_kj.parseAs<double>(), -inf());
+  EXPECT_EQ("-INFINITY"_kj.parseAs<double>(), -inf());
+  EXPECT_EQ("-1e100000"_kj.parseAs<double>(), -inf());
+  EXPECT_TRUE(isNaN("nan"_kj.parseAs<double>()));
+  EXPECT_TRUE(isNaN("NAN"_kj.parseAs<double>()));
+  EXPECT_TRUE(isNaN("NaN"_kj.parseAs<double>()));
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", ""_kj.parseAs<double>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "a"_kj.parseAs<double>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "1a"_kj.parseAs<double>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "+-1"_kj.parseAs<double>());
 
-  EXPECT_EQ(StringPtr("1").parseAs<float>(), 1.0);
+  EXPECT_EQ("1"_kj.parseAs<float>(), 1.0);
 
-  EXPECT_EQ(StringPtr("1").parseAs<int64_t>(), 1);
-  EXPECT_EQ(StringPtr("9223372036854775807").parseAs<int64_t>(), 9223372036854775807LL);
-  EXPECT_EQ(StringPtr("-9223372036854775808").parseAs<int64_t>(), -9223372036854775808ULL);
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("9223372036854775808").parseAs<int64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("-9223372036854775809").parseAs<int64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("").parseAs<int64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("a").parseAs<int64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("1a").parseAs<int64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("+-1").parseAs<int64_t>());
-  EXPECT_EQ(StringPtr("010").parseAs<int64_t>(), 10);
-  EXPECT_EQ(StringPtr("0010").parseAs<int64_t>(), 10);
-  EXPECT_EQ(StringPtr("0x10").parseAs<int64_t>(), 16);
-  EXPECT_EQ(StringPtr("0X10").parseAs<int64_t>(), 16);
-  EXPECT_EQ(StringPtr("-010").parseAs<int64_t>(), -10);
-  EXPECT_EQ(StringPtr("-0x10").parseAs<int64_t>(), -16);
-  EXPECT_EQ(StringPtr("-0X10").parseAs<int64_t>(), -16);
+  EXPECT_EQ("1"_kj.parseAs<int64_t>(), 1);
+  EXPECT_EQ("9223372036854775807"_kj.parseAs<int64_t>(), 9223372036854775807LL);
+  EXPECT_EQ("-9223372036854775808"_kj.parseAs<int64_t>(), -9223372036854775808ULL);
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "9223372036854775808"_kj.parseAs<int64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "-9223372036854775809"_kj.parseAs<int64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", ""_kj.parseAs<int64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "a"_kj.parseAs<int64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "1a"_kj.parseAs<int64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "+-1"_kj.parseAs<int64_t>());
+  EXPECT_EQ("010"_kj.parseAs<int64_t>(), 10);
+  EXPECT_EQ("0010"_kj.parseAs<int64_t>(), 10);
+  EXPECT_EQ("0x10"_kj.parseAs<int64_t>(), 16);
+  EXPECT_EQ("0X10"_kj.parseAs<int64_t>(), 16);
+  EXPECT_EQ("-010"_kj.parseAs<int64_t>(), -10);
+  EXPECT_EQ("-0x10"_kj.parseAs<int64_t>(), -16);
+  EXPECT_EQ("-0X10"_kj.parseAs<int64_t>(), -16);
 
-  EXPECT_EQ(StringPtr("1").parseAs<uint64_t>(), 1);
-  EXPECT_EQ(StringPtr("0").parseAs<uint64_t>(), 0);
-  EXPECT_EQ(StringPtr("18446744073709551615").parseAs<uint64_t>(), 18446744073709551615ULL);
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("-1").parseAs<uint64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("18446744073709551616").parseAs<uint64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("").parseAs<uint64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("a").parseAs<uint64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("1a").parseAs<uint64_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", StringPtr("+-1").parseAs<uint64_t>());
+  EXPECT_EQ("1"_kj.parseAs<uint64_t>(), 1);
+  EXPECT_EQ("0"_kj.parseAs<uint64_t>(), 0);
+  EXPECT_EQ("18446744073709551615"_kj.parseAs<uint64_t>(), 18446744073709551615ULL);
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "-1"_kj.parseAs<uint64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "18446744073709551616"_kj.parseAs<uint64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", ""_kj.parseAs<uint64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "a"_kj.parseAs<uint64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "1a"_kj.parseAs<uint64_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("not contain valid", "+-1"_kj.parseAs<uint64_t>());
 
-  EXPECT_EQ(StringPtr("1").parseAs<int32_t>(), 1);
-  EXPECT_EQ(StringPtr("2147483647").parseAs<int32_t>(), 2147483647);
-  EXPECT_EQ(StringPtr("-2147483648").parseAs<int32_t>(), -2147483648);
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("2147483648").parseAs<int32_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("-2147483649").parseAs<int32_t>());
+  EXPECT_EQ("1"_kj.parseAs<int32_t>(), 1);
+  EXPECT_EQ("2147483647"_kj.parseAs<int32_t>(), 2147483647);
+  EXPECT_EQ("-2147483648"_kj.parseAs<int32_t>(), -2147483648);
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "2147483648"_kj.parseAs<int32_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "-2147483649"_kj.parseAs<int32_t>());
 
-  EXPECT_EQ(StringPtr("1").parseAs<uint32_t>(), 1);
-  EXPECT_EQ(StringPtr("0").parseAs<uint32_t>(), 0U);
-  EXPECT_EQ(StringPtr("4294967295").parseAs<uint32_t>(), 4294967295U);
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("-1").parseAs<uint32_t>());
-  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", StringPtr("4294967296").parseAs<uint32_t>());
+  EXPECT_EQ("1"_kj.parseAs<uint32_t>(), 1);
+  EXPECT_EQ("0"_kj.parseAs<uint32_t>(), 0U);
+  EXPECT_EQ("4294967295"_kj.parseAs<uint32_t>(), 4294967295U);
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "-1"_kj.parseAs<uint32_t>());
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("out-of-range", "4294967296"_kj.parseAs<uint32_t>());
 
-  EXPECT_EQ(StringPtr("1").parseAs<int16_t>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<uint16_t>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<int8_t>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<uint8_t>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<char>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<signed char>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<unsigned char>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<short>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<unsigned short>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<int>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<unsigned>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<long>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<unsigned long>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<long long>(), 1);
-  EXPECT_EQ(StringPtr("1").parseAs<unsigned long long>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<int16_t>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<uint16_t>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<int8_t>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<uint8_t>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<char>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<signed char>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<unsigned char>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<short>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<unsigned short>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<int>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<unsigned>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<long>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<unsigned long>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<long long>(), 1);
+  EXPECT_EQ("1"_kj.parseAs<unsigned long long>(), 1);
 
   EXPECT_EQ(heapString("1").parseAs<int>(), 1);
 }
 
 TEST(String, tryParseAs) {
-  KJ_EXPECT(StringPtr("0").tryParseAs<double>() == 0.0);
-  KJ_EXPECT(StringPtr("0").tryParseAs<double>() == 0.0);
-  KJ_EXPECT(StringPtr("0.0").tryParseAs<double>() == 0.0);
-  KJ_EXPECT(StringPtr("1").tryParseAs<double>() == 1.0);
-  KJ_EXPECT(StringPtr("1.0").tryParseAs<double>() == 1.0);
-  KJ_EXPECT(StringPtr("1e100").tryParseAs<double>() == 1e100);
-  KJ_EXPECT(StringPtr("inf").tryParseAs<double>() == inf());
-  KJ_EXPECT(StringPtr("infinity").tryParseAs<double>() == inf());
-  KJ_EXPECT(StringPtr("INF").tryParseAs<double>() == inf());
-  KJ_EXPECT(StringPtr("INFINITY").tryParseAs<double>() == inf());
-  KJ_EXPECT(StringPtr("1e100000").tryParseAs<double>() == inf());
-  KJ_EXPECT(StringPtr("-inf").tryParseAs<double>() == -inf());
-  KJ_EXPECT(StringPtr("-infinity").tryParseAs<double>() == -inf());
-  KJ_EXPECT(StringPtr("-INF").tryParseAs<double>() == -inf());
-  KJ_EXPECT(StringPtr("-INFINITY").tryParseAs<double>() == -inf());
-  KJ_EXPECT(StringPtr("-1e100000").tryParseAs<double>() == -inf());
-  KJ_EXPECT(isNaN(StringPtr("nan").tryParseAs<double>().orDefault(0.0)) == true);
-  KJ_EXPECT(isNaN(StringPtr("NAN").tryParseAs<double>().orDefault(0.0)) == true);
-  KJ_EXPECT(isNaN(StringPtr("NaN").tryParseAs<double>().orDefault(0.0)) == true);
-  KJ_EXPECT(StringPtr("").tryParseAs<double>() == kj::none);
-  KJ_EXPECT(StringPtr("a").tryParseAs<double>() == kj::none);
-  KJ_EXPECT(StringPtr("1a").tryParseAs<double>() == kj::none);
-  KJ_EXPECT(StringPtr("+-1").tryParseAs<double>() == kj::none);
+  KJ_EXPECT("0"_kj.tryParseAs<double>() == 0.0);
+  KJ_EXPECT("0"_kj.tryParseAs<double>() == 0.0);
+  KJ_EXPECT("0.0"_kj.tryParseAs<double>() == 0.0);
+  KJ_EXPECT("1"_kj.tryParseAs<double>() == 1.0);
+  KJ_EXPECT("1.0"_kj.tryParseAs<double>() == 1.0);
+  KJ_EXPECT("1e100"_kj.tryParseAs<double>() == 1e100);
+  KJ_EXPECT("inf"_kj.tryParseAs<double>() == inf());
+  KJ_EXPECT("infinity"_kj.tryParseAs<double>() == inf());
+  KJ_EXPECT("INF"_kj.tryParseAs<double>() == inf());
+  KJ_EXPECT("INFINITY"_kj.tryParseAs<double>() == inf());
+  KJ_EXPECT("1e100000"_kj.tryParseAs<double>() == inf());
+  KJ_EXPECT("-inf"_kj.tryParseAs<double>() == -inf());
+  KJ_EXPECT("-infinity"_kj.tryParseAs<double>() == -inf());
+  KJ_EXPECT("-INF"_kj.tryParseAs<double>() == -inf());
+  KJ_EXPECT("-INFINITY"_kj.tryParseAs<double>() == -inf());
+  KJ_EXPECT("-1e100000"_kj.tryParseAs<double>() == -inf());
+  KJ_EXPECT(isNaN("nan"_kj.tryParseAs<double>().orDefault(0.0)) == true);
+  KJ_EXPECT(isNaN("NAN"_kj.tryParseAs<double>().orDefault(0.0)) == true);
+  KJ_EXPECT(isNaN("NaN"_kj.tryParseAs<double>().orDefault(0.0)) == true);
+  KJ_EXPECT(""_kj.tryParseAs<double>() == kj::none);
+  KJ_EXPECT("a"_kj.tryParseAs<double>() == kj::none);
+  KJ_EXPECT("1a"_kj.tryParseAs<double>() == kj::none);
+  KJ_EXPECT("+-1"_kj.tryParseAs<double>() == kj::none);
 
-  KJ_EXPECT(StringPtr("1").tryParseAs<float>() == 1.0);
+  KJ_EXPECT("1"_kj.tryParseAs<float>() == 1.0);
 
-  KJ_EXPECT(StringPtr("1").tryParseAs<int64_t>() == 1);
-  KJ_EXPECT(StringPtr("9223372036854775807").tryParseAs<int64_t>() == 9223372036854775807LL);
-  KJ_EXPECT(StringPtr("-9223372036854775808").tryParseAs<int64_t>() == -9223372036854775808ULL);
-  KJ_EXPECT(StringPtr("9223372036854775808").tryParseAs<int64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("-9223372036854775809").tryParseAs<int64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("").tryParseAs<int64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("a").tryParseAs<int64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("1a").tryParseAs<int64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("+-1").tryParseAs<int64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("010").tryParseAs<int64_t>() == 10);
-  KJ_EXPECT(StringPtr("0010").tryParseAs<int64_t>() == 10);
-  KJ_EXPECT(StringPtr("0x10").tryParseAs<int64_t>() == 16);
-  KJ_EXPECT(StringPtr("0X10").tryParseAs<int64_t>() == 16);
-  KJ_EXPECT(StringPtr("-010").tryParseAs<int64_t>() == -10);
-  KJ_EXPECT(StringPtr("-0x10").tryParseAs<int64_t>() == -16);
-  KJ_EXPECT(StringPtr("-0X10").tryParseAs<int64_t>() == -16);
+  KJ_EXPECT("1"_kj.tryParseAs<int64_t>() == 1);
+  KJ_EXPECT("9223372036854775807"_kj.tryParseAs<int64_t>() == 9223372036854775807LL);
+  KJ_EXPECT("-9223372036854775808"_kj.tryParseAs<int64_t>() == -9223372036854775808ULL);
+  KJ_EXPECT("9223372036854775808"_kj.tryParseAs<int64_t>() == kj::none);
+  KJ_EXPECT("-9223372036854775809"_kj.tryParseAs<int64_t>() == kj::none);
+  KJ_EXPECT(""_kj.tryParseAs<int64_t>() == kj::none);
+  KJ_EXPECT("a"_kj.tryParseAs<int64_t>() == kj::none);
+  KJ_EXPECT("1a"_kj.tryParseAs<int64_t>() == kj::none);
+  KJ_EXPECT("+-1"_kj.tryParseAs<int64_t>() == kj::none);
+  KJ_EXPECT("010"_kj.tryParseAs<int64_t>() == 10);
+  KJ_EXPECT("0010"_kj.tryParseAs<int64_t>() == 10);
+  KJ_EXPECT("0x10"_kj.tryParseAs<int64_t>() == 16);
+  KJ_EXPECT("0X10"_kj.tryParseAs<int64_t>() == 16);
+  KJ_EXPECT("-010"_kj.tryParseAs<int64_t>() == -10);
+  KJ_EXPECT("-0x10"_kj.tryParseAs<int64_t>() == -16);
+  KJ_EXPECT("-0X10"_kj.tryParseAs<int64_t>() == -16);
 
-  KJ_EXPECT(StringPtr("1").tryParseAs<uint64_t>() == 1);
-  KJ_EXPECT(StringPtr("0").tryParseAs<uint64_t>() == 0);
-  KJ_EXPECT(StringPtr("18446744073709551615").tryParseAs<uint64_t>() == 18446744073709551615ULL);
-  KJ_EXPECT(StringPtr("-1").tryParseAs<uint64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("18446744073709551616").tryParseAs<uint64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("").tryParseAs<uint64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("a").tryParseAs<uint64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("1a").tryParseAs<uint64_t>() == kj::none);
-  KJ_EXPECT(StringPtr("+-1").tryParseAs<uint64_t>() == kj::none);
+  KJ_EXPECT("1"_kj.tryParseAs<uint64_t>() == 1);
+  KJ_EXPECT("0"_kj.tryParseAs<uint64_t>() == 0);
+  KJ_EXPECT("18446744073709551615"_kj.tryParseAs<uint64_t>() == 18446744073709551615ULL);
+  KJ_EXPECT("-1"_kj.tryParseAs<uint64_t>() == kj::none);
+  KJ_EXPECT("18446744073709551616"_kj.tryParseAs<uint64_t>() == kj::none);
+  KJ_EXPECT(""_kj.tryParseAs<uint64_t>() == kj::none);
+  KJ_EXPECT("a"_kj.tryParseAs<uint64_t>() == kj::none);
+  KJ_EXPECT("1a"_kj.tryParseAs<uint64_t>() == kj::none);
+  KJ_EXPECT("+-1"_kj.tryParseAs<uint64_t>() == kj::none);
 
-  KJ_EXPECT(StringPtr("1").tryParseAs<int32_t>() == 1);
-  KJ_EXPECT(StringPtr("2147483647").tryParseAs<int32_t>() == 2147483647);
-  KJ_EXPECT(StringPtr("-2147483648").tryParseAs<int32_t>() == -2147483648);
-  KJ_EXPECT(StringPtr("2147483648").tryParseAs<int32_t>() == kj::none);
-  KJ_EXPECT(StringPtr("-2147483649").tryParseAs<int32_t>() == kj::none);
+  KJ_EXPECT("1"_kj.tryParseAs<int32_t>() == 1);
+  KJ_EXPECT("2147483647"_kj.tryParseAs<int32_t>() == 2147483647);
+  KJ_EXPECT("-2147483648"_kj.tryParseAs<int32_t>() == -2147483648);
+  KJ_EXPECT("2147483648"_kj.tryParseAs<int32_t>() == kj::none);
+  KJ_EXPECT("-2147483649"_kj.tryParseAs<int32_t>() == kj::none);
 
-  KJ_EXPECT(StringPtr("1").tryParseAs<uint32_t>() == 1);
-  KJ_EXPECT(StringPtr("0").tryParseAs<uint32_t>() == 0U);
-  KJ_EXPECT(StringPtr("4294967295").tryParseAs<uint32_t>() == 4294967295U);
-  KJ_EXPECT(StringPtr("-1").tryParseAs<uint32_t>() == kj::none);
-  KJ_EXPECT(StringPtr("4294967296").tryParseAs<uint32_t>() == kj::none);
+  KJ_EXPECT("1"_kj.tryParseAs<uint32_t>() == 1);
+  KJ_EXPECT("0"_kj.tryParseAs<uint32_t>() == 0U);
+  KJ_EXPECT("4294967295"_kj.tryParseAs<uint32_t>() == 4294967295U);
+  KJ_EXPECT("-1"_kj.tryParseAs<uint32_t>() == kj::none);
+  KJ_EXPECT("4294967296"_kj.tryParseAs<uint32_t>() == kj::none);
 
-  KJ_EXPECT(StringPtr("1").tryParseAs<int16_t>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<uint16_t>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<int8_t>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<uint8_t>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<char>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<signed char>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<unsigned char>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<short>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<unsigned short>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<int>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<unsigned>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<long>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<unsigned long>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<long long>() == 1);
-  KJ_EXPECT(StringPtr("1").tryParseAs<unsigned long long>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<int16_t>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<uint16_t>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<int8_t>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<uint8_t>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<char>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<signed char>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<unsigned char>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<short>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<unsigned short>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<int>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<unsigned>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<long>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<unsigned long>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<long long>() == 1);
+  KJ_EXPECT("1"_kj.tryParseAs<unsigned long long>() == 1);
 
   KJ_EXPECT(heapString("1").tryParseAs<int>() == 1);
 }
@@ -271,6 +271,17 @@ TEST(String, ToString) {
   EXPECT_EQ("foo", kj::str(Stringable()));
 }
 #endif
+
+KJ_TEST("StringPtr constructors") {
+  KJ_EXPECT(StringPtr("") == "");
+  KJ_EXPECT(StringPtr(nullptr) == "");
+  KJ_EXPECT(StringPtr("abc") == "abc");
+  KJ_EXPECT(StringPtr("abc", 3) == "abc");
+
+#ifdef KJ_DEBUG
+  KJ_EXPECT_THROW_MESSAGE("StringPtr must be NUL-terminated", StringPtr("abc", 2));
+#endif  
+}
 
 KJ_TEST("string literals with _kj suffix") {
   static constexpr StringPtr FOO = "foo"_kj;
@@ -307,12 +318,12 @@ KJ_TEST("parsing 'nan' returns canonical NaN value") {
   // There are many representations of NaN. We would prefer that parsing "NaN" produces exactly the
   // same bits that kj::nan() returns.
   {
-    double parsedNan = StringPtr("NaN").parseAs<double>();
+    double parsedNan = "NaN"_kj.parseAs<double>();
     double canonicalNan = kj::nan();
     KJ_EXPECT(kj::arrayPtr(parsedNan).asBytes() == kj::arrayPtr(canonicalNan).asBytes());
   }
   {
-    float parsedNan = StringPtr("NaN").parseAs<float>();
+    float parsedNan = "NaN"_kj.parseAs<float>();
     float canonicalNan = kj::nan();
     KJ_EXPECT(kj::arrayPtr(parsedNan).asBytes() == kj::arrayPtr(canonicalNan).asBytes());
   }

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -196,7 +196,7 @@ StringPtr Stringifier::operator*(decltype(nullptr)) const {
 }
 
 StringPtr Stringifier::operator*(bool b) const {
-  return b ? StringPtr("true") : StringPtr("false");
+  return b ? "true"_kj : "false"_kj;
 }
 
 template <typename T, typename Unsigned>


### PR DESCRIPTION
Automatic regexp-based translation. Helpful while updating async calls (char => byte) in tests