### PR TITLE
KJ_DEBUG_MEMORY flag

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -42,10 +42,12 @@ jobs:
       fail-fast: false
       matrix:
         clang: [15, 16, 17, 18, 19]
-        driver: [bazel, super-test]
+        driver: [bazel-dbg, bazel-opt, super-test]
         include:
-          - driver: bazel
-            run-test: cd c++ && bazel test --verbose_failures --test_output=errors -k --cxxopt='-Werror' //... && bazel test -c opt --verbose_failures --test_output=errors -k --cxxopt='-Werror' //...
+          - driver: bazel-dbg
+            run-test: cd c++ && bazel test --config=dbg --verbose_failures --test_output=errors -k --cxxopt='-Werror' //...
+          - driver: bazel-opt
+            run-test: cd c++ && bazel test --config=opt --verbose_failures --test_output=errors -k --cxxopt='-Werror' //...
           - driver: super-test
             run-test: ./super-test.sh quick
     steps:

--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -6,6 +6,12 @@ common --enable_platform_specific_config
 common --enable_workspace
 common --incompatible_autoload_externally=
 
+# Debug build configuration with maximum runtime checks
+build:dbg -c dbg --//src/kj:debug_memory=True
+
+# Opt build
+build:opt -c opt
+
 build:unix --cxxopt='-std=c++20' --host_cxxopt='-std=c++20' --force_pic --verbose_failures
 build:unix --cxxopt='-Wall'
 build:unix --cxxopt='-Wextra'

--- a/c++/src/kj/configure.bzl
+++ b/c++/src/kj/configure.bzl
@@ -36,6 +36,11 @@ def kj_configure():
         name = "deprecate_empty_maybe_from_nullptr",
         build_setting_default = True,
     )
+     
+    bool_flag(
+        name = "debug_memory",
+        build_setting_default = False,
+    )
 
     # Settings to use in select() expressions
     native.config_setting(
@@ -69,6 +74,11 @@ def kj_configure():
         flag_values = {"deprecate_empty_maybe_from_nullptr": "True"},
     )
 
+    native.config_setting(
+        name = "use_debug_memory",
+        flag_values = {"debug_memory": "True"},
+    )
+
     native.cc_library(
         name = "kj-defines",
         defines = select({
@@ -89,5 +99,8 @@ def kj_configure():
         }) + select({
             "//src/kj:use_deprecate_empty_maybe_from_nullptr": ["KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR=1"],
             "//conditions:default": ["KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR=0"],
+        }) + select({
+            "//src/kj:use_debug_memory": ["KJ_DEBUG_MEMORY=1"],
+            "//conditions:default": [],
         }),
     )

--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -616,7 +616,7 @@ KJ_TEST("kj::Ptr<T> subtyping") {
   KJ_EXPECT(ptr3 == pin);
 }
 
-#ifdef KJ_ASSERT_PTR_COUNTERS  
+#if KJ_ASSERT_PTR_COUNTERS
 KJ_TEST("kj::Pin<T> destroyed with active ptrs crashed") {
   PtrHolder* holder = nullptr;
   

--- a/c++/src/kj/memory.c++
+++ b/c++/src/kj/memory.c++
@@ -27,8 +27,9 @@ namespace kj {
 
 const NullDisposer NullDisposer::instance = NullDisposer();
 
-#ifdef KJ_ASSERT_PTR_COUNTERS
 namespace _ {
+
+#if KJ_ASSERT_PTR_COUNTERS
 
 void atomicPtrCounterAssertionFailed(char const* reason) {
   KJ_FAIL_ASSERT("ptr counter contract violated", reason);
@@ -37,11 +38,12 @@ void atomicPtrCounterAssertionFailed(char const* reason) {
   KJ_KNOWN_UNREACHABLE(abort());
 }
 
+#endif // KJ_ASSERT_PTR_COUNTERS
+
 void throwWrongDisposerError() {
   KJ_FAIL_REQUIRE("When disowning an object, disposer must be equal to Own's disposer");
 }
 
 }
-#endif
 
 }  // namespace kj


### PR DESCRIPTION
Will enable additional checks in follow up prs too.

Redoes the way KJ_ASSERT_PTR_COUNTERS is defined, which adresses the comment in #2100.