### PR TITLE
run CI in opt mode too

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -45,7 +45,7 @@ jobs:
         driver: [bazel, super-test]
         include:
           - driver: bazel
-            run-test: cd c++ && bazel test --verbose_failures --test_output=errors -k --cxxopt='-Werror' //...
+            run-test: cd c++ && bazel test --verbose_failures --test_output=errors -k --cxxopt='-Werror' //... && bazel test -c opt --verbose_failures --test_output=errors -k --cxxopt='-Werror' //...
           - driver: super-test
             run-test: ./super-test.sh quick
     steps:


### PR DESCRIPTION
I think it makes sense to run tests without KJ_DEBUG too. Added `opt` runs to bazel builds