### PR TITLE
kj::ThreadId

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -24,6 +24,7 @@
 #include <inttypes.h>
 #include <kj/compat/gtest.h>
 #include <span>
+#include "thread.h"
 
 namespace kj {
 namespace {
@@ -1273,6 +1274,23 @@ KJ_TEST("memzero<T>()") {
   for (auto& t: arr) {
     KJ_EXPECT(t.pi == 0);
   }
+}
+
+KJ_TEST("ThreadId") {
+  auto id1 = ThreadId::current();
+  id1.assertCurrentThread();
+
+  auto id2 = ThreadId::current();
+  KJ_ASSERT(id2 == id1);
+  
+  Thread thread([&]() {
+    auto id3 = ThreadId::current();
+    id3.assertCurrentThread();
+    KJ_ASSERT(id1 != id3);
+    KJ_ASSERT(id2 != id3);
+
+    KJ_EXPECT_THROW_MESSAGE("expected id == &currentThreadId", id1.assertCurrentThread());
+  });
 }
 
 }  // namespace

--- a/c++/src/kj/common.c++
+++ b/c++/src/kj/common.c++
@@ -44,6 +44,13 @@ void unreachable() {
   KJ_KNOWN_UNREACHABLE(abort());
 }
 
+
 }  // namespace _ (private)
+
+namespace { static thread_local bool currentThreadId; }
+
+ThreadId ThreadId::current() { return ThreadId(&currentThreadId); }
+
+void ThreadId::assertCurrentThread() const { KJ_ASSERT(id == &currentThreadId); }
 
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2278,6 +2278,25 @@ struct ByteLiteral<1ul> {
 
 }
 
+class ThreadId {
+  // Unique thread identifier.
+  // Implemented as thread_local address, so could be efficient even for production
+  // environments especially with LTO.
+
+public:  
+  static ThreadId current();
+  // Obtain current thread id
+
+  inline bool operator==(const ThreadId& other) const { return id == other.id; }
+
+  void assertCurrentThread() const;
+  // KJ_ASSERTs that current thread matches this identifier.
+
+private:
+  inline ThreadId(void* id) : id(id) {}
+  void* id;  
+};
+
 }  // namespace kj
 
 template <kj::_::ByteLiteral s>


### PR DESCRIPTION
I intend to use it from `refcount.h`. Let me know if `common.h` is not a best place for this. @kentonv 