### PR TITLE
kj::some() helper function

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -430,6 +430,25 @@ TEST(Common, Maybe) {
     KJ_EXPECT(m4 == m5);
     KJ_EXPECT(m4 != m1);
   }
+
+  {
+    // type deduction in various circumstances
+    struct IntWrapper {
+      IntWrapper(int i): i(i) {}
+      int i;
+    
+      static int twice(Maybe<IntWrapper> i) {
+        return i.orDefault(0).i * 2;
+      }
+    };
+    
+    // You can't write twice(5), you need to specify some of the types
+    KJ_EXPECT(10 == IntWrapper::twice(Maybe<IntWrapper>(5)));
+    KJ_EXPECT(10 == IntWrapper::twice(IntWrapper(5)));
+
+    // kj::some solves this problem elegantly
+    KJ_EXPECT(10 == IntWrapper::twice(kj::some(5)));
+  }
 }
 
 TEST(Common, MaybeConstness) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1369,6 +1369,11 @@ static constexpr None none;
 // compare equal to all empty Maybes, and will compare not-equal to all non-empty Maybes. If you
 // construct or assign to a Maybe from `kj::none`, the constructed/assigned Maybe will be empty.
 
+template <typename T>
+inline Maybe<T> some(T&& t) { return Maybe<T>(kj::mv(t)); }
+// Helper function to auto-deduce maybe argument.
+// Useful when there is a complicated conversion chain to T to avoid spelling types out.
+
 #if __GNUC__ || __clang__
 // These two macros provide a friendly syntax to extract the value of a Maybe or return early.
 //


### PR DESCRIPTION
I found it useful when passing parameters requiring long conversion chains.