### PR TITLE
Allow calling Reader::asGeneric() on const readers

### DIFF
--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1834,7 +1834,7 @@ private:
         case AsGenericRole::READER:
           self = kj::strTree(
               "  ", templateContext.decl(true, "2"),
-              "  typename ", returnType(), "::Reader ", kj::mv(asGeneric), " {\n"
+              "  typename ", returnType(), "::Reader ", kj::mv(asGeneric), " const {\n"
               "    return typename ", returnType(), "::Reader(_reader);\n"
               "  }\n"
               "\n");


### PR DESCRIPTION
Pretty much the title. In my case I want to change generic's parameter type, and reader is passed as const reference. Maybe this function should be also marked as `const` in Builders and Clients.  
```
struct Msg(T) {
    val @0 :T;
    metadata @1 :Text;
}

struct SimpleMessage {
   val @1 :UInt32;
}
```

```c++
capnp::FlatArrayMessageReader reader{...};
processSimpleMessage(reader.getRoot<Msg<SimpleMessage>>());

void processSimpleMessage(const Msg<SimpleMessage>::Reader &message) {
    debugDump(message.asGeneric<capnp::AnyStruct>()); // <-- now it fails because Reader::asGeneric is not const
    // ...
}

void debugDump(const Msg<capnp::AnyStruct>::Reader &message) {
    // dump message
}
```