### PR TITLE
Add `bzlmod` support (3rd attempt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@
 
 # bazel output
 bazel-*
+/c++/MODULE.bazel.lock

--- a/c++/MODULE.bazel
+++ b/c++/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "capnp-cpp",
+    version = "1.1.0",
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
+bazel_dep(name = "boringssl", version = "0.20241024.0")
+bazel_dep(name = "brotli", version = "1.1.0")

--- a/c++/WORKSPACE
+++ b/c++/WORKSPACE
@@ -17,7 +17,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 http_archive(
-    name = "ssl",
+    name = "boringssl",
     sha256 = "873ec711658f65192e9c58554ce058d1cfa4e57e13ab5366ee16f76d1c757efc",
     strip_prefix = "google-boringssl-ed2e74e",
     type = "tgz",

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -18,7 +18,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/kj:kj-async",
-        "@ssl",
+        "@boringssl//:ssl",
     ],
 )
 


### PR DESCRIPTION
Minimal set of changes to make this work with `bzlmod`.

This PR specifically does not tackle publishing to BCR, changing the existing build or changing the release infrastructure.

With this the `c++` directory continues to build with `bazel` 6.1.2 without `bzlmod`. And with `bazel` 8.1.1 that has `bzlmod` enabled by default. The PR allows users to include `capnproto/c++` as:

```
bazel_dep(name = "capnp-cpp")
git_override(
    module_name = "capnp-cpp",
    remote = "https://github.com/capnproto/capnproto",
    commit = "...",
    strip_prefix = "c++/",
)
```

It will simplify publishing to BCR as patching over there will no longer be required:
- https://registry.bazel.build/modules/capnp-cpp
- https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/capnp-cpp/1.1.0/patches/bazelmod-compatible-boringssl.patch

## Previously
- https://github.com/capnproto/capnproto/discussions/1908
- https://github.com/capnproto/capnproto/pull/1909
- https://github.com/capnproto/capnproto/pull/2247