### PR TITLE
Update minimum CMake version to 3.10.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project("Cap'n Proto Root" CXX)
 include(CTest)
 

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project("Cap'n Proto" CXX)
 set(VERSION 1.1-dev)
 

--- a/c++/samples/CMakeLists.txt
+++ b/c++/samples/CMakeLists.txt
@@ -16,7 +16,7 @@
 #      cmake ../c++/samples
 #      cmake --build .
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 project("Cap'n Proto Samples" CXX)
 
 find_package(CapnProto CONFIG REQUIRED)

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -78,8 +78,7 @@ set(kj-std_headers
 )
 add_library(kj ${kj_sources})
 add_library(CapnProto::kj ALIAS kj)
-# TODO(cleanup): Use cxx_std_14 once it's safe to require cmake 3.8.
-target_compile_features(kj PUBLIC cxx_generic_lambdas)
+target_compile_features(kj PUBLIC cxx_std_14)
 
 if(UNIX AND NOT ANDROID)
   target_link_libraries(kj PUBLIC pthread)

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -78,7 +78,7 @@ set(kj-std_headers
 )
 add_library(kj ${kj_sources})
 add_library(CapnProto::kj ALIAS kj)
-target_compile_features(kj PUBLIC cxx_std_14)
+target_compile_features(kj PUBLIC cxx_std_17)
 
 if(UNIX AND NOT ANDROID)
   target_link_libraries(kj PUBLIC pthread)


### PR DESCRIPTION
Fixes build errors when using CMake 4.0. Technically, just 3.5 would be sufficient to avoid the errors, but targeting 3.10 avoids deprecation warnings as well.