### PR TITLE
Add member startByte and endByte

### DIFF
--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -691,10 +691,8 @@ void NodeTranslator::compileNode(Declaration::Reader decl, schema::Node::Builder
       break;
   }
 
-  if (decl.which() != Declaration::ANNOTATION) {
-    builder.setStartByte(decl.getStartByte());
-    builder.setEndByte(decl.getEndByte());
-  }
+  builder.setStartByte(decl.getStartByte());
+  builder.setEndByte(decl.getEndByte());
 
   builder.adoptAnnotations(compileAnnotationApplications(decl.getAnnotations(), targetsFlagName));
 
@@ -942,9 +940,12 @@ void NodeTranslator::compileEnum(Void decl,
 
     dupDetector.check(enumerantDecl.getId().getOrdinal());
 
+    auto sourceInfo = sourceInfoList[i];
     if (enumerantDecl.hasDocComment()) {
-      sourceInfoList[i].setDocComment(enumerantDecl.getDocComment());
+      sourceInfo.setDocComment(enumerantDecl.getDocComment());
     }
+    sourceInfo.setStartByte(enumerantDecl.getStartByte());
+    sourceInfo.setEndByte(enumerantDecl.getEndByte());
 
     auto enumerantBuilder = list[i++];
     enumerantBuilder.setName(enumerantDecl.getName().getValue());
@@ -1124,6 +1125,8 @@ private:
         KJ_IF_SOME(dc, docComment) {
           builderPair.sourceInfo.setDocComment(dc);
         }
+        builderPair.sourceInfo.setStartByte(startByte);
+        builderPair.sourceInfo.setEndByte(endByte);
 
         schema = builder;
         return builder;
@@ -1586,9 +1589,12 @@ void NodeTranslator::compileInterface(Declaration::Interface::Reader decl,
     dupDetector.check(ordinalDecl);
     uint16_t ordinal = ordinalDecl.getValue();
 
+    auto sourceInfo = sourceInfoList[i];
     if (methodDecl.hasDocComment()) {
-      sourceInfoList[i].setDocComment(methodDecl.getDocComment());
+      sourceInfo.setDocComment(methodDecl.getDocComment());
     }
+    sourceInfo.setStartByte(methodDecl.getStartByte());
+    sourceInfo.setEndByte(methodDecl.getEndByte());
 
     auto methodBuilder = list[i++];
     methodBuilder.setName(methodDecl.getName().getValue());

--- a/c++/src/capnp/schema.capnp
+++ b/c++/src/capnp/schema.capnp
@@ -195,6 +195,8 @@ struct Node {
     struct Member {
       docComment @0 :Text;
       # Doc comment on the member.
+      startByte @1 :UInt32;
+      endByte @2 :UInt32;
     }
 
     startByte @3 :UInt32;

--- a/c++/src/capnp/schema.capnp.c++
+++ b/c++/src/capnp/schema.capnp.c++
@@ -5,13 +5,14 @@
 
 namespace capnp {
 namespace schemas {
-static const ::capnp::_::AlignedData<256> b_e682ab4cf923a417 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<257> b_e682ab4cf923a417 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
      19,   0,   0,   0,   1,   0,   6,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       6,   0,   7,   0,   0,   0,   6,   0,
       6,   0,   0,   0,   0,   0,   0,   0,
+     61,   5,   0,   0, 179,  31,   0,   0,
      21,   0,   0,   0, 194,   0,   0,   0,
      29,   0,   0,   0,  55,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -278,17 +279,18 @@ static const ::capnp::_::RawSchema* const d_e682ab4cf923a417[] = {
 static const uint16_t m_e682ab4cf923a417[] = {11, 5, 10, 1, 2, 15, 8, 6, 0, 9, 13, 4, 12, 3, 14, 7};
 static const uint16_t i_e682ab4cf923a417[] = {6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 12, 13, 14, 15};
 const ::capnp::_::RawSchema s_e682ab4cf923a417 = {
-  0xe682ab4cf923a417, b_e682ab4cf923a417.words, 256, d_e682ab4cf923a417, m_e682ab4cf923a417,
+  0xe682ab4cf923a417, b_e682ab4cf923a417.words, 257, d_e682ab4cf923a417, m_e682ab4cf923a417,
   8, 16, i_e682ab4cf923a417, nullptr, nullptr, { &s_e682ab4cf923a417, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<34> b_b9521bccf10fa3b1 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<35> b_b9521bccf10fa3b1 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     177, 163,  15, 241, 204,  27,  82, 185,
      24,   0,   0,   0,   1,   0,   0,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       1,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+     33,  10,   0,   0, 129,  10,   0,   0,
      21,   0,   0,   0,  18,   1,   0,   0,
      37,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -323,17 +325,18 @@ static const ::capnp::_::AlignedData<34> b_b9521bccf10fa3b1 = {
 static const uint16_t m_b9521bccf10fa3b1[] = {0};
 static const uint16_t i_b9521bccf10fa3b1[] = {0};
 const ::capnp::_::RawSchema s_b9521bccf10fa3b1 = {
-  0xb9521bccf10fa3b1, b_b9521bccf10fa3b1.words, 34, nullptr, m_b9521bccf10fa3b1,
+  0xb9521bccf10fa3b1, b_b9521bccf10fa3b1.words, 35, nullptr, m_b9521bccf10fa3b1,
   0, 1, i_b9521bccf10fa3b1, nullptr, nullptr, { &s_b9521bccf10fa3b1, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<49> b_debf55bbfa0fc242 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<50> b_debf55bbfa0fc242 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      66, 194,  15, 250, 187,  85, 191, 222,
      24,   0,   0,   0,   1,   0,   1,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       1,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+     10,  11,   0,   0, 144,  12,   0,   0,
      21,   0,   0,   0,  26,   1,   0,   0,
      37,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -383,17 +386,18 @@ static const ::capnp::_::AlignedData<49> b_debf55bbfa0fc242 = {
 static const uint16_t m_debf55bbfa0fc242[] = {1, 0};
 static const uint16_t i_debf55bbfa0fc242[] = {0, 1};
 const ::capnp::_::RawSchema s_debf55bbfa0fc242 = {
-  0xdebf55bbfa0fc242, b_debf55bbfa0fc242.words, 49, nullptr, m_debf55bbfa0fc242,
+  0xdebf55bbfa0fc242, b_debf55bbfa0fc242.words, 50, nullptr, m_debf55bbfa0fc242,
   0, 2, i_debf55bbfa0fc242, nullptr, nullptr, { &s_debf55bbfa0fc242, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<103> b_f38e1de3041357ae = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<104> b_f38e1de3041357ae = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     174,  87,  19,   4, 227,  29, 142, 243,
      24,   0,   0,   0,   1,   0,   2,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    177,  27,   0,   0, 177,  31,   0,   0,
      21,   0,   0,   0,  26,   1,   0,   0,
      37,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -500,21 +504,22 @@ static const ::capnp::_::RawSchema* const d_f38e1de3041357ae[] = {
 static const uint16_t m_f38e1de3041357ae[] = {1, 4, 0, 2, 3};
 static const uint16_t i_f38e1de3041357ae[] = {0, 1, 2, 3, 4};
 const ::capnp::_::RawSchema s_f38e1de3041357ae = {
-  0xf38e1de3041357ae, b_f38e1de3041357ae.words, 103, d_f38e1de3041357ae, m_f38e1de3041357ae,
+  0xf38e1de3041357ae, b_f38e1de3041357ae.words, 104, d_f38e1de3041357ae, m_f38e1de3041357ae,
   1, 5, i_f38e1de3041357ae, nullptr, nullptr, { &s_f38e1de3041357ae, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<36> b_c2ba9038898e1fa2 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<68> b_c2ba9038898e1fa2 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     162,  31, 142, 137,  56, 144, 186, 194,
-     35,   0,   0,   0,   1,   0,   0,   0,
+     35,   0,   0,   0,   1,   0,   1,   0,
     174,  87,  19,   4, 227,  29, 142, 243,
       1,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    241,  30,   0,   0, 122,  31,   0,   0,
      21,   0,   0,   0,  82,   1,   0,   0,
      41,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     37,   0,   0,   0,  63,   0,   0,   0,
+     37,   0,   0,   0, 175,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      99,  97, 112, 110, 112,  47, 115,  99,
@@ -524,14 +529,28 @@ static const ::capnp::_::AlignedData<36> b_c2ba9038898e1fa2 = {
     102, 111,  46,  77, 101, 109,  98, 101,
     114,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   1,   0,   1,   0,
-      4,   0,   0,   0,   3,   0,   4,   0,
+     12,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     13,   0,   0,   0,  90,   0,   0,   0,
+     69,   0,   0,   0,  90,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     12,   0,   0,   0,   3,   0,   1,   0,
-     24,   0,   0,   0,   2,   0,   1,   0,
+     68,   0,   0,   0,   3,   0,   1,   0,
+     80,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     77,   0,   0,   0,  82,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     76,   0,   0,   0,   3,   0,   1,   0,
+     88,   0,   0,   0,   2,   0,   1,   0,
+      2,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   2,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     85,   0,   0,   0,  66,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     80,   0,   0,   0,   3,   0,   1,   0,
+     92,   0,   0,   0,   2,   0,   1,   0,
     100, 111,  99,  67, 111, 109, 109, 101,
     110, 116,   0,   0,   0,   0,   0,   0,
      12,   0,   0,   0,   0,   0,   0,   0,
@@ -540,23 +559,41 @@ static const ::capnp::_::AlignedData<36> b_c2ba9038898e1fa2 = {
       0,   0,   0,   0,   0,   0,   0,   0,
      12,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    115, 116,  97, 114, 116,  66, 121, 116,
+    101,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    101, 110, 100,  66, 121, 116, 101,   0,
+      8,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
 ::capnp::word const* const bp_c2ba9038898e1fa2 = b_c2ba9038898e1fa2.words;
 #if !CAPNP_LITE
-static const uint16_t m_c2ba9038898e1fa2[] = {0};
-static const uint16_t i_c2ba9038898e1fa2[] = {0};
+static const uint16_t m_c2ba9038898e1fa2[] = {0, 2, 1};
+static const uint16_t i_c2ba9038898e1fa2[] = {0, 1, 2};
 const ::capnp::_::RawSchema s_c2ba9038898e1fa2 = {
-  0xc2ba9038898e1fa2, b_c2ba9038898e1fa2.words, 36, nullptr, m_c2ba9038898e1fa2,
-  0, 1, i_c2ba9038898e1fa2, nullptr, nullptr, { &s_c2ba9038898e1fa2, nullptr, nullptr, 0, 0, nullptr }, false
+  0xc2ba9038898e1fa2, b_c2ba9038898e1fa2.words, 68, nullptr, m_c2ba9038898e1fa2,
+  0, 3, i_c2ba9038898e1fa2, nullptr, nullptr, { &s_c2ba9038898e1fa2, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<134> b_9ea0b19b37fb4435 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<135> b_9ea0b19b37fb4435 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      53,  68, 251,  55, 155, 177, 160, 158,
      24,   0,   0,   0,   1,   0,   6,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       6,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 250,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -697,16 +734,17 @@ static const ::capnp::_::RawSchema* const d_9ea0b19b37fb4435[] = {
 static const uint16_t m_9ea0b19b37fb4435[] = {0, 4, 5, 6, 3, 1, 2};
 static const uint16_t i_9ea0b19b37fb4435[] = {0, 1, 2, 3, 4, 5, 6};
 const ::capnp::_::RawSchema s_9ea0b19b37fb4435 = {
-  0x9ea0b19b37fb4435, b_9ea0b19b37fb4435.words, 134, d_9ea0b19b37fb4435, m_9ea0b19b37fb4435,
+  0x9ea0b19b37fb4435, b_9ea0b19b37fb4435.words, 135, d_9ea0b19b37fb4435, m_9ea0b19b37fb4435,
   3, 7, i_9ea0b19b37fb4435, nullptr, nullptr, { &s_9ea0b19b37fb4435, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<37> b_b54ab3364333f598 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<38> b_b54ab3364333f598 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     152, 245,  51,  67,  54, 179,  74, 181,
      24,   0,   0,   0,   1,   0,   6,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       6,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 234,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -749,16 +787,17 @@ static const ::capnp::_::RawSchema* const d_b54ab3364333f598[] = {
 static const uint16_t m_b54ab3364333f598[] = {0};
 static const uint16_t i_b54ab3364333f598[] = {0};
 const ::capnp::_::RawSchema s_b54ab3364333f598 = {
-  0xb54ab3364333f598, b_b54ab3364333f598.words, 37, d_b54ab3364333f598, m_b54ab3364333f598,
+  0xb54ab3364333f598, b_b54ab3364333f598.words, 38, d_b54ab3364333f598, m_b54ab3364333f598,
   2, 1, i_b54ab3364333f598, nullptr, nullptr, { &s_b54ab3364333f598, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<57> b_e82753cff0c2218f = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<58> b_e82753cff0c2218f = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     143,  33, 194, 240, 207,  83,  39, 232,
      24,   0,   0,   0,   1,   0,   6,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       6,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0,  18,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -822,16 +861,17 @@ static const ::capnp::_::RawSchema* const d_e82753cff0c2218f[] = {
 static const uint16_t m_e82753cff0c2218f[] = {0, 1};
 static const uint16_t i_e82753cff0c2218f[] = {0, 1};
 const ::capnp::_::RawSchema s_e82753cff0c2218f = {
-  0xe82753cff0c2218f, b_e82753cff0c2218f.words, 57, d_e82753cff0c2218f, m_e82753cff0c2218f,
+  0xe82753cff0c2218f, b_e82753cff0c2218f.words, 58, d_e82753cff0c2218f, m_e82753cff0c2218f,
   3, 2, i_e82753cff0c2218f, nullptr, nullptr, { &s_e82753cff0c2218f, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<47> b_b18aa5ac7a0d9420 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<48> b_b18aa5ac7a0d9420 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      32, 148,  13, 122, 172, 165, 138, 177,
      24,   0,   0,   0,   1,   0,   6,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       6,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -885,16 +925,17 @@ static const ::capnp::_::RawSchema* const d_b18aa5ac7a0d9420[] = {
 static const uint16_t m_b18aa5ac7a0d9420[] = {0, 1};
 static const uint16_t i_b18aa5ac7a0d9420[] = {0, 1};
 const ::capnp::_::RawSchema s_b18aa5ac7a0d9420 = {
-  0xb18aa5ac7a0d9420, b_b18aa5ac7a0d9420.words, 47, d_b18aa5ac7a0d9420, m_b18aa5ac7a0d9420,
+  0xb18aa5ac7a0d9420, b_b18aa5ac7a0d9420.words, 48, d_b18aa5ac7a0d9420, m_b18aa5ac7a0d9420,
   3, 2, i_b18aa5ac7a0d9420, nullptr, nullptr, { &s_b18aa5ac7a0d9420, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<228> b_ec1619d4400a0290 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<229> b_ec1619d4400a0290 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     144,   2,  10,  64, 212,  25,  22, 236,
      24,   0,   0,   0,   1,   0,   6,   0,
      23, 164,  35, 249,  76, 171, 130, 230,
       6,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0,  26,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1128,17 +1169,18 @@ static const ::capnp::_::RawSchema* const d_ec1619d4400a0290[] = {
 static const uint16_t m_ec1619d4400a0290[] = {12, 2, 3, 4, 6, 1, 8, 9, 10, 11, 5, 7, 0};
 static const uint16_t i_ec1619d4400a0290[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 const ::capnp::_::RawSchema s_ec1619d4400a0290 = {
-  0xec1619d4400a0290, b_ec1619d4400a0290.words, 228, d_ec1619d4400a0290, m_ec1619d4400a0290,
+  0xec1619d4400a0290, b_ec1619d4400a0290.words, 229, d_ec1619d4400a0290, m_ec1619d4400a0290,
   2, 13, i_ec1619d4400a0290, nullptr, nullptr, { &s_ec1619d4400a0290, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<114> b_9aad50a41f4af45f = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<115> b_9aad50a41f4af45f = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      95, 244,  74,  31, 164,  80, 173, 154,
      19,   0,   0,   0,   1,   0,   3,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       4,   0,   7,   0,   0,   0,   2,   0,
       4,   0,   0,   0,   0,   0,   0,   0,
+    181,  31,   0,   0, 198,  40,   0,   0,
      21,   0,   0,   0, 202,   0,   0,   0,
      33,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1259,17 +1301,18 @@ static const ::capnp::_::RawSchema* const d_9aad50a41f4af45f[] = {
 static const uint16_t m_9aad50a41f4af45f[] = {2, 1, 3, 5, 0, 6, 4};
 static const uint16_t i_9aad50a41f4af45f[] = {4, 5, 0, 1, 2, 3, 6};
 const ::capnp::_::RawSchema s_9aad50a41f4af45f = {
-  0x9aad50a41f4af45f, b_9aad50a41f4af45f.words, 114, d_9aad50a41f4af45f, m_9aad50a41f4af45f,
+  0x9aad50a41f4af45f, b_9aad50a41f4af45f.words, 115, d_9aad50a41f4af45f, m_9aad50a41f4af45f,
   4, 7, i_9aad50a41f4af45f, nullptr, nullptr, { &s_9aad50a41f4af45f, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<25> b_97b14cbe7cfec712 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<26> b_97b14cbe7cfec712 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      18, 199, 254, 124, 190,  76, 177, 151,
      25,   0,   0,   0,   4,   0,   0,   0,
      95, 244,  74,  31, 164,  80, 173, 154,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+     97,  34,   0,   0, 135,  34,   0,   0,
      21,   0,   0,   0,  66,   1,   0,   0,
      37,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1293,16 +1336,17 @@ static const ::capnp::_::AlignedData<25> b_97b14cbe7cfec712 = {
 ::capnp::word const* const bp_97b14cbe7cfec712 = b_97b14cbe7cfec712.words;
 #if !CAPNP_LITE
 const ::capnp::_::RawSchema s_97b14cbe7cfec712 = {
-  0x97b14cbe7cfec712, b_97b14cbe7cfec712.words, 25, nullptr, nullptr,
+  0x97b14cbe7cfec712, b_97b14cbe7cfec712.words, 26, nullptr, nullptr,
   0, 0, nullptr, nullptr, nullptr, { &s_97b14cbe7cfec712, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<80> b_c42305476bb4746f = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<81> b_c42305476bb4746f = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     111, 116, 180, 107,  71,   5,  35, 196,
      25,   0,   0,   0,   1,   0,   3,   0,
      95, 244,  74,  31, 164,  80, 173, 154,
       4,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1389,16 +1433,17 @@ static const ::capnp::_::RawSchema* const d_c42305476bb4746f[] = {
 static const uint16_t m_c42305476bb4746f[] = {2, 3, 0, 1};
 static const uint16_t i_c42305476bb4746f[] = {0, 1, 2, 3};
 const ::capnp::_::RawSchema s_c42305476bb4746f = {
-  0xc42305476bb4746f, b_c42305476bb4746f.words, 80, d_c42305476bb4746f, m_c42305476bb4746f,
+  0xc42305476bb4746f, b_c42305476bb4746f.words, 81, d_c42305476bb4746f, m_c42305476bb4746f,
   3, 4, i_c42305476bb4746f, nullptr, nullptr, { &s_c42305476bb4746f, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<32> b_cafccddb68db1d11 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<33> b_cafccddb68db1d11 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      17,  29, 219, 104, 219, 205, 252, 202,
      25,   0,   0,   0,   1,   0,   3,   0,
      95, 244,  74,  31, 164,  80, 173, 154,
       4,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 250,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1435,17 +1480,18 @@ static const ::capnp::_::RawSchema* const d_cafccddb68db1d11[] = {
 static const uint16_t m_cafccddb68db1d11[] = {0};
 static const uint16_t i_cafccddb68db1d11[] = {0};
 const ::capnp::_::RawSchema s_cafccddb68db1d11 = {
-  0xcafccddb68db1d11, b_cafccddb68db1d11.words, 32, d_cafccddb68db1d11, m_cafccddb68db1d11,
+  0xcafccddb68db1d11, b_cafccddb68db1d11.words, 33, d_cafccddb68db1d11, m_cafccddb68db1d11,
   1, 1, i_cafccddb68db1d11, nullptr, nullptr, { &s_cafccddb68db1d11, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<50> b_bb90d5c287870be6 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<51> b_bb90d5c287870be6 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     230,  11, 135, 135, 194, 213, 144, 187,
      25,   0,   0,   0,   1,   0,   3,   0,
      95, 244,  74,  31, 164,  80, 173, 154,
       4,   0,   7,   0,   1,   0,   2,   0,
       5,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0,  10,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1499,17 +1545,18 @@ static const ::capnp::_::RawSchema* const d_bb90d5c287870be6[] = {
 static const uint16_t m_bb90d5c287870be6[] = {1, 0};
 static const uint16_t i_bb90d5c287870be6[] = {0, 1};
 const ::capnp::_::RawSchema s_bb90d5c287870be6 = {
-  0xbb90d5c287870be6, b_bb90d5c287870be6.words, 50, d_bb90d5c287870be6, m_bb90d5c287870be6,
+  0xbb90d5c287870be6, b_bb90d5c287870be6.words, 51, d_bb90d5c287870be6, m_bb90d5c287870be6,
   1, 2, i_bb90d5c287870be6, nullptr, nullptr, { &s_bb90d5c287870be6, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<69> b_978a7cebdc549a4d = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<70> b_978a7cebdc549a4d = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      77, 154,  84, 220, 235, 124, 138, 151,
      19,   0,   0,   0,   1,   0,   1,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    200,  40,   0,   0, 182,  41,   0,   0,
      21,   0,   0,   0, 234,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1582,17 +1629,18 @@ static const ::capnp::_::RawSchema* const d_978a7cebdc549a4d[] = {
 static const uint16_t m_978a7cebdc549a4d[] = {2, 1, 0};
 static const uint16_t i_978a7cebdc549a4d[] = {0, 1, 2};
 const ::capnp::_::RawSchema s_978a7cebdc549a4d = {
-  0x978a7cebdc549a4d, b_978a7cebdc549a4d.words, 69, d_978a7cebdc549a4d, m_978a7cebdc549a4d,
+  0x978a7cebdc549a4d, b_978a7cebdc549a4d.words, 70, d_978a7cebdc549a4d, m_978a7cebdc549a4d,
   1, 3, i_978a7cebdc549a4d, nullptr, nullptr, { &s_978a7cebdc549a4d, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<48> b_a9962a9ed0a4d7f8 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<49> b_a9962a9ed0a4d7f8 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     248, 215, 164, 208, 158,  42, 150, 169,
      19,   0,   0,   0,   1,   0,   1,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       1,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    184,  41,   0,   0, 237,  41,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1644,17 +1692,18 @@ static const ::capnp::_::RawSchema* const d_a9962a9ed0a4d7f8[] = {
 static const uint16_t m_a9962a9ed0a4d7f8[] = {1, 0};
 static const uint16_t i_a9962a9ed0a4d7f8[] = {0, 1};
 const ::capnp::_::RawSchema s_a9962a9ed0a4d7f8 = {
-  0xa9962a9ed0a4d7f8, b_a9962a9ed0a4d7f8.words, 48, d_a9962a9ed0a4d7f8, m_a9962a9ed0a4d7f8,
+  0xa9962a9ed0a4d7f8, b_a9962a9ed0a4d7f8.words, 49, d_a9962a9ed0a4d7f8, m_a9962a9ed0a4d7f8,
   1, 2, i_a9962a9ed0a4d7f8, nullptr, nullptr, { &s_a9962a9ed0a4d7f8, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<155> b_9500cce23b334d80 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<156> b_9500cce23b334d80 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     128,  77,  51,  59, 226, 204,   0, 149,
      19,   0,   0,   0,   1,   0,   3,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       5,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    239,  41,   0,   0,  60,  47,   0,   0,
      21,   0,   0,   0, 210,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -1815,17 +1864,18 @@ static const ::capnp::_::RawSchema* const d_9500cce23b334d80[] = {
 static const uint16_t m_9500cce23b334d80[] = {4, 1, 7, 0, 5, 2, 6, 3};
 static const uint16_t i_9500cce23b334d80[] = {0, 1, 2, 3, 4, 5, 6, 7};
 const ::capnp::_::RawSchema s_9500cce23b334d80 = {
-  0x9500cce23b334d80, b_9500cce23b334d80.words, 155, d_9500cce23b334d80, m_9500cce23b334d80,
+  0x9500cce23b334d80, b_9500cce23b334d80.words, 156, d_9500cce23b334d80, m_9500cce23b334d80,
   3, 8, i_9500cce23b334d80, nullptr, nullptr, { &s_9500cce23b334d80, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<269> b_d07378ede1f9cc60 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<270> b_d07378ede1f9cc60 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      96, 204, 249, 225, 237, 120, 115, 208,
      19,   0,   0,   0,   1,   0,   3,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       1,   0,   7,   0,   0,   0,  19,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+     62,  47,   0,   0, 151,  54,   0,   0,
      21,   0,   0,   0, 194,   0,   0,   0,
      29,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2102,16 +2152,17 @@ static const ::capnp::_::RawSchema* const d_d07378ede1f9cc60[] = {
 static const uint16_t m_d07378ede1f9cc60[] = {18, 1, 13, 15, 10, 11, 3, 4, 5, 2, 17, 14, 16, 12, 7, 8, 9, 6, 0};
 static const uint16_t i_d07378ede1f9cc60[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
 const ::capnp::_::RawSchema s_d07378ede1f9cc60 = {
-  0xd07378ede1f9cc60, b_d07378ede1f9cc60.words, 269, d_d07378ede1f9cc60, m_d07378ede1f9cc60,
+  0xd07378ede1f9cc60, b_d07378ede1f9cc60.words, 270, d_d07378ede1f9cc60, m_d07378ede1f9cc60,
   5, 19, i_d07378ede1f9cc60, nullptr, nullptr, { &s_d07378ede1f9cc60, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<33> b_87e739250a60ea97 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<34> b_87e739250a60ea97 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     151, 234,  96,  10,  37,  57, 231, 135,
      24,   0,   0,   0,   1,   0,   3,   0,
      96, 204, 249, 225, 237, 120, 115, 208,
       1,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 234,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2149,16 +2200,17 @@ static const ::capnp::_::RawSchema* const d_87e739250a60ea97[] = {
 static const uint16_t m_87e739250a60ea97[] = {0};
 static const uint16_t i_87e739250a60ea97[] = {0};
 const ::capnp::_::RawSchema s_87e739250a60ea97 = {
-  0x87e739250a60ea97, b_87e739250a60ea97.words, 33, d_87e739250a60ea97, m_87e739250a60ea97,
+  0x87e739250a60ea97, b_87e739250a60ea97.words, 34, d_87e739250a60ea97, m_87e739250a60ea97,
   1, 1, i_87e739250a60ea97, nullptr, nullptr, { &s_87e739250a60ea97, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<47> b_9e0e78711a7f87a9 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<48> b_9e0e78711a7f87a9 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     169, 135, 127,  26, 113, 120,  14, 158,
      24,   0,   0,   0,   1,   0,   3,   0,
      96, 204, 249, 225, 237, 120, 115, 208,
       1,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 234,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2211,16 +2263,17 @@ static const ::capnp::_::RawSchema* const d_9e0e78711a7f87a9[] = {
 static const uint16_t m_9e0e78711a7f87a9[] = {1, 0};
 static const uint16_t i_9e0e78711a7f87a9[] = {0, 1};
 const ::capnp::_::RawSchema s_9e0e78711a7f87a9 = {
-  0x9e0e78711a7f87a9, b_9e0e78711a7f87a9.words, 47, d_9e0e78711a7f87a9, m_9e0e78711a7f87a9,
+  0x9e0e78711a7f87a9, b_9e0e78711a7f87a9.words, 48, d_9e0e78711a7f87a9, m_9e0e78711a7f87a9,
   2, 2, i_9e0e78711a7f87a9, nullptr, nullptr, { &s_9e0e78711a7f87a9, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<47> b_ac3a6f60ef4cc6d3 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<48> b_ac3a6f60ef4cc6d3 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     211, 198,  76, 239,  96, 111,  58, 172,
      24,   0,   0,   0,   1,   0,   3,   0,
      96, 204, 249, 225, 237, 120, 115, 208,
       1,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 250,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2273,16 +2326,17 @@ static const ::capnp::_::RawSchema* const d_ac3a6f60ef4cc6d3[] = {
 static const uint16_t m_ac3a6f60ef4cc6d3[] = {1, 0};
 static const uint16_t i_ac3a6f60ef4cc6d3[] = {0, 1};
 const ::capnp::_::RawSchema s_ac3a6f60ef4cc6d3 = {
-  0xac3a6f60ef4cc6d3, b_ac3a6f60ef4cc6d3.words, 47, d_ac3a6f60ef4cc6d3, m_ac3a6f60ef4cc6d3,
+  0xac3a6f60ef4cc6d3, b_ac3a6f60ef4cc6d3.words, 48, d_ac3a6f60ef4cc6d3, m_ac3a6f60ef4cc6d3,
   2, 2, i_ac3a6f60ef4cc6d3, nullptr, nullptr, { &s_ac3a6f60ef4cc6d3, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<48> b_ed8bca69f7fb0cbf = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<49> b_ed8bca69f7fb0cbf = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     191,  12, 251, 247, 105, 202, 139, 237,
      24,   0,   0,   0,   1,   0,   3,   0,
      96, 204, 249, 225, 237, 120, 115, 208,
       1,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0,  18,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2336,17 +2390,18 @@ static const ::capnp::_::RawSchema* const d_ed8bca69f7fb0cbf[] = {
 static const uint16_t m_ed8bca69f7fb0cbf[] = {1, 0};
 static const uint16_t i_ed8bca69f7fb0cbf[] = {0, 1};
 const ::capnp::_::RawSchema s_ed8bca69f7fb0cbf = {
-  0xed8bca69f7fb0cbf, b_ed8bca69f7fb0cbf.words, 48, d_ed8bca69f7fb0cbf, m_ed8bca69f7fb0cbf,
+  0xed8bca69f7fb0cbf, b_ed8bca69f7fb0cbf.words, 49, d_ed8bca69f7fb0cbf, m_ed8bca69f7fb0cbf,
   2, 2, i_ed8bca69f7fb0cbf, nullptr, nullptr, { &s_ed8bca69f7fb0cbf, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<46> b_c2573fe8a23e49f1 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<47> b_c2573fe8a23e49f1 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     241,  73,  62, 162, 232,  63,  87, 194,
      24,   0,   0,   0,   1,   0,   3,   0,
      96, 204, 249, 225, 237, 120, 115, 208,
       1,   0,   7,   0,   1,   0,   3,   0,
       4,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0,  26,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2399,17 +2454,18 @@ static const ::capnp::_::RawSchema* const d_c2573fe8a23e49f1[] = {
 static const uint16_t m_c2573fe8a23e49f1[] = {2, 1, 0};
 static const uint16_t i_c2573fe8a23e49f1[] = {0, 1, 2};
 const ::capnp::_::RawSchema s_c2573fe8a23e49f1 = {
-  0xc2573fe8a23e49f1, b_c2573fe8a23e49f1.words, 46, d_c2573fe8a23e49f1, m_c2573fe8a23e49f1,
+  0xc2573fe8a23e49f1, b_c2573fe8a23e49f1.words, 47, d_c2573fe8a23e49f1, m_c2573fe8a23e49f1,
   4, 3, i_c2573fe8a23e49f1, nullptr, nullptr, { &s_c2573fe8a23e49f1, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<81> b_8e3b5f79fe593656 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<82> b_8e3b5f79fe593656 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      86,  54,  89, 254, 121,  95,  59, 142,
      35,   0,   0,   0,   1,   0,   3,   0,
     241,  73,  62, 162, 232,  63,  87, 194,
       1,   0,   7,   0,   1,   0,   4,   0,
       5,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 138,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2494,16 +2550,17 @@ static const ::capnp::_::RawSchema* const d_8e3b5f79fe593656[] = {
 static const uint16_t m_8e3b5f79fe593656[] = {0, 3, 2, 1};
 static const uint16_t i_8e3b5f79fe593656[] = {0, 1, 2, 3};
 const ::capnp::_::RawSchema s_8e3b5f79fe593656 = {
-  0x8e3b5f79fe593656, b_8e3b5f79fe593656.words, 81, d_8e3b5f79fe593656, m_8e3b5f79fe593656,
+  0x8e3b5f79fe593656, b_8e3b5f79fe593656.words, 82, d_8e3b5f79fe593656, m_8e3b5f79fe593656,
   1, 4, i_8e3b5f79fe593656, nullptr, nullptr, { &s_8e3b5f79fe593656, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<50> b_9dd1f724f4614a85 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<51> b_9dd1f724f4614a85 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     133,  74,  97, 244,  36, 247, 209, 157,
      35,   0,   0,   0,   1,   0,   3,   0,
     241,  73,  62, 162, 232,  63,  87, 194,
       1,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 106,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2558,16 +2615,17 @@ static const ::capnp::_::RawSchema* const d_9dd1f724f4614a85[] = {
 static const uint16_t m_9dd1f724f4614a85[] = {1, 0};
 static const uint16_t i_9dd1f724f4614a85[] = {0, 1};
 const ::capnp::_::RawSchema s_9dd1f724f4614a85 = {
-  0x9dd1f724f4614a85, b_9dd1f724f4614a85.words, 50, d_9dd1f724f4614a85, m_9dd1f724f4614a85,
+  0x9dd1f724f4614a85, b_9dd1f724f4614a85.words, 51, d_9dd1f724f4614a85, m_9dd1f724f4614a85,
   1, 2, i_9dd1f724f4614a85, nullptr, nullptr, { &s_9dd1f724f4614a85, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<37> b_baefc9120c56e274 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<38> b_baefc9120c56e274 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     116, 226,  86,  12,  18, 201, 239, 186,
      35,   0,   0,   0,   1,   0,   3,   0,
     241,  73,  62, 162, 232,  63,  87, 194,
       1,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 218,   1,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2609,17 +2667,18 @@ static const ::capnp::_::RawSchema* const d_baefc9120c56e274[] = {
 static const uint16_t m_baefc9120c56e274[] = {0};
 static const uint16_t i_baefc9120c56e274[] = {0};
 const ::capnp::_::RawSchema s_baefc9120c56e274 = {
-  0xbaefc9120c56e274, b_baefc9120c56e274.words, 37, d_baefc9120c56e274, m_baefc9120c56e274,
+  0xbaefc9120c56e274, b_baefc9120c56e274.words, 38, d_baefc9120c56e274, m_baefc9120c56e274,
   1, 1, i_baefc9120c56e274, nullptr, nullptr, { &s_baefc9120c56e274, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<43> b_903455f06065422b = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<44> b_903455f06065422b = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      43,  66, 101,  96, 240,  85,  52, 144,
      19,   0,   0,   0,   1,   0,   0,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       1,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    153,  54,   0,   0, 143,  60,   0,   0,
      21,   0,   0,   0, 202,   0,   0,   0,
      33,   0,   0,   0,  39,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2666,17 +2725,18 @@ static const ::capnp::_::RawSchema* const d_903455f06065422b[] = {
 static const uint16_t m_903455f06065422b[] = {0};
 static const uint16_t i_903455f06065422b[] = {0};
 const ::capnp::_::RawSchema s_903455f06065422b = {
-  0x903455f06065422b, b_903455f06065422b.words, 43, d_903455f06065422b, m_903455f06065422b,
+  0x903455f06065422b, b_903455f06065422b.words, 44, d_903455f06065422b, m_903455f06065422b,
   1, 1, i_903455f06065422b, nullptr, nullptr, { &s_903455f06065422b, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<67> b_abd73485a9636bc9 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<68> b_abd73485a9636bc9 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     201, 107,  99, 169, 133,  52, 215, 171,
      25,   0,   0,   0,   1,   0,   2,   0,
      43,  66, 101,  96, 240,  85,  52, 144,
       1,   0,   7,   0,   0,   0,   2,   0,
       4,   0,   0,   0,   0,   0,   0,   0,
+    109,  56,   0,   0, 241,  59,   0,   0,
      21,   0,   0,   0, 250,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2747,17 +2807,18 @@ static const ::capnp::_::RawSchema* const d_abd73485a9636bc9[] = {
 static const uint16_t m_abd73485a9636bc9[] = {1, 2, 0};
 static const uint16_t i_abd73485a9636bc9[] = {1, 2, 0};
 const ::capnp::_::RawSchema s_abd73485a9636bc9 = {
-  0xabd73485a9636bc9, b_abd73485a9636bc9.words, 67, d_abd73485a9636bc9, m_abd73485a9636bc9,
+  0xabd73485a9636bc9, b_abd73485a9636bc9.words, 68, d_abd73485a9636bc9, m_abd73485a9636bc9,
   1, 3, i_abd73485a9636bc9, nullptr, nullptr, { &s_abd73485a9636bc9, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<49> b_c863cd16969ee7fc = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<50> b_c863cd16969ee7fc = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     252, 231, 158, 150,  22, 205,  99, 200,
      25,   0,   0,   0,   1,   0,   1,   0,
      43,  66, 101,  96, 240,  85,  52, 144,
       1,   0,   7,   0,   0,   0,   2,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    245,  59,   0,   0, 141,  60,   0,   0,
      21,   0,   0,   0,  10,   1,   0,   0,
      37,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -2810,17 +2871,18 @@ static const ::capnp::_::RawSchema* const d_c863cd16969ee7fc[] = {
 static const uint16_t m_c863cd16969ee7fc[] = {1, 0};
 static const uint16_t i_c863cd16969ee7fc[] = {0, 1};
 const ::capnp::_::RawSchema s_c863cd16969ee7fc = {
-  0xc863cd16969ee7fc, b_c863cd16969ee7fc.words, 49, d_c863cd16969ee7fc, m_c863cd16969ee7fc,
+  0xc863cd16969ee7fc, b_c863cd16969ee7fc.words, 50, d_c863cd16969ee7fc, m_c863cd16969ee7fc,
   1, 2, i_c863cd16969ee7fc, nullptr, nullptr, { &s_c863cd16969ee7fc, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<305> b_ce23dcd2d7b00c9b = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<306> b_ce23dcd2d7b00c9b = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     155,  12, 176, 215, 210, 220,  35, 206,
      19,   0,   0,   0,   1,   0,   2,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       1,   0,   7,   0,   0,   0,  19,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    145,  60,   0,   0, 113,  63,   0,   0,
      21,   0,   0,   0, 202,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3126,17 +3188,18 @@ static const ::capnp::_::AlignedData<305> b_ce23dcd2d7b00c9b = {
 static const uint16_t m_ce23dcd2d7b00c9b[] = {18, 1, 13, 15, 10, 11, 3, 4, 5, 2, 17, 14, 16, 12, 7, 8, 9, 6, 0};
 static const uint16_t i_ce23dcd2d7b00c9b[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
 const ::capnp::_::RawSchema s_ce23dcd2d7b00c9b = {
-  0xce23dcd2d7b00c9b, b_ce23dcd2d7b00c9b.words, 305, nullptr, m_ce23dcd2d7b00c9b,
+  0xce23dcd2d7b00c9b, b_ce23dcd2d7b00c9b.words, 306, nullptr, m_ce23dcd2d7b00c9b,
   0, 19, i_ce23dcd2d7b00c9b, nullptr, nullptr, { &s_ce23dcd2d7b00c9b, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<63> b_f1c8950dab257542 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<64> b_f1c8950dab257542 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      66, 117,  37, 171,  13, 149, 200, 241,
      19,   0,   0,   0,   1,   0,   1,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    115,  63,   0,   0,   3,  65,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3204,17 +3267,18 @@ static const ::capnp::_::RawSchema* const d_f1c8950dab257542[] = {
 static const uint16_t m_f1c8950dab257542[] = {2, 0, 1};
 static const uint16_t i_f1c8950dab257542[] = {0, 1, 2};
 const ::capnp::_::RawSchema s_f1c8950dab257542 = {
-  0xf1c8950dab257542, b_f1c8950dab257542.words, 63, d_f1c8950dab257542, m_f1c8950dab257542,
+  0xf1c8950dab257542, b_f1c8950dab257542.words, 64, d_f1c8950dab257542, m_f1c8950dab257542,
   2, 3, i_f1c8950dab257542, nullptr, nullptr, { &s_f1c8950dab257542, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<54> b_d1958f7dba521926 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<55> b_d1958f7dba521926 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      38,  25,  82, 186, 125, 143, 149, 209,
      19,   0,   0,   0,   2,   0,   0,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+      5,  65,   0,   0,  80,  66,   0,   0,
      21,   0,   0,   0, 250,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3268,17 +3332,18 @@ static const ::capnp::_::AlignedData<54> b_d1958f7dba521926 = {
 #if !CAPNP_LITE
 static const uint16_t m_d1958f7dba521926[] = {1, 2, 5, 0, 4, 7, 6, 3};
 const ::capnp::_::RawSchema s_d1958f7dba521926 = {
-  0xd1958f7dba521926, b_d1958f7dba521926.words, 54, nullptr, m_d1958f7dba521926,
+  0xd1958f7dba521926, b_d1958f7dba521926.words, 55, nullptr, m_d1958f7dba521926,
   0, 8, nullptr, nullptr, nullptr, { &s_d1958f7dba521926, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<63> b_d85d305b7d839963 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<64> b_d85d305b7d839963 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      99, 153, 131, 125,  91,  48,  93, 216,
      19,   0,   0,   0,   1,   0,   1,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       0,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+     82,  66,   0,   0, 163,  66,   0,   0,
      21,   0,   0,   0,   2,   1,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3342,17 +3407,18 @@ static const ::capnp::_::AlignedData<63> b_d85d305b7d839963 = {
 static const uint16_t m_d85d305b7d839963[] = {0, 2, 1};
 static const uint16_t i_d85d305b7d839963[] = {0, 1, 2};
 const ::capnp::_::RawSchema s_d85d305b7d839963 = {
-  0xd85d305b7d839963, b_d85d305b7d839963.words, 63, nullptr, m_d85d305b7d839963,
+  0xd85d305b7d839963, b_d85d305b7d839963.words, 64, nullptr, m_d85d305b7d839963,
   0, 3, i_d85d305b7d839963, nullptr, nullptr, { &s_d85d305b7d839963, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<98> b_bfc546f6210ad7ce = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<99> b_bfc546f6210ad7ce = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     206, 215,  10,  33, 246,  70, 197, 191,
      19,   0,   0,   0,   1,   0,   0,   0,
     217, 114,  76,  98,   9, 197,  63, 169,
       4,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    165,  66,   0,   0,  83,  75,   0,   0,
      21,   0,   0,   0,  66,   1,   0,   0,
      37,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3457,17 +3523,18 @@ static const ::capnp::_::RawSchema* const d_bfc546f6210ad7ce[] = {
 static const uint16_t m_bfc546f6210ad7ce[] = {2, 0, 1, 3};
 static const uint16_t i_bfc546f6210ad7ce[] = {0, 1, 2, 3};
 const ::capnp::_::RawSchema s_bfc546f6210ad7ce = {
-  0xbfc546f6210ad7ce, b_bfc546f6210ad7ce.words, 98, d_bfc546f6210ad7ce, m_bfc546f6210ad7ce,
+  0xbfc546f6210ad7ce, b_bfc546f6210ad7ce.words, 99, d_bfc546f6210ad7ce, m_bfc546f6210ad7ce,
   4, 4, i_bfc546f6210ad7ce, nullptr, nullptr, { &s_bfc546f6210ad7ce, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<94> b_cfea0eb02e810062 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<95> b_cfea0eb02e810062 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      98,   0, 129,  46, 176,  14, 234, 207,
      40,   0,   0,   0,   1,   0,   1,   0,
     206, 215,  10,  33, 246,  70, 197, 191,
       3,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+     14,  70,   0,   0,  81,  75,   0,   0,
      21,   0,   0,   0, 178,   1,   0,   0,
      45,   0,   0,   0,  39,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3566,17 +3633,18 @@ static const ::capnp::_::RawSchema* const d_cfea0eb02e810062[] = {
 static const uint16_t m_cfea0eb02e810062[] = {3, 1, 0, 2};
 static const uint16_t i_cfea0eb02e810062[] = {0, 1, 2, 3};
 const ::capnp::_::RawSchema s_cfea0eb02e810062 = {
-  0xcfea0eb02e810062, b_cfea0eb02e810062.words, 94, d_cfea0eb02e810062, m_cfea0eb02e810062,
+  0xcfea0eb02e810062, b_cfea0eb02e810062.words, 95, d_cfea0eb02e810062, m_cfea0eb02e810062,
   2, 4, i_cfea0eb02e810062, nullptr, nullptr, { &s_cfea0eb02e810062, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<52> b_ae504193122357e5 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<53> b_ae504193122357e5 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     229,  87,  35,  18, 147,  65,  80, 174,
      54,   0,   0,   0,   1,   0,   1,   0,
      98,   0, 129,  46, 176,  14, 234, 207,
       1,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+     73,  71,   0,   0,  97,  73,   0,   0,
      21,   0,   0,   0, 234,   1,   0,   0,
      49,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3629,17 +3697,18 @@ static const ::capnp::_::AlignedData<52> b_ae504193122357e5 = {
 static const uint16_t m_ae504193122357e5[] = {0, 1};
 static const uint16_t i_ae504193122357e5[] = {0, 1};
 const ::capnp::_::RawSchema s_ae504193122357e5 = {
-  0xae504193122357e5, b_ae504193122357e5.words, 52, nullptr, m_ae504193122357e5,
+  0xae504193122357e5, b_ae504193122357e5.words, 53, nullptr, m_ae504193122357e5,
   0, 2, i_ae504193122357e5, nullptr, nullptr, { &s_ae504193122357e5, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<47> b_f8ea2bf176925da0 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<48> b_f8ea2bf176925da0 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     160,  93, 146, 118, 241,  43, 234, 248,
      54,   0,   0,   0,   1,   0,   0,   0,
      98,   0, 129,  46, 176,  14, 234, 207,
       1,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    146,  73,   0,   0,  77,  75,   0,   0,
      21,   0,   0,   0,  42,   2,   0,   0,
      53,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3690,17 +3759,18 @@ static const ::capnp::_::RawSchema* const d_f8ea2bf176925da0[] = {
 static const uint16_t m_f8ea2bf176925da0[] = {0};
 static const uint16_t i_f8ea2bf176925da0[] = {0};
 const ::capnp::_::RawSchema s_f8ea2bf176925da0 = {
-  0xf8ea2bf176925da0, b_f8ea2bf176925da0.words, 47, d_f8ea2bf176925da0, m_f8ea2bf176925da0,
+  0xf8ea2bf176925da0, b_f8ea2bf176925da0.words, 48, d_f8ea2bf176925da0, m_f8ea2bf176925da0,
   1, 1, i_f8ea2bf176925da0, nullptr, nullptr, { &s_f8ea2bf176925da0, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<78> b_dda719892e0499bb = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<79> b_dda719892e0499bb = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
     187, 153,   4,  46, 137,  25, 167, 221,
      69,   0,   0,   0,   1,   0,   3,   0,
     160,  93, 146, 118, 241,  43, 234, 248,
       0,   0,   7,   0,   0,   0,   2,   0,
       8,   0,   0,   0,   0,   0,   0,   0,
+    217,  73,   0,   0,  71,  75,   0,   0,
      21,   0,   0,   0, 130,   2,   0,   0,
      57,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3782,16 +3852,17 @@ static const ::capnp::_::RawSchema* const d_dda719892e0499bb[] = {
 static const uint16_t m_dda719892e0499bb[] = {1, 3, 0, 2};
 static const uint16_t i_dda719892e0499bb[] = {2, 3, 0, 1};
 const ::capnp::_::RawSchema s_dda719892e0499bb = {
-  0xdda719892e0499bb, b_dda719892e0499bb.words, 78, d_dda719892e0499bb, m_dda719892e0499bb,
+  0xdda719892e0499bb, b_dda719892e0499bb.words, 79, d_dda719892e0499bb, m_dda719892e0499bb,
   1, 4, i_dda719892e0499bb, nullptr, nullptr, { &s_dda719892e0499bb, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<55> b_fc69d5e1d630a151 = {
-  {   0,   0,   0,   0,   5,   0,   6,   0,
+static const ::capnp::_::AlignedData<56> b_fc69d5e1d630a151 = {
+  {   0,   0,   0,   0,   6,   0,   6,   0,
      81, 161,  48, 214, 225, 213, 105, 252,
      80,   0,   0,   0,   1,   0,   3,   0,
     187, 153,   4,  46, 137,  25, 167, 221,
       0,   0,   7,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 186,   2,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -3851,7 +3922,7 @@ static const ::capnp::_::RawSchema* const d_fc69d5e1d630a151[] = {
 static const uint16_t m_fc69d5e1d630a151[] = {1, 0};
 static const uint16_t i_fc69d5e1d630a151[] = {0, 1};
 const ::capnp::_::RawSchema s_fc69d5e1d630a151 = {
-  0xfc69d5e1d630a151, b_fc69d5e1d630a151.words, 55, d_fc69d5e1d630a151, m_fc69d5e1d630a151,
+  0xfc69d5e1d630a151, b_fc69d5e1d630a151.words, 56, d_fc69d5e1d630a151, m_fc69d5e1d630a151,
   1, 2, i_fc69d5e1d630a151, nullptr, nullptr, { &s_fc69d5e1d630a151, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE

--- a/c++/src/capnp/schema.capnp.h
+++ b/c++/src/capnp/schema.capnp.h
@@ -161,7 +161,7 @@ struct Node::SourceInfo::Member {
   class Pipeline;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(c2ba9038898e1fa2, 0, 1)
+    CAPNP_DECLARE_STRUCT_HEADER(c2ba9038898e1fa2, 1, 1)
     #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() { return &schema->defaultBrand; }
     #endif  // !CAPNP_LITE
@@ -1237,6 +1237,10 @@ public:
   inline bool hasDocComment() const;
   inline  ::capnp::Text::Reader getDocComment() const;
 
+  inline  ::uint32_t getStartByte() const;
+
+  inline  ::uint32_t getEndByte() const;
+
 private:
   ::capnp::_::StructReader _reader;
   template <typename, ::capnp::Kind>
@@ -1271,6 +1275,12 @@ public:
   inline  ::capnp::Text::Builder initDocComment(unsigned int size);
   inline void adoptDocComment(::capnp::Orphan< ::capnp::Text>&& value);
   inline ::capnp::Orphan< ::capnp::Text> disownDocComment();
+
+  inline  ::uint32_t getStartByte();
+  inline void setStartByte( ::uint32_t value);
+
+  inline  ::uint32_t getEndByte();
+  inline void setEndByte( ::uint32_t value);
 
 private:
   ::capnp::_::StructBuilder _builder;
@@ -5278,6 +5288,34 @@ inline void Node::SourceInfo::Member::Builder::adoptDocComment(
 inline ::capnp::Orphan< ::capnp::Text> Node::SourceInfo::Member::Builder::disownDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline  ::uint32_t Node::SourceInfo::Member::Reader::getStartByte() const {
+  return _reader.getDataField< ::uint32_t>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+
+inline  ::uint32_t Node::SourceInfo::Member::Builder::getStartByte() {
+  return _builder.getDataField< ::uint32_t>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+inline void Node::SourceInfo::Member::Builder::setStartByte( ::uint32_t value) {
+  _builder.setDataField< ::uint32_t>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
+}
+
+inline  ::uint32_t Node::SourceInfo::Member::Reader::getEndByte() const {
+  return _reader.getDataField< ::uint32_t>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
+}
+
+inline  ::uint32_t Node::SourceInfo::Member::Builder::getEndByte() {
+  return _builder.getDataField< ::uint32_t>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
+}
+inline void Node::SourceInfo::Member::Builder::setEndByte( ::uint32_t value) {
+  _builder.setDataField< ::uint32_t>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getDataWordCount() const {


### PR DESCRIPTION
There was no discussion, sorry about that, but I figured the change is small enough that a PR could illustrate the change and host discussion if needed.

(And emit source information for `Annotation`s as per https://github.com/capnproto/capnproto/pull/2126#discussion_r2029886844).

This follows the work in #2126.