### PR TITLE
add source information to generated structs

### DIFF
--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -1223,7 +1223,7 @@ private:
 
             memberInfo = &arena.allocate<MemberInfo>(
                 parent, codeOrder++, member,
-                newGroupNode(parent.node, member.getName().getValue()),
+                newGroupNode(parent.node, member),
                 true);
             allMembers.add(memberInfo);
             memberInfo->unionScope = &unionLayout;
@@ -1240,7 +1240,7 @@ private:
           StructLayout::Group& group = arena.allocate<StructLayout::Group>(layout);
           memberInfo = &arena.allocate<MemberInfo>(
               parent, codeOrder++, member,
-              newGroupNode(parent.node, member.getName().getValue()),
+              newGroupNode(parent.node, member),
               true);
           allMembers.add(memberInfo);
           traverseGroup(member.getNestedDecls(), *memberInfo, group);
@@ -1298,7 +1298,7 @@ private:
             parent.childCount++;
             memberInfo = &arena.allocate<MemberInfo>(
                 parent, codeOrder++, member,
-                newGroupNode(parent.node, member.getName().getValue()),
+                newGroupNode(parent.node, member),
                 false);
             allMembers.add(memberInfo);
           }
@@ -1314,7 +1314,7 @@ private:
           parent.childCount++;
           memberInfo = &arena.allocate<MemberInfo>(
               parent, codeOrder++, member,
-              newGroupNode(parent.node, member.getName().getValue()),
+              newGroupNode(parent.node, member),
               false);
           allMembers.add(memberInfo);
 
@@ -1347,19 +1347,25 @@ private:
     }
   }
 
-  NodeSourceInfoBuilderPair newGroupNode(schema::Node::Reader parent, kj::StringPtr name) {
+  NodeSourceInfoBuilderPair newGroupNode(schema::Node::Reader parent, Declaration::Reader decl) {
     AuxNode aux {
       translator.orphanage.newOrphan<schema::Node>(),
       translator.orphanage.newOrphan<schema::Node::SourceInfo>()
     };
     auto node = aux.node.get();
     auto sourceInfo = aux.sourceInfo.get();
+    auto name = decl.getName().getValue();
 
     // We'll set the ID and scope ID later.
     node.setDisplayName(kj::str(parent.getDisplayName(), '.', name));
     node.setDisplayNamePrefixLength(node.getDisplayName().size() - name.size());
     node.setIsGeneric(parent.getIsGeneric());
     node.initStruct().setIsGroup(true);
+    node.setStartByte(decl.getStartByte());
+    node.setEndByte(decl.getEndByte());
+
+    sourceInfo.setStartByte(decl.getStartByte());
+    sourceInfo.setEndByte(decl.getEndByte());
 
     // The remaining contents of node.struct will be filled in later.
 
@@ -1648,8 +1654,19 @@ uint64_t NodeTranslator::compileParamList(
       builder.setDisplayNamePrefixLength(builder.getDisplayName().size() - typeName.size());
       builder.setIsGeneric(parent.getIsGeneric() || implicitParams.size() > 0);
       builder.setScopeId(0);  // detached struct type
+      builder.setStartByte(paramList.getStartByte());
+      builder.setEndByte(paramList.getEndByte());
 
       builder.initStruct();
+
+      // Put `sourceInfoBuilder` is a smaller scope since we move `newSourceInfo` later.
+      {
+        auto sourceInfoBuilder = newSourceInfo.get();
+
+        sourceInfoBuilder.setId(builder.getId());
+        sourceInfoBuilder.setStartByte(paramList.getStartByte());
+        sourceInfoBuilder.setEndByte(paramList.getEndByte());
+      }
 
       // Note that the struct we create here has a brand parameter list mirrioring the method's
       // implicit parameter list. Of course, fields inside the struct using the method's implicit


### PR DESCRIPTION
That is, set `startByte` / `endByte` in generated method params and result types, and in generated group structs.

Given `test.capnp`:

```capnp
@0xf46795117f51d8f6;

interface I {
  method @0 (param :Text) -> (res :UInt32);
}

struct S {
  group :group {
    field @0 :Text;
  }
}
```

Compiled and printed to stdout with (filtering out struct and interface definitions to keep the output simple):

```sh
capnp compile test.capnp -o- \
  | capnp convert binary:text c++/src/capnp/schema.capnp CodeGeneratorRequest \
  | perl -0pe 's/(struct|interface) = \((\n\s{8,}.+)*/$1 = (...),/g'
```

Before:

```capnp
( nodes = [
    ( id = 17611208770238666998,
      displayName = "test.capnp",
      displayNamePrefixLength = 5,
      scopeId = 0,
      nestedNodes = [
        (name = "I", id = 9865039190638141284),
        ( name = "S",
          id = 12715584206684640787 ) ],
      file = void,
      isGeneric = false,
      startByte = 0,
      endByte = 0 ),
    ( id = 17114518286520256397,
      displayName = "test.capnp:I.method$Params",
      displayNamePrefixLength = 13,
      scopeId = 0,
      struct = (...),
      isGeneric = false,
      startByte = 0,
      endByte = 0 ),
    ( id = 14427863489442573064,
      displayName = "test.capnp:I.method$Results",
      displayNamePrefixLength = 13,
      scopeId = 0,
      struct = (...),
      isGeneric = false,
      startByte = 0,
      endByte = 0 ),
    ( id = 9865039190638141284,
      displayName = "test.capnp:I",
      displayNamePrefixLength = 11,
      scopeId = 17611208770238666998,
      nestedNodes = [],
      interface = (...),
      isGeneric = false,
      startByte = 22,
      endByte = 81 ),
    ( id = 12715584206684640787,
      displayName = "test.capnp:S",
      displayNamePrefixLength = 11,
      scopeId = 17611208770238666998,
      nestedNodes = [],
      struct = (...),
      isGeneric = false,
      startByte = 83,
      endByte = 136 ),
    ( id = 9752742055153047448,
      displayName = "test.capnp:S.group",
      displayNamePrefixLength = 13,
      scopeId = 12715584206684640787,
      struct = (...),
      isGeneric = false,
      startByte = 0,
      endByte = 0 ) ],
  requestedFiles = [
    ( id = 17611208770238666998,
      filename = "test.capnp",
      imports = [],
      fileSourceInfo = (
        identifiers = [
          (startByte = 56, endByte = 60, typeId = 1026),
          (startByte = 71, endByte = 77, typeId = 1022),
          (startByte = 125, endByte = 129, typeId = 1026) ] ) ) ],
  capnpVersion = (major = 2, minor = 0, micro = 0),
  sourceInfo = [
    ( id = 12715584206684640787,
      members = [()],
      startByte = 83,
      endByte = 136 ),
    (id = 0, members = [()], startByte = 0, endByte = 0),
    (id = 9865039190638141284, members = [()], startByte = 22, endByte = 81),
    (id = 9752742055153047448, members = [()], startByte = 0, endByte = 0),
    ( id = 17611208770238666998,
      startByte = 0,
      endByte = 0 ) ] )
```

After:

```capnp
( nodes = [
    ( id = 17611208770238666998,
      displayName = "test.capnp",
      displayNamePrefixLength = 5,
      scopeId = 0,
      nestedNodes = [
        (name = "I", id = 9865039190638141284),
        ( name = "S",
          id = 12715584206684640787 ) ],
      file = void,
      isGeneric = false,
      startByte = 0,
      endByte = 0 ),
    ( id = 17114518286520256397,
      displayName = "test.capnp:I.method$Params",
      displayNamePrefixLength = 13,
      scopeId = 0,
      struct = (...),
      isGeneric = false,
      startByte = 48,
      endByte = 61 ),
    ( id = 14427863489442573064,
      displayName = "test.capnp:I.method$Results",
      displayNamePrefixLength = 13,
      scopeId = 0,
      struct = (...),
      isGeneric = false,
      startByte = 65,
      endByte = 78 ),
    ( id = 9865039190638141284,
      displayName = "test.capnp:I",
      displayNamePrefixLength = 11,
      scopeId = 17611208770238666998,
      nestedNodes = [],
      interface = (...),
      isGeneric = false,
      startByte = 22,
      endByte = 81 ),
    ( id = 12715584206684640787,
      displayName = "test.capnp:S",
      displayNamePrefixLength = 11,
      scopeId = 17611208770238666998,
      nestedNodes = [],
      struct = (...),
      isGeneric = false,
      startByte = 83,
      endByte = 136 ),
    ( id = 9752742055153047448,
      displayName = "test.capnp:S.group",
      displayNamePrefixLength = 13,
      scopeId = 12715584206684640787,
      struct = (...),
      isGeneric = false,
      startByte = 96,
      endByte = 134 ) ],
  requestedFiles = [
    ( id = 17611208770238666998,
      filename = "test.capnp",
      imports = [],
      fileSourceInfo = (
        identifiers = [
          (startByte = 56, endByte = 60, typeId = 1026),
          (startByte = 71, endByte = 77, typeId = 1022),
          (startByte = 125, endByte = 129, typeId = 1026) ] ) ) ],
  capnpVersion = (major = 2, minor = 0, micro = 0),
  sourceInfo = [
    ( id = 9752742055153047448,
      members = [()],
      startByte = 96,
      endByte = 134 ),
    ( id = 12715584206684640787,
      members = [()],
      startByte = 83,
      endByte = 136 ),
    ( id = 17114518286520256397,
      members = [()],
      startByte = 48,
      endByte = 61 ),
    ( id = 14427863489442573064,
      members = [()],
      startByte = 65,
      endByte = 78 ),
    (id = 9865039190638141284, members = [()], startByte = 22, endByte = 81),
    ( id = 17611208770238666998,
      startByte = 0,
      endByte = 0 ) ] )
```

With diff:

```diff
@@ -17,16 +17,16 @@
       scopeId = 0,
       struct = (...),
       isGeneric = false,
-      startByte = 0,
-      endByte = 0 ),
+      startByte = 48,
+      endByte = 61 ),
     ( id = 14427863489442573064,
       displayName = "test.capnp:I.method$Results",
       displayNamePrefixLength = 13,
       scopeId = 0,
       struct = (...),
       isGeneric = false,
-      startByte = 0,
-      endByte = 0 ),
+      startByte = 65,
+      endByte = 78 ),
     ( id = 9865039190638141284,
       displayName = "test.capnp:I",
       displayNamePrefixLength = 11,
@@ -51,8 +51,8 @@
       scopeId = 12715584206684640787,
       struct = (...),
       isGeneric = false,
-      startByte = 0,
-      endByte = 0 ) ],
+      startByte = 96,
+      endByte = 134 ) ],
   requestedFiles = [
     ( id = 17611208770238666998,
       filename = "test.capnp",
@@ -64,13 +64,23 @@
           (startByte = 125, endByte = 129, typeId = 1026) ] ) ) ],
   capnpVersion = (major = 2, minor = 0, micro = 0),
   sourceInfo = [
+    ( id = 9752742055153047448,
+      members = [()],
+      startByte = 96,
+      endByte = 134 ),
     ( id = 12715584206684640787,
       members = [()],
       startByte = 83,
       endByte = 136 ),
-    (id = 0, members = [()], startByte = 0, endByte = 0),
+    ( id = 17114518286520256397,
+      members = [()],
+      startByte = 48,
+      endByte = 61 ),
+    ( id = 14427863489442573064,
+      members = [()],
+      startByte = 65,
+      endByte = 78 ),
     (id = 9865039190638141284, members = [()], startByte = 22, endByte = 81),
-    (id = 9752742055153047448, members = [()], startByte = 0, endByte = 0),
     ( id = 17611208770238666998,
       startByte = 0,
       endByte = 0 ) ] )
```

From what I see, the one remaining problem is that `startByte` and `endByte` are both 0 for file nodes, but I couldn't easily find where to fix it and I reckon file ranges don't matter that much, so I didn't try to fix it.