### PR TITLE
implement stringification for kj::OneOf

### DIFF
--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -248,6 +248,17 @@ KJ_TEST("OneOf equality") {
   }
 }
 
+KJ_TEST("OneOf stringification") {
+  {
+    OneOf<int, bool> a = 0;
+    OneOf<int, bool> b = false;
+    OneOf<int, bool> uninit;
+    KJ_EXPECT(kj::str(a) == kj::str(0));
+    KJ_EXPECT(kj::str(b) == kj::str(false));
+    KJ_EXPECT(kj::str(uninit) == kj::str("(null OneOf)"));
+  }
+}
+
 template<unsigned int N>
 struct T {
   unsigned int n = N;

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -921,6 +921,12 @@ _::Delimited<T> delimited(T&& arr, kj::StringPtr delim) {
   return _::Delimited<T>(kj::fwd<T>(arr), delim);
 }
 
+
+template <typename T>
+concept Stringifiable = requires(_::Stringifier s, T&& t) {
+  { s * kj::fwd<T>(t) };
+};
+
 }  // namespace kj
 
 constexpr kj::StringPtr operator ""_kj(const char* str, size_t n) {


### PR DESCRIPTION
Made this with openai o4-mini-high. Tried claude code multiple times, which utterly failed each time, despite receiving a more detailed prompt than chatgpt.

Constraints are necessary to avoid compilation failures for types that try to instantiate this stringify implementation in debug code.