### PR TITLE
Reduce promise continuation templating for Promise<void> where possible

### DIFF
--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -202,6 +202,11 @@ public:
   template <typename Func>
   PromiseForResult<Func, T> then(Func&& func) KJ_WARN_UNUSED_RESULT;
 
+  // Specialized variants for Promise<void> continuations. This results in substantial code size
+  // improvements.
+  Promise<void> thenV(kj::Function<void()>&& func) requires std::is_void_v<T> KJ_WARN_UNUSED_RESULT;
+  Promise<void> thenVP(kj::Function<Promise<void>()>&& func) requires std::is_void_v<T> KJ_WARN_UNUSED_RESULT;
+
   template <typename Func, typename ErrorFunc>
   PromiseForResult<Func, T> then(Func&& func, ErrorFunc&& errorHandler,
                                  SourceLocation location = {}) KJ_WARN_UNUSED_RESULT;


### PR DESCRIPTION
if constexpr allows us to easily define a special case for void promise continuations where we don't need to include the continuation function in the promise template, which reduces the number of duplications of TransformPromiseNode variants. This significantly improves code size and likely also compile times for code using promises.

Rationale: Recursive templating for promise continuations is a big contributor to file size bloat (see #2079). By reducing such templating for Promise<void> -> Promise<void> continuations, this reduces opt binary sizes by **6.7%** for http-test (which uses promises a lot); compile times should improve too. ~~I expect smaller but still significant gains for downstream projects~~ Looks like downstream gains are not even close, the downstream release binary should shrink by ~0.3%.

Learned more C++17/C++20 techniques than I ever wanted to while working on this. Still need to test this with downstream. Also do we have clang-format set up for capnproto in some capacity? It works so well in workerd that I'm no longer used to manually formatting code 😅