### PR TITLE
[nfc] if constexpr and send().ignoreResult() optimizations

### DIFF
--- a/c++/src/capnp/capability-test.c++
+++ b/c++/src/capnp/capability-test.c++
@@ -1430,7 +1430,7 @@ KJ_TEST("RevocableServer") {
 
   KJ_EXPECT_THROW_RECOVERABLE_MESSAGE(
       "capability was revoked",
-      revocable.getClient().waitForeverRequest().send().ignoreResult().wait(waitScope));
+      revocable.getClient().waitForeverRequest().sendIgnoringResult().wait(waitScope));
 
   KJ_EXPECT(!revocable.isInUse());
 }

--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -141,7 +141,7 @@ public:
     KJ_SWITCH_ONEOF(state) {
       KJ_CASE_ONEOF(redirected, Redirected) {
         // Ugh I guess we need to send a real end() request here.
-        return redirected.replacement.endRequest(MessageSize {2, 0}).send().ignoreResult();
+        return redirected.replacement.endRequest(MessageSize {2, 0}).sendIgnoringResult();
       }
       KJ_CASE_ONEOF(e, Ended) {
         // whatever
@@ -154,7 +154,7 @@ public:
       KJ_CASE_ONEOF(streaming, Streaming) {
         auto req = streaming.callback.endedRequest(MessageSize {4, 0});
         req.setByteCount(completed);
-        auto promise = req.send().ignoreResult();
+        auto promise = req.sendIgnoringResult();
         streaming.parent.returnStream(completed);
         state = Ended();
         return promise;
@@ -236,7 +236,7 @@ public:
 
         auto req = streaming.callback.endedRequest(MessageSize {4, 0});
         req.setByteCount(completed);
-        auto result = req.send().ignoreResult();
+        auto result = req.sendIgnoringResult();
         streaming.parent.returnStream(completed);
         state = Ended();
         return result;
@@ -437,7 +437,7 @@ public:
       }
       KJ_CASE_ONEOF(capnpStream, capnp::ByteStream::Client) {
         // Ugh I guess we need to send a real end() request here.
-        return capnpStream.endRequest(MessageSize {2, 0}).send().ignoreResult();
+        return capnpStream.endRequest(MessageSize {2, 0}).sendIgnoringResult();
       }
       KJ_CASE_ONEOF(b, Borrowed) {
         // Fine, ignore.
@@ -858,7 +858,7 @@ public:
     KJ_IF_SOME(o, optimized) {
       return o.directExplicitEnd();
     } else {
-      return inner.endRequest(MessageSize {2, 0}).send().ignoreResult();
+      return inner.endRequest(MessageSize {2, 0}).sendIgnoringResult();
     }
   }
 

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -232,7 +232,7 @@ public:
     req.setCode(code);
     req.setReason(reason);
     sentBytes += reason.size() + 2;
-    return req.send().ignoreResult();
+    return req.sendIgnoringResult();
   }
 
   void disconnect() override {
@@ -802,7 +802,7 @@ public:
     rpcResponse.adoptHeaders(factory.headersToCapnp(
         headers, Orphanage::getForMessageContaining(rpcResponse)));
 
-    replyTask = req.send().ignoreResult();
+    replyTask = req.sendIgnoringResult();
   }
 
   kj::Own<kj::AsyncOutputStream> reject(

--- a/c++/src/capnp/reconnect-test.c++
+++ b/c++/src/capnp/reconnect-test.c++
@@ -200,7 +200,7 @@ KJ_TEST("lazyAutoReconnect() initializes lazily") {
     auto req = client.fooRequest();
     req.setI(i);
     req.setJ(j);
-    req.send().ignoreResult().wait(ws);
+    req.sendIgnoringResult().wait(ws);
   };
 
   KJ_EXPECT(connectCount == 1);

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -1580,7 +1580,7 @@ KJ_TEST("method throws exception") {
   auto client = context.connect().getTestMoreStuffRequest().send().getCap();
 
   kj::Maybe<kj::Exception> maybeException;
-  client.throwExceptionRequest().send().ignoreResult()
+  client.throwExceptionRequest().sendIgnoringResult()
       .catch_([&](kj::Exception&& e) {
     maybeException = kj::mv(e);
   }).wait(context.waitScope);
@@ -1596,7 +1596,7 @@ KJ_TEST("method throws exception won't redundantly add remote exception prefix")
   auto client = context.connect().getTestMoreStuffRequest().send().getCap();
 
   kj::Maybe<kj::Exception> maybeException;
-  client.throwRemoteExceptionRequest().send().ignoreResult()
+  client.throwRemoteExceptionRequest().sendIgnoringResult()
       .catch_([&](kj::Exception&& e) {
     maybeException = kj::mv(e);
   }).wait(context.waitScope);
@@ -1616,7 +1616,7 @@ KJ_TEST("method throws exception with trace encoder") {
   auto client = context.connect().getTestMoreStuffRequest().send().getCap();
 
   kj::Maybe<kj::Exception> maybeException;
-  client.throwExceptionRequest().send().ignoreResult()
+  client.throwExceptionRequest().sendIgnoringResult()
       .catch_([&](kj::Exception&& e) {
     maybeException = kj::mv(e);
   }).wait(context.waitScope);
@@ -1632,7 +1632,7 @@ KJ_TEST("method throws exception with detail") {
   auto client = context.connect().getTestMoreStuffRequest().send().getCap();
 
   kj::Maybe<kj::Exception> maybeException;
-  client.throwExceptionWithDetailRequest().send().ignoreResult()
+  client.throwExceptionWithDetailRequest().sendIgnoringResult()
       .catch_([&](kj::Exception&& e) {
     maybeException = kj::mv(e);
   }).wait(context.waitScope);
@@ -2059,7 +2059,7 @@ KJ_TEST("three-party handoff introduce to self") {
     req.setI(123);
     req.setJ(true);
     req.setExpectedCallCount(0);
-    call1 = req.send().ignoreResult();
+    call1 = req.sendIgnoringResult();
 
     roundTripCap = pipeline.wait(context.waitScope).getCap();
   }

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -426,12 +426,12 @@ TEST(TwoPartyNetwork, HugeMessage) {
     req.initA(100000000);  // 100 MB
 
     KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("larger than our single-message size limit",
-        req.send().ignoreResult().wait(ioContext.waitScope));
+        req.sendIgnoringResult().wait(ioContext.waitScope));
   }
 
   // Oversized response fails.
   KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("larger than our single-message size limit",
-      client.getEnormousStringRequest().send().ignoreResult().wait(ioContext.waitScope));
+      client.getEnormousStringRequest().sendIgnoringResult().wait(ioContext.waitScope));
 
   // Connection is still up.
   {

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -568,8 +568,7 @@ public:
     auto& dyingConnectionRef = *dyingConnection;
     auto shutdownPromise = dyingConnection->shutdown()
         .attach(kj::mv(dyingConnection))
-        .then([]() -> kj::Promise<void> { return kj::READY_NOW; },
-              [self = kj::addRef(*this), origException = kj::mv(exception)](
+        .catch_([self = kj::addRef(*this), origException = kj::mv(exception)](
                   kj::Exception&& shutdownException) -> kj::Promise<void> {
           // Don't report disconnects as an error.
           if (shutdownException.getType() == kj::Exception::Type::DISCONNECTED) {

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -2390,7 +2390,7 @@ KJ_TEST("WebSocket pump disconnect on send") {
   KJ_EXPECT_THROW_RECOVERABLE(DISCONNECTED, pumpTask.wait(waitScope));
 
   // client1 may or may not have been able to send its whole message depending on buffering.
-  sendTask.then([]() {}, [](kj::Exception&& e) {
+  sendTask.catch_([](kj::Exception&& e) {
     KJ_EXPECT(e.getType() == kj::Exception::Type::DISCONNECTED);
   }).wait(waitScope);
 }

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -517,7 +517,6 @@ public:
   OP(|, true)   // bitwise ops can't overflow
 
   COMPARE_OP(==)
-  COMPARE_OP(!=)
   COMPARE_OP(< )
   COMPARE_OP(> )
   COMPARE_OP(<=)
@@ -641,7 +640,6 @@ public:
   // subtraction requires proof that subtrahend is not greater than the minuend.
 
   COMPARE_OP(==)
-  COMPARE_OP(!=)
   COMPARE_OP(< )
   COMPARE_OP(> )
   COMPARE_OP(<=)
@@ -927,7 +925,6 @@ OP(|, maxN | cvalue)
 REVERSE_OP(|, maxN | cvalue)
 
 COMPARE_OP(==)
-COMPARE_OP(!=)
 COMPARE_OP(< )
 COMPARE_OP(> )
 COMPARE_OP(<=)
@@ -1074,7 +1071,6 @@ OP(>>)
 OP(&)
 OP(|)
 OP(==)
-OP(!=)
 OP(<=)
 OP(>=)
 OP(<)


### PR DESCRIPTION
This simplifies a bunch of code and reduces the debug binary size by 0.9% downstream if the sendIgnore() trick is used where applicable. Let's hope this optimization won't turn out to have pesky side effects 😅