### PR TITLE
kj/test.c++: Pretty-print test duration

### DIFF
--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -270,7 +270,7 @@ public:
           }
           auto end = readClock();
 
-          auto message = kj::str(name, " (", (end - start) / kj::MICROSECONDS, " μs)");
+          auto message = kj::str(name, " (", end - start, ")");
 
           if (currentFailed) {
             write(RED, "[ FAIL ]", message);


### PR DESCRIPTION
KJ currently prints the elapsed time for each test in microseconds. This PR changes this to instead use KJ's duration pretty-printing logic, which automatically selects a suitable unit.

Example:

```
[ TEST ] http-test.c++:6546: HttpServer.listenHttp() doesn't prematurely terminate if an accepted connection is broken
[ PASS ] http-test.c++:6546: HttpServer.listenHttp() doesn't prematurely terminate if an accepted connection is broken (19.842ms)
[ TEST ] http-test.c++:6567: HttpServer handles disconnected exception for clients disconnecting after headers
[ PASS ] http-test.c++:6567: HttpServer handles disconnected exception for clients disconnecting after headers (147μs)
```

cc: @anonrig 