### PR TITLE
Remove check for monotonic time

### DIFF
--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -110,16 +110,12 @@ Maybe<uint64_t> TimerImpl::timeoutToNextEvent(TimePoint start, Duration unit, ui
 }
 
 void TimerImpl::advanceTo(TimePoint newTime) {
-  // On Macs, it has been observed that clock_gettime 
+  // It has been observed that clock_gettime 
   // may return non monotonic time, even when CLOCK_MONOTONIC is used.
-  // This workaround is to avoid the assert triggering if this happens.
-  // See also https://github.com/capnproto/capnproto/issues/1693
-#if __APPLE__
+  // We use std::max to guard against this rare issue.
+  // - on mac: https://github.com/capnproto/capnproto/issues/1693
+  // - on linux: https://github.com/capnproto/capnproto/issues/2261
   time = std::max(time, newTime);
-#else
-  KJ_REQUIRE(newTime >= time, "can't advance backwards in time") { return; }
-  time = newTime;
-#endif
 
   for (;;) {
     auto front = impl->timers.begin();


### PR DESCRIPTION
The check was disabled on Mac, but in #2261 it was reported also on Linux. At this point, it makes more sense to remove the KJ_REQUIRE for monotonicity alltogether.