### PR TITLE
Use kj::max instead of std::max in kj/timer.c++ (was: Include <algorithm> in kj/timer.c++ to satisfy clang-20)

### DIFF
--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -112,10 +112,10 @@ Maybe<uint64_t> TimerImpl::timeoutToNextEvent(TimePoint start, Duration unit, ui
 void TimerImpl::advanceTo(TimePoint newTime) {
   // It has been observed that clock_gettime 
   // may return non monotonic time, even when CLOCK_MONOTONIC is used.
-  // We use std::max to guard against this rare issue.
+  // We use kj::max to guard against this rare issue.
   // - on mac: https://github.com/capnproto/capnproto/issues/1693
   // - on linux: https://github.com/capnproto/capnproto/issues/2261
-  time = std::max(time, newTime);
+  time = kj::max(time, newTime);
 
   for (;;) {
     auto front = impl->timers.begin();


### PR DESCRIPTION
I noticed that compiling `libkj` fails with clang-20.1.5 for me:

```
/home/lewinb/.conan2/p/b/capnp25c9fdddbfd6b/b/src/c++/src/kj/timer.c++:118:10: error: no member named 'max' in namespace 'std'; did you mean simply 'max'?
  118 |   time = std::max(time, newTime);
      |          ^~~~~~~~
      |          max
```

This PR fixes the error by including `<algorithm>` for `std::max()` on `master`.