### PR TITLE
Put kj::Own<T>::attach() refcounted warning behind a flag

### DIFF
--- a/c++/src/kj/filesystem-disk-unix.c++
+++ b/c++/src/kj/filesystem-disk-unix.c++
@@ -1687,6 +1687,7 @@ private:
 #endif
           return result;
         }
+#else
 	KJ_FALLTHROUGH;
 #endif
       default:

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -29,6 +29,12 @@
 #define KJ_DEBUG_MEMORY 0
 #endif
 
+// KJ_WARN_REFCOUNTED_ATTACH == 1 enables deprecation warnings when using kj::Own<T>::attach() on
+// refcounted objects.
+#if !defined(KJ_WARN_REFCOUNTED_ATTACH)
+#define KJ_WARN_REFCOUNTED_ATTACH 0
+#endif
+
 // KJ_ASSERT_PTR_COUNTERS == 1 keeps track of active Ptr<T> instances and asserts validity
 // of their ownership.
 // Matches KJ_DEBUG_MEMORY by default.
@@ -291,7 +297,9 @@ public:
   // foo.attach(bar, baz) is equivalent to (but more efficient than) foo.attach(bar).attach(baz).
 
   template <typename... Attachments> requires (::kj::_::IsRefcounted<T>)
+#if KJ_WARN_REFCOUNTED_ATTACH
   KJ_DEPRECATED("using attach() with refcounted objects can be a bug; if intentional, use attachToThisReference()")
+#endif
   Own<T> attach(Attachments&&... attachments) KJ_WARN_UNUSED_RESULT;
 
   template <typename... Attachments> requires (::kj::_::IsRefcounted<T>)


### PR DESCRIPTION
 Put `kj::Own<T>::attach()` refcounted warning behind a `KJ_WARN_REFCOUNTED_ATTACH` flag, to allow deprecation-sensitive builds of capnproto code current using refcounted attach to pass.
