### PR TITLE
restrict asBytes and asChars to canMemcpy types

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -201,10 +201,22 @@ public:
   inline ArrayPtr<T> first(size_t count) KJ_LIFETIMEBOUND { return slice(0, count); }
   inline ArrayPtr<const T> first(size_t count) const KJ_LIFETIMEBOUND { return slice(0, count); }
 
-  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { return asPtr().asBytes(); }
-  inline ArrayPtr<PropagateConst<T, byte>> asBytes() KJ_LIFETIMEBOUND { return asPtr().asBytes(); }
-  inline ArrayPtr<const char> asChars() const KJ_LIFETIMEBOUND { return asPtr().asChars(); }
-  inline ArrayPtr<PropagateConst<T, char>> asChars() KJ_LIFETIMEBOUND { return asPtr().asChars(); }
+  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { 
+    KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
+    return asPtr().asBytes(); 
+  }
+  inline ArrayPtr<PropagateConst<T, byte>> asBytes() KJ_LIFETIMEBOUND { 
+    KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
+    return asPtr().asBytes(); 
+  }
+  inline ArrayPtr<const char> asChars() const KJ_LIFETIMEBOUND { 
+    KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
+    return asPtr().asChars(); 
+  }
+  inline ArrayPtr<PropagateConst<T, char>> asChars() KJ_LIFETIMEBOUND { 
+    KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
+    return asPtr().asChars(); 
+  }
 
   inline Array<PropagateConst<T, byte>> releaseAsBytes() {
     // Like asBytes() but transfers ownership.

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1907,11 +1907,13 @@ public:
   constexpr ArrayPtr<PropagateConst<T, byte>> asBytes() const {
     // Reinterpret the array as a byte array. This is explicitly legal under C++ aliasing
     // rules.
+    KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
     return { reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_ * sizeof(T) };
   }
   inline ArrayPtr<PropagateConst<T, char>> asChars() const {
     // Reinterpret the array as a char array. This is explicitly legal under C++ aliasing
     // rules.
+    KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
     return { reinterpret_cast<PropagateConst<T, char>*>(ptr), size_ * sizeof(T) };
   }
 


### PR DESCRIPTION
Depends on #2323 
Downstreams do not have any problem with this.