### PR TITLE
PtmfHelper: Use NOLINT to disable UndefinedBinaryOperatorResult error

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -606,6 +606,7 @@ class PtmfHelper {
     if (voff & 1) {
       voff &= ~1;
 #endif
+      // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
       return *(void**)(*(char**)obj + voff);
     } else {
       return ptr;


### PR DESCRIPTION
Disable `clang-analyzer-core.UndefinedBinaryOperatorResult` error in `PtmfHelper` using a NOLINT comment to appease clang-tidy.

A complete description of the error and rationale for the change is in the commit message.