### PR TITLE
fix compilation error when compiling with -Werror and C++20

### DIFF
--- a/c++/src/capnp/encoding-test.c++
+++ b/c++/src/capnp/encoding-test.c++
@@ -1828,7 +1828,8 @@ TEST(Encoding, NameAnnotation) {
   EXPECT_EQ(true, root.getGoodFieldName());
   EXPECT_TRUE(root.isGoodFieldName());
 
-  root.setBar(0xff);
+  // should the following set 255 (unsigned char) or -1 (signed char)?
+  root.setBar(static_cast<signed char>(0xff));
   EXPECT_FALSE(root.isGoodFieldName());
 
   root.setAnotherGoodFieldName(test::RenamedStruct::RenamedEnum::QUX);

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1771,7 +1771,7 @@ public:
     if (alreadyDone()) return constPromise<size_t, 0>();
 
     return getInner().tryRead(buffer, minBytes, maxBytes)
-        .then([=](size_t amount) {
+        .then([=,this](size_t amount) {
       if (amount < minBytes) {
         doneReading();
       }
@@ -1813,7 +1813,7 @@ private:
     // We have to set minBytes to 1 here so that if we read any data at all, we update our
     // counter immediately, so that we still know where we are in case of cancellation.
     return getInner().tryRead(buffer, 1, kj::min(maxBytes, length))
-        .then([=](size_t amount) -> kj::Promise<size_t> {
+        .then([=,this](size_t amount) -> kj::Promise<size_t> {
       length -= amount;
       if (length > 0) {
         // We haven't reached the end of the entity body yet.
@@ -1859,7 +1859,7 @@ private:
       return alreadyRead;
     } else if (chunkSize == 0) {
       // Read next chunk header.
-      return getInner().readChunkHeader().then([=](uint64_t nextChunkSize) {
+      return getInner().readChunkHeader().then([=,this](uint64_t nextChunkSize) {
         if (nextChunkSize == 0) {
           doneReading();
         }
@@ -1872,7 +1872,7 @@ private:
       // We have to set minBytes to 1 here so that if we read any data at all, we update our
       // counter immediately, so that we still know where we are in case of cancellation.
       return getInner().tryRead(buffer, 1, kj::min(maxBytes, chunkSize))
-          .then([=](size_t amount) -> kj::Promise<size_t> {
+          .then([=,this](size_t amount) -> kj::Promise<size_t> {
         chunkSize -= amount;
         if (amount == 0) {
           kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED, "premature EOF in HTTP chunk"));


### PR DESCRIPTION
these changes fix compilation errors when compiling with -Werror and C++20. This was seen with the following settings in the cmake configuration and the gcc 11.4.0 compiler.

```
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -16,6 +16,9 @@ if(NOT HAS_CXX14)
   message(SEND_ERROR "Requires a C++14 compiler and standard library.")
 endif()
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 # these arguments are passed to all install(TARGETS) calls
 set(INSTALL_TARGETS_DEFAULT_ARGS
   EXPORT CapnProtoTargets
@@ -152,7 +155,7 @@ else()
   #   recognize as safe.
   # * sign-compare: Low S/N ratio.
   # * unused-parameter: Low S/N ratio.
-  add_compile_options(-Wall -Wextra -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter)
+  add_compile_options(-Wall -Wpedantic -Wextra -Werror -Wno-vla -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter)
 
   if(DEFINED CMAKE_CXX_EXTENSIONS AND NOT CMAKE_CXX_EXTENSIONS)
     message(SEND_ERROR "Cap'n Proto requires compiler-specific extensions (e.g., -std=gnu++14). Please leave CMAKE_CXX_EXTENSIONS undefined or ON.")
```