### PR TITLE
Improve building with bazel on Windows (using cl.exe)

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -53,6 +53,10 @@ cc_library(
         # `//src/capnp` and `//src/capnp/compat:std-iterator``.
         "//src/capnp/compat:std-iterator.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "capnp",
     visibility = ["//visibility:public"],
     deps = [
@@ -85,6 +89,10 @@ cc_library(
         "rpc-twoparty.capnp.h",
         "rpc-twoparty.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "capnp",
     visibility = ["//visibility:public"],
     deps = [
@@ -120,6 +128,10 @@ cc_library(
         "compiler/resolver.h",
         "compiler/type-id.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "capnp",
     visibility = ["//visibility:public"],
     deps = [
@@ -133,6 +145,10 @@ cc_binary(
         "compiler/capnp.c++",
         "compiler/module-loader.c++",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":capnpc",
@@ -145,6 +161,10 @@ cc_binary(
     srcs = [
         "compiler/capnpc-c++.c++",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":capnpc",
@@ -156,6 +176,10 @@ cc_binary(
     srcs = [
         "compiler/capnpc-capnp.c++",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":capnpc",
@@ -211,18 +235,26 @@ cc_library(
     name = "capnp-test",
     srcs = ["test-util.c++"],
     hdrs = ["test-util.h"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
+    visibility = [":__subpackages__"],
     deps = [
         ":capnp-rpc",
         ":capnp_test",
         ":capnpc",
         "//src/kj:kj-test",
     ],
-    visibility = [":__subpackages__" ]
 )
 
 [cc_test(
     name = f.removesuffix(".c++"),
     srcs = [f],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     deps = [":capnp-test"],
 ) for f in [
     "any-test.c++",
@@ -256,22 +288,34 @@ cc_library(
 cc_test(
     name = "endian-reverse-test",
     srcs = ["endian-reverse-test.c++"],
-    deps = [":capnp-test"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    deps = [":capnp-test"],
 )
 
 cc_library(
     name = "endian-test-base",
     hdrs = ["endian-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     deps = [":capnp-test"],
 )
 
 cc_test(
     name = "endian-fallback-test",
     srcs = ["endian-fallback-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     deps = [":endian-test-base"],
 )
 
@@ -279,5 +323,9 @@ cc_test(
     name = "fuzz-test",
     size = "large",
     srcs = ["fuzz-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     deps = [":capnp-test"],
 )

--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -57,7 +57,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "capnp",
     visibility = ["//visibility:public"],
     deps = [
         "//src/kj:kj-async",
@@ -93,7 +92,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "capnp",
     visibility = ["//visibility:public"],
     deps = [
         ":capnp",
@@ -132,7 +130,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "capnp",
     visibility = ["//visibility:public"],
     deps = [
         ":capnp",
@@ -227,7 +224,6 @@ cc_capnp_library(
         "stream.capnp",
         ":testdata",
     ],
-    include_prefix = "capnp",
     src_prefix = "src",
 )
 

--- a/c++/src/capnp/cc_capnp_library.bzl
+++ b/c++/src/capnp/cc_capnp_library.bzl
@@ -86,6 +86,7 @@ def cc_capnp_library(
         srcs = [],
         data = [],
         deps = [],
+        copts = [],
         src_prefix = "",
         visibility = None,
         target_compatible_with = None,
@@ -98,6 +99,7 @@ def cc_capnp_library(
         data: additional files to provide to the compiler - data files and includes that need not to
             be compiled
         deps: other cc_capnp_library rules to depend on
+        copts: options for the compilation of the library
         src_prefix: src_prefix for capnp compiler to the source root
         visibility: rule visibility
         target_compatible_with: target compatibility
@@ -124,5 +126,9 @@ def cc_capnp_library(
         deps = deps + ["@capnp-cpp//src/capnp:capnp_runtime"],
         visibility = visibility,
         target_compatible_with = target_compatible_with,
+        copts = select({
+            "@platforms//os:windows": ["/TP"], # compile .c++ files as .cpp files
+            "//conditions:default": [],
+        }) + copts,
         **kwargs
     )

--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -21,7 +21,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "capnp/compat",
     visibility = ["//visibility:public"],
     deps = [
         "//src/capnp",
@@ -34,7 +33,6 @@ cc_capnp_library(
         "byte-stream.capnp",
         "http-over-capnp.capnp",
     ],
-    include_prefix = "capnp/compat",
     src_prefix = "src",
     visibility = ["//visibility:public"],
 )
@@ -53,7 +51,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "capnp/compat",
     visibility = ["//visibility:public"],
     deps = [
         ":http-over-capnp_capnp",
@@ -73,7 +70,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "capnp/compat",
     visibility = ["//visibility:public"],
     deps = [
         "//src/capnp",

--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -17,6 +17,10 @@ cc_library(
         "json.capnp.h",
         "json.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "capnp/compat",
     visibility = ["//visibility:public"],
     deps = [
@@ -45,6 +49,10 @@ cc_library(
         "byte-stream.h",
         "http-over-capnp.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "capnp/compat",
     visibility = ["//visibility:public"],
     deps = [
@@ -61,6 +69,10 @@ cc_library(
     hdrs = [
         "websocket-rpc.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "capnp/compat",
     visibility = ["//visibility:public"],
     deps = [
@@ -72,10 +84,14 @@ cc_library(
 [cc_test(
     name = f.removesuffix(".c++"),
     srcs = [f],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     deps = [
-        ":websocket-rpc",
         ":http-over-capnp",
-        "//src/capnp:capnp-test"
+        ":websocket-rpc",
+        "//src/capnp:capnp-test",
     ],
 ) for f in [
     "byte-stream-test.c++",
@@ -92,8 +108,8 @@ cc_test(
     name = "http-over-capnp-old-test",
     srcs = ["http-over-capnp-old-test.c++"],
     deps = [
-        ":http-over-capnp-test-as-header",
         ":http-over-capnp",
-        "//src/capnp:capnp-test"
+        ":http-over-capnp-test-as-header",
+        "//src/capnp:capnp-test",
     ],
 )

--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -73,7 +73,7 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "kj",
+    includes = [".."],
     linkopts = select({
         "@platforms//os:windows": [],
         ":use_libdl": [
@@ -112,7 +112,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "kj",
     linkopts = select({
         "@platforms//os:windows": [
             "Ws2_32.lib",
@@ -133,7 +132,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "kj",
     visibility = ["//visibility:public"],
     deps = [
         ":kj",

--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -69,6 +69,10 @@ cc_library(
         "win32-api-version.h",
         "windows-sanity.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "kj",
     linkopts = select({
         "@platforms//os:windows": [],
@@ -104,6 +108,10 @@ cc_library(
         "async-win32.h",
         "timer.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "kj",
     linkopts = select({
         "@platforms//os:windows": [
@@ -121,6 +129,10 @@ cc_library(
     srcs = [
         "test.c++",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "kj",
     visibility = ["//visibility:public"],
     deps = [
@@ -132,6 +144,10 @@ cc_library(
 [cc_test(
     name = f.removesuffix(".c++"),
     srcs = [f],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     deps = [
         ":kj",
         ":kj-async",
@@ -174,6 +190,10 @@ cc_library(
 cc_test(
     name = "async-coroutine-test",
     srcs = ["async-coroutine-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         ":use_coroutines": [],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -195,24 +215,32 @@ cc_library(
 cc_test(
     name = "filesystem-disk-generic-test",
     srcs = ["filesystem-disk-generic-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     deps = [
         ":filesystem-disk-test-base",
         ":kj-test",
-    ],
-    target_compatible_with = [
-        "@platforms//os:linux",
     ],
 )
 
 cc_test(
     name = "filesystem-disk-old-kernel-test",
     srcs = ["filesystem-disk-old-kernel-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     deps = [
         ":filesystem-disk-test-base",
         ":kj-test",
-    ],
-    target_compatible_with = [
-        "@platforms//os:linux",
     ],
 )
 
@@ -221,6 +249,10 @@ cc_test(
     srcs = select({
         "@platforms//os:windows": ["async-win32-test.c++"],
         "//conditions:default": ["async-unix-test.c++"],
+    }),
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
     }),
     deps = [
         ":kj",
@@ -250,12 +282,16 @@ cc_test(
 cc_test(
     name = "exception-override-symbolizer-test",
     srcs = ["exception-override-symbolizer-test.c++"],
-    deps = [
-        ":kj",
-        ":kj-test",
-    ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     linkstatic = True,
     target_compatible_with = [
         "@platforms//os:linux",
+    ],
+    deps = [
+        ":kj",
+        ":kj-test",
     ],
 )

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -10,6 +10,10 @@ cc_library(
         "readiness-io.h",
         "tls.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "kj/compat",
     target_compatible_with = select({
         "//src/kj:use_openssl": [],
@@ -32,6 +36,10 @@ cc_library(
         "http.h",
         "url.h",
     ],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = [
@@ -44,6 +52,10 @@ cc_library(
     name = "kj-gzip",
     srcs = ["gzip.c++"],
     hdrs = ["gzip.h"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = [
@@ -56,16 +68,20 @@ cc_library(
     name = "kj-brotli",
     srcs = ["brotli.c++"],
     hdrs = ["brotli.h"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     include_prefix = "kj/compat",
-    visibility = ["//visibility:public"],
     target_compatible_with = select({
         "//src/kj:use_brotli": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+    visibility = ["//visibility:public"],
     deps = [
         "//src/kj:kj-async",
-        "@brotli//:brotlienc",
         "@brotli//:brotlidec",
+        "@brotli//:brotlienc",
     ],
 )
 
@@ -85,6 +101,10 @@ kj_tests = [
 [cc_test(
     name = f.removesuffix(".c++"),
     srcs = [f],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     deps = [
         ":kj-http",
         "//src/kj:kj-test",
@@ -99,13 +119,17 @@ cc_library(
 cc_test(
     name = "http-socketpair-test",
     srcs = ["http-socketpair-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
+    target_compatible_with = [
+        "@platforms//os:linux",  # TODO: Investigate why this fails on macOS
+    ],
     deps = [
         ":http-socketpair-test-base",
         ":kj-http",
         "//src/kj:kj-test",
-    ],
-    target_compatible_with = [
-        "@platforms//os:linux", # TODO: Investigate why this fails on macOS
     ],
 )
 
@@ -117,13 +141,17 @@ kj_tls_tests = [
 [cc_test(
     name = f.removesuffix(".c++"),
     srcs = [f],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         "//src/kj:use_openssl": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
-        ":kj-tls",
         ":kj-http",
+        ":kj-tls",
         "//src/kj:kj-test",
     ],
 ) for f in kj_tls_tests]
@@ -131,6 +159,10 @@ kj_tls_tests = [
 cc_test(
     name = "gzip-test",
     srcs = ["gzip-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         "//src/kj:use_zlib": [],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -144,6 +176,10 @@ cc_test(
 cc_test(
     name = "brotli-test",
     srcs = ["brotli-test.c++"],
+    copts = select({
+        "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         "//src/kj:use_brotli": [],
         "//conditions:default": ["@platforms//:incompatible"],

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -14,7 +14,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "kj/compat",
     target_compatible_with = select({
         "//src/kj:use_openssl": [],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -40,7 +39,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = [
         "//src/kj:kj-async",
@@ -56,7 +54,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = [
         "//src/kj:kj-async",
@@ -72,7 +69,6 @@ cc_library(
         "@platforms//os:windows": ["/TP"],  # compile .c++ files as .cpp files
         "//conditions:default": [],
     }),
-    include_prefix = "kj/compat",
     target_compatible_with = select({
         "//src/kj:use_brotli": [],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -88,7 +84,6 @@ cc_library(
 cc_library(
     name = "gtest",
     hdrs = ["gtest.h"],
-    include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = ["//src/kj"],
 )


### PR DESCRIPTION
 - build(bazel): use `includes` instead of `include_prefix`
    
    With this `bazel` does not need to create virtual include folders to
    make headers available under a specific prefix. Virtual include folders
    contain symlinks to the actual folders. This:
    - confuses IDEs and debuggers
    - confuses `cl.exe` on Windows

- build(bazel): use `/TP` on Windows
    
    To enable compiling `.c++` files as C++ with `cl.exe`

This fixes workarounds like: https://github.com/cloudflare/workerd/blob/a018eee88da5245a50c9340cf1bb07747cda6846/.bazelrc#L296-L302