### PR TITLE
timer.c++: include <algorithm> for std::max

### DIFF
--- a/c++/src/kj/timer.c++
+++ b/c++/src/kj/timer.c++
@@ -22,6 +22,7 @@
 
 #include "timer.h"
 #include "debug.h"
+#include <algorithm>
 #include <set>
 
 namespace kj {


### PR DESCRIPTION
As `<algorithm>` was not included, `std::max` would not be found:

```
[ 62%] Building CXX object _deps/capnproto-build/c++/src/kj/CMakeFiles/kj-async.dir/timer.c++.o
/Users/martin/Source/klayout-pex/build/kpex_RelWithDbgInfo/_deps/capnproto-src/c++/src/kj/timer.c++:118:10: error: no member named 'max' in namespace 'std'; did you mean simply 'max'?
  118 |   time = std::max(time, newTime);
      |          ^~~~~~~~
      |          max
```