### PR TITLE
add KJ_ASSERT_SOME and KJ_REQUIRE_SOME

### DIFF
--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -395,7 +395,7 @@ namespace kj {
 // Use "ASSERT" in place of "REQUIRE" when the problem is local to the immediate surrounding code.
 // That is, if the assert ever fails, it indicates that the immediate surrounding code is broken.
 
-#define KJ_ASSERT_SOME KJ_REQUIRE_NONNULL
+#define KJ_ASSERT_SOME KJ_ASSERT_NONNULL
 #define KJ_REQUIRE_SOME KJ_REQUIRE_NONNULL
 // SOME is a better wording since KJ_REQUIRE_NONNULL checks for kj::Maybe.
 


### PR DESCRIPTION
This was a recommendation by @kentonv from couple of months ago, when I recommended using KJ_REQUIRE_NONNULL for checking for `nullptr`.