### PR TITLE
Wrap shutdown() call in disconnect() to catch synchronously thrown exceptions

### DIFF
--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -566,8 +566,9 @@ public:
 
     // Indicate disconnect.
     auto& dyingConnectionRef = *dyingConnection;
-    auto shutdownPromise = dyingConnection->shutdown()
-        .attach(kj::mv(dyingConnection))
+    auto shutdownPromise = kj::evalNow([&dyingConnectionRef]() {
+      return dyingConnectionRef.shutdown();
+    }).attach(kj::mv(dyingConnection))
         .catch_([self = kj::addRef(*this), origException = kj::mv(exception)](
                   kj::Exception&& shutdownException) -> kj::Promise<void> {
           // Don't report disconnects as an error.


### PR DESCRIPTION
If this happens when we're inside taskFailed(), it's Bad.