### PR TITLE
Retain exception details for exceptions that cause RPC disconnection

### DIFF
--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -481,6 +481,11 @@ public:
     // all future calls on this connection.
     networkException.addTraceHere();
 
+    // Retain details from the original exception.
+    for (auto& detail : exception.getDetails()) {
+      networkException.setDetail(detail.id, kj::heapArray<kj::byte>(detail.value));
+    }
+
     // Set our connection state to Disconnected now so that no one tries to write any messages to
     // it in their destructors.
     auto& rpcSystem = connection.get<Connected>().rpcSystem;


### PR DESCRIPTION
I'd like to be able to set details on the exceptions that cause the underlying connection to disconnect and later read them out, but currently the details get stripped.