### PR TITLE
fix(kj): gracefully handle aborted sockets in accept on macOS

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1367,14 +1367,12 @@ public:
         int one = 1;
         KJ_SYSCALL_HANDLE_ERRORS(::setsockopt(
               ownFd.get(), IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(one))) {
-#if __APPLE__
-          case EINVAL:  // macOS: fd already dead (RST race)
-            return acceptImpl(authenticated);   // retry accept()
-#endif
           case EOPNOTSUPP:
           case ENOPROTOOPT: // (returned for AF_UNIX in cygwin)
-#if __FreeBSD__
-          case EINVAL: // (returned for AF_UNIX in FreeBSD)
+#if __APPLE__ || __FreeBSD__
+          case EINVAL:
+            // On FreeBSD, EINVAL is returned for AF_UNIX sockets.
+            // On macOS, EINVAL may be returned for sockets that are already dead (due to a race with RST).
 #endif
             break;
           default:


### PR DESCRIPTION
This fixes https://github.com/cloudflare/workerd/issues/4623

Adding two extra tests, reproducing the 2 crashes macOS users might observe
(`EINVAL` on `setsockopt()` and `addrlen == 0` on `accept()`, throwing in `NetworkFilter::shouldAllow()`)
```
❯ make -j6 capnp-test && ./capnp-test --filter 'src/kj/async-io*'
...
[ TEST ] kj/async-io-test.c++:3585: accept() skips aborted IPv4 connection
kj/async-io-unix.c++:1365: failed: setsocketopt(IPPROTO_TCP, TCP_NODELAY): Invalid argument
stack: 103ad1e73 103ad1667 102e03cfb 103521987
[ FAIL ] kj/async-io-test.c++:3585: accept() skips aborted IPv4 connection (2.366ms)
[ TEST ] kj/async-io-test.c++:3658: accept() skips aborted dual-stack connection
kj/async-io.c++:3120: failed: expected addrlen >= sizeof(addr->sa_family) [0 >= 1]
stack: 103a9d2e7 103ad1a8f 103ad1667 102e04e3b 103521987
[ FAIL ] kj/async-io-test.c++:3658: accept() skips aborted dual-stack connection (2.28ms)
95 test(s) passed
2 test(s) failed
```

Pushing a first commit with tests, so we can see the failures in CI, followed by a fix.

## 