### PR TITLE
Try to debug RPC system bugs

### DIFF
--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -466,6 +466,18 @@ public:
       return;
     }
 
+    if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
+      // We're going to convert this exception's type to DISCONNECTED before reporting it anywhere.
+      // However, lots of logging ignores DISCONNECTED errors. If the error here was not
+      // DISCONNECTED, it's probably a bug in the RPC system itself, and we need to see those.
+      // So log it directly here.
+      // TODO(soon): This is not a great solution (especilaly the NOSENTRY part, which is
+      //   recognized specifically by the Cloudflare Workers runtime's error reporting). Once we
+      //   get a handle on what kind of errors are being reported, we should do something better
+      //   here.
+      KJ_LOG(WARNING, "NOSENTRY RPC connection broken for non-DISCONNECTED reason.", exception);
+    }
+
     kj::Exception networkException(kj::Exception::Type::DISCONNECTED,
         exception.getFile(), exception.getLine(), kj::heapString(exception.getDescription()));
 


### PR DESCRIPTION
It turns out that RPC state machine bugs which cause the connection to be broken are probably not being reported properly by our logging because the exception type is set to DISCONNECTED, and we often avoid logging such exceptions.

This is a temporary stopgap to get a handle on the problem, and to debug one issue we've seen in particular.