### PR TITLE
Implement SmallArray

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -144,7 +144,7 @@ public:
       : ptr(firstElement), size_(size), disposer(&disposer) {}
 
   KJ_DISALLOW_COPY(Array);
-  inline ~Array() noexcept { dispose(); }
+  inline ~Array() noexcept(false) { dispose(); }
 
   inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
     return ArrayPtr<T>(ptr, size_);

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -201,21 +201,21 @@ public:
   inline ArrayPtr<T> first(size_t count) KJ_LIFETIMEBOUND { return slice(0, count); }
   inline ArrayPtr<const T> first(size_t count) const KJ_LIFETIMEBOUND { return slice(0, count); }
 
-  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND { 
+  inline ArrayPtr<const byte> asBytes() const KJ_LIFETIMEBOUND {
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
-    return asPtr().asBytes(); 
+    return asPtr().asBytes();
   }
-  inline ArrayPtr<PropagateConst<T, byte>> asBytes() KJ_LIFETIMEBOUND { 
+  inline ArrayPtr<PropagateConst<T, byte>> asBytes() KJ_LIFETIMEBOUND {
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
-    return asPtr().asBytes(); 
+    return asPtr().asBytes();
   }
-  inline ArrayPtr<const char> asChars() const KJ_LIFETIMEBOUND { 
+  inline ArrayPtr<const char> asChars() const KJ_LIFETIMEBOUND {
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
-    return asPtr().asChars(); 
+    return asPtr().asChars();
   }
-  inline ArrayPtr<PropagateConst<T, char>> asChars() KJ_LIFETIMEBOUND { 
+  inline ArrayPtr<PropagateConst<T, char>> asChars() KJ_LIFETIMEBOUND {
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
-    return asPtr().asChars(); 
+    return asPtr().asChars();
   }
 
   inline Array<PropagateConst<T, byte>> releaseAsBytes() {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2295,7 +2295,7 @@ class ThreadId {
   // Implemented as thread_local address, so could be efficient even for production
   // environments especially with LTO.
 
-public:  
+public:
   static ThreadId current();
   // Obtain current thread id
 
@@ -2306,7 +2306,7 @@ public:
 
 private:
   inline ThreadId(void* id) : id(id) {}
-  void* id;  
+  void* id;
 };
 
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -382,6 +382,8 @@ KJ_NORETURN(void unreachable());
 // variable-sized arrays.  For other compilers we could just use a fixed-size array.  `minStack`
 // is the stack array size to use if variable-width arrays are not supported.  `maxStack` is the
 // maximum stack array size if variable-width arrays *are* supported.
+//
+// TODO(cleanup): Deprecate this in favor of kj::SmallArray, over in array.h
 #if __GNUC__ && !__clang__
 #define KJ_STACK_ARRAY(type, name, size, minStack, maxStack) \
   size_t name##_size = (size); \

--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -112,6 +112,9 @@ struct HashCoder {
   uint operator*(ArrayPtr<T> arr) const;
   template <typename T, typename = decltype(instance<const HashCoder&>() * instance<const T&>())>
   uint operator*(const Array<T>& arr) const;
+  template <typename T, size_t smallSize,
+      typename = decltype(instance<const HashCoder&>() * instance<const T&>())>
+  uint operator*(const SmallArray<T, smallSize>& arr) const;
   template <typename T, typename = EnableIf<__is_enum(T)>>
   inline uint operator*(T e) const;
 
@@ -208,6 +211,10 @@ inline uint HashCoder::operator*(ArrayPtr<T> arr) const {
 }
 template <typename T, typename>
 inline uint HashCoder::operator*(const Array<T>& arr) const {
+  return operator*(arr.asPtr());
+}
+template <typename T, size_t smallSize, typename>
+inline uint HashCoder::operator*(const SmallArray<T, smallSize>& arr) const {
   return operator*(arr.asPtr());
 }
 


### PR DESCRIPTION
These utilities originally landed in https://github.com/capnproto/capnproto/pull/1762. Unfortunately, they landed at the same time as a [subtle bug in our fiber implementation](https://github.com/capnproto/capnproto/pull/1842) began causing production crashes in the Workers runtime, and we reverted this `SmallArray` feature out of an abundance of caution.

I've been meaning to re-submit `SmallArray`. It is a more ergonomic interface than KJ_STACK_ARRAY, and the primary compiler we target nowadays (clang) does not support VLAs, which is KJ_STACK_ARRAY's competitive advantage.

In the intervening years, some HeapArrayDisposer was refactored to use `if constexpr` instead of a dispatch struct template in: https://github.com/capnproto/capnproto/pull/2288/files#diff-a50b82e04212952a2c02eee72504e7cca446a9b6bc0c89348bdf3f34fa5b4fa0. This meant that my old PR did not cleanly apply, but ultimately it made the diff here easier to follow, obviating a preliminary refactoring commit.

In my original PR where this work landed, I replaced KJ_STACK_ARRAY wholesale in a synchronized multiple-repo. That was, in retrospect, dumb and unnecessary. I would like to go through and replace instances of KJ_STACK_ARRAY with `SmallArray` and `SmallArrayBuilder`, but that can come at our leisure.