### PR TITLE
RPC bugfix: Properly catch exceptions from ClientHook::call().

### DIFF
--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -3860,7 +3860,26 @@ private:
       uint64_t interfaceId, uint64_t methodId,
       kj::Own<ClientHook>&& capability, kj::Own<CallContextHook>&& context,
       ClientHook::CallHints hints) {
-    return capability->call(interfaceId, methodId, kj::mv(context), hints);
+    try {
+      return capability->call(interfaceId, methodId, kj::mv(context), hints);
+    } catch (...) {
+      auto exception = kj::getCaughtExceptionAsKj();
+      auto pipeline = newBrokenPipeline(kj::cp(exception));
+
+      // In the past, an exception here would have killed the entire connection (and also caused
+      // us to send back a bogus Finish message claiming the call was canceled). We have evidence
+      // that such exceptions are being thrown, but we're not sure what they are. Hopefully they
+      // will now show up in a more reasonable place, but just to understand what was going on,
+      // let's log.
+      //
+      // TODO(cleanup): Remove this log once investigation is complete.
+      KJ_LOG(WARNING, "NOSENTRY RPC startCall() threw", exception);
+
+      return {
+        .promise = kj::mv(exception),
+        .pipeline = kj::mv(pipeline),
+      };
+    }
   }
 
   kj::Own<ClientHook> getMessageTarget(const rpc::MessageTarget::Reader& target) {


### PR DESCRIPTION
Arguably, ClientHooks should not throw from this -- they should return a broken promise. But there are a lot of ClientHook implementations and they could really be doing anything.

Previously, an exception from here would propagate right out of `handleCall()` and kill the connection read loop, aborting the connection. Another side effect is that the `RpcCallContext` constructed in `handleCall()` would be destroyed without having sent a response, which would cause it to send a "canceled" return, despite the client not having actually asked to cancel anything. We are seeing these unexpected "canceled" returns in the wild.