### PR TITLE
[rust] fix unused import warnings on re-export

### DIFF
--- a/c++/src/capnp/rust_capnp_library.bzl
+++ b/c++/src/capnp/rust_capnp_library.bzl
@@ -76,6 +76,7 @@ def _lib_rs_content(crate_name, deps, outs):
 {outs}
 }}
 // re-export names to be accessible directly
+#[allow(unused_imports)] 
 pub use {crate_name}::*;
 // use dependencies
 {deps}


### PR DESCRIPTION
The Rust compiler flags `pub use module::*` as unused when the wildcard only brings in a single module (vs multiple items), even though the import is actually used for re-export.