### PR TITLE
[build] 08-08-25 Bazel cleanup

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -3,6 +3,10 @@ load(":configure.bzl", "capnp_configure")
 
 capnp_configure()
 
+exports_files([
+    "c++.capnp",
+])
+
 cc_library(
     name = "capnp",
     srcs = [
@@ -216,14 +220,14 @@ cc_library(
     name = "capnp-test",
     srcs = ["test-util.c++"],
     hdrs = ["test-util.h"],
+    include_prefix = "capnp",
+    visibility = [":__subpackages__"],
     deps = [
         ":capnp-rpc",
         ":capnp_test",
         ":capnpc",
         "//src/kj:kj-test",
     ],
-    include_prefix = "capnp",
-    visibility = [":__subpackages__" ]
 )
 
 [cc_test(
@@ -262,11 +266,11 @@ cc_library(
 cc_test(
     name = "endian-reverse-test",
     srcs = ["endian-reverse-test.c++"],
-    deps = [":capnp-test"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    deps = [":capnp-test"],
 )
 
 cc_library(
@@ -285,6 +289,6 @@ cc_test(
     name = "fuzz-test",
     size = "large",
     srcs = ["fuzz-test.c++"],
-    deps = [":capnp-test"],
     tags = ["manual"],
+    deps = [":capnp-test"],
 )

--- a/c++/src/capnp/cc_capnp_library.bzl
+++ b/c++/src/capnp/cc_capnp_library.bzl
@@ -1,4 +1,5 @@
 """Bazel rule to compile .capnp files into c++."""
+
 load(":capnp_gen.bzl", "capnp_gen", _capnp_provider = "capnp_provider")
 
 # re-export for backward compatibility

--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -182,8 +182,3 @@ cc_test(
         "//src/capnp:capnp-test",
     ],
 )
-
-cc_library(
-    name = "http-over-capnp-test-as-header",
-    hdrs = ["http-over-capnp-test.c++"],
-)

--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -118,9 +118,9 @@ cc_library(
         "@platforms//os:windows": ["async-win32.h"],
         "//conditions:default": ["async-unix.h"],
     }),
-    include_prefix = "kj",
     # Disable header parsing based on async-inl.h
     features = ["-parse_headers"],
+    include_prefix = "kj",
     linkopts = select({
         "@platforms//os:windows": [
             "Ws2_32.lib",

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -63,15 +63,15 @@ cc_library(
     srcs = ["brotli.c++"],
     hdrs = ["brotli.h"],
     include_prefix = "kj/compat",
-    visibility = ["//visibility:public"],
     target_compatible_with = select({
         "//src/kj:use_brotli": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+    visibility = ["//visibility:public"],
     deps = [
         "//src/kj:kj-async",
-        "@brotli//:brotlienc",
         "@brotli//:brotlidec",
+        "@brotli//:brotlienc",
     ],
 )
 
@@ -105,13 +105,13 @@ cc_library(
 cc_test(
     name = "http-socketpair-test",
     srcs = ["http-socketpair-test.c++"],
+    target_compatible_with = [
+        "@platforms//os:linux",  # TODO: Investigate why this fails on macOS
+    ],
     deps = [
         ":http-socketpair-test-base",
         ":kj-http",
         "//src/kj:kj-test",
-    ],
-    target_compatible_with = [
-        "@platforms//os:linux", # TODO: Investigate why this fails on macOS
     ],
 )
 
@@ -128,8 +128,8 @@ kj_tls_tests = [
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
-        ":kj-tls",
         ":kj-http",
+        ":kj-tls",
         "//src/kj:kj-test",
     ],
 ) for f in kj_tls_tests]

--- a/c++/src/kj/configure.bzl
+++ b/c++/src/kj/configure.bzl
@@ -36,7 +36,7 @@ def kj_configure():
         name = "deprecate_empty_maybe_from_nullptr",
         build_setting_default = True,
     )
-     
+
     bool_flag(
         name = "debug_memory",
         build_setting_default = False,


### PR DESCRIPTION
- Apply buildifier
- Drop obsolete http-over-capnp-test-as-header target
- Export c++.capnp (the change that will actually be useful downstream)