### PR TITLE
fix: include libucontext in Requires.private in cmake builds

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -96,6 +96,9 @@ set_property(CACHE WITH_FIBERS PROPERTY STRINGS AUTO ON OFF)
 # CapnProtoConfig.cmake.in needs this variable.
 set(_WITH_LIBUCONTEXT OFF)
 
+# Used by pkg-config files
+set(ASYNC_REQUIRES_PRIVATE "")
+
 if (WITH_FIBERS OR WITH_FIBERS STREQUAL "AUTO")
   set(_capnp_fibers_found OFF)
   if (WIN32 OR CYGWIN)
@@ -116,6 +119,7 @@ if (WITH_FIBERS OR WITH_FIBERS STREQUAL "AUTO")
         if (libucontext_FOUND)
           set(_WITH_LIBUCONTEXT ON)
           set(_capnp_fibers_found ON)
+          set(ASYNC_REQUIRES_PRIVATE "${ASYNC_REQUIRES_PRIVATE} libucontext")
         endif()
       else()
         set(_capnp_fibers_found OFF)

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -216,6 +216,8 @@ AS_IF([test "$with_fibers" != no], [
   ])
 ])
 
+ASYNC_REQUIRES_PRIVATE=""
+
 # Check for library support necessary for fibers.
 AS_IF([test "$with_fibers" != no], [
   case "${host_os}" in
@@ -241,6 +243,7 @@ AS_IF([test "$with_fibers" != no], [
         ])
         AS_IF([test "$ucontext_supports_fibers" = yes], [
           ASYNC_LIBS="$ASYNC_LIBS -lucontext"
+          ASYNC_REQUIRES_PRIVATE="$ASYNC_REQUIRES_PRIVATE libucontext"
           with_fibers=yes
         ], [
           AS_IF([test "$with_fibers" = yes], [
@@ -259,6 +262,7 @@ AS_IF([test "$with_fibers" = yes], [
 ], [
   CXXFLAGS="$CXXFLAGS -DKJ_USE_FIBERS=0"
 ])
+AC_SUBST(ASYNC_REQUIRES_PRIVATE, $ASYNC_REQUIRES_PRIVATE)
 
 # CapnProtoConfig.cmake.in needs these variables,
 # we force them to NO because we don't need the CMake dependency for them,

--- a/c++/pkgconfig/kj-async.pc.in
+++ b/c++/pkgconfig/kj-async.pc.in
@@ -8,4 +8,5 @@ Description: Basic utility library called KJ (async part)
 Version: @VERSION@
 Libs: -L${libdir} -lkj-async @ASYNC_LIBS@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
 Requires: kj = @VERSION@
+Requires.private: @ASYNC_REQUIRES_PRIVATE@
 Cflags: -I${includedir} @ASYNC_LIBS@ @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@


### PR DESCRIPTION
This is required so that static musl actually links to libucontext correctly to get setcontext/etc for fibers.

Using this allows the packager to set up the libucontext pkg-config however they wish so it actually works, rather than requiring that the -L path or other stuff is correct by downstream users.

The current state is that -lucontext isn't set at all on cmake builds, which is unambiguously broken (https://github.com/NixOS/nixpkgs/pull/432323), but it is not the correct approach to copy the autoconf build and merely set `-lucontext` in `Libs` as the latter ignores the pkg-config of libucontext itself (problematic!). 