### PR TITLE
Use apple_support toolchain when building on macOS

### DIFF
--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -55,6 +55,9 @@ build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-u
 # set the correct value.
 build:windows --cxxopt='/Zc:__cplusplus' --host_cxxopt='/Zc:__cplusplus'
 
+# build with the apple_support toolchain on macOS
+build:macos --extra_toolchains=@local_config_apple_cc_toolchains//:all
+
 # build with ssl, zlib and bazel by default
 build --//src/kj:openssl=True
 build --//src/kj:zlib=True

--- a/c++/MODULE.bazel
+++ b/c++/MODULE.bazel
@@ -18,3 +18,13 @@ register_toolchains(
     "@local_config_cc_toolchains//:all",
     dev_dependency = True,
 )
+
+# While the build should succeed with the default toolchain configuration from rules_cc,
+# apple_support is more tailored to macOS and allows us to cross-compile easily.
+bazel_dep(name = "apple_support", version = "1.22.1")
+
+# Toolchain registration adapted from apple_suport's MODULE.bazel
+apple_cc_configure = use_extension("@apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
+use_repo(apple_cc_configure, "local_config_apple_cc", "local_config_apple_cc_toolchains")
+
+register_toolchains("@local_config_apple_cc_toolchains//:all")


### PR DESCRIPTION
For macOS, there is a specific `apple_support` toolchain that we use for `workerd`. This PR adds it to `capnproto` builds as well.

On my laptop, using `apple_support` fixes an issue where `/usr/local/include/openssl` is mistakenly added to the include path, interfering with our `boringssl` dependency and breaking the build.

cc @fhanau 