### PR TITLE
Deprecate and replace the HttpHeaders set/add methods taking ptrs

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-perf-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-perf-test.c++
@@ -258,8 +258,8 @@ public:
     KJ_ASSERT(headers.get(customHeaderId) == "corge"_kj);
 
     kj::HttpHeaders responseHeaders(headerTable);
-    responseHeaders.set(kj::HttpHeaderId::CONTENT_TYPE, "text/plain");
-    responseHeaders.set(customHeaderId, "foobar"_kj);
+    responseHeaders.setPtr(kj::HttpHeaderId::CONTENT_TYPE, "text/plain");
+    responseHeaders.setPtr(customHeaderId, "foobar"_kj);
     auto stream = response.send(200, "OK", responseHeaders);
     auto promise = stream->write(HELLO_WORLD.asBytes());
     return promise.attach(kj::mv(stream));
@@ -278,7 +278,7 @@ public:
 
   kj::Promise<void> sendRequest(kj::HttpClient& client) {
     kj::HttpHeaders headers(headerTable);
-    headers.set(customHeaderId, "corge"_kj);
+    headers.setPtr(customHeaderId, "corge"_kj);
     auto req = client.request(kj::HttpMethod::GET, "http://foo"_kj, headers);
     req.body = nullptr;
     auto resp = co_await req.response;
@@ -292,7 +292,7 @@ public:
 
   kj::Promise<void> sendRequest(kj::HttpService& service) {
     kj::HttpHeaders headers(headerTable);
-    headers.set(customHeaderId, "corge"_kj);
+    headers.setPtr(customHeaderId, "corge"_kj);
     NullInputStream requestBody;
     co_await service.request(kj::HttpMethod::GET, "http://foo"_kj, headers, requestBody, *this);
     KJ_ASSERT(responseBody.consume() == HELLO_WORLD);

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -503,7 +503,7 @@ public:
       kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override {
     kj::HttpHeaders respHeaders(headerTable);
-    respHeaders.add("X-Foo", "bar");
+    respHeaders.addPtrPtr("X-Foo", "bar");
     fulfiller->fulfill(response.acceptWebSocket(respHeaders));
     return kj::mv(done);
   }

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -1074,18 +1074,18 @@ kj::HttpHeaders HttpOverCapnpFactory::capnpToKj(
             auto cvInt = static_cast<uint>(nv.getCommonValue());
             KJ_REQUIRE(nameInt < valueCapnpToKj.size(),
                 "unknown common header value", nv.getCommonValue());
-            result.set(nameCapnpToKj[nameInt], valueCapnpToKj[cvInt]);
+            result.setPtr(nameCapnpToKj[nameInt], valueCapnpToKj[cvInt]);
             break;
           }
           case capnp::HttpHeader::Common::VALUE: {
             auto headerId = nameCapnpToKj[nameInt];
             if (result.get(headerId) == kj::none) {
-              result.set(headerId, nv.getValue());
+              result.setPtr(headerId, nv.getValue());
             } else {
               // Unusual: This is a duplicate header, so fall back to add(), which may trigger
               //   comma-concatenation, except in certain cases where comma-concatentaion would
               //   be problematic.
-              result.add(headerId.toString(), nv.getValue());
+              result.addPtrPtr(headerId.toString(), nv.getValue());
             }
             break;
           }
@@ -1094,7 +1094,7 @@ kj::HttpHeaders HttpOverCapnpFactory::capnpToKj(
       }
       case capnp::HttpHeader::UNCOMMON: {
         auto nv = header.getUncommon();
-        result.add(nv.getName(), nv.getValue());
+        result.addPtrPtr(nv.getName(), nv.getValue());
       }
     }
   }

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -478,7 +478,7 @@ Promise<void> httpClient(Own<AsyncIoStream> connection) {
   auto client = newHttpClient(table, *connection);
 
   HttpHeaders headers(table);
-  headers.set(HttpHeaderId::HOST, "capnproto.org");
+  headers.setPtr(HttpHeaderId::HOST, "capnproto.org");
 
   auto response = co_await client->request(HttpMethod::GET, "/", headers).response;
   KJ_EXPECT(response.statusCode / 100 == 3);

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -358,23 +358,23 @@ KJ_TEST("HttpHeaders validation") {
   auto table = HttpHeaderTable::Builder().build();
   HttpHeaders headers(*table);
 
-  headers.add("Valid-Name", "valid value");
+  headers.addPtrPtr("Valid-Name", "valid value");
 
   // The HTTP RFC prohibits control characters, but browsers only prohibit \0, \r, and \n. KJ goes
   // with the browsers for compatibility.
-  headers.add("Valid-Name", "valid\x01value");
+  headers.addPtrPtr("Valid-Name", "valid\x01value");
 
   // The HTTP RFC does not permit non-ASCII values.
   // KJ chooses to interpret them as UTF-8, to avoid the need for any expensive conversion.
   // Browsers apparently interpret them as LATIN-1. Applications can reinterpet these strings as
   // LATIN-1 easily enough if they really need to.
-  headers.add("Valid-Name", u8"valid€value");
+  headers.addPtrPtr("Valid-Name", u8"valid€value");
 
-  KJ_EXPECT_THROW_MESSAGE("invalid header name", headers.add("Invalid Name", "value"));
-  KJ_EXPECT_THROW_MESSAGE("invalid header name", headers.add("Invalid@Name", "value"));
+  KJ_EXPECT_THROW_MESSAGE("invalid header name", headers.addPtrPtr("Invalid Name", "value"));
+  KJ_EXPECT_THROW_MESSAGE("invalid header name", headers.addPtrPtr("Invalid@Name", "value"));
 
-  KJ_EXPECT_THROW_MESSAGE("invalid header value", headers.set(HttpHeaderId::HOST, "in\nvalid"));
-  KJ_EXPECT_THROW_MESSAGE("invalid header value", headers.add("Valid-Name", "in\nvalid"));
+  KJ_EXPECT_THROW_MESSAGE("invalid header value", headers.setPtr(HttpHeaderId::HOST, "in\nvalid"));
+  KJ_EXPECT_THROW_MESSAGE("invalid header value", headers.addPtrPtr("Valid-Name", "in\nvalid"));
 }
 
 KJ_TEST("HttpHeaders Set-Cookie handling") {
@@ -384,12 +384,12 @@ KJ_TEST("HttpHeaders Set-Cookie handling") {
   auto table = builder.build();
 
   HttpHeaders headers(*table);
-  headers.set(hCookie, "Foo");
-  headers.add("Cookie", "Bar");
-  headers.add("Cookie", "Baz");
-  headers.set(hSetCookie, "Foo");
-  headers.add("Set-Cookie", "Bar");
-  headers.add("Set-Cookie", "Baz");
+  headers.setPtr(hCookie, "Foo");
+  headers.addPtrPtr("Cookie", "Bar");
+  headers.addPtrPtr("Cookie", "Baz");
+  headers.setPtr(hSetCookie, "Foo");
+  headers.addPtrPtr("Set-Cookie", "Bar");
+  headers.addPtrPtr("Set-Cookie", "Baz");
 
   auto text = headers.toString();
   KJ_EXPECT(text ==
@@ -572,7 +572,7 @@ void testHttpClientRequest(kj::WaitScope& waitScope, const HttpRequestTestCase& 
 
   HttpHeaders headers(table);
   for (auto& header: testCase.requestHeaders) {
-    headers.set(header.id, header.value);
+    headers.setPtr(header.id, header.value);
   }
 
   auto request = client->request(testCase.method, testCase.path, headers, testCase.requestBodySize);
@@ -643,7 +643,7 @@ void testHttpClient(kj::WaitScope& waitScope, HttpHeaderTable& table,
 
   HttpHeaders headers(table);
   for (auto& header: testCase.request.requestHeaders) {
-    headers.set(header.id, header.value);
+    headers.setPtr(header.id, header.value);
   }
 
   auto request = client.request(
@@ -715,7 +715,7 @@ public:
 
       responseHeaders.clear();
       for (auto& header: response.responseHeaders) {
-        responseHeaders.set(header.id, header.value);
+        responseHeaders.setPtr(header.id, header.value);
       }
 
       auto stream = responseSender.send(response.statusCode, response.statusText,
@@ -1456,7 +1456,7 @@ KJ_TEST("HttpClient parallel pipeline") {
 
     HttpHeaders headers(table);
     for (auto& header: testCase.request.requestHeaders) {
-      headers.set(header.id, header.value);
+      headers.setPtr(header.id, header.value);
     }
 
     auto request = client->request(
@@ -2689,7 +2689,7 @@ kj::ArrayPtr<const byte> asBytes(const char (&chars)[s]) {
 void testWebSocketClient(kj::WaitScope& waitScope, HttpHeaderTable& headerTable,
                          kj::HttpHeaderId hMyHeader, HttpClient& client) {
   kj::HttpHeaders headers(headerTable);
-  headers.set(hMyHeader, "foo");
+  headers.setPtr(hMyHeader, "foo");
   auto response = client.openWebSocket("/websocket", headers).wait(waitScope);
 
   KJ_EXPECT(response.statusCode == 101);
@@ -2729,7 +2729,7 @@ void testWebSocketTwoMessageCompression(kj::WaitScope& waitScope, HttpHeaderTabl
   // compressed message changes.
 
   kj::HttpHeaders headers(headerTable);
-  headers.set(extHeader, extensions);
+  headers.setPtr(extHeader, extensions);
   auto response = client.openWebSocket("/websocket", headers).wait(waitScope);
 
   KJ_EXPECT(response.statusCode == 101);
@@ -2771,7 +2771,7 @@ void testWebSocketThreeMessageCompression(kj::WaitScope& waitScope, HttpHeaderTa
   // The third message is the same as the first (from the application code's perspective).
 
   kj::HttpHeaders headers(headerTable);
-  headers.set(extHeader, extensions);
+  headers.setPtr(extHeader, extensions);
   auto response = client.openWebSocket("/websocket", headers).wait(waitScope);
 
   KJ_EXPECT(response.statusCode == 101);
@@ -2821,7 +2821,7 @@ void testWebSocketEmptyMessageCompression(kj::WaitScope& waitScope, HttpHeaderTa
   // Confirm that we can send empty messages when compression is enabled.
 
   kj::HttpHeaders headers(headerTable);
-  headers.set(extHeader, extensions);
+  headers.setPtr(extHeader, extensions);
   auto response = client.openWebSocket("/websocket", headers).wait(waitScope);
 
   KJ_EXPECT(response.statusCode == 101);
@@ -2876,7 +2876,7 @@ void testWebSocketOptimizePumpProxy(kj::WaitScope& waitScope, HttpHeaderTable& h
   // configuration and pass it to `proxyServer` in a way that would allow for optimizedPumping.
 
   kj::HttpHeaders headers(headerTable);
-  headers.set(extHeader, extensions);
+  headers.setPtr(extHeader, extensions);
   auto response = client.openWebSocket("/websocket", headers).wait(waitScope);
 
   KJ_EXPECT(response.statusCode == 101);
@@ -2914,7 +2914,7 @@ void testWebSocketFourMessageCompression(kj::WaitScope& waitScope, HttpHeaderTab
   // the message). We will receive three messages.
 
   kj::HttpHeaders headers(headerTable);
-  headers.set(extHeader, extensions);
+  headers.setPtr(extHeader, extensions);
   auto response = client.openWebSocket("/websocket", headers).wait(waitScope);
 
   KJ_EXPECT(response.statusCode == 101);
@@ -3796,7 +3796,7 @@ KJ_TEST("HttpClient WebSocket error") {
   auto client = newHttpClient(*headerTable, *pipe.ends[0], clientSettings);
 
   kj::HttpHeaders headers(*headerTable);
-  headers.set(hMyHeader, "foo");
+  headers.setPtr(hMyHeader, "foo");
 
   {
     auto response = client->openWebSocket("/websocket", headers).wait(waitScope);
@@ -6199,7 +6199,7 @@ KJ_TEST("HttpClient to capnproto.org") {
     auto client = newHttpClient(table, *conn);
 
     HttpHeaders headers(table);
-    headers.set(HttpHeaderId::HOST, "capnproto.org");
+    headers.setPtr(HttpHeaderId::HOST, "capnproto.org");
 
     auto response = client->request(HttpMethod::GET, "/", headers).response.wait(io.waitScope);
     KJ_EXPECT(response.statusCode / 100 == 3);

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -697,6 +697,11 @@ bool HttpHeaders::isWebSocket() const {
 }
 
 void HttpHeaders::set(HttpHeaderId id, kj::StringPtr value) {
+  // TODO(cleanup): Remove this soon.
+  setPtr(id, value);
+}
+
+void HttpHeaders::setPtr(HttpHeaderId id, kj::StringPtr value) {
   id.requireFrom(*table);
   requireValidHeaderValue(value, id);
 
@@ -704,24 +709,32 @@ void HttpHeaders::set(HttpHeaderId id, kj::StringPtr value) {
 }
 
 void HttpHeaders::set(HttpHeaderId id, kj::String&& value) {
-  set(id, kj::StringPtr(value));
+  setPtr(id, kj::StringPtr(value));
   takeOwnership(kj::mv(value));
 }
 
-void HttpHeaders::add(kj::StringPtr name, kj::StringPtr value) {
+void HttpHeaders::addPtrPtr(kj::StringPtr name, kj::StringPtr value) {
   requireValidHeaderName(name);
   requireValidHeaderValue(value, name);
 
   addNoCheck(name, value);
 }
 
-void HttpHeaders::add(kj::StringPtr name, kj::String&& value) {
-  add(name, kj::StringPtr(value));
+void HttpHeaders::add(kj::StringPtr name, kj::StringPtr value) {
+  addPtrPtr(name, value);
+}
+
+void HttpHeaders::addPtr(kj::StringPtr name, kj::String&& value) {
+  addPtrPtr(name, kj::StringPtr(value));
   takeOwnership(kj::mv(value));
 }
 
+void HttpHeaders::add(kj::StringPtr name, kj::String&& value) {
+  addPtr(name, kj::mv(value));
+}
+
 void HttpHeaders::add(kj::String&& name, kj::String&& value) {
-  add(kj::StringPtr(name), kj::StringPtr(value));
+  addPtrPtr(kj::StringPtr(name), kj::StringPtr(value));
   takeOwnership(kj::mv(name));
   takeOwnership(kj::mv(value));
 }
@@ -6296,7 +6309,7 @@ public:
     auto parsed = Url::parse(url, Url::HTTP_PROXY_REQUEST, urlOptions);
     auto path = parsed.toString(Url::HTTP_REQUEST);
     auto headersCopy = headers.clone();
-    headersCopy.set(HttpHeaderId::HOST, parsed.host);
+    headersCopy.setPtr(HttpHeaderId::HOST, parsed.host);
     return getClient(parsed).request(method, path, headersCopy, expectedBodySize);
   }
 
@@ -6312,7 +6325,7 @@ public:
     auto parsed = Url::parse(url, Url::HTTP_PROXY_REQUEST, urlOptions);
     auto path = parsed.toString(Url::HTTP_REQUEST);
     auto headersCopy = headers.clone();
-    headersCopy.set(HttpHeaderId::HOST, parsed.host);
+    headersCopy.setPtr(HttpHeaderId::HOST, parsed.host);
     return getClient(parsed).openWebSocket(path, headersCopy);
   }
 
@@ -6737,7 +6750,7 @@ public:
     // `Upgrade: websocket` so that headers.isWebSocket() returns true on the service side.
     auto urlCopy = kj::str(url);
     auto headersCopy = kj::heap(headers.clone());
-    headersCopy->set(HttpHeaderId::UPGRADE, "websocket");
+    headersCopy->setPtr(HttpHeaderId::UPGRADE, "websocket");
     KJ_DASSERT(headersCopy->isWebSocket());
 
     auto paf = kj::newPromiseAndFulfiller<WebSocketResponse>();
@@ -8275,7 +8288,7 @@ kj::Promise<void> HttpServerErrorHandler::handleClientProtocolError(
 
   HttpHeaderTable headerTable {};
   HttpHeaders headers(headerTable);
-  headers.set(HttpHeaderId::CONTENT_TYPE, "text/plain");
+  headers.setPtr(HttpHeaderId::CONTENT_TYPE, "text/plain");
 
   auto errorMessage = kj::str("ERROR: ", protocolError.description);
   auto body = response.send(protocolError.statusCode, protocolError.statusMessage,
@@ -8304,7 +8317,7 @@ kj::Promise<void> HttpServerErrorHandler::handleApplicationError(
 
     HttpHeaderTable headerTable {};
     HttpHeaders headers(headerTable);
-    headers.set(HttpHeaderId::CONTENT_TYPE, "text/plain");
+    headers.setPtr(HttpHeaderId::CONTENT_TYPE, "text/plain");
 
     kj::String errorMessage;
     kj::Own<AsyncOutputStream> body;
@@ -8338,7 +8351,7 @@ void HttpServerErrorHandler::handleListenLoopException(kj::Exception&& exception
 kj::Promise<void> HttpServerErrorHandler::handleNoResponse(kj::HttpService::Response& response) {
   HttpHeaderTable headerTable {};
   HttpHeaders headers(headerTable);
-  headers.set(HttpHeaderId::CONTENT_TYPE, "text/plain");
+  headers.setPtr(HttpHeaderId::CONTENT_TYPE, "text/plain");
 
   constexpr auto errorMessage = "ERROR: The HttpService did not generate a response."_kj;
   auto body = response.send(500, "Internal Server Error", headers, errorMessage.size());

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -208,7 +208,7 @@ class HttpHeaderTable {
   //
   //     // Get http://example.com.
   //     HttpHeaders headers(table);
-  //     headers.set(accept, "text/html");
+  //     headers.setPtr(accept, "text/html");
   //     auto response = client->send(kj::HttpMethod::GET, "http://example.com", headers)
   //         .wait(waitScope);
   //     auto msg = kj::str("Response content type: ", response.headers.get(contentType));
@@ -334,7 +334,10 @@ public:
   // `func2(name, value)` for each header that does not. All calls to func1() precede all calls to
   // func2().
 
+  KJ_DEPRECATED("Use setPtr()")
   void set(HttpHeaderId id, kj::StringPtr value);
+  void setPtr(HttpHeaderId id, kj::StringPtr value);
+
   void set(HttpHeaderId id, kj::String&& value);
   // Sets a header value, overwriting the existing value.
   //
@@ -344,8 +347,14 @@ public:
   //   HttpHeaders object is destroyed. This allows string literals to be passed without making a
   //   copy, but complicates the use of dynamic values. Hint: Consider using `takeOwnership()`.
 
+  KJ_DEPRECATED("Use addPtrPtr()")
   void add(kj::StringPtr name, kj::StringPtr value);
+  void addPtrPtr(kj::StringPtr name, kj::StringPtr value);
+
+  KJ_DEPRECATED("Use addPtr()")
   void add(kj::StringPtr name, kj::String&& value);
+  void addPtr(kj::StringPtr name, kj::String&& value);
+
   void add(kj::String&& name, kj::String&& value);
   // Append a header. `name` will be looked up in the header table, but if it's not mapped, the
   // header will be added to the list of unmapped headers.


### PR DESCRIPTION
The original set/add methods that take StringPtr arguments are a potentially a bit dangerous because they can be easily confused with the variant that takes ownership of the string data. For instance,

```c++
kj::HttpHeaders headers(table);
{
  auto foo = kj::str("foo");
  // whoops! should have kj::mv'd
  headers.set(headerId, foo);
}
```

This deprecates (with the intention of removing) the set/add methods taking StringPtr and replaces them with new variants whose names indicate that they take pointers:

* `setPtr(HeaderId, StringPtr)`
* `addPtr(StringPtr, String&&)`
* `addPtrPtr(StringPtr, StringPtr)`

Once production uses have all been updated, the deprecated signatures can be removed.