### PR TITLE
fix byte-stream negative alloc

### DIFF
--- a/c++/src/capnp/compat/byte-stream.c++
+++ b/c++/src/capnp/compat/byte-stream.c++
@@ -975,7 +975,7 @@ public:
           });
         } else {
           // ughhhhhhhhhh, we need to split the pieces.
-          return splitAndWrite(pieces, kjStream.limit,
+          return splitAndWrite(pieces, limit,
               [kjStream,limit](kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) mutable {
             return kjStream.stream.write(pieces).then([kjStream,limit]() mutable {
               kjStream.lender.returnStream(limit);


### PR DESCRIPTION
Because of the way `splitAndWrite` initial while loop is written, things will break if total size of pieces is < limit. 
Which is the case when `kjStream.limit > MAX_BYTES_PER_WRITE`

Sorry, no idea how to setup BorrowedStream in tests.

