### PR TITLE
more powerful as<T>() implementation

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -611,12 +611,12 @@ TEST(Array, AttachFromArrayPtr) {
   KJ_EXPECT(destroyed1 == 3, destroyed1);
 }
 
-struct Std {
-  template<typename T>
-  static std::span<T> from(Array<T>* arr) {
-    return std::span<T>(arr->begin(), arr->size());
-  }
-};
+struct Std {};
+
+template<typename T>
+static std::span<T> asImpl(Std*, Array<T>& arr) {
+  return std::span<T>(arr.begin(), arr.size());
+}
 
 KJ_TEST("Array::as<Std>") {
   kj::Array<int> arr = kj::arr(1, 2, 4);

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -263,13 +263,13 @@ public:
   // Like Own<T>::attach(), but attaches to an Array.
 
   template <typename U>
-  inline auto as() { return U::from(this); }
-  // Syntax sugar for invoking U::from.
+  inline auto as() { return asImpl((U*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(U*, Array&).
   // Used to chain conversion calls rather than wrap with function.
 
   template <typename U>
-  inline auto as() const { return U::from(this); }
-  // Syntax sugar for invoking U::from.
+  inline auto as() const { return asImpl((U*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(U*, const Array&).
   // Used to chain conversion calls rather than wrap with function.
 
 private:

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -1169,12 +1169,12 @@ KJ_TEST("kj::ArrayPtr fill") {
   KJ_EXPECT("abcabcabca"_kjb == byteArray2);
 }
 
-struct Std {
-  template<typename T>
-  static std::span<T> from(ArrayPtr<T>* arr) {
-    return std::span<T>(arr->begin(), arr->size());
-  }
-};
+struct Std {};
+
+template<typename T>
+static std::span<T> asImpl(Std*, ArrayPtr<T>& arr) {
+  return std::span<T>(arr.begin(), arr.size());
+}
 
 KJ_TEST("ArrayPtr::as<Std>") {
   int rawArray[] = {12, 34, 56, 34, 12};

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1985,13 +1985,13 @@ public:
   // You must include kj/array.h to call this.
 
   template <typename U>
-  inline auto as() { return U::from(this); }
-  // Syntax sugar for invoking U::from.
+  inline auto as() { return asImpl((U*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(U*, ArrayPtr&).
   // Used to chain conversion calls rather than wrap with function.
 
   template <typename U>
-  inline auto as() const { return U::from(this); }
-  // Syntax sugar for invoking U::from.
+  inline auto as() const { return asImpl((U*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(U*, const ArrayPtr&).
   // Used to chain conversion calls rather than wrap with function.
 
   inline void fill(T t) {

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -480,15 +480,15 @@ KJ_TEST("StringPtr contains") {
   KJ_EXPECT(foobar.slice(2).contains(foobar.slice(1)) == false);
 }
 
-struct Std {
-  static std::string from(const String* str) {
-    return std::string(str->cStr());
-  }
+struct Std {};
 
-  static std::string from(const StringPtr* str) {
-    return std::string(str->cStr());
-  }
-};
+static std::string asImpl(Std*, const String& str) {
+  return std::string(str.cStr());
+}
+
+static std::string asImpl(Std*, const StringPtr& str) {
+  return std::string(str.cStr());
+}
 
 KJ_TEST("as<Std>") {
   String str = kj::str("foo"_kj);

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -155,13 +155,13 @@ public:
   // attachment should be an object that somehow owns the String that the StringPtr is pointing at.
 
   template <typename T>
-  inline auto as() { return T::from(this); }
-  // Syntax sugar for invoking T::from.
+  inline auto as() { return asImpl((T*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(T*, StringPtr&).
   // Used to chain conversion calls rather than wrap with function.
 
   template <typename T>
-  inline auto as() const { return T::from(this); }
-  // Syntax sugar for invoking T::from.
+  inline auto as() const { return asImpl((T*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(T*, const StringPtr&).
   // Used to chain conversion calls rather than wrap with function.
 
 private:
@@ -312,13 +312,13 @@ public:
   Maybe<T> tryParseAs() const { return StringPtr(*this).tryParseAs<T>(); }
 
   template <typename T>
-  inline auto as() { return T::from(this); }
-  // Syntax sugar for invoking T::from.
+  inline auto as() { return asImpl((T*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(T*, String&).
   // Used to chain conversion calls rather than wrap with function.
 
   template <typename T>
-  inline auto as() const { return T::from(this); }
-  // Syntax sugar for invoking T::from.
+  inline auto as() const { return asImpl((T*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(T*, const String&).
   // Used to chain conversion calls rather than wrap with function.
 
 private:
@@ -420,13 +420,13 @@ public:
   Maybe<T> tryParseAs() const { return StringPtr(*this).tryParseAs<T>(); }
 
   template <typename T>
-  inline auto as() { return T::from(this); }
-  // Syntax sugar for invoking T::from.
+  inline auto as() { return asImpl((T*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(T*, ConstString&).
   // Used to chain conversion calls rather than wrap with function.
 
   template <typename T>
-  inline auto as() const { return T::from(this); }
-  // Syntax sugar for invoking T::from.
+  inline auto as() const { return asImpl((T*)nullptr, *this); }
+  // Syntax sugar for invoking asImpl(T*, const ConstString&).
   // Used to chain conversion calls rather than wrap with function.
 
 private:


### PR DESCRIPTION
Current design converts `as<T>()`` calls into static members of T, which doesn't make it extensible: T needs to know about every type that can be converted.

Updating the design to convert as<T>() in `into(T{}, this)`, which makes T a simple marker object and you can have as many conversion targets as you like.

This is a very breaking change (for implementation, but not for interface) and will require carefull landing across worker-cxx, workerd and workers repository.

See https://github.com/cloudflare/workerd-cxx/pull/67 for similar improvement for the other direction.
See https://github.com/cloudflare/workerd-cxx/pull/69 for downstream changes.