### PR TITLE
kj::from<Domain>(t) helper function

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2327,6 +2327,13 @@ private:
   void* id;
 };
 
+template <typename U, typename T>
+decltype(auto) from(T&& t) {
+  // Helper method for uniform conversion of non-kj objects to kj.
+  // Usage: `kj::from<Something>(t)` that will translate into fromImpl((Something*)nullptr, t) call.
+  return fromImpl((U*)nullptr, kj::fwd<T>(t));
+}
+
 }  // namespace kj
 
 template <kj::_::ByteLiteral s>

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -22,6 +22,7 @@
 #include "string.h"
 #include <kj/compat/gtest.h>
 #include <string>
+#include <string_view>
 #include "vector.h"
 #include <locale.h>
 #include <stdint.h>
@@ -490,6 +491,14 @@ static std::string asImpl(Std*, const StringPtr& str) {
   return std::string(str.cStr());
 }
 
+inline kj::StringPtr fromImpl(Std*, const std::string& str) {
+  return kj::StringPtr(str.c_str(), str.length());
+}
+
+inline kj::ArrayPtr<const char> fromImpl(Std*, const std::string_view& str) {
+  return kj::arrayPtr(str.data(), str.length());
+}
+
 KJ_TEST("as<Std>") {
   String str = kj::str("foo"_kj);
   std::string stdStr = str.as<Std>();
@@ -498,6 +507,16 @@ KJ_TEST("as<Std>") {
   StringPtr ptr = "bar"_kj;
   std::string stdPtr = ptr.as<Std>();
   KJ_EXPECT(stdPtr == "bar");
+}
+
+KJ_TEST("from<Std>") {
+  std::string str("foo");
+  kj::StringPtr stdStr = kj::from<Std>(str);
+  KJ_EXPECT(stdStr == "foo"_kj);
+
+  std::string_view view(str);
+  kj::ArrayPtr<const char> stdView = kj::from<Std>(view);
+  KJ_EXPECT(stdView == "foo"_kjb);
 }
 
 struct OnlyMoves {


### PR DESCRIPTION
This is similar to https://github.com/capnproto/capnproto/pull/2396 and creates uniform way to define conversion functions like `kj::from<Rust>(rustString)`.