### PR TITLE
Fix transfer of headers when suspending a request.

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1185,7 +1185,7 @@ KJ_TEST("HttpServer handles 'chunked, chunked' as 'chunked'") {
   // This is technically invalid per HTTP spec but needed for compatibility
   KJ_HTTP_TEST_SETUP_IO;
   kj::TimerImpl timer(kj::origin<kj::TimePoint>());
-  
+
   HttpRequestTestCase REQUEST_WITH_CHUNKED_CHUNKED = {
     "POST /foo HTTP/1.1\r\n"
     "Transfer-Encoding: chunked, chunked\r\n"
@@ -1194,14 +1194,14 @@ KJ_TEST("HttpServer handles 'chunked, chunked' as 'chunked'") {
     "foobar\r\n"
     "0\r\n"
     "\r\n",
-    
+
     HttpMethod::POST,
     "/foo",
     {},
     kj::none,  // chunked encoding, no fixed length
     { "foobar" }
   };
-  
+
   HttpRequestTestCase REQUEST_WITH_CHUNKED_CHUNKED_NO_SPACE = {
     "POST /bar HTTP/1.1\r\n"
     "Transfer-Encoding: chunked,chunked\r\n"
@@ -1210,29 +1210,29 @@ KJ_TEST("HttpServer handles 'chunked, chunked' as 'chunked'") {
     "baz\r\n"
     "0\r\n"
     "\r\n",
-    
+
     HttpMethod::POST,
     "/bar",
     {},
     kj::none,  // chunked encoding, no fixed length
     { "baz" }
   };
-  
+
   HttpResponseTestCase RESPONSE = {
     "HTTP/1.1 200 OK\r\n"
     "Content-Length: 2\r\n"
     "\r\n"
     "ok",
-    
+
     200, "OK",
     {},
     2, {"ok"}
   };
-  
+
   // Test with "chunked, chunked" (with space)
   testHttpServerRequest(waitScope, timer, REQUEST_WITH_CHUNKED_CHUNKED, RESPONSE,
                         KJ_HTTP_TEST_CREATE_2PIPE);
-  
+
   // Test with "chunked,chunked" (no space)
   testHttpServerRequest(waitScope, timer, REQUEST_WITH_CHUNKED_CHUNKED_NO_SPACE, RESPONSE,
                         KJ_HTTP_TEST_CREATE_2PIPE);


### PR DESCRIPTION
We really need to transfer the original headers object, not clone it. Usually the headers all point into the original header buffer, but not necessarily always. The headers could have one or more headers backed by its `ownedStrings`.

Luckily as we are dismantling the connection anyway, we're free to take the headers with us.