### PR TITLE
make PipelineHook explicitly refcounted

### DIFF
--- a/c++/src/capnp/any.c++
+++ b/c++/src/capnp/any.c++
@@ -58,7 +58,7 @@ AnyPointer::Pipeline AnyPointer::Pipeline::noop() {
   for (auto i: kj::indices(ops)) {
     newOps[i] = ops[i];
   }
-  return Pipeline(hook->addRef(), kj::mv(newOps));
+  return Pipeline(hook.addRef(), kj::mv(newOps));
 }
 
 AnyPointer::Pipeline AnyPointer::Pipeline::getPointerField(uint16_t pointerIndex) {
@@ -70,7 +70,7 @@ AnyPointer::Pipeline AnyPointer::Pipeline::getPointerField(uint16_t pointerIndex
   newOp.type = PipelineOp::GET_POINTER_FIELD;
   newOp.pointerIndex = pointerIndex;
 
-  return Pipeline(hook->addRef(), kj::mv(newOps));
+  return Pipeline(hook.addRef(), kj::mv(newOps));
 }
 
 kj::Own<ClientHook> AnyPointer::Pipeline::asCap() {

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -26,6 +26,7 @@
 #include "list.h"
 #include <kj/windows-sanity.h>  // work-around macro conflict with `VOID`
 #include <kj/hash.h>
+#include <kj/refcount.h>
 
 CAPNP_BEGIN_HEADER
 
@@ -264,7 +265,7 @@ struct AnyPointer {
     typedef AnyPointer Pipelines;
 
     inline Pipeline(decltype(nullptr)) {}
-    inline explicit Pipeline(kj::Own<PipelineHook>&& hook): hook(kj::mv(hook)) {}
+    inline explicit Pipeline(kj::Rc<PipelineHook>&& hook): hook(kj::mv(hook)) {}
 
     Pipeline noop();
     // Just make a copy.
@@ -277,17 +278,17 @@ struct AnyPointer {
     kj::Own<ClientHook> asCap();
     // Expect that the result is a capability and construct a pipelined version of it now.
 
-    inline kj::Own<PipelineHook> releasePipelineHook() { return kj::mv(hook); }
+    inline kj::Rc<PipelineHook> releasePipelineHook() { return kj::mv(hook); }
     // For use by RPC implementations.
 
     template <typename T, typename = kj::EnableIf<CAPNP_KIND(FromClient<T>) == Kind::INTERFACE>>
     inline operator T() { return T(asCap()); }
 
   private:
-    kj::Own<PipelineHook> hook;
+    kj::Rc<PipelineHook> hook;
     kj::Array<PipelineOp> ops;
 
-    inline Pipeline(kj::Own<PipelineHook>&& hook, kj::Array<PipelineOp>&& ops)
+    inline Pipeline(kj::Rc<PipelineHook>&& hook, kj::Array<PipelineOp>&& ops)
         : hook(kj::mv(hook)), ops(kj::mv(ops)) {}
 
     friend class LocalClient;
@@ -736,13 +737,10 @@ inline bool operator==(const PipelineOp& a, const PipelineOp& b) {
   KJ_CLANG_KNOWS_THIS_IS_UNREACHABLE_BUT_GCC_DOESNT
 }
 
-class PipelineHook {
+class PipelineHook: public kj::Refcounted {
   // Represents a currently-running call, and implements pipelined requests on its result.
 
 public:
-  virtual kj::Own<PipelineHook> addRef() = 0;
-  // Increment this object's reference count.
-
   virtual kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) = 0;
   // Extract a promised Capability from the results.
 
@@ -751,7 +749,7 @@ public:
   // Default implementation just calls the other version.
 
   template <typename Pipeline, typename = FromPipeline<Pipeline>>
-  static inline kj::Own<PipelineHook> from(Pipeline&& pipeline);
+  static inline kj::Rc<PipelineHook> from(Pipeline&& pipeline);
 
   template <typename Pipeline, typename = FromPipeline<Pipeline>>
   static inline PipelineHook& from(Pipeline& pipeline);
@@ -1075,7 +1073,7 @@ struct OrphanGetImpl<AnyList, Kind::OTHER> {
 
 template <typename T>
 struct PipelineHook::FromImpl {
-  static inline kj::Own<PipelineHook> apply(typename T::Pipeline&& pipeline) {
+  static inline kj::Rc<PipelineHook> apply(typename T::Pipeline&& pipeline) {
     return from(kj::mv(pipeline._typeless));
   }
   static inline PipelineHook& apply(typename T::Pipeline& pipeline) {
@@ -1085,16 +1083,16 @@ struct PipelineHook::FromImpl {
 
 template <>
 struct PipelineHook::FromImpl<AnyPointer> {
-  static inline kj::Own<PipelineHook> apply(AnyPointer::Pipeline&& pipeline) {
+  static inline kj::Rc<PipelineHook> apply(AnyPointer::Pipeline&& pipeline) {
     return kj::mv(pipeline.hook);
   }
   static inline PipelineHook& apply(AnyPointer::Pipeline& pipeline) {
-    return *pipeline.hook;
+    return *pipeline.hook.get();
   }
 };
 
 template <typename Pipeline, typename T>
-inline kj::Own<PipelineHook> PipelineHook::from(Pipeline&& pipeline) {
+inline kj::Rc<PipelineHook> PipelineHook::from(Pipeline&& pipeline) {
   return FromImpl<T>::apply(kj::fwd<Pipeline>(pipeline));
 }
 

--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -167,7 +167,7 @@ public:
     }
     return responseBuilder;
   }
-  void setPipeline(kj::Own<PipelineHook>&& pipeline) override {
+  void setPipeline(kj::Rc<PipelineHook>&& pipeline) override {
     KJ_IF_SOME(f, tailCallPipelineFulfiller) {
       f->fulfill(AnyPointer::Pipeline(kj::mv(pipeline)));
     }
@@ -300,22 +300,18 @@ private:
 // These classes handle pipelining in the case where calls need to be queued in-memory until some
 // local operation completes.
 
-class QueuedPipeline final: public PipelineHook, public kj::Refcounted {
+class QueuedPipeline final: public PipelineHook {
   // A PipelineHook which simply queues calls while waiting for a PipelineHook to which to forward
   // them.
 
 public:
-  QueuedPipeline(kj::Promise<kj::Own<PipelineHook>>&& promiseParam)
+  QueuedPipeline(kj::Promise<kj::Rc<PipelineHook>>&& promiseParam)
       : promise(promiseParam.fork()),
-        selfResolutionOp(promise.addBranch().then([this](kj::Own<PipelineHook>&& inner) {
+        selfResolutionOp(promise.addBranch().then([this](kj::Rc<PipelineHook>&& inner) {
           redirect = kj::mv(inner);
         }, [this](kj::Exception&& exception) {
           redirect = newBrokenPipeline(kj::mv(exception));
         }).eagerlyEvaluate(nullptr)) {}
-
-  kj::Own<PipelineHook> addRef() override {
-    return kj::addRef(*this);
-  }
 
   kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
     auto copy = kj::heapArrayBuilder<PipelineOp>(ops.size());
@@ -328,9 +324,9 @@ public:
   kj::Own<ClientHook> getPipelinedCap(kj::Array<PipelineOp>&& ops) override;
 
 private:
-  kj::ForkedPromise<kj::Own<PipelineHook>> promise;
+  kj::ForkedPromise<kj::Rc<PipelineHook>> promise;
 
-  kj::Maybe<kj::Own<PipelineHook>> redirect;
+  kj::Maybe<kj::Rc<PipelineHook>> redirect;
   // Once the promise resolves, this will become non-null and point to the underlying object.
 
   kj::Promise<void> selfResolutionOp;
@@ -420,7 +416,7 @@ public:
       });
       return VoidPromiseAndPipeline {
         kj::NEVER_DONE,
-        kj::refcounted<QueuedPipeline>(kj::mv(pipelinePromise))
+        kj::rc<QueuedPipeline>(kj::mv(pipelinePromise))
       };
     } else {
       auto split = promiseForCallForwarding.addBranch()
@@ -430,9 +426,9 @@ public:
       }).split();
 
       kj::Promise<void> completionPromise = kj::mv(kj::get<0>(split));
-      kj::Promise<kj::Own<PipelineHook>> pipelinePromise = kj::mv(kj::get<1>(split));
+      kj::Promise<kj::Rc<PipelineHook>> pipelinePromise = kj::mv(kj::get<1>(split));
 
-      auto pipeline = kj::refcounted<QueuedPipeline>(kj::mv(pipelinePromise));
+      auto pipeline = kj::rc<QueuedPipeline>(kj::mv(pipelinePromise));
 
       // OK, now we can actually return our thing.
       return VoidPromiseAndPipeline { kj::mv(completionPromise), kj::mv(pipeline) };
@@ -498,7 +494,7 @@ kj::Own<ClientHook> QueuedPipeline::getPipelinedCap(kj::Array<PipelineOp>&& ops)
   } else {
     return clientMap.findOrCreate(ops.asPtr(), [&]() {
       auto clientPromise = promise.addBranch()
-          .then([ops = KJ_MAP(op, ops) { return op; }](kj::Own<PipelineHook> pipeline) {
+          .then([ops = KJ_MAP(op, ops) { return op; }](kj::Rc<PipelineHook> pipeline) {
         return pipeline->getPipelinedCap(kj::mv(ops));
       });
       return kj::HashMap<kj::Array<PipelineOp>, kj::Own<ClientHook>>::Entry {
@@ -510,15 +506,11 @@ kj::Own<ClientHook> QueuedPipeline::getPipelinedCap(kj::Array<PipelineOp>&& ops)
 
 // =======================================================================================
 
-class LocalPipeline final: public PipelineHook, public kj::Refcounted {
+class LocalPipeline final: public PipelineHook {
 public:
   inline LocalPipeline(kj::Own<CallContextHook>&& contextParam)
       : context(kj::mv(contextParam)),
         results(context->getResults(MessageSize { 0, 0 })) {}
-
-  kj::Own<PipelineHook> addRef() override {
-    return kj::addRef(*this);
-  }
 
   kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
     return results.getPipelinedCap(ops);
@@ -645,9 +637,9 @@ public:
     }
 
     auto pipelinePromise = pipelineBranch
-        .then([=,context=context->addRef()]() mutable -> kj::Own<PipelineHook> {
+        .then([=,context=context->addRef()]() mutable -> kj::Rc<PipelineHook> {
           context->releaseParams();
-          return kj::refcounted<LocalPipeline>(kj::mv(context));
+          return kj::rc<LocalPipeline>(kj::mv(context));
         });
 
     auto tailPipelinePromise = context->onTailCall()
@@ -658,7 +650,7 @@ public:
     pipelinePromise = pipelinePromise.exclusiveJoin(kj::mv(tailPipelinePromise));
 
     return VoidPromiseAndPipeline { kj::mv(completionPromise),
-        kj::refcounted<QueuedPipeline>(kj::mv(pipelinePromise)) };
+        kj::rc<QueuedPipeline>(kj::mv(pipelinePromise)) };
   }
 
   kj::Maybe<ClientHook&> getResolved() override {
@@ -941,23 +933,19 @@ kj::Own<ClientHook> newLocalPromiseClient(kj::Promise<kj::Own<ClientHook>>&& pro
   return kj::refcounted<QueuedClient>(kj::mv(promise));
 }
 
-kj::Own<PipelineHook> newLocalPromisePipeline(kj::Promise<kj::Own<PipelineHook>>&& promise) {
-  return kj::refcounted<QueuedPipeline>(kj::mv(promise));
+kj::Rc<PipelineHook> newLocalPromisePipeline(kj::Promise<kj::Rc<PipelineHook>>&& promise) {
+  return kj::rc<QueuedPipeline>(kj::mv(promise));
 }
 
 // =======================================================================================
 
 namespace _ {  // private
 
-class PipelineBuilderHook final: public PipelineHook, public kj::Refcounted {
+class PipelineBuilderHook final: public PipelineHook {
 public:
   PipelineBuilderHook(uint firstSegmentWords)
       : message(firstSegmentWords),
         root(message.getRoot<AnyPointer>()) {}
-
-  kj::Own<PipelineHook> addRef() override {
-    return kj::addRef(*this);
-  }
 
   kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
     return root.asReader().getPipelinedCap(ops);
@@ -968,7 +956,7 @@ public:
 };
 
 PipelineBuilderPair newPipelineBuilder(uint firstSegmentWords) {
-  auto hook = kj::refcounted<PipelineBuilderHook>(firstSegmentWords);
+  auto hook = kj::rc<PipelineBuilderHook>(firstSegmentWords);
   auto root = hook->root;
   return { root, kj::mv(hook) };
 }
@@ -979,13 +967,9 @@ PipelineBuilderPair newPipelineBuilder(uint firstSegmentWords) {
 
 namespace {
 
-class BrokenPipeline final: public PipelineHook, public kj::Refcounted {
+class BrokenPipeline final: public PipelineHook {
 public:
   BrokenPipeline(const kj::Exception& exception): exception(exception) {}
-
-  kj::Own<PipelineHook> addRef() override {
-    return kj::addRef(*this);
-  }
 
   kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override;
 
@@ -1000,7 +984,7 @@ public:
 
   RemotePromise<AnyPointer> send() override {
     return RemotePromise<AnyPointer>(kj::cp(exception),
-        AnyPointer::Pipeline(kj::refcounted<BrokenPipeline>(exception)));
+        AnyPointer::Pipeline(kj::rc<BrokenPipeline>(exception)));
   }
 
   kj::Promise<void> sendStreaming() override {
@@ -1008,7 +992,7 @@ public:
   }
 
   AnyPointer::Pipeline sendForPipeline() override {
-    return AnyPointer::Pipeline(kj::refcounted<BrokenPipeline>(exception));
+    return AnyPointer::Pipeline(kj::rc<BrokenPipeline>(exception));
   }
 
   kj::Exception exception;
@@ -1031,7 +1015,7 @@ public:
 
   VoidPromiseAndPipeline call(uint64_t interfaceId, uint16_t methodId,
                               kj::Own<CallContextHook>&& context, CallHints hints) override {
-    return VoidPromiseAndPipeline { kj::cp(exception), kj::refcounted<BrokenPipeline>(exception) };
+    return VoidPromiseAndPipeline { kj::cp(exception), kj::rc<BrokenPipeline>(exception) };
   }
 
   kj::Maybe<ClientHook&> getResolved() override {
@@ -1079,8 +1063,8 @@ kj::Own<ClientHook> newBrokenCap(kj::Exception&& reason) {
   return kj::refcounted<BrokenClient>(kj::mv(reason), false, &ClientHook::BROKEN_CAPABILITY_BRAND);
 }
 
-kj::Own<PipelineHook> newBrokenPipeline(kj::Exception&& reason) {
-  return kj::refcounted<BrokenPipeline>(kj::mv(reason));
+kj::Rc<PipelineHook> newBrokenPipeline(kj::Exception&& reason) {
+  return kj::rc<BrokenPipeline>(kj::mv(reason));
 }
 
 Request<AnyPointer, AnyPointer> newBrokenRequest(
@@ -1090,13 +1074,9 @@ Request<AnyPointer, AnyPointer> newBrokenRequest(
   return Request<AnyPointer, AnyPointer>(root, kj::mv(hook));
 }
 
-kj::Own<PipelineHook> getDisabledPipeline() {
+kj::Rc<PipelineHook> getDisabledPipeline() {
   class DisabledPipelineHook final: public PipelineHook {
   public:
-    kj::Own<PipelineHook> addRef() override {
-      return kj::Own<PipelineHook>(this, kj::NullDisposer::instance);
-    }
-
     kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
       return newBrokenCap(KJ_EXCEPTION(FAILED,
           "caller specified noPromisePipelining hint, but then tried to pipeline"));
@@ -1107,7 +1087,7 @@ kj::Own<PipelineHook> getDisabledPipeline() {
           "caller specified noPromisePipelining hint, but then tried to pipeline"));
     }
   };
-  static DisabledPipelineHook instance;
+  static auto instance = kj::rc<DisabledPipelineHook>();
   return instance.addRef();
 }
 

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -630,7 +630,7 @@ public:
   // consumes the `PipelineBuilder`; no further methods can be invoked.
 
 private:
-  kj::Own<PipelineHook> hook;
+  kj::Rc<PipelineHook> hook;
 
   PipelineBuilder(_::PipelineBuilderPair pair);
 };
@@ -797,7 +797,7 @@ public:
 
   struct VoidPromiseAndPipeline {
     kj::Promise<void> promise;
-    kj::Own<PipelineHook> pipeline;
+    kj::Rc<PipelineHook> pipeline;
   };
 
   virtual VoidPromiseAndPipeline call(uint64_t interfaceId, uint16_t methodId,
@@ -877,7 +877,7 @@ public:
   virtual AnyPointer::Builder getResults(kj::Maybe<MessageSize> sizeHint) = 0;
   virtual kj::Promise<void> tailCall(kj::Own<RequestHook>&& request) = 0;
 
-  virtual void setPipeline(kj::Own<PipelineHook>&& pipeline) = 0;
+  virtual void setPipeline(kj::Rc<PipelineHook>&& pipeline) = 0;
 
   virtual kj::Promise<AnyPointer::Pipeline> onTailCall() = 0;
   // If `tailCall()` is called, resolves to the PipelineHook from the tail call.  An
@@ -901,7 +901,7 @@ kj::Own<ClientHook> newLocalPromiseClient(kj::Promise<kj::Own<ClientHook>>&& pro
 // the new client.  This hook's `getResolved()` and `whenMoreResolved()` methods will reflect the
 // redirection to the eventual replacement client.
 
-kj::Own<PipelineHook> newLocalPromisePipeline(kj::Promise<kj::Own<PipelineHook>>&& promise);
+kj::Rc<PipelineHook> newLocalPromisePipeline(kj::Promise<kj::Rc<PipelineHook>>&& promise);
 // Returns a PipelineHook that queues up calls until `promise` resolves, then forwards them to
 // the new pipeline.
 
@@ -909,14 +909,14 @@ kj::Own<ClientHook> newBrokenCap(kj::StringPtr reason);
 kj::Own<ClientHook> newBrokenCap(kj::Exception&& reason);
 // Helper function that creates a capability which simply throws exceptions when called.
 
-kj::Own<PipelineHook> newBrokenPipeline(kj::Exception&& reason);
+kj::Rc<PipelineHook> newBrokenPipeline(kj::Exception&& reason);
 // Helper function that creates a pipeline which simply throws exceptions when called.
 
 Request<AnyPointer, AnyPointer> newBrokenRequest(
     kj::Exception&& reason, kj::Maybe<MessageSize> sizeHint);
 // Helper function that creates a Request object that simply throws exceptions when sent.
 
-kj::Own<PipelineHook> getDisabledPipeline();
+kj::Rc<PipelineHook> getDisabledPipeline();
 // Gets a PipelineHook appropriate to use when CallHints::noPromisePipelining is true. This will
 // throw from all calls. This does not actually allocate the object; a static global object is
 // returned with a null disposer.
@@ -1054,7 +1054,7 @@ private:
 
 template <typename T>
 RemotePromise<T> RemotePromise<T>::reducePromise(kj::Promise<RemotePromise>&& promise) {
-  kj::Tuple<kj::Promise<Response<T>>, kj::Promise<kj::Own<PipelineHook>>> splitPromise =
+  kj::Tuple<kj::Promise<Response<T>>, kj::Promise<kj::Rc<PipelineHook>>> splitPromise =
       promise.then([](RemotePromise&& inner) {
     // `inner` is multiply-inherited, and we want to move away each superclass separately.
     // Let's create two references to make clear what we're doing (though this is not strictly
@@ -1255,7 +1255,7 @@ namespace _ { // private
 
 struct PipelineBuilderPair {
   AnyPointer::Builder root;
-  kj::Own<PipelineHook> hook;
+  kj::Rc<PipelineHook> hook;
 };
 
 PipelineBuilderPair newPipelineBuilder(uint firstSegmentWords);

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -115,15 +115,11 @@ private:
   bool reverse;
 };
 
-class MembranePipelineHook final: public PipelineHook, public kj::Refcounted {
+class MembranePipelineHook final: public PipelineHook {
 public:
   MembranePipelineHook(
-      kj::Own<PipelineHook>&& inner, kj::Own<MembranePolicy>&& policy, bool reverse)
+      kj::Rc<PipelineHook>&& inner, kj::Own<MembranePolicy>&& policy, bool reverse)
       : inner(kj::mv(inner)), policy(kj::mv(policy)), reverse(reverse) {}
-
-  kj::Own<PipelineHook> addRef() override {
-    return kj::addRef(*this);
-  }
 
   kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
     return membrane(inner->getPipelinedCap(ops), *policy, reverse);
@@ -134,7 +130,7 @@ public:
   }
 
 private:
-  kj::Own<PipelineHook> inner;
+  kj::Rc<PipelineHook> inner;
   kj::Own<MembranePolicy> policy;
   bool reverse;
 };
@@ -196,7 +192,7 @@ public:
   RemotePromise<AnyPointer> send() override {
     auto promise = inner->send();
 
-    auto newPipeline = AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(
+    auto newPipeline = AnyPointer::Pipeline(kj::rc<MembranePipelineHook>(
         PipelineHook::from(kj::mv(promise)), policy->addRef(), reverse));
 
     auto onRevoked = policy->onRevoked();
@@ -233,7 +229,7 @@ public:
   }
 
   AnyPointer::Pipeline sendForPipeline() override {
-    return AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(
+    return AnyPointer::Pipeline(kj::rc<MembranePipelineHook>(
         PipelineHook::from(inner->sendForPipeline()), policy->addRef(), reverse));
   }
 
@@ -279,8 +275,8 @@ public:
     }
   }
 
-  void setPipeline(kj::Own<PipelineHook>&& pipeline) override {
-    inner->setPipeline(kj::refcounted<MembranePipelineHook>(
+  void setPipeline(kj::Rc<PipelineHook>&& pipeline) override {
+    inner->setPipeline(kj::rc<MembranePipelineHook>(
         kj::mv(pipeline), policy->addRef(), !reverse));
   }
 
@@ -290,7 +286,7 @@ public:
 
   kj::Promise<AnyPointer::Pipeline> onTailCall() override {
     return inner->onTailCall().then([this](AnyPointer::Pipeline&& innerPipeline) {
-      return AnyPointer::Pipeline(kj::refcounted<MembranePipelineHook>(
+      return AnyPointer::Pipeline(kj::rc<MembranePipelineHook>(
           PipelineHook::from(kj::mv(innerPipeline)), policy->addRef(), reverse));
     });
   }
@@ -301,7 +297,7 @@ public:
 
     return {
       kj::mv(pair.promise),
-      kj::refcounted<MembranePipelineHook>(kj::mv(pair.pipeline), policy->addRef(), reverse)
+      kj::rc<MembranePipelineHook>(kj::mv(pair.pipeline), policy->addRef(), reverse)
     };
   }
 
@@ -475,7 +471,7 @@ public:
 
       return {
         kj::mv(result.promise),
-        kj::refcounted<MembranePipelineHook>(kj::mv(result.pipeline), policy->addRef(), reverse)
+        kj::rc<MembranePipelineHook>(kj::mv(result.pipeline), policy->addRef(), reverse)
       };
     }
   }

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -508,7 +508,7 @@ public:
     KJ_IF_SOME(newException, kj::runCatchingExceptions([&]() {
       // Carefully pull all the objects out of the tables prior to releasing them because their
       // destructors could come back and mess with the tables.
-      kj::Vector<kj::Own<PipelineHook>> pipelinesToRelease;
+      kj::Vector<kj::Rc<PipelineHook>> pipelinesToRelease;
       kj::Vector<kj::Own<ClientHook>> clientsToRelease;
       kj::Vector<decltype(Answer::task)> tasksToRelease;
       kj::Vector<kj::Promise<void>> resolveOpsToRelease;
@@ -679,7 +679,7 @@ private:
     Answer& operator=(Answer&&) = default;
     // If we don't explicitly write all this, we get some stupid error deep in STL.
 
-    kj::Maybe<kj::Own<PipelineHook>> pipeline;
+    kj::Maybe<kj::Rc<PipelineHook>> pipeline;
     // Send pipelined calls here.  Becomes null as soon as a `Finish` is received.
 
     using Running = kj::Promise<void>;
@@ -2437,14 +2437,14 @@ private:
 
         auto sendResult = sendInternal(false);
 
-        kj::Own<PipelineHook> pipeline;
+        kj::Rc<PipelineHook> pipeline;
         if (noPromisePipelining) {
           pipeline = getDisabledPipeline();
         } else {
           auto forkedPromise = sendResult.promise.fork();
 
           // The pipeline must get notified of resolution before the app does to maintain ordering.
-          pipeline = kj::refcounted<RpcPipeline>(
+          pipeline = kj::rc<RpcPipeline>(
               *connectionState, kj::mv(sendResult.questionRef), forkedPromise.addBranch());
 
           sendResult.promise = forkedPromise.addBranch();
@@ -2505,8 +2505,7 @@ private:
         return send();
       } else {
         auto questionRef = sendForPipelineInternal();
-        kj::Own<PipelineHook> pipeline = kj::refcounted<RpcPipeline>(
-            *connectionState, kj::mv(questionRef));
+        kj::Rc<PipelineHook> pipeline = kj::rc<RpcPipeline>(*connectionState, kj::mv(questionRef));
         return AnyPointer::Pipeline(kj::mv(pipeline));
       }
     }
@@ -2514,7 +2513,7 @@ private:
     struct TailInfo {
       QuestionId questionId;
       kj::Promise<void> promise;
-      kj::Own<PipelineHook> pipeline;
+      kj::Rc<PipelineHook> pipeline;
     };
 
     kj::Maybe<TailInfo> tailSend() {
@@ -2545,12 +2544,12 @@ private:
 
       QuestionId questionId = sendResult.questionRef->getId();
 
-      kj::Own<PipelineHook> pipeline;
+      kj::Rc<PipelineHook> pipeline;
       bool noPromisePipelining = callBuilder.getNoPromisePipelining();
       if (noPromisePipelining) {
         pipeline = getDisabledPipeline();
       } else {
-        pipeline = kj::refcounted<RpcPipeline>(*connectionState, kj::mv(sendResult.questionRef));
+        pipeline = kj::rc<RpcPipeline>(*connectionState, kj::mv(sendResult.questionRef));
       }
 
       return TailInfo { questionId, kj::mv(promise), kj::mv(pipeline) };
@@ -2702,7 +2701,7 @@ private:
     }
   };
 
-  class RpcPipeline final: public PipelineHook, public kj::Refcounted {
+  class RpcPipeline final: public PipelineHook {
   public:
     RpcPipeline(RpcConnectionState& connectionState, kj::Own<QuestionRef>&& questionRef,
                 kj::Promise<kj::Own<RpcResponse>>&& redirectLaterParam)
@@ -2732,10 +2731,6 @@ private:
     }
 
     // implements PipelineHook ---------------------------------------
-
-    kj::Own<PipelineHook> addRef() override {
-      return kj::addRef(*this);
-    }
 
     kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
       auto copy = kj::heapArrayBuilder<PipelineOp>(ops.size());
@@ -2996,7 +2991,7 @@ private:
     MallocMessageBuilder message;
   };
 
-  class PostReturnRpcPipeline final: public PipelineHook, public kj::Refcounted {
+  class PostReturnRpcPipeline final: public PipelineHook {
     // Once an incoming call has returned, we may need to replace the `PipelineHook` with one that
     // correctly handles the Tribble 4-way race condition. Namely, we must ensure that if the
     // response contained any capabilities pointing back out to the network, then any further
@@ -3004,14 +2999,10 @@ private:
     // will resolve to the same network capability forever, *even if* that network capability is
     // itself a promise which later resolves to somewhere else.
   public:
-    PostReturnRpcPipeline(kj::Own<PipelineHook> inner,
+    PostReturnRpcPipeline(kj::Rc<PipelineHook> inner,
                           RpcServerResponseImpl& response,
                           kj::Own<RpcCallContext> context)
         : inner(kj::mv(inner)), response(response), context(kj::mv(context)) {}
-
-    kj::Own<PipelineHook> addRef() override {
-      return kj::addRef(*this);
-    }
 
     kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
       auto resolved = response.getResolutionAtReturnTime(ops);
@@ -3026,7 +3017,7 @@ private:
     }
 
   private:
-    kj::Own<PipelineHook> inner;
+    kj::Rc<PipelineHook> inner;
     RpcServerResponseImpl& response;
     kj::Own<RpcCallContext> context;  // owns `response`
 
@@ -3198,9 +3189,8 @@ private:
           auto& answer = KJ_ASSERT_NONNULL(connectionState->answers.find(answerId));
           // Swap out the `pipeline` in the answer table for one that will return capabilities
           // consistent with whatever the result caps resolved to as of the time the return was sent.
-          answer.pipeline = answer.pipeline.map([&](kj::Own<PipelineHook>& inner) {
-            return kj::refcounted<PostReturnRpcPipeline>(
-                kj::mv(inner), responseImpl, kj::addRef(*this));
+          answer.pipeline = answer.pipeline.map([&](kj::Rc<PipelineHook>& inner) {
+            return kj::rc<PostReturnRpcPipeline>(kj::mv(inner), responseImpl, kj::addRef(*this));
           });
         }
 
@@ -3301,7 +3291,7 @@ private:
         return results;
       }
     }
-    void setPipeline(kj::Own<PipelineHook>&& pipeline) override {
+    void setPipeline(kj::Rc<PipelineHook>&& pipeline) override {
       KJ_IF_SOME(f, tailCallPipelineFulfiller) {
         f->fulfill(AnyPointer::Pipeline(kj::mv(pipeline)));
       }
@@ -3693,14 +3683,10 @@ private:
   // ---------------------------------------------------------------------------
   // Level 0
 
-  class SingleCapPipeline: public PipelineHook, public kj::Refcounted {
+  class SingleCapPipeline: public PipelineHook {
   public:
     SingleCapPipeline(kj::Own<ClientHook>&& cap)
         : cap(kj::mv(cap)) {}
-
-    kj::Own<PipelineHook> addRef() override {
-      return kj::addRef(*this);
-    }
 
     kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
       if (ops.size() == 0) {
@@ -3778,7 +3764,7 @@ private:
                                      "questionId is already in use", answerId);
 
     answer.resultExports = kj::mv(resultExports);
-    answer.pipeline = kj::Own<PipelineHook>(kj::refcounted<SingleCapPipeline>(kj::mv(capHook)));
+    answer.pipeline = kj::rc<SingleCapPipeline>(kj::mv(capHook));
 
     response->send();
   }
@@ -3905,11 +3891,11 @@ private:
 
       case rpc::MessageTarget::PROMISED_ANSWER: {
         auto promisedAnswer = target.getPromisedAnswer();
-        kj::Own<PipelineHook> pipeline;
+        kj::Rc<PipelineHook> pipeline;
 
         KJ_IF_SOME(answer, answers.find(promisedAnswer.getQuestionId())) {
           KJ_IF_SOME(p, answer.pipeline) {
-            pipeline = p->addRef();
+            pipeline = p.addRef();
           }
         }
         if (pipeline.get() == nullptr) {
@@ -4077,7 +4063,7 @@ private:
     kj::Array<ExportId> exportsToRelease;
     KJ_DEFER(releaseExports(exportsToRelease));
     Answer answerToRelease;
-    kj::Maybe<kj::Own<PipelineHook>> pipelineToRelease;
+    kj::Maybe<kj::Rc<PipelineHook>> pipelineToRelease;
     kj::Maybe<decltype(Answer::task)> promiseToRelease;
 
     KJ_IF_SOME(answer, answers.find(finish.getQuestionId())) {
@@ -4456,13 +4442,9 @@ private:
     // Use a `pipeline` that'll throw exceptions if anyone actually tries to use it.
     //
     // It also holds onto `awaiter`, so that `awaiter` is dropped when `Finish` is received.
-    class ProvidePipelineHook final: public PipelineHook, public kj::Refcounted {
+    class ProvidePipelineHook final: public PipelineHook {
     public:
       ProvidePipelineHook(kj::Own<void> awaiter): awaiter(kj::mv(awaiter)) {}
-
-      kj::Own<PipelineHook> addRef() override {
-        return kj::addRef(*this);
-      }
 
       kj::Own<ClientHook> getPipelinedCap(kj::ArrayPtr<const PipelineOp> ops) override {
         return newBrokenCap(KJ_EXCEPTION(FAILED, "can't pipeline on a Provide operation"));
@@ -4476,7 +4458,7 @@ private:
       kj::Own<void> awaiter;
     };
 
-    answer.pipeline = kj::refcounted<ProvidePipelineHook>(kj::mv(awaiter));
+    answer.pipeline = kj::rc<ProvidePipelineHook>(kj::mv(awaiter));
   }
 
   void handleAccept(const rpc::Accept::Reader& accept) {
@@ -4517,8 +4499,7 @@ private:
     });
 
     // Set `answer.pipeline` to a single-cap pipeline.
-    answer.pipeline = kj::refcounted<SingleCapPipeline>(
-        newLocalPromiseClient(promise.addBranch()));
+    answer.pipeline = kj::rc<SingleCapPipeline>(newLocalPromiseClient(promise.addBranch()));
   }
 
   kj::Promise<kj::Own<ClientHook>> doAccept(


### PR DESCRIPTION
All  real implementations are.

This is similar to https://github.com/capnproto/capnproto/pull/1990