### PR TITLE
better support of forward declared classes in Rc and Arc

### DIFF
--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -174,6 +174,8 @@ public:
   template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
   inline Rc(Rc<U>&& other) noexcept : own(kj::mv(other.own)) { }
 
+  inline ~Rc() { own = nullptr; }
+
   kj::Own<T> toOwn() {
     // Convert Rc<T> to Own<T>.
     // Nullifies the original Rc<T>.
@@ -428,6 +430,8 @@ public:
 
   template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
   inline Arc(Arc<U>&& other) noexcept : own(kj::mv(other.own)) { }
+
+  inline ~Arc() { own = nullptr; }
 
   kj::Own<const T> toOwn() {
     // Convert Arc<T> to Own<const T>.


### PR DESCRIPTION
I wasn't able to build a reproducer but empirically if I replace kj::Own<ClientHook> with kj::Rc<ClientHook> then layout.h stops compiling because ClientHook is foward declared.

For some reason this fixes forward compilation.
Any ideas why?