### PR TITLE
PromiseDisposer: Use NOLINT to disable ArrayBound warning

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -401,6 +401,7 @@ public:
       //   code bloat to handle this case.
       next->arena = nullptr;
       T* ptr = reinterpret_cast<T*>(next.get()) - 1;
+      // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
       ctor(*ptr, kj::mv(next), kj::fwd<Params>(params)...);
       ptr->arena = arena;
       KJ_IREQUIRE(reinterpret_cast<void*>(ptr) ==


### PR DESCRIPTION
Disable clang-analyzer-security.ArrayBound warning in [PromiseDisposer::append](https://github.com/capnproto/capnproto/blob/6846dffe3a1e5cff164f868e2999d0d3cfad4bb2/c%2B%2B/src/kj/async-inl.h#L404) to silence clang-tidy.

More information about the warning can be found in the commit message. A similar change was also made recently in https://github.com/capnproto/capnproto/pull/2334.