### PR TITLE
[nfc] Add bazel-bin include path to compile flags

### DIFF
--- a/c++/compile_flags.txt
+++ b/c++/compile_flags.txt
@@ -1,6 +1,7 @@
 -std=c++23
 -Isrc
 -Itmp
+-Ibazel-bin/src
 -DKJ_HEADER_WARNINGS
 -DCAPNP_HEADER_WARNINGS
 -DCAPNP_DEBUG_TYPES


### PR DESCRIPTION
helps those using bazel, shouldn't hurt anyone else