### PR TITLE
bazel: use llvm_toolchains from

### DIFF
--- a/c++/WORKSPACE
+++ b/c++/WORKSPACE
@@ -65,3 +65,28 @@ http_archive(
     integrity = "sha256-BCrPtzRpstGEj+FI2Bw0IsYepHqeGQDxyew29R6OcZM=",
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.51.0/rules_rust-v0.51.0.tar.gz"],
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "toolchains_llvm",
+    sha256 = "fded02569617d24551a0ad09c0750dc53a3097237157b828a245681f0ae739f8",
+    strip_prefix = "toolchains_llvm-v1.4.0",
+    canonical_id = "v1.4.0",
+    url = "https://github.com/bazel-contrib/toolchains_llvm/releases/download/v1.4.0/toolchains_llvm-v1.4.0.tar.gz",
+)
+
+load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
+load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "20.1.2",
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()


### PR DESCRIPTION
By using toolchains from Bazel, developers can get started more easily without having to install the appropriate toolchains on their host machines. This approach leverages Bazel’s strengths by decoupling the development environment from the host system.

However downstream developers can still override the toolchains to any of their choosing