### PR TITLE
Revert "[bazel] cidr.h uses inet_ntop from Ws2_32.lib"

### DIFF
--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -74,15 +74,12 @@ cc_library(
     # these once we no longer need to support older platforms, -lpthread is duplicated many times in
     # downstream project targets and bazel is unable to deduplicate it itself.
     linkopts = select({
-        ":use_libdl": ["-ldl"],
-        "//conditions:default": [],
-    }) + select({
-        "@platforms//os:windows": ["/DEFAULTLIB:Ws2_32.lib"],
+        "@platforms//os:windows": [],
+        ":use_libdl": [
+            "-lpthread",
+            "-ldl",
+        ],
         "//conditions:default": ["-lpthread"],
-    }),
-    linkstatic = select({
-        "@platforms//os:windows": True,
-        "//conditions:default": False,
     }),
     visibility = ["//visibility:public"],
     deps = [":kj-defines"],
@@ -127,10 +124,6 @@ cc_library(
             "Advapi32.lib",
         ],
         "//conditions:default": [],
-    }),
-    linkstatic = select({
-        "@platforms//os:windows": True,
-        "//conditions:default": False,
     }),
     visibility = ["//visibility:public"],
     deps = [":kj"],


### PR DESCRIPTION
Reverts capnproto/capnproto#2290

`cidr{.h,c++}` is now in libkj-async rather than libkj, so I think this change is no longer needed. libkj-async has always dependended on ws2_32.lib.