### PR TITLE
Try to debug connections being marked idle while still having references.

### DIFF
--- a/c++/src/capnp/rpc-prelude.h
+++ b/c++/src/capnp/rpc-prelude.h
@@ -114,6 +114,10 @@ private:
 
   class RpcConnectionState;
 
+  enum class ConnectionStateOwner;
+  template <ConnectionStateOwner>
+  class OwnConnectionState;
+
   static void dropConnection(Impl& impl,
       VatNetworkBase::Connection& connection, kj::Promise<void> shutdownTask);
   // Called when RpcConnectionState becomes disconnected and so should be removed from the map of


### PR DESCRIPTION
This adds some instrumentation to keep track of which references still exist, and include these counts in the error message.