### PR TITLE
Increase default WebSocket max message size to 32MiB

### DIFF
--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -686,7 +686,7 @@ public:
 
   typedef kj::OneOf<kj::String, kj::Array<byte>, Close> Message;
 
-  static constexpr size_t SUGGESTED_MAX_MESSAGE_SIZE = 1u << 20;  // 1MB
+  static constexpr size_t SUGGESTED_MAX_MESSAGE_SIZE = 32u << 20;  // 32MB
 
   virtual kj::Promise<Message> receive(size_t maxSize = SUGGESTED_MAX_MESSAGE_SIZE) = 0;
   // Read one message from the WebSocket and return it. Can only call once at a time. Do not call


### PR DESCRIPTION
Downstream in workerd, we increased the WebSocket maximum message size to 32MiB, by adjusting the value we pass to WebSocket::receive(maxSize). Unfortunately, there are some other places where WebSocket::receive() is called, such as in the WebSocket::pumpTo() fallback implementation, and there is currently no good way to plumb the necessary parameter all the way down -- it'll require an API change in kj-http.

Instead of shaving the yak, we're just increasing the default maximum message size to match what we publicly committed to downstream. In the future, we can make this limit actually configurable.