### PR TITLE
kj/exception: KJ_USE_BACKTRACE to configure backtraces at compile

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -58,13 +58,6 @@
 #include <cxxabi.h>
 #endif
 
-// Use KJ_HAS_BACKTRACE; KJ_HAS_BACKTRACE is for backwards compat only.
-#if !defined(KJ_USE_BACKTRACE)
-#if defined(KJ_HAS_BACKTRACE) && ((KJ_HAS_BACKTRACE + 0) == 1)
-#define KJ_USE_BACKTRACE 1
-#endif
-#endif
-
 #ifndef KJ_USE_BACKTRACE
 #if (__linux__ && __GLIBC__ && !__UCLIBC__) || __APPLE__
 #define KJ_USE_BACKTRACE 1
@@ -72,7 +65,7 @@
 #endif
 
 #if KJ_USE_BACKTRACE
-# include <execinfo.h>
+#include <execinfo.h>
 #endif
 
 #if _WIN32 || __CYGWIN__


### PR DESCRIPTION
KJ_USE_BACKTRACE can enable (1) or disable (0) backtraces regardless of platform where previously it was decided by platform.

Previously KJ_HAS_BACKTRACE could be set to 1 to enable if auto detection was failing for some reason, but disabling it was not respected.

I doubt that anyone is using KJ_HAS_BACKTRACE, but we maintain the backwards compatibility of KJ_HAS_BACKTRACE and the default platform detection if neither is defined.

See [#1080](https://github.com/capnproto/capnproto/issues/1080).

This is my first issue. It is targeting master because like the linked issue I need to overwrite auto detection in my production use case. Please let me know if I should also target v2 or *only* target v2.