### PR TITLE
Remove KJ_UNREACHABLE calls from exception tests

### DIFF
--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -324,7 +324,6 @@ KJ_TEST("getDestructionReason returns default exception if exception wasn't thro
 KJ_TEST("getDestructionReason returns thrown exception if it wasn't consumed") {
   try {
     kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "test exception"));
-    KJ_UNREACHABLE("no exception");
   } catch (...) {
     auto e =
         kj::getDestructionReason(nullptr, kj::Exception::Type::FAILED, __FILE__,
@@ -338,7 +337,6 @@ KJ_TEST("getDestructionReason returns default exception if exception was "
         "consumed") {
   try {
     kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "test exception"));
-    KJ_UNREACHABLE("no exception");
   } catch (...) {
     auto caughtException = kj::getCaughtExceptionAsKj();
     KJ_EXPECT(caughtException.getType() == kj::Exception::Type::DISCONNECTED);


### PR DESCRIPTION
triggers warnings downstream