### PR TITLE
Only allocate exception in ~XThreadFulfiller() when needed

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2125,7 +2125,11 @@ public:
 
   ~XThreadFulfiller() noexcept(false) {
     if (target != nullptr) {
-      reject(XThreadPaf::unfulfilledException());
+      // reject() is inlined here to only allocate unfulfilled exception when needed
+      XThreadPaf::FulfillScope scope(&target);
+      if (scope.shouldFulfill()) {
+        scope.getTarget<T>()->result.addException(XThreadPaf::unfulfilledException());
+      }
     }
   }
   void fulfill(FixVoid<T>&& value) const override {


### PR DESCRIPTION
Currently ~XThreadFulfiller() allocates an exception for every workerd request via the IoContext deleteQueue, which holds a CrossThreadPromiseFulfiller. This represents ~1% of overall memory allocations for a Hello World worker. We can work around that by inlining the reject call, but it seems odd that `target != nullptr` seems to apply every time – maybe there's some issue on the workerd side responsible for that?