### PR TITLE
Add `tryDowncast()`, a nice wrapper for dynamic_cast.

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2175,6 +2175,23 @@ To& downcast(From& from) {
   return static_cast<To&>(from);
 }
 
+#if !KJ_NO_RTTI
+template <typename To, typename From>
+Maybe<To&> tryDowncast(From& from) {
+  // Identical to `dynamicDowncastIfAvailable()` except for use in code where RTTI is known to be
+  // enabled always. Use this when the calling code cannot cope with a spurious `none` result from
+  // RTTI being disabled.
+
+  // Force a compile error if To is not a subtype of From.  Cross-casting is rare; if it is needed
+  // we should have a separate cast function like tryCrosscast().
+  if (false) {
+    kj::implicitCast<From*>(kj::implicitCast<To*>(nullptr));
+  }
+
+  return dynamic_cast<To*>(&from);
+}
+#endif
+
 // =======================================================================================
 // Defer
 


### PR DESCRIPTION
This is actually identical to the existing `dynamicDowncastIfAvailable()`, except that it is ONLY Defined if RTTI is enabled, whereas `dynamicDowncastIfAvailable()` returns `none` when RTTI is disabled. `dynamicDowncastIfAvailable()`'s behavior makes sense when using RTTI to detect optimization opportunities, but the Wokers Runtime now has a few places that use dynamic casting that isn't just for optimization, so `dynamicDowncastIfAvailable()` feels wrong to use there.