### PR TITLE
Make TestCase::iterCount() private again.

### DIFF
--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -57,8 +57,6 @@ protected:
     }
   }
 
-  static size_t iterCount();
-
 private:
   const char* file;
   uint line;
@@ -66,6 +64,8 @@ private:
   TestCase* next;
   TestCase** prev;
   bool matchedFilter;
+
+  static size_t iterCount();
 
   friend class TestRunner;
 };


### PR DESCRIPTION
This was moved to `protected` in #2449 but it wasn't used anywhere. Seems like an unintentional change.