### PR TITLE
Extend configure.ac to check if -latomic is needed.

### DIFF
--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -113,6 +113,39 @@ AC_SUBST([CAPNP_LITE_FLAG])
 
 AC_SEARCH_LIBS(sched_yield, rt)
 
+# Check if we need to link against libatomic for atomic operations.
+# On some architectures (e.g., armel, mipsel, powerpc), GCC requires linking
+# with libatomic to support certain atomic operations.
+AC_MSG_CHECKING([if libatomic is needed])
+AC_LINK_IFELSE([
+  AC_LANG_PROGRAM(
+    [[#include <atomic>
+      #include <cstdint>]],
+    [[std::atomic<std::int64_t> a{0};
+      a.fetch_add(1, std::memory_order_relaxed);
+      return 0;]])
+], [
+  AC_MSG_RESULT([no])
+], [
+  # Linking failed, try with -latomic
+  SAVED_LIBS="$LIBS"
+  LIBS="$LIBS -latomic"
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM(
+      [[#include <atomic>
+        #include <cstdint>]],
+      [[std::atomic<std::int64_t> a{0};
+        a.fetch_add(1, std::memory_order_relaxed);
+        return 0;]])
+  ], [
+    AC_MSG_RESULT([yes])
+  ], [
+    AC_MSG_RESULT([no, but linking still fails])
+    LIBS="$SAVED_LIBS"
+    AC_MSG_ERROR([Cannot link program using atomic operations. Please ensure your compiler and system support C++ atomics.])
+  ])
+])
+
 # Users will need to use the same -stdlib as us so we'd better let pkg-config know about it.
 STDLIB_FLAG=`echo "$CXX $CXXFLAGS" | grep -o ' [[-]]stdlib=[[^ ]]*'`
 AC_SUBST([STDLIB_FLAG])


### PR DESCRIPTION
Written using Claude Code.

Fixes #1448 (the rest of the way)