### PR TITLE
More aggressively use "depth-first" promise ordering.

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -121,7 +121,18 @@ public:
 
   kj::Maybe<kj::Promise<Capability::Client>> shortenPath() override {
     auto onAbort = canceler.wrap(KJ_ASSERT_NONNULL(webSocket).whenAborted())
-        .then([]() -> kj::Promise<Capability::Client> {
+        .then([this]() -> kj::Promise<Capability::Client> {
+      // whenAborted() resolved, indicating webSocket.abort() was called, which could just be
+      // because the WebSocket was destroyed.
+
+      if (closed) {
+        // Oh, we got here because close() completed successfully and then the WebSocket was
+        // dropped. Don't bother shortening the path in this case as the caller will presumably
+        // drop this capability shortly (and also the shortening can actually outrun the return
+        // from close() which causes trouble).
+        return kj::NEVER_DONE;
+      }
+
       return KJ_EXCEPTION(DISCONNECTED, "WebSocket was aborted");
     });
     return shorteningPromise
@@ -146,7 +157,9 @@ public:
       webSocket = kj::none;
 
       return ws.close(params.getCode(), params.getReason())
-          .attach(kj::mv(ownWebSocket));
+          .attach(kj::defer([this, ws = kj::mv(ownWebSocket)]() {
+        closed = true;
+      }));
     });
   }
 
@@ -161,6 +174,7 @@ private:
   kj::Maybe<kj::Own<kj::Exception>> error;
 
   bool shortened = false;
+  bool closed = false;
 
   kj::WebSocket& getWebSocket() {
     return KJ_REQUIRE_NONNULL(webSocket, "request canceled");

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -461,16 +461,16 @@ TEST(Async, Ordering) {
       paf.fulfiller->fulfill();
     }
 
-    // .then() is scheduled breadth-first if the promise has already resolved, but depth-first
-    // if the promise resolves later.
+    // .then() is scheduled depth-first.
     tasks.add(Promise<void>(READY_NOW).then([&]() {
-      EXPECT_EQ(4, counter++);
+      EXPECT_EQ(2, counter++);
     }).then([&]() {
-      EXPECT_EQ(5, counter++);
+      EXPECT_EQ(3, counter++);
       tasks.add(kj::evalLast([&]() {
-        EXPECT_EQ(7, counter++);
+        // evalLast()s are LIFO, so although this evalLast() is registered first it'll go last.
+        EXPECT_EQ(9, counter++);
         tasks.add(kj::evalLater([&]() {
-          EXPECT_EQ(8, counter++);
+          EXPECT_EQ(10, counter++);
         }));
       }));
     }));
@@ -478,25 +478,26 @@ TEST(Async, Ordering) {
     {
       auto paf = kj::newPromiseAndFulfiller<void>();
       tasks.add(paf.promise.then([&]() {
-        EXPECT_EQ(2, counter++);
+        EXPECT_EQ(4, counter++);
         tasks.add(kj::evalLast([&]() {
-          EXPECT_EQ(9, counter++);
+          EXPECT_EQ(7, counter++);
           tasks.add(kj::evalLater([&]() {
-            EXPECT_EQ(10, counter++);
+            EXPECT_EQ(8, counter++);
           }));
         }));
       }));
       paf.fulfiller->fulfill();
     }
 
-    // evalLater() is like READY_NOW.then().
+    // evalLater() is scheduled breadth-first, so it'll come after depth-first stuff and
+    // evalLater()s scheduled before it, but before evalLast() stuff.
     tasks.add(evalLater([&]() {
       EXPECT_EQ(6, counter++);
     }));
   }));
 
   tasks.add(evalLater([&]() {
-    EXPECT_EQ(3, counter++);
+    EXPECT_EQ(5, counter++);
 
     // Making this a chain should NOT cause it to preempt the first promise.  (This was a problem
     // at one point.)

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2381,10 +2381,8 @@ void PromiseNode::setSelfPointer(OwnPromiseNode* selfPtr) noexcept {}
 
 void PromiseNode::OnReadyEvent::init(Event* newEvent) {
   if (event == _kJ_ALREADY_READY) {
-    // A new continuation was added to a promise that was already ready.  In this case, we schedule
-    // breadth-first, to make it difficult for applications to accidentally starve the event loop
-    // by repeatedly waiting on immediate promises.
-    if (newEvent) newEvent->armBreadthFirst();
+    // A new continuation was added to a promise that was already ready.
+    if (newEvent) newEvent->armDepthFirst();
   } else {
     event = newEvent;
   }
@@ -2394,9 +2392,7 @@ void PromiseNode::OnReadyEvent::arm() {
   KJ_ASSERT(event != _kJ_ALREADY_READY, "arm() should only be called once");
 
   if (event != nullptr) {
-    // A promise resolved and an event is already waiting on it.  In this case, arm in depth-first
-    // order so that the event runs immediately after the current one.  This way, chained promises
-    // execute together for better cache locality and lower latency.
+    // A promise resolved and an event is already waiting on it.
     event->armDepthFirst();
   }
 
@@ -2407,7 +2403,8 @@ void PromiseNode::OnReadyEvent::armBreadthFirst() {
   KJ_ASSERT(event != _kJ_ALREADY_READY, "armBreadthFirst() should only be called once");
 
   if (event != nullptr) {
-    // A promise resolved and an event is already waiting on it.
+    // A promise resolved and an event is already waiting on it, and the caller explicitly
+    // requested breadth-first scheduling.
     event->armBreadthFirst();
   }
 
@@ -2420,7 +2417,7 @@ ImmediatePromiseNodeBase::ImmediatePromiseNodeBase() {}
 ImmediatePromiseNodeBase::~ImmediatePromiseNodeBase() noexcept(false) {}
 
 void ImmediatePromiseNodeBase::onReady(Event* event) noexcept {
-  if (event) event->armBreadthFirst();
+  if (event) event->armDepthFirst();
 }
 
 void ImmediatePromiseNodeBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
@@ -3017,6 +3014,7 @@ Promise<void> yield() {
     void destroy() override {}
 
     void onReady(_::Event* event) noexcept override {
+      // The point of yield() is to allow other tasks in the queue to run, so arm breadth-first.
       if (event) event->armBreadthFirst();
     }
     void get(_::ExceptionOrValue& output) noexcept override {


### PR DESCRIPTION
DO NOT MERGE: This breaks many tests in the Workers Runtime, but those that I've looked at all seem spurious. Someone needs to go through them and debug everything. Hopefully it's just a matter of updating test expectations and not actual implementation.

--------

This means: When running an event causes another event to be scheduled, we should put that new event at the front of the queue, so it runs next, before anything else that had been scheduled before this event ran.

(If one event schedules N new events, we put all those events at the beginning, but we run them in the order they were scheduled.)

This approach means the event loop stays focused on one task until there is nothing left to do, before switching to a diffrent task. This is good, because:
* Less switching between tasks is nicer to the CPU cache.
* It tends to reduce latency. If N identical tasks run with regular switching between them, they will all complete in about the same amount of time -- the time to complete all the tasks. But if we focus on one task to completion before moving on to the next, then the first task will take 1/N as much time, the next 2/N, etc., with the last task taking just as much time as when interleaving. Overall, average latency is halved.
* Behavior is more predictable and race conditions less likely as unrelated tasks will not jump in and change the state of the world in the middle of a task.

There is a possible objection: If we always run a task to completion before moving on, what if it doesn't complete? A task might go into an infinite loop. In this case, the other tasks in the queue will be starved.

This objection is naive: The KJ event loop is a cooperative scheduler. It is not designed to handle scenarios in which the CPU is saturated, regardless of scheduling order. Even with strictly FIFO ordering, one task scheduling event endlessly will ruin performance for everyone else. Such heavyweight tasks should instead be scheduled to a separate thread.