### PR TITLE
[nfc] convert http-over-capnp-perf-test to google benchmark

### DIFF
--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -162,9 +162,19 @@ cc_library(
 ) for f in [
     "byte-stream-test.c++",
     "http-over-capnp-test.c++",
-    "http-over-capnp-perf-test.c++",
     "websocket-rpc-test.c++",
 ]]
+
+cc_test(
+    name = "http-over-capnp-bench",
+    srcs = ["http-over-capnp-bench.c++"],
+    tags = ["google_benchmark"],
+    deps = [
+        ":http-over-capnp",
+        "//src/capnp:capnp-rpc",
+        "@google_benchmark//:benchmark",
+    ],
+)
 
 cc_test(
     name = "json-rpc-test",


### PR DESCRIPTION
To run:

```
bazel run --config=profile //src/capnp/compat:http-over-capnp-bench -- --benchmark_min_time=1000000x
```

