### PR TITLE
Allow late -DCMAKE_INSTALL_PREFIX

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -213,10 +213,10 @@ if(NOT CAPNP_LITE)
   if(WIN32)
     # On Windows platforms symlinks are not guaranteed to support. Also different version of CMake handle create_symlink in a different way.
     # The most portable way in this case just copy the file.
-    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnp${CMAKE_EXECUTABLE_SUFFIX}\" \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/capnp${CMAKE_EXECUTABLE_SUFFIX}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
   else()
     # Symlink capnpc -> capnp
-    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
   endif()
 endif()  # NOT CAPNP_LITE
 


### PR DESCRIPTION
# Problem

The following will error with lacking permission:

```sh
mkdir -p build && cmake -DCMAKE_BUILD_TYPE=Release -B build -G Ninja && cmake --build build && cmake -DCMAKE_INSTALL_PREFIX=install -P build/cmake_install.cmake
```

because if the user doesn't **configure** with -DCMAKE_INSTALL_PREFIX, the resulting installation becomes:

```cmake
execute_process(COMMAND "/usr/bin/cmake" -E create_symlink capnp "$ENV{DESTDIR}/usr/local/bin/capnpc")
```

# Solution

With the proposed change, the symlink line becomes:

```diff
- execute_process(COMMAND "/usr/bin/cmake" -E create_symlink capnp "$ENV{DESTDIR}/usr/local/bin/capnpc")
+ execute_process(COMMAND "/usr/bin/cmake" -E create_symlink capnp "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/capnpc")
```

which matches the other commands generated by cmake, like:

```cmake
execute_process(COMMAND "/usr/bin/strip" "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/capnpc-capnp")
```

allowing the user the late-bind the installation prefix!

# Workaround

Early binding removes the error:

```diff
 mkdir -p build && \
     cmake \
+        -DCMAKE_INSTALL_PREFIX=install \
         -DCMAKE_BUILD_TYPE=Release -B build -G Ninja && \
     cmake --build build && \
     cmake \
-       -DCMAKE_INSTALL_PREFIX=install \
        -P build/cmake_install.cmake

```

# Verification

I have **NOT** tested this on Windows! It *should* work, but I can't be certain.