### PR TITLE
capnp-mode.el: fix comment configuration

### DIFF
--- a/highlighting/emacs/capnp-mode.el
+++ b/highlighting/emacs/capnp-mode.el
@@ -20,16 +20,6 @@
 
 ;;; Code:
 
-;; command to comment/uncomment text
-(defun capnp-comment-dwim (arg)
-  "Comment or uncomment current line or region in a smart way.
-For detail, see `comment-dwim' for ARG explanation."
-  (interactive "*P")
-  (require 'newcomment)
-  (let (
-        (comment-start "#") (comment-end ""))
-    (comment-dwim arg)))
-
 (defvar capnp--syntax-table
   (let ((syn-table (make-syntax-table)))
 
@@ -65,11 +55,10 @@ For detail, see `comment-dwim' for ARG explanation."
   "capn-mode is a major mode for editing capnp protocol files"
   :syntax-table capnp--syntax-table
 
+  (setq-local comment-start "# ")
+  (setq-local comment-start-skip "#+\\s-*")
   (setq font-lock-defaults '((capnp--font-lock-keywords)))
-
-
-  (setq mode-name "capnp")
-  (define-key capnp-mode-map [remap comment-dwim] 'capnp-comment-dwim))
+  (setq mode-name "capnp"))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.capnp\\'" . capnp-mode))


### PR DESCRIPTION
The existing approach only works if you use `comment-dwim`, but that function is just a wrapper around lower-level ones that actually consume the various `comment-` vars. So, if you don't use `comment-dwim`, you are not helped by capnp-mode in this regard.

So, drop the existing approach and just set an appropriate value for `comment-start` in all capnp-mode buffers. This is typically how major modes configure this kind of thing. I can't say why it was done a different way to start with. (The configuration of `comment-end` in `capnp-comment-dwim` was redundant, as `""` is the default value of this var.)