### PR TITLE
[coro] remove unwind detector from PromiseAwaiter

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2483,7 +2483,6 @@ protected:
   bool awaitSuspendImpl(CoroutineBase& coroutine);
 
 private:
-  UnwindDetector unwindDetector;
   OwnPromiseNode node;
 
   Maybe<CoroutineBase&> maybeCoroutine;

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3304,11 +3304,6 @@ PromiseAwaiterBase::~PromiseAwaiterBase() noexcept(false) {
   KJ_IF_SOME(coroutine, maybeCoroutine) {
     coroutine.clearPromiseNodeForTrace();
   }
-
-  unwindDetector.catchExceptionsIfUnwinding([this]() {
-    // No need to check for a moved-from state, node will just ignore the nullification.
-    node = nullptr;
-  });
 }
 
 void PromiseAwaiterBase::awaitResumeImpl(ExceptionOrValue& result, void* awaitedAt) {
@@ -3317,6 +3312,12 @@ void PromiseAwaiterBase::awaitResumeImpl(ExceptionOrValue& result, void* awaited
   }
 
   node->get(result);
+
+  try {
+    node = nullptr;
+  } catch (...) {
+    result.addException(getCaughtExceptionAsKj());
+  }
 
   KJ_IF_SOME(exception, result.exception) {
     // Manually extend the stack trace with the instruction address where the co_await occurred.


### PR DESCRIPTION
By disposing node in resume we get the same behavior and pay the exception handling price only if coro resolved into exception.

It is import to optimize this path since every `co_await` incurs the cost.

There's another UnwindDisposer in CoroutineBase that I'm looking at, but one tiny step at a time I guess.