### PR TITLE
allow Event.fire to delete itself

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang: [20]
+        clang: [22]
     steps:
       - uses: actions/checkout@v6
       - name: install dependencies

--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -151,21 +151,21 @@ KJ_TEST("Coroutine Frame sizes") {
     DebugCoroutineAllocator allocator;
     auto promise = immediateCoroutine(allocator);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 176);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 160);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 304);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 296);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib10(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 816);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 808);
   }
 }
 

--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -151,21 +151,21 @@ KJ_TEST("Coroutine Frame sizes") {
     DebugCoroutineAllocator allocator;
     auto promise = immediateCoroutine(allocator);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 168);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 152);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 280);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 272);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib10(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 728);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 720);
   }
 }
 

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -832,7 +832,7 @@ private:
   ForkBranchBase** tailBranch = &headBranch;
   // Tail becomes null once the inner promise is ready and all branches have been notified.
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 
   friend class ForkBranchBase;
@@ -912,7 +912,7 @@ private:
   Event* onReadyEvent = nullptr;
   OwnPromiseNode* selfPtr = nullptr;
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 };
 
@@ -958,7 +958,7 @@ private:
     bool get(ExceptionOrValue& output);
     // Returns true if this is the side that finished.
 
-    Maybe<Own<Event>> fire() override;
+    void fire() override;
     void traceEvent(TraceBuilder& builder) override;
 
   private:
@@ -1009,7 +1009,7 @@ private:
            ExceptionOrValue& output, SourceLocation location);
     ~Branch() noexcept(false);
 
-    Maybe<Own<Event>> fire() override;
+    void fire() override;
     void traceEvent(TraceBuilder& builder) override;
 
   private:
@@ -1094,7 +1094,7 @@ private:
            SourceLocation location);
     ~Branch() noexcept(false);
 
-    Maybe<Own<Event>> fire() override;
+    void fire() override;
     void traceEvent(TraceBuilder &builder) override;
 
   private:
@@ -1161,7 +1161,7 @@ private:
 
   ExceptionOrValue& resultRef;
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 };
 
@@ -1278,7 +1278,7 @@ private:
   void run();
   virtual void runImpl(WaitScope& waitScope) = 0;
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
   // Implements Event. Each time the event is fired, switchToFiber() is called.
 
@@ -1846,7 +1846,7 @@ private:
   class DelayedDoneHack;
 
   // implements Event ----------------------------------------------------------
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   // If called with promiseNode == nullptr, it's time to call execute(). If promiseNode != nullptr,
   // then it just indicated readiness and we need to get its result.
 
@@ -2333,7 +2333,7 @@ private:
   // -------------------------------------------------------
   // Event implementation
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 
   stdcoro::coroutine_handle<> coroutine;

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -840,7 +840,7 @@ private:
   ForkBranchBase** tailBranch = &headBranch;
   // Tail becomes null once the inner promise is ready and all branches have been notified.
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 
   friend class ForkBranchBase;
@@ -920,7 +920,7 @@ private:
   Event* onReadyEvent = nullptr;
   OwnPromiseNode* selfPtr = nullptr;
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 };
 
@@ -966,7 +966,7 @@ private:
     bool get(ExceptionOrValue& output);
     // Returns true if this is the side that finished.
 
-    Maybe<Own<Event>> fire() override;
+    void fire() override;
     void traceEvent(TraceBuilder& builder) override;
 
   private:
@@ -1017,7 +1017,7 @@ private:
            ExceptionOrValue& output, SourceLocation location);
     ~Branch() noexcept(false);
 
-    Maybe<Own<Event>> fire() override;
+    void fire() override;
     void traceEvent(TraceBuilder& builder) override;
 
   private:
@@ -1102,7 +1102,7 @@ private:
            SourceLocation location);
     ~Branch() noexcept(false);
 
-    Maybe<Own<Event>> fire() override;
+    void fire() override;
     void traceEvent(TraceBuilder &builder) override;
 
   private:
@@ -1169,7 +1169,7 @@ private:
 
   ExceptionOrValue& resultRef;
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 };
 
@@ -1286,7 +1286,7 @@ private:
   void run();
   virtual void runImpl(WaitScope& waitScope) = 0;
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
   // Implements Event. Each time the event is fired, switchToFiber() is called.
 
@@ -1854,7 +1854,7 @@ private:
   class DelayedDoneHack;
 
   // implements Event ----------------------------------------------------------
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   // If called with promiseNode == nullptr, it's time to call execute(). If promiseNode != nullptr,
   // then it just indicated readiness and we need to get its result.
 
@@ -2341,7 +2341,7 @@ private:
   // -------------------------------------------------------
   // Event implementation
 
-  Maybe<Own<Event>> fire() override;
+  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 
   stdcoro::coroutine_handle<> coroutine;

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -2073,11 +2073,7 @@ public:
       : Event({}), log(log), name(name) {}
 
 protected:
-  Maybe<Own<Event>> fire() override {
-    log.add(name);
-    return kj::none;
-  }
-
+  void fire() override { log.add(name); }
   void traceEvent(_::TraceBuilder& builder) override {}
 
 private:
@@ -2291,7 +2287,7 @@ public:
         armMethod(armMethod) {}
 
 protected:
-  Maybe<Own<Event>> fire() override {
+  void fire() override {
     log.add(name);
     for (auto* e : toArm) {
       switch (armMethod) {
@@ -2300,7 +2296,6 @@ protected:
         case ArmMethod::LAST: e->armLast(); break;
       }
     }
-    return kj::none;
   }
 
   void traceEvent(_::TraceBuilder& builder) override {}

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -26,6 +26,7 @@
 #include "mutex.h"
 #include "thread.h"
 #include <kj/compat/gtest.h>
+#include <signal.h>
 
 #if !_WIN32
 #include <errno.h>
@@ -2130,17 +2131,57 @@ public:
       : Event({}), log(log), name(name) {}
 
 protected:
-  Maybe<Own<Event>> fire() override {
-    log.add(name);
-    return kj::none;
-  }
-
+  void fire() override { log.add(name); }
   void traceEvent(_::TraceBuilder& builder) override {}
 
 private:
   Vector<StringPtr>& log;
   StringPtr name;
 };
+
+class SelfDeletingEvent final: public _::Event {
+public:
+  SelfDeletingEvent(Own<SelfDeletingEvent>& owner, bool permitDestruction)
+      : Event({}), owner(owner), permitDestruction(permitDestruction) {}
+
+protected:
+  void fire() override {
+    if (permitDestruction) {
+      permitSelfDestruction();
+    }
+    owner = nullptr;
+  }
+
+  void traceEvent(_::TraceBuilder& builder) override {}
+
+private:
+  Own<SelfDeletingEvent>& owner;
+  bool permitDestruction;
+};
+
+KJ_TEST("Event may delete itself after permitting self-destruction") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+  Own<SelfDeletingEvent> event;
+  event = heap<SelfDeletingEvent>(event, true);
+
+  event->armDepthFirst();
+  waitScope.poll();
+
+  KJ_EXPECT(event.get() == nullptr);
+}
+
+KJ_TEST("Event may not delete itself without permitting self-destruction") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    EventLoop loop;
+    WaitScope waitScope(loop);
+    Own<SelfDeletingEvent> event;
+    event = heap<SelfDeletingEvent>(event, false);
+
+    event->armDepthFirst();
+    waitScope.poll();
+  });
+}
 
 KJ_TEST("Event arm methods - single event each type") {
   EventLoop loop;
@@ -2348,7 +2389,7 @@ public:
         armMethod(armMethod) {}
 
 protected:
-  Maybe<Own<Event>> fire() override {
+  void fire() override {
     log.add(name);
     for (auto* e : toArm) {
       switch (armMethod) {
@@ -2357,7 +2398,6 @@ protected:
         case ArmMethod::LAST: e->armLast(); break;
       }
     }
-    return kj::none;
   }
 
   void traceEvent(_::TraceBuilder& builder) override {}

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -326,8 +326,10 @@ protected:
     }
 
     // Remove from the task list. Do this before calling taskFailed(), so that taskFailed() can
-    // safely call clear(). Will be destroyed on scope exit.
+    // safely call clear().
     auto self = pop();
+    // self will be destroyed on scope exit.
+    self->permitSelfDestruction();
 
     // We'll also process onEmpty() now, just in case `taskFailed()` actually destroys the whole
     // `TaskSet`.
@@ -1114,8 +1116,9 @@ void XThreadEvent::fire() {
   KJ_IF_SOME(n, promiseNode) {
     n->get(result);
     promiseNode = kj::none;  // make sure to destroy in the thread that created it
-    done(); // possible deletes this
-    return;
+    // Done might delete this.
+    permitSelfDestruction();
+    done();
   } else {
     KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
       promiseNode = execute();
@@ -1125,8 +1128,9 @@ void XThreadEvent::fire() {
     KJ_IF_SOME(n, promiseNode) {
       n->onReady(this);
     } else {
-      done(); // possible deletes this
-    return;
+      // Done might delete this.
+      permitSelfDestruction();
+      done();
     }
   }
 }
@@ -2166,11 +2170,15 @@ kj::EventLoop& Event::requireEventLoop() {
 }
 
 Event::~Event() noexcept {  // intentionally noexcept
-  if (threadLocalCurrentlyFiring == this) {
-    threadLocalCurrentlyFiring = nullptr;
+  if (KJ_UNLIKELY(threadLocalCurrentlyFiring == this)) {
+    KJ_FAIL_REQUIRE("Promise callback destroyed itself.");
   }
-
   disarm();
+}
+
+void Event::permitSelfDestruction() {
+  KJ_REQUIRE(threadLocalCurrentlyFiring == this, "Event needs to be firing.");
+  threadLocalCurrentlyFiring = nullptr;
 }
 
 void Event::armDepthFirst() {
@@ -2230,8 +2238,6 @@ String TraceBuilder::toString() {
 }  // namespace _ (private)
 
 ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space) {
-  EventLoop* loop = threadLocalEventLoop;
-  if (loop == nullptr) return nullptr;
   if (threadLocalCurrentlyFiring == nullptr) return nullptr;
 
   _::TraceBuilder builder(space);
@@ -2566,8 +2572,11 @@ void ChainPromiseNode::fire() {
   state = STEP2;
 
   if (selfPtr != nullptr) {
-    // Hey, we can shorten the chain here. Will be destroyed on scope exit.
+    // Hey, we can shorten the chain here.
     auto chain = selfPtr->downcast<ChainPromiseNode>();
+    // self will be destroyed on scope exit.
+    chain->permitSelfDestruction();
+
     *selfPtr = kj::mv(inner);
     selfPtr->get()->setSelfPointer(selfPtr);
     if (onReadyEvent != nullptr) {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -166,6 +166,7 @@ AllowAsyncDestructorsScope::~AllowAsyncDestructorsScope() {
 namespace {
 
 thread_local EventLoop* threadLocalEventLoop = nullptr;
+thread_local _::Event* threadLocalCurrentlyFiring = nullptr;
 
 #define _kJ_ALREADY_READY reinterpret_cast< ::kj::_::Event*>(1)
 
@@ -182,10 +183,7 @@ public:
 
   bool fired = false;
 
-  Maybe<Own<_::Event>> fire() override {
-    fired = true;
-    return kj::none;
-  }
+  void fire() override { fired = true; }
 
   void traceEvent(_::TraceBuilder& builder) override {
     node->tracePromise(builder, true);
@@ -315,7 +313,7 @@ public:
   }
 
 protected:
-  Maybe<Own<Event>> fire() override {
+  void fire() override {
     // Get the result.
     _::ExceptionOr<_::Void> result;
     node->get(result);
@@ -328,7 +326,7 @@ protected:
     }
 
     // Remove from the task list. Do this before calling taskFailed(), so that taskFailed() can
-    // safely call clear().
+    // safely call clear(). Will be destroyed on scope exit.
     auto self = pop();
 
     // We'll also process onEmpty() now, just in case `taskFailed()` actually destroys the whole
@@ -351,8 +349,6 @@ protected:
         taskSet.errorHandler.taskFailed(kj::mv(e));
       })();
     }
-
-    return Own<Event>(mv(self));
   }
 
   void traceEvent(_::TraceBuilder& builder) override {
@@ -1114,34 +1110,12 @@ void XThreadEvent::setDisconnected() {
       "Executor's event loop exited before cross-thread event could complete"));
 }
 
-class XThreadEvent::DelayedDoneHack: public Disposer {
-  // Crazy hack: In fire(), we want to call done() if the event is finished. But done() signals
-  // the requesting thread to wake up and possibly delete the XThreadEvent. But the caller (the
-  // EventLoop) still has to set `event->firing = false` after `fire()` returns, so this would be
-  // a race condition use-after-free.
-  //
-  // It just so happens, though, that fire() is allowed to return an optional `Own<Event>` to drop,
-  // and the caller drops that pointer immediately after setting event->firing = false. So we
-  // return a pointer whose disposer calls done().
-  //
-  // It's not quite as much of a hack as it seems: The whole reason fire() returns an Own<Event> is
-  // so that the event can delete itself, but do so after the caller sets event->firing = false.
-  // It just happens to be that in this case, the event isn't deleting itself, but rather releasing
-  // itself back to the other thread.
-
-protected:
-  void disposeImpl(void* pointer) const override {
-    reinterpret_cast<XThreadEvent*>(pointer)->done();
-  }
-};
-
-Maybe<Own<Event>> XThreadEvent::fire() {
-  static constexpr DelayedDoneHack DISPOSER {};
-
+void XThreadEvent::fire() {
   KJ_IF_SOME(n, promiseNode) {
     n->get(result);
     promiseNode = kj::none;  // make sure to destroy in the thread that created it
-    return Own<Event>(this, DISPOSER);
+    done(); // possible deletes this
+    return;
   } else {
     KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
       promiseNode = execute();
@@ -1151,11 +1125,10 @@ Maybe<Own<Event>> XThreadEvent::fire() {
     KJ_IF_SOME(n, promiseNode) {
       n->onReady(this);
     } else {
-      return Own<Event>(this, DISPOSER);
+      done(); // possible deletes this
+    return;
     }
   }
-
-  return kj::none;
 }
 
 void XThreadEvent::traceEvent(TraceBuilder& builder) {
@@ -1646,11 +1619,10 @@ void FiberBase::cancel() {
   }
 }
 
-Maybe<Own<Event>> FiberBase::fire() {
+void FiberBase::fire() {
   KJ_ASSERT(state == WAITING);
   state = RUNNING;
   stack->switchToFiber();
-  return kj::none;
 }
 
 void FiberStack::switchToFiber() {
@@ -1845,13 +1817,10 @@ bool EventLoop::turn() {
   };
   resetDepthFirstInsertPoint();
 
-  Maybe<Own<_::Event>> eventToDestroy;
   {
-    event->firing = true;
-    KJ_DEFER(event->firing = false);
-    currentlyFiring = event;
-    KJ_DEFER(currentlyFiring = nullptr);
-    eventToDestroy = event->fire();
+    threadLocalCurrentlyFiring = event;
+    KJ_DEFER(threadLocalCurrentlyFiring = nullptr);
+    event->fire();
   }
 
   resetDepthFirstInsertPoint();
@@ -2197,74 +2166,40 @@ kj::EventLoop& Event::requireEventLoop() {
 }
 
 Event::~Event() noexcept {  // intentionally noexcept
-  live = 0;
-
-  // Prevent compiler from eliding this store above. This line probably isn't needed because there
-  // are complex calls later in this destructor, and the compiler probably can't prove that they
-  // won't come back and examine `live`, so it won't elide the write anyway. However, an
-  // atomic_signal_fence is also sufficient to tell the compiler that a signal handler might access
-  // `live`, so it won't optimize away the write. Note that a signal fence does not produce
-  // any instructions, it just blocks compiler optimizations.
-  std::atomic_signal_fence(std::memory_order_acq_rel);
+  if (threadLocalCurrentlyFiring == this) {
+    threadLocalCurrentlyFiring = nullptr;
+  }
 
   disarm();
-
-  // If this fails, we'll abort due to `noexcept`. That's good because otherwise we're likely to
-  // be in a use-after-free situation.
-  KJ_REQUIRE(!firing, "Promise callback destroyed itself.");
 }
 
 void Event::armDepthFirst() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertBefore(loop.depthFirstInsertPoint);
     loop.setRunnable(true);
   }
 }
 
 void Event::armBreadthFirst() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertBefore(loop.breadthFirstInsertPoint);
     loop.setRunnable(true);
   }
 }
 
 void Event::armLast() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertAfter(loop.breadthFirstInsertPoint);
     loop.setRunnable(true);
   }
 }
 
 void Event::armWhenWouldSleep() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertAfter(loop.wouldSleepHead);
     loop.setRunnable(true);
   }
@@ -2297,10 +2232,10 @@ String TraceBuilder::toString() {
 ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space) {
   EventLoop* loop = threadLocalEventLoop;
   if (loop == nullptr) return nullptr;
-  if (loop->currentlyFiring == nullptr) return nullptr;
+  if (threadLocalCurrentlyFiring == nullptr) return nullptr;
 
   _::TraceBuilder builder(space);
-  loop->currentlyFiring->traceEvent(builder);
+  threadLocalCurrentlyFiring->traceEvent(builder);
   return builder.finish();
 }
 
@@ -2519,7 +2454,7 @@ ForkHubBase::ForkHubBase(OwnPromiseNode&& innerParam, ExceptionOrValue& resultRe
   inner->onReady(this);
 }
 
-Maybe<Own<Event>> ForkHubBase::fire() {
+void ForkHubBase::fire() {
   // Dependency is ready.  Fetch its result and then delete the node.
   inner->get(resultRef);
   KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
@@ -2537,8 +2472,6 @@ Maybe<Own<Event>> ForkHubBase::fire() {
 
   // Indicate that the list is no longer active.
   tailBranch = nullptr;
-
-  return kj::none;
 }
 
 void ForkHubBase::traceEvent(TraceBuilder& builder) {
@@ -2601,7 +2534,7 @@ void ChainPromiseNode::tracePromise(TraceBuilder& builder, bool stopAtNextEvent)
   inner->tracePromise(builder, stopAtNextEvent);
 }
 
-Maybe<Own<Event>> ChainPromiseNode::fire() {
+void ChainPromiseNode::fire() {
   KJ_REQUIRE(state != STEP2);
 
   static_assert(sizeof(Promise<int>) == sizeof(PromiseBase),
@@ -2633,23 +2566,18 @@ Maybe<Own<Event>> ChainPromiseNode::fire() {
   state = STEP2;
 
   if (selfPtr != nullptr) {
-    // Hey, we can shorten the chain here.
+    // Hey, we can shorten the chain here. Will be destroyed on scope exit.
     auto chain = selfPtr->downcast<ChainPromiseNode>();
     *selfPtr = kj::mv(inner);
     selfPtr->get()->setSelfPointer(selfPtr);
     if (onReadyEvent != nullptr) {
       selfPtr->get()->onReady(onReadyEvent);
     }
-
-    // Return our self-pointer so that the caller takes care of deleting it.
-    return Own<Event>(kj::Own<ChainPromiseNode>(kj::mv(chain)));
   } else {
     inner->setSelfPointer(&inner);
     if (onReadyEvent != nullptr) {
       inner->onReady(onReadyEvent);
     }
-
-    return kj::none;
   }
 }
 
@@ -2722,7 +2650,7 @@ bool ExclusiveJoinPromiseNode::Branch::get(ExceptionOrValue& output) {
   }
 }
 
-Maybe<Own<Event>> ExclusiveJoinPromiseNode::Branch::fire() {
+void ExclusiveJoinPromiseNode::Branch::fire() {
   if (dependency) {
     // Cancel the branch that didn't return first.  Ignore exceptions caused by cancellation.
     if (this == &joinNode.left) {
@@ -2736,7 +2664,6 @@ Maybe<Own<Event>> ExclusiveJoinPromiseNode::Branch::fire() {
     // The other branch already fired, and this branch was canceled. It's possible for both
     // branches to fire if both were armed simultaneously.
   }
-  return kj::none;
 }
 
 void ExclusiveJoinPromiseNode::Branch::traceEvent(TraceBuilder& builder) {
@@ -2815,7 +2742,7 @@ ArrayJoinPromiseNodeBase::Branch::Branch(
 
 ArrayJoinPromiseNodeBase::Branch::~Branch() noexcept(false) {}
 
-Maybe<Own<Event>> ArrayJoinPromiseNodeBase::Branch::fire() {
+void ArrayJoinPromiseNodeBase::Branch::fire() {
   if (--joinNode.countLeft == 0 && !joinNode.armed) {
     joinNode.onReadyEvent.arm();
     joinNode.armed = true;
@@ -2829,8 +2756,6 @@ Maybe<Own<Event>> ArrayJoinPromiseNodeBase::Branch::fire() {
       joinNode.armed = true;
     }
   }
-
-  return kj::none;
 }
 
 void ArrayJoinPromiseNodeBase::Branch::traceEvent(TraceBuilder& builder) {
@@ -2904,11 +2829,11 @@ RaceSuccessfulPromiseNodeBase::Branch::Branch(
 
 RaceSuccessfulPromiseNodeBase::Branch::~Branch() noexcept(false) {}
 
-Maybe<Own<Event>> RaceSuccessfulPromiseNodeBase::Branch::fire() {
+void RaceSuccessfulPromiseNodeBase::Branch::fire() {
   if (parent.armed) {
     // the parent node has already received the value, no need to bother with
     // anything
-    return kj::none;
+    return;
   }
 
   auto count = --parent.countLeft;
@@ -2930,8 +2855,6 @@ Maybe<Own<Event>> RaceSuccessfulPromiseNodeBase::Branch::fire() {
     parent.armed = true;
     parent.onReadyEvent.arm();
   }
-
-  return kj::none;
 }
 
 void RaceSuccessfulPromiseNodeBase::Branch::traceEvent(TraceBuilder &builder) {
@@ -3052,7 +2975,7 @@ void EagerPromiseNodeBase::traceEvent(TraceBuilder& builder) {
   onReadyEvent.traceEvent(builder);
 }
 
-Maybe<Own<Event>> EagerPromiseNodeBase::fire() {
+void EagerPromiseNodeBase::fire() {
   dependency->get(resultRef);
   KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
     dependency = nullptr;
@@ -3061,7 +2984,6 @@ Maybe<Own<Event>> EagerPromiseNodeBase::fire() {
   }
 
   onReadyEvent.arm();
-  return kj::none;
 }
 
 // -------------------------------------------------------------------
@@ -3163,7 +3085,7 @@ void CoroutineBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
   builder.add(GetFunctorStartAddress<>::apply(coroutine));
 };
 
-Maybe<Own<Event>> CoroutineBase::fire() {
+void CoroutineBase::fire() {
   // Call PromiseAwaiter::await_resume() and proceed with the coroutine. Note that this will not
   // destroy the coroutine if control flows off the end of it, because we return suspend_always()
   // from final_suspend().
@@ -3174,8 +3096,6 @@ Maybe<Own<Event>> CoroutineBase::fire() {
   // try-catch block, so we have no choice but to resume and throw later.
 
   coroutine.resume();
-
-  return kj::none;
 }
 
 void CoroutineBase::traceEvent(TraceBuilder& builder) {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -166,6 +166,7 @@ AllowAsyncDestructorsScope::~AllowAsyncDestructorsScope() {
 namespace {
 
 thread_local EventLoop* threadLocalEventLoop = nullptr;
+thread_local _::Event* threadLocalCurrentlyFiring = nullptr;
 
 #define _kJ_ALREADY_READY reinterpret_cast< ::kj::_::Event*>(1)
 
@@ -182,10 +183,7 @@ public:
 
   bool fired = false;
 
-  Maybe<Own<_::Event>> fire() override {
-    fired = true;
-    return kj::none;
-  }
+  void fire() override { fired = true; }
 
   void traceEvent(_::TraceBuilder& builder) override {
     node->tracePromise(builder, true);
@@ -315,7 +313,7 @@ public:
   }
 
 protected:
-  Maybe<Own<Event>> fire() override {
+  void fire() override {
     // Get the result.
     _::ExceptionOr<_::Void> result;
     node->get(result);
@@ -330,6 +328,8 @@ protected:
     // Remove from the task list. Do this before calling taskFailed(), so that taskFailed() can
     // safely call clear().
     auto self = pop();
+    // self will be destroyed on scope exit.
+    self->permitSelfDestruction();
 
     // We'll also process onEmpty() now, just in case `taskFailed()` actually destroys the whole
     // `TaskSet`.
@@ -351,8 +351,6 @@ protected:
         taskSet.errorHandler.taskFailed(kj::mv(e));
       })();
     }
-
-    return Own<Event>(mv(self));
   }
 
   void traceEvent(_::TraceBuilder& builder) override {
@@ -1114,34 +1112,13 @@ void XThreadEvent::setDisconnected() {
       "Executor's event loop exited before cross-thread event could complete"));
 }
 
-class XThreadEvent::DelayedDoneHack: public Disposer {
-  // Crazy hack: In fire(), we want to call done() if the event is finished. But done() signals
-  // the requesting thread to wake up and possibly delete the XThreadEvent. But the caller (the
-  // EventLoop) still has to set `event->firing = false` after `fire()` returns, so this would be
-  // a race condition use-after-free.
-  //
-  // It just so happens, though, that fire() is allowed to return an optional `Own<Event>` to drop,
-  // and the caller drops that pointer immediately after setting event->firing = false. So we
-  // return a pointer whose disposer calls done().
-  //
-  // It's not quite as much of a hack as it seems: The whole reason fire() returns an Own<Event> is
-  // so that the event can delete itself, but do so after the caller sets event->firing = false.
-  // It just happens to be that in this case, the event isn't deleting itself, but rather releasing
-  // itself back to the other thread.
-
-protected:
-  void disposeImpl(void* pointer) const override {
-    reinterpret_cast<XThreadEvent*>(pointer)->done();
-  }
-};
-
-Maybe<Own<Event>> XThreadEvent::fire() {
-  static constexpr DelayedDoneHack DISPOSER {};
-
+void XThreadEvent::fire() {
   KJ_IF_SOME(n, promiseNode) {
     n->get(result);
     promiseNode = kj::none;  // make sure to destroy in the thread that created it
-    return Own<Event>(this, DISPOSER);
+    // Done might delete this.
+    permitSelfDestruction();
+    done();
   } else {
     KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
       promiseNode = execute();
@@ -1151,11 +1128,11 @@ Maybe<Own<Event>> XThreadEvent::fire() {
     KJ_IF_SOME(n, promiseNode) {
       n->onReady(this);
     } else {
-      return Own<Event>(this, DISPOSER);
+      // Done might delete this.
+      permitSelfDestruction();
+      done();
     }
   }
-
-  return kj::none;
 }
 
 void XThreadEvent::traceEvent(TraceBuilder& builder) {
@@ -1646,11 +1623,10 @@ void FiberBase::cancel() {
   }
 }
 
-Maybe<Own<Event>> FiberBase::fire() {
+void FiberBase::fire() {
   KJ_ASSERT(state == WAITING);
   state = RUNNING;
   stack->switchToFiber();
-  return kj::none;
 }
 
 void FiberStack::switchToFiber() {
@@ -1851,13 +1827,10 @@ bool EventLoop::turn() {
   };
   resetDepthFirstInsertPoint();
 
-  Maybe<Own<_::Event>> eventToDestroy;
   {
-    event->firing = true;
-    KJ_DEFER(event->firing = false);
-    currentlyFiring = event;
-    KJ_DEFER(currentlyFiring = nullptr);
-    eventToDestroy = event->fire();
+    threadLocalCurrentlyFiring = event;
+    KJ_DEFER(threadLocalCurrentlyFiring = nullptr);
+    event->fire();
   }
 
   resetDepthFirstInsertPoint();
@@ -2212,74 +2185,46 @@ kj::EventLoop& Event::requireEventLoop() {
 }
 
 Event::~Event() noexcept {  // intentionally noexcept
-  live = 0;
-
-  // Prevent compiler from eliding this store above. This line probably isn't needed because there
-  // are complex calls later in this destructor, and the compiler probably can't prove that they
-  // won't come back and examine `live`, so it won't elide the write anyway. However, an
-  // atomic_signal_fence is also sufficient to tell the compiler that a signal handler might access
-  // `live`, so it won't optimize away the write. Note that a signal fence does not produce
-  // any instructions, it just blocks compiler optimizations.
-  std::atomic_signal_fence(std::memory_order_acq_rel);
-
+  if (KJ_UNLIKELY(threadLocalCurrentlyFiring == this)) {
+    // If this fails, we'll abort due to `noexcept`. That's good because otherwise we're likely to
+    // be in a use-after-free situation.
+    KJ_FAIL_REQUIRE("Promise callback destroyed itself.");
+  }
   disarm();
+}
 
-  // If this fails, we'll abort due to `noexcept`. That's good because otherwise we're likely to
-  // be in a use-after-free situation.
-  KJ_REQUIRE(!firing, "Promise callback destroyed itself.");
+void Event::permitSelfDestruction() {
+  KJ_REQUIRE(threadLocalCurrentlyFiring == this, "Event needs to be firing.");
+  threadLocalCurrentlyFiring = nullptr;
 }
 
 void Event::armDepthFirst() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertBefore(loop.depthFirstInsertPoint);
     loop.setRunnable(true);
   }
 }
 
 void Event::armBreadthFirst() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertBefore(loop.breadthFirstInsertPoint);
     loop.setRunnable(true);
   }
 }
 
 void Event::armLast() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertAfter(loop.breadthFirstInsertPoint);
     loop.setRunnable(true);
   }
 }
 
 void Event::armWhenWouldSleep() {
-  auto& loop = requireEventLoop();
-  if (live != MAGIC_LIVE_VALUE) {
-    ([this]() noexcept {
-      KJ_FAIL_ASSERT("tried to arm Event after it was destroyed", location);
-    })();
-  }
-
   if (prev == nullptr) {
+    auto& loop = requireEventLoop();
     insertAfter(loop.wouldSleepHead);
     loop.setRunnable(true);
   }
@@ -2310,12 +2255,10 @@ String TraceBuilder::toString() {
 }  // namespace _ (private)
 
 ArrayPtr<void* const> getAsyncTrace(ArrayPtr<void*> space) {
-  EventLoop* loop = threadLocalEventLoop;
-  if (loop == nullptr) return nullptr;
-  if (loop->currentlyFiring == nullptr) return nullptr;
+  if (threadLocalCurrentlyFiring == nullptr) return nullptr;
 
   _::TraceBuilder builder(space);
-  loop->currentlyFiring->traceEvent(builder);
+  threadLocalCurrentlyFiring->traceEvent(builder);
   return builder.finish();
 }
 
@@ -2534,7 +2477,7 @@ ForkHubBase::ForkHubBase(OwnPromiseNode&& innerParam, ExceptionOrValue& resultRe
   inner->onReady(this);
 }
 
-Maybe<Own<Event>> ForkHubBase::fire() {
+void ForkHubBase::fire() {
   // Dependency is ready.  Fetch its result and then delete the node.
   inner->get(resultRef);
   KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
@@ -2552,8 +2495,6 @@ Maybe<Own<Event>> ForkHubBase::fire() {
 
   // Indicate that the list is no longer active.
   tailBranch = nullptr;
-
-  return kj::none;
 }
 
 void ForkHubBase::traceEvent(TraceBuilder& builder) {
@@ -2616,7 +2557,7 @@ void ChainPromiseNode::tracePromise(TraceBuilder& builder, bool stopAtNextEvent)
   inner->tracePromise(builder, stopAtNextEvent);
 }
 
-Maybe<Own<Event>> ChainPromiseNode::fire() {
+void ChainPromiseNode::fire() {
   KJ_REQUIRE(state != STEP2);
 
   static_assert(sizeof(Promise<int>) == sizeof(PromiseBase),
@@ -2650,21 +2591,19 @@ Maybe<Own<Event>> ChainPromiseNode::fire() {
   if (selfPtr != nullptr) {
     // Hey, we can shorten the chain here.
     auto chain = selfPtr->downcast<ChainPromiseNode>();
+    // self will be destroyed on scope exit.
+    chain->permitSelfDestruction();
+
     *selfPtr = kj::mv(inner);
     selfPtr->get()->setSelfPointer(selfPtr);
     if (onReadyEvent != nullptr) {
       selfPtr->get()->onReady(onReadyEvent);
     }
-
-    // Return our self-pointer so that the caller takes care of deleting it.
-    return Own<Event>(kj::Own<ChainPromiseNode>(kj::mv(chain)));
   } else {
     inner->setSelfPointer(&inner);
     if (onReadyEvent != nullptr) {
       inner->onReady(onReadyEvent);
     }
-
-    return kj::none;
   }
 }
 
@@ -2737,7 +2676,7 @@ bool ExclusiveJoinPromiseNode::Branch::get(ExceptionOrValue& output) {
   }
 }
 
-Maybe<Own<Event>> ExclusiveJoinPromiseNode::Branch::fire() {
+void ExclusiveJoinPromiseNode::Branch::fire() {
   if (dependency) {
     // Cancel the branch that didn't return first.  Ignore exceptions caused by cancellation.
     if (this == &joinNode.left) {
@@ -2751,7 +2690,6 @@ Maybe<Own<Event>> ExclusiveJoinPromiseNode::Branch::fire() {
     // The other branch already fired, and this branch was canceled. It's possible for both
     // branches to fire if both were armed simultaneously.
   }
-  return kj::none;
 }
 
 void ExclusiveJoinPromiseNode::Branch::traceEvent(TraceBuilder& builder) {
@@ -2830,7 +2768,7 @@ ArrayJoinPromiseNodeBase::Branch::Branch(
 
 ArrayJoinPromiseNodeBase::Branch::~Branch() noexcept(false) {}
 
-Maybe<Own<Event>> ArrayJoinPromiseNodeBase::Branch::fire() {
+void ArrayJoinPromiseNodeBase::Branch::fire() {
   if (--joinNode.countLeft == 0 && !joinNode.armed) {
     joinNode.onReadyEvent.arm();
     joinNode.armed = true;
@@ -2844,8 +2782,6 @@ Maybe<Own<Event>> ArrayJoinPromiseNodeBase::Branch::fire() {
       joinNode.armed = true;
     }
   }
-
-  return kj::none;
 }
 
 void ArrayJoinPromiseNodeBase::Branch::traceEvent(TraceBuilder& builder) {
@@ -2919,11 +2855,11 @@ RaceSuccessfulPromiseNodeBase::Branch::Branch(
 
 RaceSuccessfulPromiseNodeBase::Branch::~Branch() noexcept(false) {}
 
-Maybe<Own<Event>> RaceSuccessfulPromiseNodeBase::Branch::fire() {
+void RaceSuccessfulPromiseNodeBase::Branch::fire() {
   if (parent.armed) {
     // the parent node has already received the value, no need to bother with
     // anything
-    return kj::none;
+    return;
   }
 
   auto count = --parent.countLeft;
@@ -2948,8 +2884,6 @@ Maybe<Own<Event>> RaceSuccessfulPromiseNodeBase::Branch::fire() {
     parent.armed = true;
     parent.onReadyEvent.arm();
   }
-
-  return kj::none;
 }
 
 void RaceSuccessfulPromiseNodeBase::Branch::traceEvent(TraceBuilder &builder) {
@@ -3070,7 +3004,7 @@ void EagerPromiseNodeBase::traceEvent(TraceBuilder& builder) {
   onReadyEvent.traceEvent(builder);
 }
 
-Maybe<Own<Event>> EagerPromiseNodeBase::fire() {
+void EagerPromiseNodeBase::fire() {
   dependency->get(resultRef);
   KJ_IF_SOME(exception, kj::runCatchingExceptions([this]() {
     dependency = nullptr;
@@ -3079,7 +3013,6 @@ Maybe<Own<Event>> EagerPromiseNodeBase::fire() {
   }
 
   onReadyEvent.arm();
-  return kj::none;
 }
 
 // -------------------------------------------------------------------
@@ -3181,7 +3114,7 @@ void CoroutineBase::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
   builder.add(GetFunctorStartAddress<>::apply(coroutine));
 };
 
-Maybe<Own<Event>> CoroutineBase::fire() {
+void CoroutineBase::fire() {
   // Call PromiseAwaiter::await_resume() and proceed with the coroutine. Note that this will not
   // destroy the coroutine if control flows off the end of it, because we return suspend_always()
   // from final_suspend().
@@ -3192,8 +3125,6 @@ Maybe<Own<Event>> CoroutineBase::fire() {
   // try-catch block, so we have no choice but to resume and throw later.
 
   coroutine.resume();
-
-  return kj::none;
 }
 
 void CoroutineBase::traceEvent(TraceBuilder& builder) {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1251,7 +1251,13 @@ public:
 
 protected:
   virtual void fire() = 0;
-  // Fire the event. Possibly deletes itself, so event shoudn't be used after calling this.
+  // Fire the event. Possibly deletes itself, so event shouldn't be used after calling this.
+  // To aid debugging promises that cancel itself the event that is going to delete itself in `fire`
+  // needs to call `permitSelfDestruction` before doing so.
+  // Otherwise deleting currently firing event will result in exception.
+
+  void permitSelfDestruction();
+  // Must be called from within `fire()` method if Event intends to self-destroy after fire.
 
 private:
   friend class kj::EventLoop;

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1250,10 +1250,8 @@ public:
   // Helper that builds a trace and stringifies it.
 
 protected:
-  virtual Maybe<Own<Event>> fire() = 0;
-  // Fire the event.  Possibly returns a pointer to itself, which will be discarded by the
-  // caller.  This is the only way that an event can delete itself as a result of firing, as
-  // doing so from within fire() will throw an exception.
+  virtual void fire() = 0;
+  // Fire the event. Possibly deletes itself, so event shoudn't be used after calling this.
 
 private:
   friend class kj::EventLoop;
@@ -1279,10 +1277,6 @@ private:
   Event* next;
   Event** prev;
 
-  bool firing = false;
-
-  static constexpr uint MAGIC_LIVE_VALUE = 0x1e366381u;
-  uint live = MAGIC_LIVE_VALUE;
   SourceLocation location;
 };
 
@@ -1386,7 +1380,7 @@ private:
       prev = nullptr;
     }
 
-    Maybe<Own<_::Event>> fire() override { KJ_UNREACHABLE; }
+    void fire() override { KJ_UNREACHABLE; }
     void traceEvent(_::TraceBuilder& builder) override { KJ_UNREACHABLE; }
   };
 
@@ -1428,8 +1422,6 @@ private:
   // For EventLoopLocal. Allocated separately to avoid including HashMap here.
 
   Own<TaskSet> daemons;
-
-  _::Event* currentlyFiring = nullptr;
 
   void resetDepthFirstQueue();
   bool turn();

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1250,10 +1250,14 @@ public:
   // Helper that builds a trace and stringifies it.
 
 protected:
-  virtual Maybe<Own<Event>> fire() = 0;
-  // Fire the event.  Possibly returns a pointer to itself, which will be discarded by the
-  // caller.  This is the only way that an event can delete itself as a result of firing, as
-  // doing so from within fire() will throw an exception.
+  virtual void fire() = 0;
+  // Fire the event. Possibly deletes itself, so event shouldn't be used after calling this.
+  // To aid debugging promises that cancel itself the event that is going to delete itself in `fire`
+  // needs to call `permitSelfDestruction` before doing so.
+  // Otherwise deleting currently firing event will result in exception.
+
+  void permitSelfDestruction();
+  // Must be called from within `fire()` method if Event intends to self-destroy after fire.
 
 private:
   friend class kj::EventLoop;
@@ -1279,10 +1283,6 @@ private:
   Event* next;
   Event** prev;
 
-  bool firing = false;
-
-  static constexpr uint MAGIC_LIVE_VALUE = 0x1e366381u;
-  uint live = MAGIC_LIVE_VALUE;
   SourceLocation location;
 };
 
@@ -1411,7 +1411,7 @@ private:
       prev = nullptr;
     }
 
-    Maybe<Own<_::Event>> fire() override { KJ_UNREACHABLE; }
+    void fire() override { KJ_UNREACHABLE; }
     void traceEvent(_::TraceBuilder& builder) override { KJ_UNREACHABLE; }
   };
 
@@ -1457,8 +1457,6 @@ private:
   // For EventLoopLocal. Allocated separately to avoid including HashMap here.
 
   Own<TaskSet> daemons;
-
-  _::Event* currentlyFiring = nullptr;
 
   void resetDepthFirstQueue();
   bool turn();


### PR DESCRIPTION
Removes `firing` tracking. Besides making self-deletion possible this simplification improves performance across the board: https://gist.github.com/mikea/6216a6512423e6eaa2784e1e94594cc9 (`bm_Http_FullProtocol` is ~4.8%)