### PR TITLE
[coro] explicit coroutine allocator argument

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -169,6 +169,7 @@ includekj_HEADERS =                                            \
   src/kj/filesystem.h                                          \
   src/kj/async-prelude.h                                       \
   src/kj/async.h                                               \
+  src/kj/async-coroutine-alloc.h                               \
   src/kj/async-inl.h                                           \
   src/kj/time.h                                                \
   src/kj/timer.h                                               \
@@ -516,6 +517,7 @@ heavy_tests =                                                  \
   src/kj/async-test.c++                                        \
   src/kj/async-xthread-test.c++                                \
   src/kj/async-coroutine-test.c++                              \
+  src/kj/async-coroutine-alloc-test.c++                        \
   src/kj/async-unix-test.c++                                   \
   src/kj/async-unix-xthread-test.c++                           \
   src/kj/async-win32-test.c++                                  \

--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -106,6 +106,7 @@ cc_library(
     }),
     hdrs = [
         "async.h",
+        "async-coroutine-alloc.h",
         "async-inl.h",
         "async-io.h",
         "async-io-internal.h",
@@ -193,6 +194,15 @@ cc_library(
 cc_test(
     name = "async-coroutine-test",
     srcs = ["async-coroutine-test.c++"],
+    deps = [
+        ":kj-test",
+        "//src/kj/compat:kj-http",
+    ],
+)
+
+cc_test(
+    name = "async-coroutine-alloc-test",
+    srcs = ["async-coroutine-alloc-test.c++"],
     deps = [
         ":kj-test",
         "//src/kj/compat:kj-http",

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -143,6 +143,7 @@ set(kj-async_sources
 set(kj-async_headers
   async-prelude.h
   async.h
+  async-coroutine-alloc.h
   async-inl.h
   async-unix.h
   async-win32.h
@@ -284,6 +285,7 @@ if(BUILD_TESTING)
       async-test.c++
       async-xthread-test.c++
       async-coroutine-test.c++
+      async-coroutine-alloc-test.c++
       async-unix-test.c++
       async-unix-xthread-test.c++
       async-win32-test.c++

--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <kj/array.h>
+#include <kj/async-coroutine-alloc.h>
+#include <kj/async.h>
+#include <kj/compat/http.h>
+#include <kj/debug.h>
+#include <kj/exception.h>
+#include <kj/test.h>
+
+namespace kj {
+namespace {
+
+using _::DefaultCoroutineAllocator;
+
+// CoroutineAllocator::hasAllocator tests
+static_assert(!_::CoroutineAllocator::hasAllocator<>);
+static_assert(!_::CoroutineAllocator::hasAllocator<int>);
+static_assert(!_::CoroutineAllocator::hasAllocator<int, double, char *>);
+static_assert(_::CoroutineAllocator::hasAllocator<_::CoroutineAllocator &>);
+static_assert(_::CoroutineAllocator::hasAllocator<DebugCoroutineAllocator &>);
+static_assert(_::CoroutineAllocator::hasAllocator<int, DebugCoroutineAllocator &>);
+static_assert(_::CoroutineAllocator::hasAllocator<DebugCoroutineAllocator &, int>);
+static_assert(_::CoroutineAllocator::hasAllocator<
+              int, double, DefaultCoroutineAllocator &, char *>);
+
+// CoroutineAllocator::AllocatorType tests
+static_assert(isSameType<_::CoroutineAllocator::AllocatorType<>,
+                         _::DefaultCoroutineAllocator>());
+static_assert(isSameType<_::CoroutineAllocator::AllocatorType<int>,
+                         _::DefaultCoroutineAllocator>());
+static_assert(isSameType<_::CoroutineAllocator::AllocatorType<int, double>,
+                         _::DefaultCoroutineAllocator>());
+static_assert(
+    isSameType<_::CoroutineAllocator::AllocatorType<DebugCoroutineAllocator &>,
+               DebugCoroutineAllocator>());
+static_assert(isSameType<
+              _::CoroutineAllocator::AllocatorType<DefaultCoroutineAllocator &>,
+              DefaultCoroutineAllocator>());
+static_assert(
+    isSameType<_::CoroutineAllocator::AllocatorType<int, DebugCoroutineAllocator &>,
+               DebugCoroutineAllocator>());
+static_assert(
+    isSameType<_::CoroutineAllocator::AllocatorType<DebugCoroutineAllocator &, int>,
+               DebugCoroutineAllocator>());
+static_assert(isSameType<_::CoroutineAllocator::AllocatorType<
+                             int, double, DefaultCoroutineAllocator &, char *>,
+                         DefaultCoroutineAllocator>());
+static_assert(isSameType<_::CoroutineAllocator::AllocatorType<
+                             DebugCoroutineAllocator &, DefaultCoroutineAllocator &>,
+                         DebugCoroutineAllocator>());
+static_assert(isSameType<_::CoroutineAllocator::AllocatorType<
+                             DefaultCoroutineAllocator &, DebugCoroutineAllocator &>,
+                         DefaultCoroutineAllocator>());
+
+KJ_TEST("CoroutineAllocator::getAllocator") {
+  DefaultCoroutineAllocator def;
+  DebugCoroutineAllocator debug;
+  int x = 0;
+  double y = 0.0;
+
+  KJ_EXPECT(&_::CoroutineAllocator::getAllocator(debug) == &debug);
+  KJ_EXPECT(&_::CoroutineAllocator::getAllocator(def) == &def);
+  KJ_EXPECT(&_::CoroutineAllocator::getAllocator(x, debug) == &debug);
+  KJ_EXPECT(&_::CoroutineAllocator::getAllocator(debug, x) == &debug);
+  KJ_EXPECT(&_::CoroutineAllocator::getAllocator(x, y, def) == &def);
+  KJ_EXPECT(&_::CoroutineAllocator::getAllocator(debug, def) == &debug);
+  KJ_EXPECT(&_::CoroutineAllocator::getAllocator(def, debug) == &def);
+}
+
+template <typename Allocator>
+kj::Promise<size_t> immediateCoroutine(Allocator &) {
+  co_return 42;
+}
+
+KJ_TEST("DefaultCoroutineAllocator") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  _::DefaultCoroutineAllocator allocator;
+  auto promise = immediateCoroutine(allocator);
+  KJ_EXPECT(promise.wait(waitScope) == 42);
+}
+
+KJ_TEST("DebugAllocator") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  DebugCoroutineAllocator allocator;
+  auto promise = immediateCoroutine(allocator);
+  KJ_EXPECT(promise.wait(waitScope) == 42);
+  
+  KJ_EXPECT(allocator.totalAllocCount == 1);
+  KJ_EXPECT(allocator.totalAllocSize > 0);
+  KJ_EXPECT(allocator.totalFreeCount == 1);
+  KJ_EXPECT(allocator.totalFreeSize == allocator.totalFreeSize);
+
+}
+
+template <typename Allocator>
+kj::Promise<size_t> coroFib(Allocator& alloc, size_t i) {
+  if (i <= 10)
+    co_return 1;
+  co_return (co_await coroFib(alloc, i - 1)) + (co_await coroFib(alloc, i - 2));
+}
+
+template <typename Allocator>
+kj::Promise<size_t> coroFib10(Allocator& alloc, size_t i) {
+  if (i <= 10)
+    co_return 1;
+  co_return (co_await coroFib10(alloc, i - 1)) + (co_await coroFib10(alloc, i - 2)) +
+      (co_await coroFib10(alloc, i - 3)) + (co_await coroFib10(alloc, i - 4)) +
+      (co_await coroFib10(alloc, i - 5)) + (co_await coroFib10(alloc, i - 6)) +
+      (co_await coroFib10(alloc, i - 7)) + (co_await coroFib10(alloc, i - 8)) +
+      (co_await coroFib10(alloc, i - 9)) + (co_await coroFib10(alloc, i - 10));
+}
+
+KJ_TEST("Coroutine Frame sizes") {
+  // Coroutine size varies between compilers and optimization level. We still want to keep track
+  // of coroutine sizes. Thus restrict check to newest clang opt build.
+  // We intentionally keep the upper bound open to detect when production compiler deviates.
+#if !(defined(__clang__) && __clang_major__ >= 20 && defined(NDEBUG))
+  return;
+#else
+#endif
+
+
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  {
+    DebugCoroutineAllocator allocator;
+    auto promise = immediateCoroutine(allocator);
+    KJ_EXPECT(allocator.totalAllocCount == 1);
+    KJ_EXPECT(allocator.totalAllocSize == 192);
+  }
+
+  {
+    DebugCoroutineAllocator allocator;
+    auto promise = coroFib(allocator, 10);
+    KJ_EXPECT(allocator.totalAllocCount == 1);
+    KJ_EXPECT(allocator.totalAllocSize == 352);
+  }
+
+  {
+    DebugCoroutineAllocator allocator;
+    auto promise = coroFib10(allocator, 10);
+    KJ_EXPECT(allocator.totalAllocCount == 1);
+    KJ_EXPECT(allocator.totalAllocSize == 928);
+  }
+}
+
+} // namespace
+} // namespace kj

--- a/c++/src/kj/async-coroutine-alloc.h
+++ b/c++/src/kj/async-coroutine-alloc.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Cloudflare, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Various async coroutine allocators.
+
+#pragma once
+
+#include <kj/async.h>
+
+#include <new> // for placement new
+
+namespace kj {
+
+template <typename Allocator> 
+struct CoroutineFrame {
+  // Represents allocated coroutine frame that tracks its size and allocator
+
+  inline CoroutineFrame(size_t dataSize, Allocator &allocator) noexcept
+      : dataSize(dataSize), allocator(allocator) {}
+
+  size_t dataSize;
+  Allocator &allocator;
+  kj::byte data[];
+
+  inline constexpr kj::byte *dataBegin() { return data; }
+  inline constexpr size_t allocSize() {
+    return sizeof(CoroutineFrame) + dataSize;
+  }
+  inline constexpr static size_t allocSize(size_t dataSize) {
+    return sizeof(CoroutineFrame) + dataSize;
+  }
+  inline constexpr static CoroutineFrame *fromDataPtr(void *dataPtr) {
+    return reinterpret_cast<CoroutineFrame *>(
+        reinterpret_cast<kj::byte *>(dataPtr) - sizeof(CoroutineFrame));
+  }
+};
+
+struct DebugCoroutineAllocator : public _::CoroutineAllocator {
+  // Debug coroutine allocator that:
+  // - keeps track of allocation statistics
+  // - asserts that all coroutines were freed at its destructor.
+
+  ~DebugCoroutineAllocator() {
+    KJ_IREQUIRE(totalAllocCount == totalFreeCount, "Alloc/Free count mismatch");
+    KJ_IREQUIRE(totalAllocSize == totalFreeSize, "Alloc/Free size mismatch");
+  }
+
+  using Frame = CoroutineFrame<DebugCoroutineAllocator>;
+
+  void *alloc(std::size_t frameSize) {
+    auto allocSize = Frame::allocSize(frameSize);
+    auto ptr = ::operator new(allocSize);
+    auto frame = new (ptr) Frame(frameSize, *this);
+
+    totalAllocCount += 1;
+    // increment by frame size since clients are not interested in our
+    // implementation details
+    totalAllocSize += frameSize;
+    return frame->dataBegin();
+  }
+
+  static void free(void *dataPtr, size_t frameSize) {
+    auto frame = Frame::fromDataPtr(dataPtr);
+    KJ_IREQUIRE(frame->dataSize == frameSize, "Frame size mismatch");
+    frame->allocator.free(frame);
+  }
+
+  static void free(void *dataPtr) {
+    auto frame = Frame::fromDataPtr(dataPtr);
+    frame->allocator.free(frame);
+  }
+
+  size_t totalAllocCount = 0;
+  size_t totalAllocSize = 0;
+  size_t totalFreeCount = 0;
+  size_t totalFreeSize = 0;
+
+private:
+  void free(Frame *frame) {
+    totalFreeCount++;
+    totalFreeSize += frame->dataSize;
+    // Use unsized delete for maximum compatibility - performance is irrelevant here.
+    ::operator delete(reinterpret_cast<void *>(frame));
+  }
+};
+
+} // namespace kj

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2212,13 +2212,105 @@ PromiseCrossThreadFulfillerPair<T> Executor::newPromiseAndCrossThreadFulfiller()
 
 namespace kj::_ {
 
-template <typename T> class Coroutine;
+template <typename T, typename Allocator> class Coroutine;
 
 template <typename T>
 concept NoWaitScope = !isSameType<Decay<T>, WaitScope>();
 // Define a Concept to use in our `coroutine_traits` specialization to validate allowable coroutine
 // parameter types.
 // TODO(cleanup): This can be removed by adding KJ_DISALLOW_AS_COROUTINE_PARAM to WaitScope.
+
+struct DefaultCoroutineAllocator;
+
+class CoroutineAllocator {
+  // Marker class for all coroutine allocators.
+  // Custom allocators need to publicly extend `CoroutineAllocator` and implement following methods:
+  // - `void* alloc(std::size_t frameSize)`
+  // - `static void free(void* framePtr, std::size_t frameSize)`
+  // - `static void free(void* framePtr)` - this is needed for older compilers only (slower).
+  //
+  // Notice that allocator instance is not available in `free()` - the allocator needs to recover it
+  // itself if necessary.
+  //
+  // To use custom allocator, pass a reference to it to the coroutine function as any parameter.
+  // Keep passing the allocator reference around if you want to keep using the allocator for
+  // inner coroutines.
+  // If allocator parameter is not present, then `DefaultCoroutineAllocator` is used.
+
+private:
+  // Implementations of public meta-programming api.
+
+  template <typename X>
+  requires (!kj::canConvert<X, CoroutineAllocator>())
+  static constexpr std::nullptr_t tryGetAllocator(X&&) { return nullptr; }
+
+  template <typename X>
+  requires (kj::canConvert<X, CoroutineAllocator>())
+  static constexpr X* tryGetAllocator(X& alloc) { return &alloc; }
+
+  template <typename... Args>
+  struct AllocatorTypeHelper {
+    using Type = DefaultCoroutineAllocator;
+  };
+
+  template <typename First, typename... Rest>
+  struct AllocatorTypeHelper<First, Rest...>:
+      AllocatorTypeHelper<Rest...> {};
+
+  template <typename First, typename... Rest>
+  requires (kj::canConvert<First, CoroutineAllocator>())
+  struct AllocatorTypeHelper<First, Rest...> {
+    using Type = Decay<First>;
+  };
+
+public:
+  // Meta-programming api to detect and extract allocator arguments.
+
+  template <typename... Args>
+  static constexpr bool hasAllocator = (kj::canConvert<Args, CoroutineAllocator &>() || ...);
+  // Check if any of the argument is an allocator reference.
+
+  template <typename... Args>
+  using AllocatorType = typename AllocatorTypeHelper<Args...>::Type;
+  // Extract exact allocator type, returns `DefaultCoroutineAllocator` if no allocator argument
+  // is present.
+
+  template <typename First, typename... Rest>
+  static constexpr auto& getAllocator(First&& first, Rest&&... rest) {
+    // Extract allocator argument, assumes `hasAllocator` is true.
+
+    if constexpr (kj::canConvert<First, CoroutineAllocator>()) {
+      return first;
+    } else {
+      static_assert(sizeof...(Rest) > 0, "No allocator found in arguments");
+      return getAllocator(kj::fwd<Rest>(rest)...);
+    }
+  }
+
+};
+
+struct DefaultCoroutineAllocator: public CoroutineAllocator {
+  // Default coroutine allocator.
+  // Used when now allocator parameter is specified in coroutine declaration.
+  // Can be instantiated and passed as a reference as well.
+
+  inline static void* alloc(std::size_t frameSize) {
+    // Note: new[]/delete[] are measurably slower.
+    return ::operator new(frameSize);
+  }
+
+  inline static void free(void* framePtr, std::size_t frameSize) {
+#if defined(__cpp_sized_deallocation)
+    ::operator delete(framePtr, frameSize);
+#else
+    ::operator delete(framePtr);
+#endif
+  }
+
+  inline static void free(void* framePtr) {
+    ::operator delete(framePtr);
+  }
+};
 
 }  // namespace kj::_
 
@@ -2244,7 +2336,7 @@ struct coroutine_traits<kj::Promise<T>, Args...> {
   // A second note: This has the reasonable side effect of making it impossible for us to write
   // WaitScope member coroutines.
 
-  using promise_type = kj::_::Coroutine<T>;
+  using promise_type = kj::_::Coroutine<T, kj::_::CoroutineAllocator::AllocatorType<Args...>>;
   // The C++ standard calls this the "promise type". This makes sense when thinking of coroutines
   // returning `std::future<T>`, since the coroutine implementation would be a wrapper around
   // a `std::promise<T>`. It's extremely confusing from a KJ perspective, however, so I call it
@@ -2304,28 +2396,6 @@ public:
   bool canImmediatelyResume() {
     return hasSuspendedAtLeastOnce && isNext();
   }
-
-  template <typename... Args>
-  inline void* operator new(size_t frameSize, Args&&...args) {
-    // Allocates new coroutine frame of `frameSize` bytes.
-    // `args` are coroutine function arguments that will be copied/moved to the coroutine state.
-
-    // Curiously operator new[]/delete[] pair is slower.
-    return ::operator new (frameSize);
-  }
-
-#if defined(__clang__) && __clang_major__ > 18
-  // Sized delete for coroutines are supported since clang-19
-  inline void operator delete(void* framePtr, size_t frameSize) {
-    // Deallocates coroutine frame.
-    ::operator delete (framePtr, frameSize);
-  }
-#else
-  inline void operator delete(void* framePtr) {
-    // Deallocates coroutine frame.
-    ::operator delete (framePtr);
-  }
-#endif
 
 protected:
   bool isWaiting() { return waiting; }
@@ -2391,20 +2461,19 @@ template <typename Self, typename T>
 class CoroutineMixin;
 // CRTP mixin, covered later.
 
-template <typename T>
+template <typename T, typename Allocator>
 class Coroutine final: public CoroutineBase,
-                       public CoroutineMixin<Coroutine<T>, T> {
+                       public CoroutineMixin<Coroutine<T, Allocator>, T> {
   // The standard calls this the `promise_type` object. We can call this the "coroutine
   // implementation object" since the word promise means different things in KJ and std styles. This
   // is where we implement how a `kj::Promise<T>` is returned from a coroutine, and how that promise
   // is later fulfilled. We also fill in a few lifetime-related details.
   //
-  // The implementation object is also where we can customize memory allocation of coroutine frames,
-  // by implementing a member `operator new(size_t, Args...)` (same `Args...` as in
-  // coroutine_traits).
+  // The type is statically parametrized by an `Allocator` to enable custom coroutine allocators
+  // without any overhead. See `CoroutineAllocator` for more details.
 
 public:
-  using Handle = stdcoro::coroutine_handle<Coroutine<T>>;
+  using Handle = stdcoro::coroutine_handle<Coroutine<T, Allocator>>;
 
   Coroutine(SourceLocation location = {}): Coroutine(Handle::from_promise(*this), location) {}
 
@@ -2457,6 +2526,29 @@ public:
   }
 
   void unhandled_exception() { unhandledExceptionImpl(result); }
+
+
+  template <typename... Args>
+  inline void* operator new(std::size_t frameSize, Args&&... args) {
+    if constexpr (CoroutineAllocator::hasAllocator<Args...>) {
+      return CoroutineAllocator::getAllocator(args...).alloc(frameSize);
+    } else {
+      return Allocator::alloc(frameSize);
+    }
+  }
+
+
+#if defined(__cpp_sized_deallocation)
+  inline void operator delete(void* framePtr, size_t frameSize) {
+    // Deallocates coroutine frame.
+    Allocator::free(framePtr, frameSize);
+  }
+#else
+  inline void operator delete(void* framePtr) {
+    // Deallocates coroutine frame.
+    Allocator::free(framePtr);
+  }
+#endif
 
 private:
   // -------------------------------------------------------


### PR DESCRIPTION
This introduces `CoroutineAllocator` marker type and parametrizes `Coroutine` by `Allocator`. This will allow me to experiment with allocators (PRs coming) without any performance overhead before enabling anything by default.

Adds `DebugCoroutineAllocator` to be able to perform coroutine size measurements. Our current empty coro is 192 bytes.

I tried to put as much code as possible into new header not to pile up on async-inl.h LMK if you want me to rearrange.

performance neutral: https://gist.github.com/mikea/2749fff1fd409fec57e154696b05604f