### PR TITLE
Fix spurious exceptions in kj::ExceptionCallback when using HWASan

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -1281,6 +1281,7 @@ thread_local ExceptionCallback* threadLocalCallback = nullptr;
 void requireOnStack(void* ptr, kj::StringPtr description) {
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) || \
     KJ_HAS_COMPILER_FEATURE(address_sanitizer) || \
+    KJ_HAS_COMPILER_FEATURE(hwaddress_sanitizer) || \
     defined(__SANITIZE_ADDRESS__)
   // When using libfuzzer or ASAN, this sanity check may spurriously fail, so skip it.
 #else


### PR DESCRIPTION
Fixes #2500, HWASan on Android does not seem to define the regular ASan macros / features, and this is the only way I found to detect it