### PR TITLE
c++/src/kj: Fix build failure on GCC 15.2.1

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -35,6 +35,8 @@
 #include <intrin.h>  // _ReturnAddress
 #endif
 
+#include <cstdint>
+
 #include <kj/list.h>
 
 KJ_BEGIN_HEADER


### PR DESCRIPTION
With GCC 15.2.1, the `<cstdint>` header is required for `uintptr_t`:

```
In file included from $ROOT/capnproto/c++/src/kj/async.h:1409:
$ROOT/capnproto/c++/src/kj/async-inl.h:39:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   38 | #include <kj/list.h>
  +++ |+#include <cstdint>
```

Fixes: #2506