### PR TITLE
kj/test.c++: output a message when a test fails due to error output

### DIFF
--- a/c++/src/kj/test.c++
+++ b/c++/src/kj/test.c++
@@ -98,9 +98,14 @@ public:
 
     text = kj::str(kj::repeat('_', contextDepth), file, ':', line, ": ", kj::mv(text));
 
+    bool hadSeenError = sawError;
     if (severity == LogSeverity::ERROR || severity == LogSeverity::FATAL) {
       fail();
       context.error(kj::str(text, "\nstack: ", stringifyStackTraceAddresses(trace), stringifyStackTrace(trace)));
+      if (!hadSeenError) {
+        context.warning("Test failed due to logging an unexpected ERROR (above). "
+            "Expected error logs must be captured via KJ_EXPECT_LOG() or an ExceptionCallback.");
+      }
     } else {
       context.warning(text);
     }


### PR DESCRIPTION
In addition to throwing an exception, kj tests are also allowed to signal test failure by recording log output at either the ERROR or FATAL level; this is for example how KJ_EXPECT() is able to signal test failure while also continuing to run later code.

However, when testing code that logs errors, it's not obvious that the mere act of logging can be the cause of a test failure, which is a common source of confusion.  This commit outputs an additional message when a test fails due to a logged error, to hopefully make the failure reason clearer.