### PR TITLE
[coro] optimize ExceptionOrValue& from CoroutineBase

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3163,16 +3163,14 @@ Promise<void> IdentityFunc<Promise<void>>::operator()() const { return READY_NOW
 
 namespace _ {  // (private)
 
-CoroutineBase::CoroutineBase(stdcoro::coroutine_handle<> coroutine, ExceptionOrValue& resultRef,
-                             SourceLocation location)
+CoroutineBase::CoroutineBase(stdcoro::coroutine_handle<> coroutine, SourceLocation location)
     : Event(location),
-      coroutine(coroutine),
-      resultRef(resultRef) {}
+      coroutine(coroutine) {}
 CoroutineBase::~CoroutineBase() noexcept(false) {
   readMaybe(maybeDisposalResults)->destructorRan = true;
 }
 
-void CoroutineBase::unhandled_exception() {
+void CoroutineBase::unhandledExceptionImpl(ExceptionOrValue& resultRef) {
   // Pretty self-explanatory, we propagate the exception to the promise which owns us, unless
   // we're being destroyed, in which case we propagate it back to our disposer. Note that all
   // unhandled exceptions end up here, not just ones after the first co_await.


### PR DESCRIPTION
every byte counts.

Up to `0.5%` on `bm_Coro_Fib10`:


```
=== cachegrind.bm_Coro_Fib10.diff ===
-- Summary
--------------------------------------------------------------------------------
Ir____________________ I1mr_____________ ILmr____________ Dr_______________________ D1mr_______________ DLmr____________ Dw__________________ D1mw_____________ DLmw____________ Bc______________________ Bcm______________ Bi___________ Bim____________ 

  -101,019 (-0.5%, -0.5%)    -9 (-0.1%, -0.1%)    11 (0.3%, 0.3%)        -5  (-0.0%, -0.0%)     -4 (-0.0%, -0.0%)     7 (0.1%, 0.1%)   -61,001 (-1.3%, -1.3%)     3 (0.1%, 0.1%)     2 (0.1%, 0.1%)        -4 (-0.0%, -0.0%) -6,663 (-8.5%, -9.3%)       0 (0.0%, 0.0%)  6,998 (13.8%, 12.1%)  PROGRAM TOTALS

19,902,701             7,530             3,905            5,662,110                 10,962              6,557            4,677,393            3,277             1,976            2,295,879                78,139            409,317       50,704           file 1
19,801,682             7,521             3,916            5,662,105                 10,958              6,564            4,616,392            3,280             1,978            2,295,875                71,476            409,317       57,702           file 2

```