### PR TITLE
[coro] do not propagate exception during cancellation

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2345,6 +2345,9 @@ private:
   // already been called. To prove that our assumptions are correct in that function, we want to be
   // able to assert that `final_suspend()` has not yet been called. This boolean hack allows us to
   // preserve that assertion.
+  inline bool isDone() const { return finalSuspendCalled; }
+#else
+  inline bool isDone() const { return coroutine.done(); }
 #endif
 
   Maybe<OwnPromiseNode&> promiseNodeForTrace;

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3180,7 +3180,13 @@ void CoroutineBase::unhandled_exception() {
   auto exception = getCaughtExceptionAsKj();
 
   KJ_IF_SOME(disposalResults, maybeDisposalResults) {
-    // Exception during coroutine destruction. Only record the first one.
+    // Exception during coroutine destruction.
+    if (!isDone()) {
+      // do not report destructor exception during cancellation.
+      return;
+    }
+
+    // Record only the first one.
     if (disposalResults.exception == kj::none) {
       disposalResults.exception = kj::mv(exception);
     }
@@ -3199,13 +3205,7 @@ void CoroutineBase::unhandled_exception() {
     // Event we may have armed has not yet fired, because we haven't had a chance to return to
     // the event loop.
 
-    // final_suspend() has not been called.
-#if _MSC_VER && !defined(__clang__)
-    // See comment at `finalSuspendCalled`'s definition.
-    KJ_IASSERT(!finalSuspendCalled);
-#else
-    KJ_IASSERT(!coroutine.done());
-#endif
+    KJ_IASSERT(!isDone());
 
     // Since final_suspend() hasn't been called, whatever Event is waiting on us has not fired,
     // and will see this exception.


### PR DESCRIPTION
As discussed, the reasonings are:

- promise is destroyed there is no place to report an error
- clients have no good recourse to cancellation errors
- promise is usually cancelled as a result of error handling path

performance-neutral according to cachegrind