### PR TITLE
HTTP: Return 405 for unrecognized methods instead of 501.

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -4301,7 +4301,7 @@ KJ_TEST("HttpServer bad requests") {
       // invalid method
       .request = "bad request\r\n\r\n"_kj,
       .expectedResponse =
-          "HTTP/1.1 501 Not Implemented\r\n"
+          "HTTP/1.1 405 Method Not Allowed\r\n"
           "Connection: close\r\n"
           "Content-Length: 35\r\n"
           "Content-Type: text/plain\r\n"

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -972,7 +972,7 @@ HttpHeaders::RequestConnectOrProtocolError HttpHeaders::tryParseRequestOrConnect
 
   KJ_IF_SOME(method, consumeHttpMethod(ptr)) {
     if (*ptr != ' ' && *ptr != '\t') {
-      return ProtocolError { 501, "Not Implemented",
+      return ProtocolError { 405, "Method Not Allowed",
           "Unrecognized request method.", content };
     }
     ++ptr;
@@ -994,7 +994,7 @@ HttpHeaders::RequestConnectOrProtocolError HttpHeaders::tryParseRequestOrConnect
       }
     }
   } else {
-    return ProtocolError { 501, "Not Implemented",
+    return ProtocolError { 405, "Method Not Allowed",
         "Unrecognized request method.", content };
   }
 

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -408,7 +408,7 @@ public:
     uint statusCode;
     // Suggested HTTP status code that should be used when returning an error to the client.
     //
-    // Most errors are 400. An unrecognized method will be 501.
+    // Most errors are 400.
 
     kj::StringPtr statusMessage;
     // HTTP status message to go with `statusCode`, e.g. "Bad Request".


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/405