### PR TITLE
[async] allow observation of EventLoop

### DIFF
--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1347,7 +1347,7 @@ public:
       if (addrlen == 0) {
 #if __APPLE__
         // A bug in XNU (the macOS kernel) can cause accept() to return a socket but addrlen=0
-        // The socket is already dead and should be discarded 
+        // The socket is already dead and should be discarded
         // https://github.com/apple-oss-distributions/xnu/blob/e3723e1f17661b24996789d8afc084c0c3303b26/bsd/kern/uipc_syscalls.c#L663-L691
 #else
         KJ_LOG(ERROR, "accept() returned zero-size address?");
@@ -2053,16 +2053,18 @@ Own<LowLevelAsyncIoProvider> newLowLevelAsyncIoProvider(UnixEventPort& eventPort
   return kj::heap<LowLevelAsyncIoProviderImpl>(eventPort);
 }
 
-AsyncIoContext setupAsyncIo() {
+AsyncIoContext setupAsyncIo(kj::Maybe<EventLoopObserver&> observer) {
   struct BasicContext {
     UnixEventPort eventPort;
     EventLoop eventLoop;
     WaitScope waitScope;
 
-    BasicContext(): eventLoop(eventPort), waitScope(eventLoop) {}
+    BasicContext(kj::Maybe<EventLoopObserver&> observer)
+      : eventLoop(eventPort, observer),
+        waitScope(eventLoop) {}
   };
 
-  auto basicContext = heap<BasicContext>();
+  auto basicContext = heap<BasicContext>(observer);
   auto lowLevel = heap<LowLevelAsyncIoProviderImpl>(basicContext->eventPort);
   auto ioProvider = kj::heap<AsyncIoProviderImpl>(*lowLevel);
   auto& waitScope = basicContext->waitScope;

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -1169,7 +1169,7 @@ Own<LowLevelAsyncIoProvider> newLowLevelAsyncIoProvider(Win32EventPort& eventPor
   return kj::heap<LowLevelAsyncIoProviderImpl>(eventPort);
 }
 
-AsyncIoContext setupAsyncIo() {
+AsyncIoContext setupAsyncIo(kj::Maybe<EventLoopObserver&> observer) {
   _::initWinsockOnce();
 
   struct BasicContext {
@@ -1177,10 +1177,12 @@ AsyncIoContext setupAsyncIo() {
     EventLoop eventLoop;
     WaitScope waitScope;
 
-    BasicContext(): eventLoop(eventPort), waitScope(eventLoop) {}
+    BasicContext(kj::Maybe<EventLoopObserver&> observer)
+      : eventLoop(eventPort, observer),
+        waitScope(eventLoop) {}
   };
 
-  auto basicContext = heap<BasicContext>();
+  auto basicContext = heap<BasicContext>(observer);
   auto lowLevel = heap<LowLevelAsyncIoProviderImpl>(basicContext->eventPort);
   auto ioProvider = kj::heap<AsyncIoProviderImpl>(*lowLevel);
   auto& waitScope = basicContext->waitScope;

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -978,7 +978,7 @@ struct AsyncIoContext {
 #endif
 };
 
-AsyncIoContext setupAsyncIo();
+AsyncIoContext setupAsyncIo(kj::Maybe<EventLoopObserver&> observer = kj::none);
 // Convenience method which sets up the current thread with everything it needs to do async I/O.
 // The returned objects contain an `EventLoop` which is wrapping an appropriate `EventPort` for
 // doing I/O on the host system, so everything is ready for the thread to start making async calls


### PR DESCRIPTION
Introduces `EventLoopObserver` that allows monitoring of of event port events and thus measure event queue saturation.