### PR TITLE
[nfc] use thin lto for opt builds

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -18,7 +18,7 @@ env:
   INSTALL_DEPS: |
     install_deps() {
       local clang=$1
-      export DEBIAN_FRONTEND=noninteractive && sudo apt-get update && sudo apt-get install --no-upgrade --no-install-recommends -y clang-$clang libc++-$clang-dev libc++abi-$clang-dev libclang-rt-$clang-dev lld-$clang
+      export DEBIAN_FRONTEND=noninteractive && sudo apt-get update && sudo apt-get install --no-upgrade --no-install-recommends -y clang-$clang libc++-$clang-dev libc++abi-$clang-dev libclang-rt-$clang-dev lld-$clang llvm-$clang
     }
 
 jobs:
@@ -61,10 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         clang: [20]
-        driver: [bazel-opt]
-        include:
-          - driver: bazel-opt
-            run-test: cd c++ && bazel test --config=ci --config=opt //...
     steps:
       - uses: actions/checkout@v5
       - name: install dependencies
@@ -73,7 +69,9 @@ jobs:
         run: |
             export CC=clang-${{ matrix.clang }}
             export CXX=clang++-${{ matrix.clang }}
-            ${{ matrix.run-test }}
+            export LD=lld-${{ matrix.clang }}
+            export AR=llvm-ar-${{ matrix.clang }}
+            cd c++ && bazel test --config=ci --config=opt //...
   Linux-clang-arm64:
     runs-on: ubuntu-24.04-arm
     strategy:

--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -18,13 +18,13 @@ build:max-debug-info --copt='-mno-omit-leaf-frame-pointer'
 build:opt -c opt
 build:opt --copt='-O3'
 build:opt --linkopt="-Wl,-O3"
+build:opt --config=thin-lto
 
-build:thin-lto --config=opt
 build:thin-lto --cxxopt='-flto=thin'
 build:thin-lto --linkopt='-flto=thin'
 build:thin-lto --dynamic_mode=off
 
-build:profile --config=thin-lto
+build:profile --config=opt
 
 build:unix --cxxopt='-std=c++23' --host_cxxopt='-std=c++23' --force_pic
 build:unix --cxxopt='-Wall'

--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -151,21 +151,21 @@ KJ_TEST("Coroutine Frame sizes") {
     DebugCoroutineAllocator allocator;
     auto promise = immediateCoroutine(allocator);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 192);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 184);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 352);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 336);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib10(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 928);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 920);
   }
 }
 


### PR DESCRIPTION
This matches our configuration downstream