### PR TITLE
[nfc] fixing coro frame size test one more time

### DIFF
--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -19,6 +19,10 @@ build:opt -c opt
 build:opt --copt='-O3'
 build:opt --linkopt="-Wl,-O3"
 build:opt --config=thin-lto
+# Test coroutine frame sizes in opt build. 
+# This won't propagate to projects downstream and cause unnecessary breakage because of different
+# configuration
+build:opt --per_file_copt=src/kj/async-coroutine-alloc-test.c++@-DKJ_ASYNC_COROUTINE_ALLOC_TEST_ASSERT_FRAME_SIZE=1
 
 build:thin-lto --cxxopt='-flto=thin'
 build:thin-lto --linkopt='-flto=thin'

--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -135,7 +135,7 @@ kj::Promise<size_t> coroFib10(Allocator& alloc, size_t i) {
 }
 
 KJ_TEST("Coroutine Frame sizes") {
-#if defined(__clang__) && __clang_major__ >= 20 && defined(NDEBUG)
+#if defined(__clang__) && defined(KJ_ASYNC_COROUTINE_ALLOC_TEST_ASSERT_FRAME_SIZE)
   // Coroutine size varies between compilers and optimization level. We still want to keep track
   // of coroutine sizes. Thus restrict check to newest clang opt build.
   // We intentionally keep the upper bound open to detect when production compiler deviates.


### PR DESCRIPTION
Downstream configuration is stubbornly different. Make sure that frame sizes are asserted only when running directly.