### PR TITLE
[coro] throwy parameter test with fix

### DIFF
--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -484,7 +484,8 @@ struct ThrowInDestructor {
   UnwindDetector unwindDetector;
 };
 
-Promise<size_t> fortyTwo(ThrowInDestructor arg) {
+Promise<size_t> fortyTwo(ThrowInDestructor arg, Promise<void> wait) {
+  co_await wait;
   co_return 42;
 }
 
@@ -492,19 +493,18 @@ KJ_TEST("Exception thrown by parameter destructor rejects the promise") {
   EventLoop loop;
   WaitScope waitScope(loop);
 
-  auto promise = fortyTwo(ThrowInDestructor());
+  auto promise = fortyTwo(ThrowInDestructor(), READY_NOW);
   KJ_EXPECT_THROW_MESSAGE("~ThrowInDestructor()", promise.wait(waitScope));
 }
 
-// TODO(mikea): this behavior is wrong, we want to ignore all exceptions during cancellation.
-KJ_TEST("Exception thrown by parameter destructor during cancellation rejects the promise") {
+KJ_TEST("Exception thrown by parameter destructor during cancellation is ignored") {
   EventLoop loop;
   WaitScope waitScope(loop);
 
-  auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
-      (void)fortyTwo(ThrowInDestructor());
-  }));
-  KJ_EXPECT(exception.getDescription() == "~ThrowInDestructor()");
+  auto exception = kj::runCatchingExceptions([&]() {
+      (void)fortyTwo(ThrowInDestructor(), NEVER_DONE);
+  });
+  KJ_EXPECT(exception == kj::none);
 }
 
 #if !_MSC_VER && !__aarch64__

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2445,7 +2445,6 @@ private:
 
   struct DisposalResults {
     bool destructorRan = false;
-    Maybe<Exception> exception;
   };
   Maybe<DisposalResults&> maybeDisposalResults;
   // Only non-null during destruction. Before calling coroutine.destroy(), our disposer sets this

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3175,32 +3175,29 @@ CoroutineBase::~CoroutineBase() noexcept(false) {
 }
 
 void CoroutineBase::unhandledExceptionImpl(ExceptionOrValue& resultRef) {
-  // Pretty self-explanatory, we propagate the exception to the promise which owns us, unless
-  // we're being destroyed, in which case we propagate it back to our disposer. Note that all
-  // unhandled exceptions end up here, not just ones after the first co_await.
+  // We propagate the exception to the promise which owns us, unless
+  // we're being destroyed.
 
-  auto exception = getCaughtExceptionAsKj();
-  
-  KJ_IF_SOME(disposalResults, maybeDisposalResults) {
-    // Exception during coroutine destruction.
+  if (maybeDisposalResults != kj::none) {
+    // Coroutine is destroyed.
+
     if (!isDone()) {
-      // do not report destructor exception during cancellation.
+      // Ignore cancellation exceptions
       return;
     }
 
-    // Record only the first one.
-    if (disposalResults.exception == kj::none) {
-      disposalResults.exception = kj::mv(exception);
-    }
-  } else {
-    resultRef.addException(kj::mv(exception));
-    if (!onReadyEvent.armed()) {
-      // Exception during coroutine execution.
-      onReadyEvent.arm();
-    } 
-    // Otherwise this is an exception during during coroutine frame-unwind
-    // in-between co_return and final_suspend().
+    // Coroutine has already finished.
+    // Let .destroy() caller handle destructor exceptions
+    throw;
   }
+
+  resultRef.addException(getCaughtExceptionAsKj());
+  if (!onReadyEvent.armed()) {
+    // Exception during coroutine execution.
+    onReadyEvent.arm();
+  }
+  // Otherwise this is an exception during during coroutine frame-unwind
+  // in-between co_return and final_suspend().
 }
 
 void CoroutineBase::onReady(Event* event) noexcept {
@@ -3259,6 +3256,9 @@ void CoroutineBase::destroy() {
   DisposalResults disposalResults;
   maybeDisposalResults = &disposalResults;
 
+  bool done = isDone();
+  kj::Maybe<Exception> disposalException;
+
   do {
     // Clang's implementation of Coroutines does not destroy the Coroutine object or deallocate the
     // coroutine frame if a destructor of an object on the frame threw an exception. This is despite
@@ -3268,14 +3268,27 @@ void CoroutineBase::destroy() {
     // On Clang, `disposalResults.exception != kj::none` implies `!disposalResults.destructorRan`.
     // We could optimize out the separate `destructorRan` flag if we verify that other compilers
     // behave the same way.
-    coroutine.destroy();
+    try {
+#if defined(_MSC_VER)
+      // MSVC (and clang-cl) simply refuse to catch the exception below unless this noop
+      // is present.
+      if (bool b = false; b) { KJ_UNREACHABLE; }
+#endif
+      coroutine.destroy();
+    } catch (...) {
+      if (disposalException == kj::none) {
+        auto e = kj::getCaughtExceptionAsKj();
+        disposalException = kj::mv(e);
+      }
+    }
   } while (!disposalResults.destructorRan);
+
 
   // WARNING: `this` is now a dangling pointer.
 
-  KJ_IF_SOME(exception, disposalResults.exception) {
-    if (UnwindDetector::uncaughtExceptionCount() == 0) {
-      // Technically this does not equal the `UnwindDetector` logic, 
+  KJ_IF_SOME(exception, disposalException) {
+    if (UnwindDetector::uncaughtExceptionCount() == 0 && done) {
+      // Technically this does not equal the `UnwindDetector` logic,
       // but this behaviour will never lead to trouble, is almost always true on practice
       // (only coroutines _created_ during unwind could notice a difference in behaviour),
       // and, more importantly, much faster.


### PR DESCRIPTION
reapplying the original test (was crashing on arm downstream) with a fix for desired behavior - ignoring cancellation exception.