### PR TITLE
[ci] enable proper exception handling on windows

### DIFF
--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -70,6 +70,8 @@ build:windows --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-cla
 build:windows --extra_execution_platforms=//:x64_windows-clang-cl
 
 build:windows --cxxopt='/std:c++23preview' --host_cxxopt='/std:c++23preview'
+# Enable proper C++ exceptions
+build:windows --cxxopt='/EHs' --host_cxxopt='/EHs'
 # The `/std:c++23preview` argument is unused during boringssl compilation and we don't
 # want a warning when compiling each file.
 build:windows --cxxopt='-Wno-unused-command-line-argument' --host_cxxopt='-Wno-unused-command-line-argument'

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -11,7 +11,7 @@ include(CheckIncludeFileCXX)
 include(GNUInstallDirs)
 # <print> header was added in C++23
 if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++23preview")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++23preview /EHs")
   check_include_file_cxx(print HAS_CXX23)
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++23")


### PR DESCRIPTION
Default mode is weird: https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170#default-exception-handling-behavior