### PR TITLE
define virtual destructor for TaskSet::ErrorHandler

### DIFF
--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -961,6 +961,7 @@ class TaskSet: private AsyncObject {
 public:
   class ErrorHandler {
   public:
+    virtual ~ErrorHandler() noexcept(false) = default;
     virtual void taskFailed(kj::Exception&& exception) = 0;
   };
 


### PR DESCRIPTION
needs to be noexcept(false) since some implementations (HttpServer) are noexcept(false)