### PR TITLE
Revert "define virtual destructor for TaskSet::ErrorHandler"

### DIFF
--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -961,7 +961,6 @@ class TaskSet: private AsyncObject {
 public:
   class ErrorHandler {
   public:
-    virtual ~ErrorHandler() noexcept(false) = default;
     virtual void taskFailed(kj::Exception&& exception) = 0;
   };
 


### PR DESCRIPTION
Reverts capnproto/capnproto#2544

Virtual destructors on abstract interfaces are against KJ style and no explanation was given for why this is needed.