### PR TITLE
Add KJ_DEFER() block syntax to avoid -Wdangling-else warnings

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -1107,6 +1107,31 @@ KJ_TEST("kj::defer()") {
 
 }
 
+KJ_TEST("KJ_DEFER() block syntax") {
+  // Test the KJ_DEFER() { ... }; block syntax, which allows statement macros like KJ_IF_SOME
+  // inside the deferred code without triggering -Wdangling-else warnings.
+  uint i = 0;
+
+  {
+    KJ_DEFER() { ++i; };
+    KJ_EXPECT(i == 0);
+  }
+  KJ_EXPECT(i == 1);
+
+  // Test that KJ_IF_SOME works inside KJ_DEFER() without warnings.
+  Maybe<int> maybeVal = 42;
+  int captured = 0;
+  {
+    KJ_DEFER() {
+      KJ_IF_SOME(val, maybeVal) {
+        captured = val;
+      }
+    };
+    KJ_EXPECT(captured == 0);
+  }
+  KJ_EXPECT(captured == 42);
+}
+
 KJ_TEST("kj::ArrayPtr startsWith / endsWith / findFirst / findLast") {
   // Note: char-/byte- optimized versions are covered by string-test.c++.
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2219,6 +2219,14 @@ private:
   // out.
 };
 
+struct DeferHelper {
+  // Helper for KJ_DEFER() { ... }; syntax. The operator* takes a lambda and returns a Deferred.
+  template <typename Func>
+  Deferred<Func> operator*(Func&& func) {
+    return Deferred<Func>(kj::fwd<Func>(func));
+  }
+};
+
 }  // namespace _ (private)
 
 template <typename Func>
@@ -2237,8 +2245,24 @@ _::Deferred<Func> defer(Func&& func) {
   return _::Deferred<Func>(kj::fwd<Func>(func));
 }
 
-#define KJ_DEFER(code) auto KJ_UNIQUE_NAME(_kjDefer) = ::kj::defer([&](){code;})
+// Selects between:
+//   KJ_DEFER(code);      -> legacy syntax, code inside macro argument
+//   KJ_DEFER() { code }; -> block syntax, code outside macro argument
+#define KJ_DEFER_LEGACY_(code) auto KJ_UNIQUE_NAME(_kjDefer) = ::kj::defer([&](){code;})
+#define KJ_DEFER_BLOCK_ auto KJ_UNIQUE_NAME(_kjDefer) = ::kj::_::DeferHelper{} * [&]()
+#define KJ_DEFER_SELECT_(_0, _1, selected, ...) selected
+#define KJ_DEFER(...) KJ_DEFER_SELECT_(_placeholder __VA_OPT__(,) __VA_ARGS__, \
+    KJ_DEFER_LEGACY_(__VA_ARGS__), KJ_DEFER_BLOCK_)
 // Run the given code when the function exits, whether by return or exception.
+//
+// Two syntaxes are supported:
+//
+//     KJ_DEFER(doSomething());              // Traditional syntax (code as macro argument)
+//     KJ_DEFER() { doSomething(); };        // Block syntax (code outside macro argument)
+//
+// The block syntax is preferred when the deferred code itself uses statement macros like
+// KJ_IF_SOME, because those macros use _Pragma directives that don't work correctly when
+// nested inside another macro's arguments.
 
 // =======================================================================================
 // IsDisallowedInCoroutine


### PR DESCRIPTION
Possible fix for the dangling else issue uncovered in https://github.com/capnproto/capnproto/pull/2536#discussion_r2755945147.

I asked Claude to cook up a backwards-compatible block-style KJ_DEFER implementation. I think it might be worthwhile.

--- 

KJ_IF_SOME uses a deliberate dangling-else pattern with _Pragma to suppress warnings. However, _Pragma doesn't work correctly when KJ_IF_SOME is nested inside another macro's arguments (like KJ_DEFER), because the pragma is processed during argument prescan before the outer macro completes expansion.

This adds a new block syntax: KJ_DEFER() { code; };

The empty parentheses signal the new syntax, which places the lambda body outside the macro argument, allowing _Pragma to work correctly. The traditional KJ_DEFER(code) syntax remains supported for backward compatibility.