### PR TITLE
Add match() function to CidrRange for string IP address

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1233,6 +1233,41 @@ KJ_TEST("CIDR parsing") {
   }
 }
 
+KJ_TEST("CidrRange::matches") {
+  KJ_EXPECT(CidrRange("1.2.255.255/18").matches("1.2.223.255"));
+  KJ_EXPECT(!CidrRange("1.2.255.255/19").matches("1.2.223.255"));
+  KJ_EXPECT(CidrRange("1.2.0.0/16").matches("1.2.223.255"));
+  KJ_EXPECT(!CidrRange("1.3.0.0/16").matches("1.2.223.255"));
+  KJ_EXPECT(CidrRange("1.2.223.255/32").matches("1.2.223.255"));
+  KJ_EXPECT(!CidrRange("192.168.1.1/32").matches("192.168.1.2"));
+  KJ_EXPECT(CidrRange("0.0.0.0/0").matches("1.2.223.255"));
+  KJ_EXPECT(CidrRange("0.0.0.0/0").matches("255.255.255.255"));
+  KJ_EXPECT(!CidrRange("::/0").matches("1.2.223.255"));
+
+  KJ_EXPECT(CidrRange("0102:03ff::/24").matches("0102:0304:0506:0708:090a:0b0c:0d0e:0f10"));
+  KJ_EXPECT(!CidrRange("0102:02ff::/24").matches("0102:0304:0506:0708:090a:0b0c:0d0e:0f10"));
+  KJ_EXPECT(CidrRange("0102:02ff::/23").matches("0102:0304:0506:0708:090a:0b0c:0d0e:0f10"));
+  KJ_EXPECT(CidrRange("0102:0304:0506:0708:090a:0b0c:0d0e:0f10/128")
+      .matches("0102:0304:0506:0708:090a:0b0c:0d0e:0f10"));
+  KJ_EXPECT(CidrRange("::1/128").matches("::1"));
+  KJ_EXPECT(!CidrRange("::1/128").matches("::2"));
+  KJ_EXPECT(CidrRange("::/0").matches("0102:0304:0506:0708:090a:0b0c:0d0e:0f10"));
+  KJ_EXPECT(CidrRange("::/0").matches("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+  KJ_EXPECT(!CidrRange("0.0.0.0/0").matches("0102:0304:0506:0708:090a:0b0c:0d0e:0f10"));
+
+  KJ_EXPECT(CidrRange("1.2.255.255/18").matches("::ffff:1.2.223.255"));
+  KJ_EXPECT(!CidrRange("1.2.255.255/19").matches("::ffff:1.2.223.255"));
+  KJ_EXPECT(CidrRange("1.2.0.0/16").matches("::ffff:1.2.223.255"));
+  KJ_EXPECT(!CidrRange("1.3.0.0/16").matches("::ffff:1.2.223.255"));
+  KJ_EXPECT(CidrRange("1.2.223.255/32").matches("::ffff:1.2.223.255"));
+  KJ_EXPECT(CidrRange("0.0.0.0/0").matches("::ffff:1.2.223.255"));
+  KJ_EXPECT(CidrRange("::/0").matches("::ffff:1.2.223.255"));
+
+  KJ_EXPECT_THROW_MESSAGE("Invalid IP address", CidrRange("0.0.0.0/0").matches("not-an-ip"));
+  KJ_EXPECT_THROW_MESSAGE("Invalid IP address", CidrRange("0.0.0.0/0").matches(""));
+  KJ_EXPECT_THROW_MESSAGE("Invalid IP address", CidrRange("0.0.0.0/0").matches("1.2.3.4/24"));
+}
+
 bool allowed4(_::NetworkFilter& filter, StringPtr addrStr) {
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));

--- a/c++/src/kj/cidr.h
+++ b/c++/src/kj/cidr.h
@@ -46,6 +46,7 @@ public:
   uint getSpecificity() const { return bitCount; }
 
   bool matches(const struct sockaddr* addr) const;
+  bool matches(StringPtr addr) const;
   bool matchesFamily(int family) const;
 
   String toString() const;


### PR DESCRIPTION
Consumers of kj::CidrRange had to manually parse a string address with sockaddr_storage+sockaddr_in. It's verbose and they have to handle `inet_pton` includes for both Unix/Windows platforms.