### PR TITLE
Fix cross-type Maybe assignment to not copy source Maybe

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1808,7 +1808,7 @@ public:
 
   template <typename U>
   Maybe& operator=(Maybe<U>&& other) {
-    Maybe<U> temp(kj::mv(other));
+    Maybe temp(kj::mv(other));
     KJ_IF_SOME(value, kj::mv(temp)) {
       ptr.emplace(kj::mv(value));
     } else {
@@ -1818,8 +1818,8 @@ public:
   }
   template <typename U>
   Maybe& operator=(const Maybe<U>& other) {
-    Maybe<U> temp(other);
-    KJ_IF_SOME(value, temp) {
+    Maybe temp(other);
+    KJ_IF_SOME(value, kj::mv(temp)) {
       ptr.emplace(kj::mv(value));
     } else {
       *this = kj::none;


### PR DESCRIPTION
I managed to screw up again -- my previous fix broke "copy" assignment from `Maybe<String>` to `Maybe<StringPtr>`. I'm not sure how I missed this; I distinctly remember running all downstream tests. :/

Claude's prose follows.

---

When assigning `Maybe<T>` from `Maybe<U>` (cross-type), the assignment operators were constructing a Maybe<U> temporary, which requires U to be copyable. This broke cases like assigning `Maybe<StringPtr>` from `Maybe<String>`, since String is not copyable.

The fix is to construct a `Maybe<T>` temporary instead, using the existing converting constructors. This converts U -> T directly without needing to copy the `Maybe<U>`. The converting constructors already handle nullifying the source for move operations.

Added tests for:
- `Maybe<StringPtr>` assigned from `Maybe<String>` (the original bug)
- Cross-type assignment with move-only types (`Own<Derived>` -> `Own<Base>`)
- Self-assignment (m = m, m = kj::mv(m))