### PR TITLE
Reapply "optimize CoroutineBase::waiting flag out"

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -338,6 +338,8 @@ protected:
       if (event != nullptr && !builder.full()) event->traceEvent(builder);
     }
 
+    bool armed() const;
+
   private:
     Event* event = nullptr;
   };
@@ -2398,11 +2400,7 @@ public:
   }
 
 protected:
-  bool isWaiting() { return waiting; }
-  void scheduleResumption() {
-    onReadyEvent.arm();
-    waiting = false;
-  }
+  inline void scheduleResumption() { onReadyEvent.arm(); }
 
   void unhandledExceptionImpl(ExceptionOrValue& resultRef);
 
@@ -2422,7 +2420,6 @@ private:
   stdcoro::coroutine_handle<> coroutine;
 
   OnReadyEvent onReadyEvent;
-  bool waiting = true;
 
   bool hasSuspendedAtLeastOnce = false;
 
@@ -2519,10 +2516,8 @@ public:
   void fulfill(FixVoid<T>&& value) {
     // Called by the return_value()/return_void() functions in our mixin class.
 
-    if (isWaiting()) {
-      result = kj::mv(value);
-      scheduleResumption();
-    }
+    result = kj::mv(value);
+    scheduleResumption();
   }
 
   void unhandled_exception() { unhandledExceptionImpl(result); }


### PR DESCRIPTION
This reverts commit 86129e875868dfc89167e2dca42868eb564d5701.

We thought it broke downstream, but looks like it doesn't.