### PR TITLE
[build] Add define to consistently enable CRC32 hash

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -226,6 +226,7 @@ typedef unsigned char byte;
 
 #if defined(_MSC_VER) && !__clang__
 #define KJ_NORETURN(prototype) __declspec(noreturn) prototype
+#define KJ_USED
 #define KJ_UNUSED
 #define KJ_WARN_UNUSED_RESULT
 // TODO(msvc): KJ_WARN_UNUSED_RESULT can use _Check_return_ on MSVC, but it's a prefix, so
@@ -233,6 +234,7 @@ typedef unsigned char byte;
 //   Similarly, KJ_UNUSED could use __pragma(warning(suppress:...)), but again that's a prefix.
 #else
 #define KJ_NORETURN(prototype) prototype __attribute__((noreturn))
+#define KJ_USED __attribute__((used))
 #define KJ_UNUSED __attribute__((unused))
 #define KJ_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #endif

--- a/c++/src/kj/configure.bzl
+++ b/c++/src/kj/configure.bzl
@@ -48,6 +48,11 @@ def kj_configure():
         build_setting_default = False,
     )
 
+    bool_flag(
+        name = "kj_crc32_hash",
+        build_setting_default = False,
+    )
+
     # Settings to use in select() expressions
     native.config_setting(
         name = "use_openssl",
@@ -89,6 +94,12 @@ def kj_configure():
         name = "use_kj_enable_irequire",
         flag_values = {"kj_enable_irequire": "True"},
     )
+
+    native.config_setting(
+        name = "use_kj_crc32_hash",
+        flag_values = {"kj_crc32_hash": "True"},
+    )
+
     cc_library(
         name = "kj-defines",
         defines = select({
@@ -114,6 +125,9 @@ def kj_configure():
             "//conditions:default": [],
         }) + select({
             "//src/kj:use_kj_enable_irequire": ["KJ_ENABLE_IREQUIRE=1"],
+            "//conditions:default": [],
+        }) + select({
+            "//src/kj:use_kj_crc32_hash": ["KJ_HAS_CRC32=1"],
             "//conditions:default": [],
         }),
     )

--- a/c++/src/kj/hash.c++
+++ b/c++/src/kj/hash.c++
@@ -61,5 +61,17 @@ uint HashCoder::operator*(ArrayPtr<const byte> s) const {
   return h;
 }
 
+// Enforce that if the CRC32 integer hash is enabled on any translation unit, it will be enabled on
+// all of them to avoid ODR violations.
+#if KJ_HAS_CRC32
+#if defined (__CRC32__) || defined (__ARM_FEATURE_CRC32)
+const char kjCrc32HashEnabled = 0;
+#else
+#error "CRC32 hardware support must be available when KJ_HAS_CRC32 is set."
+#endif
+#else
+const char kjCrc32HashDisabled = 0;
+#endif
+
 }  // namespace _ (private)
 } // namespace kj

--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -24,9 +24,12 @@
 #include "string.h"
 #include <stdint.h>
 
-// clang has dedicated builtins for crc32 on arm64, for GCC we fall back to ARM ACLE intrinsics.
+// When crc32 is enabled and we have clang, use the dedicated builtins for crc32 on arm64, for GCC
+// we fall back to ARM ACLE intrinsics.
+#if KJ_HAS_CRC32
 #if __ARM_FEATURE_CRC32 && !__clang__
 #include <arm_acle.h>
+#endif
 #endif
 
 KJ_BEGIN_HEADER
@@ -237,13 +240,20 @@ inline uint intHash32(uint32_t i) {
 
   // On architectures with a hardware CRC32 instruction, use it. Otherwise fall back to a
   // reasonable shifty hash.
+  // To avoid mixing code using CRC32 and not using it, we either don't use crc32 (when KJ_HAS_CRC32
+  // is undefined) or require that hardware support for it is available. The define should always
+  // be used consistently, if it is not the link-time kjCrcHashGuard check will catch it.
+#if KJ_HAS_CRC32
 #if __CRC32__
   return __builtin_ia32_crc32si(0, i);
 #elif __ARM_FEATURE_CRC32
 #ifdef __clang__
-  return __builtin_arm_crc32w(0, i);
+  return __builtin_arm_crc32cw(0, i);
 #else
   return __crc32w(0, i);
+#endif
+#else
+#error "CRC32 hardware support must be available when KJ_HAS_CRC32 is set."
 #endif
 #else
   // Thomas Wang 32 bit integer hash function from https://gist.github.com/badboy/6267743
@@ -270,13 +280,17 @@ inline uint intHash64(uint64_t i) {
     return intHash32(i);
   }
 
+#if KJ_HAS_CRC32
 #if __CRC32__
   return __builtin_ia32_crc32di(0, i);
 #elif __ARM_FEATURE_CRC32
 #ifdef __clang__
-  return __builtin_arm_crc32d(0, i);
+  return __builtin_arm_crc32cd(0, i);
 #else
   return __crc32d(0, i);
+#endif
+#else
+#error "CRC32 hardware support must be available when KJ_HAS_CRC32 is set."
 #endif
 #else
   // Thomas Wang hash6432shift() from https://gist.github.com/badboy/6267743

--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -226,6 +226,19 @@ inline uint HashCoder::operator*(T e) const {
   return operator*(static_cast<__underlying_type(T)>(e));
 }
 
+// Ensure we don't mix different hash implementations. The template will only be instantiated in
+// translation units where intHash32 or intHash64 are called, so there is no overhead otherwise.
+extern const char kjCrc32HashEnabled;
+extern const char kjCrc32HashDisabled;
+
+template <bool enabled>
+struct kjCrcHashGuard {
+    kjCrcHashGuard() {
+    KJ_USED static constexpr const char* value =
+        enabled ? &kjCrc32HashEnabled : &kjCrc32HashDisabled;
+    }
+};
+
 inline uint intHash32(uint32_t i) {
   // Basic 32-bit integer hash function.
   //
@@ -244,18 +257,22 @@ inline uint intHash32(uint32_t i) {
   // is undefined) or require that hardware support for it is available. The define should always
   // be used consistently, if it is not the link-time kjCrcHashGuard check will catch it.
 #if KJ_HAS_CRC32
+  kjCrcHashGuard<true> guard;
+  (void)guard;
 #if __CRC32__
   return __builtin_ia32_crc32si(0, i);
 #elif __ARM_FEATURE_CRC32
 #ifdef __clang__
   return __builtin_arm_crc32cw(0, i);
 #else
-  return __crc32w(0, i);
+  return __crc32cw(0, i);
 #endif
 #else
 #error "CRC32 hardware support must be available when KJ_HAS_CRC32 is set."
 #endif
 #else
+  kjCrcHashGuard<false> guard;
+  (void)guard;
   // Thomas Wang 32 bit integer hash function from https://gist.github.com/badboy/6267743
   // This page says it's public domain: http://burtleburtle.net/bob/hash/integer.html
   i = ~i + (i << 15); // i = (i << 15) - i - 1;
@@ -281,18 +298,22 @@ inline uint intHash64(uint64_t i) {
   }
 
 #if KJ_HAS_CRC32
+  kjCrcHashGuard<true> guard;
+  (void)guard;
 #if __CRC32__
   return __builtin_ia32_crc32di(0, i);
 #elif __ARM_FEATURE_CRC32
 #ifdef __clang__
   return __builtin_arm_crc32cd(0, i);
 #else
-  return __crc32d(0, i);
+  return __crc32cd(0, i);
 #endif
 #else
 #error "CRC32 hardware support must be available when KJ_HAS_CRC32 is set."
 #endif
 #else
+  kjCrcHashGuard<false> guard;
+  (void)guard;
   // Thomas Wang hash6432shift() from https://gist.github.com/badboy/6267743
   // This page says it's public domain (inthash.c):
   //     https://github.com/markokr/pghashlib/blob/master/COPYRIGHT

--- a/c++/src/kj/hash.h
+++ b/c++/src/kj/hash.h
@@ -233,10 +233,10 @@ extern const char kjCrc32HashDisabled;
 
 template <bool enabled>
 struct kjCrcHashGuard {
-    kjCrcHashGuard() {
+  kjCrcHashGuard() {
     KJ_USED static constexpr const char* value =
         enabled ? &kjCrc32HashEnabled : &kjCrc32HashDisabled;
-    }
+  }
 };
 
 inline uint intHash32(uint32_t i) {


### PR DESCRIPTION
This should eliminate the footgun here. We use a define that basically means: I promise to use this define on all code that ends up including KJ headers; and I will enable the required hardware extensions (this part is enforced through a compiler error). This way, we can enable CRC extensions in the downstream project (where we can configure hardware extensions well) and for workerd release builds (hard to set in the general case, but easy enough if we only have to do it for release CI).