### PR TITLE
use static disposer for Exception storage

### DIFF
--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -151,21 +151,21 @@ KJ_TEST("Coroutine Frame sizes") {
     DebugCoroutineAllocator allocator;
     auto promise = immediateCoroutine(allocator);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 176);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 168);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 304);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 280);
   }
 
   {
     DebugCoroutineAllocator allocator;
     auto promise = coroFib10(allocator, 10);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 816);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 728);
   }
 }
 

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -984,7 +984,7 @@ String KJ_STRINGIFY(const Exception& e) {
              stringifyStackTrace(e.getStackTrace()));
 }
 
-static_assert(sizeof(kj::Exception) == 2 * sizeof(size_t),
+static_assert(sizeof(kj::Exception) == sizeof(size_t),
     "exception type is too big, please keep it lean");
 
 Exception::Exception(Type type, const char* file, int line, String description) noexcept {

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -190,7 +190,11 @@ private:
     kj::Vector<Detail> details;
   };
 
-  kj::Own<Storage> storage = kj::heap<Storage>();
+  struct StorageDisposer {
+    static void dispose(Storage* storage) { delete storage; }
+  };
+
+  kj::Own<Storage, StorageDisposer> storage { new Storage() };
   // It is very important for sizeof(kj::Exception) to be small, since it is used in result types
   // everywhere. Encapsulate all storage in a heap-allocated object.
 


### PR DESCRIPTION
This reduces ExceptionOr size even further and has the biggest effect on coroutines with many awaiters.

Memory wins are really big for many co_awaitors case: 816->728 bytes in our benchmark with 10 of them.

Also translate to minor performance wins across the stack, with biggest outliers bm_Coro_Pow2_20 (-0.9%), bm_Coro_Fib10 (-0.7%) along with promise benchmarks: bm_Promise_Fib10 (-0.5%), bm_Promise_Pow2_20 (-0.4%)

https://gist.github.com/mikea/1974e80b41166477185ac9a2d6830e9e