### PR TITLE
Avoid signal starvation caused by rapidly repeating timers

### DIFF
--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -1025,6 +1025,26 @@ KJ_TEST("UnixEventPort poll for signals") {
   promise2.wait(waitScope);
 }
 
+KJ_TEST("UnixEventPort wait for signals with repeating timer") {
+  captureSignals();
+  UnixEventPort port;
+  EventLoop loop(port);
+  WaitScope waitScope(loop);
+
+  auto promise1 = port.onSignal(SIGIO).ignoreResult();
+  auto promise2 = [&]() -> kj::Promise<void> {
+    while (true) {
+      co_await port.getTimer().afterDelay(kj::NANOSECONDS);
+    }
+  }();
+
+  KJ_SYSCALL(kill(getpid(), SIGIO));
+
+  port.getTimer().timeoutAfter(
+    kj::SECONDS*5,
+    promise1.exclusiveJoin(kj::mv(promise2))).wait(waitScope);
+}
+
 #if defined(SIGRTMIN) && !__CYGWIN__ && !__aarch64__
 // TODO(someday): Figure out why RT signals don't seem to work correctly on Cygwin. It looks like
 //   only the first signal is delivered, like how non-RT signals work. Is it possible Cygwin

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -597,6 +597,13 @@ bool UnixEventPort::wait() {
     //   the parent process exit while the child thread lives on. In this case, if a UnixEventPort
     //   had been created before daemonizing, signal handling would be forever broken in the child.
 
+    // If the timeout is zero, use the alternative approach implemented by poll()
+    // to deliver pending signals. Otherwise a repeating timer with a timeout less than
+    // 1ms resolution will prevent signals from ever being delivered.
+    if (timeout == 0) {
+      return poll();
+    }
+
     sigset_t waitMask = originalMask;
 
     // Unblock the signals we care about.


### PR DESCRIPTION
A kj::Timer of duration less than 1ms prevents signals from being delivered. Repeating timers of such duration prevent signals from ever being delivered.