### PR TITLE
optimize ExceptionOr<T> operator=

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -67,7 +67,7 @@ protected:
   // Allow subclasses to have move constructor / assignment.
   ExceptionOrValue() = default;
   ExceptionOrValue(ExceptionOrValue&& other) = default;
-  ExceptionOrValue& operator=(ExceptionOrValue&& other) = default;
+  ExceptionOrValue& operator=(ExceptionOrValue&&) = delete;
 };
 
 template <typename T>
@@ -77,7 +77,14 @@ public:
   ExceptionOr(T&& value): value(kj::mv(value)) {}
   ExceptionOr(bool, Exception&& exception): ExceptionOrValue(false, kj::mv(exception)) {}
   ExceptionOr(ExceptionOr&&) = default;
-  ExceptionOr& operator=(ExceptionOr&&) = default;
+
+  inline ExceptionOr& operator=(ExceptionOr&& other) {
+    KJ_IREQUIRE(value == kj::none && exception == kj::none,
+        "ExceptionOr must be empty to be assigned to.");
+    value.emplaceInit(kj::mv(other.value));
+    exception.emplaceInit(kj::mv(other.exception));
+    return *this;
+  }
 
   Maybe<T> value;
 };

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -803,6 +803,36 @@ TEST(Async, RaceSuccessful) {
   }
 
   {
+    EventLoop loop;
+    WaitScope waitScope(loop);
+
+    auto left = newPromiseAndFulfiller<int>();
+    auto right = newPromiseAndFulfiller<int>();
+
+    auto race = raceSuccessful(kj::arr(kj::mv(left.promise), kj::mv(right.promise)));
+
+    left.fulfiller->reject(KJ_EXCEPTION(FAILED, "left failed"));
+    right.fulfiller->reject(KJ_EXCEPTION(FAILED, "right failed"));
+
+    KJ_EXPECT_THROW(FAILED, race.wait(waitScope));
+  }
+
+  {
+    EventLoop loop;
+    WaitScope waitScope(loop);
+
+    auto left = newPromiseAndFulfiller<int>();
+    auto right = newPromiseAndFulfiller<int>();
+
+    auto race = raceSuccessful(kj::arr(kj::mv(left.promise), kj::mv(right.promise)));
+
+    left.fulfiller->reject(KJ_EXCEPTION(FAILED, "left failed"));
+    right.fulfiller->fulfill(123);
+
+    EXPECT_EQ(123, race.wait(waitScope));
+  }
+
+  {
     struct NoCopy {
       int i;
 

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -2912,6 +2912,9 @@ Maybe<Own<Event>> RaceSuccessfulPromiseNodeBase::Branch::fire() {
   }
 
   auto count = --parent.countLeft;
+  // This is either the first fire() or all previous ones have failed.
+  // In such case we need to clear the previous exception.
+  parent.output.exception = kj::none;
   promise->get(parent.output);
 
   if (parent.output.exception == kj::none) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1397,7 +1397,10 @@ public:
     return *this;
   }
 
-  inline bool operator==(decltype(nullptr)) const { return !isSet; }
+  inline bool operator==(decltype(nullptr)) const {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn) really confused by coros
+    return !isSet;
+  }
 
   NullableValue(const T* t) = delete;
   NullableValue& operator=(const T* other) = delete;


### PR DESCRIPTION
(This build on top of https://github.com/capnproto/capnproto/pull/2592)

As noticed in https://github.com/capnproto/capnproto/pull/2592 this _typical_ code:

```
  void get(ExceptionOrValue& output) noexcept override {
    output.as<FixVoid<T>>() = kj::mv(result);
  }
```

results in compiler generating ~T and ~Exception calls.

This change makes operator= valid only with empty ExceptionOr and uses emplaceInit methods to generate more efficient code. This gives a free perf boost (https://gist.github.com/mikea/a6f11a3e082aa8d35c282a47dff49cbd):

- 3.6% on bm_Http_FullProtocol
- 5.5% is the biggest improvement for bm_Promise_Fib10


I have explored other design options, in particular, making get look like `get(kj::SpaceFor<ExceptionOrValue>&)` with various attempts to make this type safer, but 

a) all the bloat didn't materialize in performance gain
b) the changes are huge and risky and hard to land

so I think this represents a pragmatic middle ground. I'm curious what you think @kentonv 

Also worth mentioning that this PR is required to make full use of https://github.com/capnproto/capnproto/pull/2586 (otherwise inlining blows up ir cache, and I'd rather kept inlining since it is the whole purpose of optimization)