### PR TITLE
[maybe] emplaceInit

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1318,6 +1318,13 @@ public:
     return value;
   }
 
+  template <typename... Params>
+  inline T& emplaceInit(Params&&... params) {
+    ctor(value, kj::fwd<Params>(params)...);
+    isSet = true;
+    return value;
+  }
+
   inline NullableValue(): isSet(false) {}
   inline NullableValue(T&& t)
       : isSet(true) {
@@ -1522,6 +1529,12 @@ public:
       initNone(&value);  // noexcept - leave in none state
       throw;
     }
+    return value;
+  }
+
+  template <typename... Params>
+  inline T& emplaceInit(Params&&... params) {
+    ctor(value, kj::fwd<Params>(params)...);
     return value;
   }
 
@@ -1790,20 +1803,20 @@ public:
   template <typename U>
   Maybe(Maybe<U>&& other) {
     KJ_IF_SOME(val, kj::mv(other)) {
-      ptr.emplace(kj::mv(val));
+      ptr.emplaceInit(kj::mv(val));
     }
   }
   template <typename U>
   Maybe(Maybe<U&>&& other) {
     KJ_IF_SOME(val, other) {
-      ptr.emplace(val);
+      ptr.emplaceInit(val);
       other = kj::none;
     }
   }
   template <typename U>
   Maybe(const Maybe<U>& other) {
     KJ_IF_SOME(val, other) {
-      ptr.emplace(val);
+      ptr.emplaceInit(val);
     }
   }
 
@@ -1839,6 +1852,24 @@ public:
     // T's constructor. This can be used to initialize a Maybe without copying or even moving a T.
     // Returns a reference to the newly-constructed value.
     return ptr.emplace(kj::fwd<Params>(params)...);
+  }
+
+  template <typename... Params>
+  inline T& emplaceInit(Params&&... params) {
+    // A variant of `emplace` which assume `this` to be empty.
+    // Generates more efficient code by not invoking `~T`.
+    KJ_IREQUIRE(ptr == nullptr, "emplaceInit() requires an empty Maybe");
+    return ptr.emplaceInit(kj::fwd<Params>(params)...);
+  }
+
+  inline Maybe& emplaceInit(Maybe&& other) {
+    // A variant of `Maybe& operator=(T&& other)` which assume `this` to be empty.
+    // Generates more efficient code by not invoking `~T`.
+    KJ_IREQUIRE(ptr == nullptr, "emplaceInit() requires an empty Maybe");
+    KJ_IF_SOME(val, kj::mv(other)) {
+      ptr.emplaceInit(kj::mv(val));
+    }
+    return *this;
   }
 
   // Assignment operators.

--- a/c++/src/kj/maybe-test.c++
+++ b/c++/src/kj/maybe-test.c++
@@ -752,6 +752,75 @@ KJ_TEST("Maybe") {
   }
 }
 
+KJ_TEST("Maybe emplaceInit") {
+  {
+    Maybe<int> m;
+    m.emplaceInit(123);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(m) == 123);
+  }
+
+  {
+    // from another maybe
+    Maybe<int> src = 456;
+    Maybe<int> dst;
+    dst.emplaceInit(kj::mv(src));
+    KJ_EXPECT(KJ_ASSERT_NONNULL(dst) == 456);
+    KJ_EXPECT(src == kj::none);
+  }
+
+  {
+    // from another maybe
+    Maybe<int> src = kj::none;
+    Maybe<int> dst;
+    dst.emplaceInit(kj::mv(src));
+    KJ_EXPECT(dst == kj::none);
+    KJ_EXPECT(src == kj::none);
+  }
+#if defined(KJ_DEBUG) || (defined(KJ_ENABLE_IREQUIRE) && KJ_ENABLE_IREQUIRE)
+  {
+    Maybe<int> m = 1;
+    KJ_EXPECT_THROW(FAILED, m.emplaceInit(2));
+  }
+
+  {
+    Maybe<int> src = 2;
+    Maybe<int> dst = 1;
+    KJ_EXPECT_THROW(FAILED, dst.emplaceInit(kj::mv(src)));
+    KJ_EXPECT(KJ_ASSERT_NONNULL(src) == 2);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(dst) == 1);
+  }
+#endif
+}
+
+KJ_TEST("Maybe emplaceInit with niche-optimized type") {
+  NoneDestructorCounter::noneDestroyCount = 0;
+  NoneDestructorCounter::nonNoneDestroyCount = 0;
+
+  {
+    Maybe<NoneDestructorCounter> src;
+    src.emplaceInit(42);
+    KJ_EXPECT(src != kj::none);
+
+    // from another maybe
+    Maybe<NoneDestructorCounter> dst;
+    dst.emplaceInit(kj::mv(src));
+    KJ_EXPECT(src == kj::none);
+    KJ_EXPECT(dst != kj::none);
+  }
+
+  KJ_EXPECT(NoneDestructorCounter::noneDestroyCount == 0);
+
+  {
+    Maybe<NoneDestructorCounter> src;
+    Maybe<NoneDestructorCounter> dst;
+    dst.emplaceInit(kj::mv(src));
+    KJ_EXPECT(src == kj::none);
+    KJ_EXPECT(dst == kj::none);
+  }
+
+  KJ_EXPECT(NoneDestructorCounter::noneDestroyCount == 0);
+}
+
 KJ_TEST("Maybe constness") {
   int i;
 


### PR DESCRIPTION
The following expression `maybe = kj::mv(otherMaybe)` results in generationg code for ~T in case target maybe is not empty.

Sometimes (often) compiler can't prove the emptiness of maybe and fails to eliminate ~T branch. Not only this generates longer code (bad for instruction cache), it also prevents further optimizations from happening. This is particularly bad for ExceptionOr case (will be addressed in later PRs).

This pr introduces emplaceInit operations to be used when engineer can prove the empty target.