### PR TITLE
bazel: enable irequire checks in all configurations

### DIFF
--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -4,7 +4,7 @@ common --verbose_failures
 # Needed for Brotli, which does not import rules_cc symbols itself (otherwise needed with Bazel 9)
 common --incompatible_autoload_externally=+cc_library,+cc_binary
 
-# we run and recommend irequre checks in production
+# we enable irequre checks in production
 build --@capnp-cpp//src/kj:kj_enable_irequire=True
 
 test --test_timeout=1,5,30,30

--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -4,6 +4,9 @@ common --verbose_failures
 # Needed for Brotli, which does not import rules_cc symbols itself (otherwise needed with Bazel 9)
 common --incompatible_autoload_externally=+cc_library,+cc_binary
 
+# we run and recommend irequre checks in production
+build --@capnp-cpp//src/kj:kj_enable_irequire=True
+
 test --test_timeout=1,5,30,30
 
 # Debug build configuration with maximum runtime checks


### PR DESCRIPTION
Added irequire checks for production builds.