### PR TITLE
Add overload of OneOf::tryGet() when the OneOf is an rvalue.

### DIFF
--- a/c++/src/kj/one-of.h
+++ b/c++/src/kj/one-of.h
@@ -425,7 +425,7 @@ public:
   }
 
   template <typename T>
-  Maybe<T&> tryGet() {
+  Maybe<T&> tryGet() & {
     if (is<T>()) {
       return *reinterpret_cast<T*>(space);
     } else {
@@ -433,9 +433,17 @@ public:
     }
   }
   template <typename T>
-  Maybe<const T&> tryGet() const {
+  Maybe<const T&> tryGet() const & {
     if (is<T>()) {
       return *reinterpret_cast<const T*>(space);
+    } else {
+      return kj::none;
+    }
+  }
+  template <typename T>
+  Maybe<T> tryGet() && {
+    if (is<T>()) {
+      return kj::mv(*reinterpret_cast<T*>(space));
     } else {
       return kj::none;
     }


### PR DESCRIPTION
Note this is actually a breaking change. There are 6 places in our edge runtime (zero in workerd) that do:

    kj::mv(KJ_ASSERT_NONNULL(kj::mv(someOneOf).tryGet<T>()))

The outer `kj::mv` is not just to longer necessary, it becomes an error. I have updated them in a concurrent PR.