### PR TITLE
Two random API improvements

### DIFF
--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -623,5 +623,16 @@ _::OrphanBuilder copyOutOfMembrane(ListReader from, Orphanage to,
 
 }  // namespace _ (private)
 
+AnyPointer::Pipeline membranePipeline(AnyPointer::Pipeline inner, kj::Own<MembranePolicy> policy) {
+  return AnyPointer::Pipeline(kj::heap<MembranePipelineHook>(
+      PipelineHook::from(kj::mv(inner)), kj::mv(policy), false));
+}
+
+AnyPointer::Pipeline reverseMembranePipeline(
+    AnyPointer::Pipeline inner, kj::Own<MembranePolicy> policy) {
+  return AnyPointer::Pipeline(kj::heap<MembranePipelineHook>(
+      PipelineHook::from(kj::mv(inner)), kj::mv(policy), true));
+}
+
 }  // namespace capnp
 

--- a/c++/src/capnp/membrane.h
+++ b/c++/src/capnp/membrane.h
@@ -240,6 +240,12 @@ Orphan<typename kj::Decay<Reader>::Reads> copyOutOfMembrane(
     Reader&& from, Orphanage to, kj::Own<MembranePolicy> policy);
 // Like copyIntoMembrane() except that `from` is "inside" the membrane and `to` is "outside".
 
+template <typename PipelineType>
+PipelineType membranePipeline(PipelineType inner, kj::Own<MembranePolicy> policy);
+template <typename PipelineType>
+PipelineType reverseMembranePipeline(PipelineType inner, kj::Own<MembranePolicy> policy);
+// Applies a membrane to a `Pipeline` object.
+
 // =======================================================================================
 // inline implementation details
 
@@ -298,6 +304,21 @@ Orphan<typename kj::Decay<Reader>::Reads> copyOutOfMembrane(
   return _::copyOutOfMembrane(
       _::PointerHelpers<typename kj::Decay<Reader>::Reads>::getInternalReader(from),
       to, kj::mv(policy), false);
+}
+
+AnyPointer::Pipeline membranePipeline(AnyPointer::Pipeline inner, kj::Own<MembranePolicy> policy);
+AnyPointer::Pipeline reverseMembranePipeline(
+    AnyPointer::Pipeline inner, kj::Own<MembranePolicy> policy);
+
+template <typename PipelineType>
+PipelineType membranePipeline(PipelineType inner, kj::Own<MembranePolicy> policy) {
+  return PipelineType(membranePipeline(
+      AnyPointer::Pipeline(PipelineHook::from(kj::mv(inner))), kj::mv(policy)));
+}
+template <typename PipelineType>
+PipelineType reverseMembranePipeline(PipelineType inner, kj::Own<MembranePolicy> policy) {
+  return PipelineType(reverseMembranePipeline(
+      AnyPointer::Pipeline(PipelineHook::from(kj::mv(inner))), kj::mv(policy)));
 }
 
 } // namespace capnp

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -122,6 +122,42 @@ TEST(Serialize, FlatArray) {
   }
 }
 
+KJ_TEST("FlatArrayMessageReader from aligned byte array") {
+  TestMessageBuilder builder(1);
+  initTestMessage(builder.initRoot<TestAllTypes>());
+
+  kj::Array<word> serialized = messageToFlatArray(builder);
+  kj::ArrayPtr<const byte> bytes = serialized.asBytes();
+
+  // Verify precondition: the byte pointer is word-aligned.
+  KJ_ASSERT(reinterpret_cast<uintptr_t>(bytes.begin()) % sizeof(word) == 0);
+
+  FlatArrayMessageReader reader(bytes);
+  checkTestMessage(reader.getRoot<TestAllTypes>());
+
+  // getEnd() should point into the original array, confirming no copy was made.
+  KJ_EXPECT(serialized.end() == reader.getEnd());
+}
+
+KJ_TEST("FlatArrayMessageReader from unaligned byte array") {
+  TestMessageBuilder builder(1);
+  initTestMessage(builder.initRoot<TestAllTypes>());
+
+  kj::Array<word> serialized = messageToFlatArray(builder);
+  size_t byteSize = serialized.asBytes().size();
+
+  // Allocate a buffer with extra space and offset by 1 byte to guarantee misalignment.
+  auto buffer = kj::heapArray<byte>(byteSize + sizeof(word));
+  auto unaligned = buffer.slice(1, 1 + byteSize);
+  memcpy(unaligned.begin(), serialized.asBytes().begin(), byteSize);
+
+  // Verify precondition: the byte pointer is NOT word-aligned.
+  KJ_ASSERT(reinterpret_cast<uintptr_t>(unaligned.begin()) % sizeof(word) != 0);
+
+  FlatArrayMessageReader reader(unaligned);
+  checkTestMessage(reader.getRoot<TestAllTypes>());
+}
+
 TEST(Serialize, FlatArrayOddSegmentCount) {
   TestMessageBuilder builder(7);
   initTestMessage(builder.initRoot<TestAllTypes>());

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -32,7 +32,28 @@ namespace capnp {
 
 FlatArrayMessageReader::FlatArrayMessageReader(
     kj::ArrayPtr<const word> array, ReaderOptions options)
-    : MessageReader(options), end(array.end()) {
+    : MessageReader(options) {
+  init(array);
+}
+
+FlatArrayMessageReader::FlatArrayMessageReader(
+    kj::ArrayPtr<const byte> bytes, ReaderOptions options)
+    : MessageReader(options) {
+  KJ_REQUIRE(bytes.size() % sizeof(word) == 0, "message must be a whole number of words");
+  auto wordCount = bytes.size() / sizeof(word);
+
+  if (reinterpret_cast<uintptr_t>(bytes.begin()) % sizeof(word) == 0) {
+    init(kj::arrayPtr(reinterpret_cast<const word*>(bytes.begin()), wordCount));
+  } else {
+    alignedCopy = kj::heapArray<word>(wordCount);
+    alignedCopy.asBytes().copyFrom(bytes);
+    init(alignedCopy);
+  }
+}
+
+void FlatArrayMessageReader::init(kj::ArrayPtr<const word> array) {
+  end = array.end();
+
   if (array.size() < 1) {
     // Assume empty message.
     return;

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -54,6 +54,12 @@ class FlatArrayMessageReader: public MessageReader {
 public:
   FlatArrayMessageReader(kj::ArrayPtr<const word> array, ReaderOptions options = ReaderOptions());
   // The array must remain valid until the MessageReader is destroyed.
+  //
+  // `array` MUST be aligned, or this is likely to throw.
+
+  FlatArrayMessageReader(kj::ArrayPtr<const byte> bytes, ReaderOptions options = ReaderOptions());
+  // Reads from a byte array instead of a word array. If the bytes are not aligned, a copy will
+  // be made.
 
   kj::ArrayPtr<const word> getSegment(uint id) override;
 
@@ -68,6 +74,10 @@ private:
   kj::ArrayPtr<const word> segment0;
   kj::Array<kj::ArrayPtr<const word>> moreSegments;
   const word* end;
+
+  kj::Array<word> alignedCopy;
+
+  void init(kj::ArrayPtr<const word> array);
 };
 
 kj::ArrayPtr<const word> initMessageBuilderFromFlatArrayCopy(
@@ -121,7 +131,7 @@ size_t expectedSizeInWordsFromPrefix(kj::ArrayPtr<const word> messagePrefix);
 
 kj::Array<word> serializeSegmentTable(kj::ArrayPtr<const kj::ArrayPtr<const word>> segments);
 // Returns the segments table for given message segments.
-// Fully serialized message consists of the table and segments written consecutively. 
+// Fully serialized message consists of the table and segments written consecutively.
 
 // =======================================================================================
 


### PR DESCRIPTION
* Add functions to membrane-wrap a `Pipeline` object.
* Extend FlatArrayMessageReader to accept byte arrays.

I needed both of these as part of the same workers runtime change, so grouping them together.