### PR TITLE
Revert "Add AsyncIoStreamWithGuards::getFd delegating to inner AsyncIoStream"

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -4901,10 +4901,6 @@ public:
     }
   }
 
-  kj::Maybe<int> getFd() const override {
-    return inner->getFd();
-  }
-
 private:
   kj::Own<kj::AsyncIoStream> inner;
   kj::ForkedPromise<void> readGuard;


### PR DESCRIPTION
Reverts capnproto/capnproto#2602

getFd() can only return the underlying FD in cases where the underlying FD is equivalent to the stream. In this case, the underlying FD does not enforce the "guards". Maybe there's an argument that it'd be safe if the guard has already been lifted? But we need to be careful here.