### PR TITLE
mark ~Exception as KJ_NOINLINE

### DIFF
--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -74,7 +74,7 @@ public:
   Exception(Type type, String file, int line, String description = nullptr) noexcept;
   Exception(const Exception& other) noexcept;
   Exception(Exception&& other) noexcept = default;
-  ~Exception() noexcept;
+  KJ_NOINLINE ~Exception() noexcept;
 
   const char* getFile() const { return storage->file; }
   int getLine() const { return storage->line; }


### PR DESCRIPTION
This reduces the happy case code pressure across the code.

https://gist.github.com/mikea/903de5a262ee5b6a7d87f88d0c34aa85

Biggest winners are bm_Promise_Pow2_20 (-1.4%) and bm_Promise_Shift_20 (-1.3%) since compiler can better optimise `SimpleTransformPromiseNode::getImpl` now.

This micro-optimization is required to reduce inlining storm when switching Exception::storage to static disposer. (https://github.com/capnproto/capnproto/pull/2586)