### PR TITLE
kj::cp should use explicit copy constructor

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -788,5 +788,51 @@ KJ_TEST("ThreadId") {
   });
 }
 
+class ExplicitCopy {
+public:
+  ExplicitCopy() {}
+  explicit ExplicitCopy(const ExplicitCopy& other) = default;
+  ExplicitCopy(ExplicitCopy&& other) = delete;
+};
+
+KJ_TEST("kj::cp() invokes explicit constructor") {
+  {
+    // non-const copy
+    ExplicitCopy a;
+    auto aCopy = kj::cp(a);
+    (void)aCopy;
+  }
+
+  {
+    // const copy
+    const ExplicitCopy a;
+    auto aCopy = kj::cp(a);
+    (void)aCopy;
+  }
+}
+
+class ImplicitCopy {
+public:
+  ImplicitCopy() {}
+  ImplicitCopy(const ImplicitCopy& other) = default;
+  ImplicitCopy(ImplicitCopy&& other) = delete;
+};
+
+KJ_TEST("kj::cp() invokes implicit constructor") {
+  {
+    // non-const copy
+    ImplicitCopy a;
+    auto aCopy = kj::cp(a);
+    (void)aCopy;
+  }
+
+  {
+    // const copy
+    const ImplicitCopy a;
+    auto aCopy = kj::cp(a);
+    (void)aCopy;
+  }
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -703,8 +703,8 @@ private:
 template<typename T> constexpr T&& mv(T& t) noexcept { return static_cast<T&&>(t); }
 template<typename T> constexpr T&& fwd(NoInfer<T>& t) noexcept { return static_cast<T&&>(t); }
 
-template<typename T> constexpr T cp(T& t) noexcept { return t; }
-template<typename T> constexpr T cp(const T& t) noexcept { return t; }
+template<typename T> constexpr T cp(T& t) noexcept { return T(t); }
+template<typename T> constexpr T cp(const T& t) noexcept { return T(t); }
 // Useful to force a copy, particularly to pass into a function that expects T&&.
 
 template <typename T, typename U, bool takeT, bool uOK = true> struct ChooseType_;


### PR DESCRIPTION
`kj::cp` is an explicit copy, so it should be compatible with explicit copy constructors.