### PR TITLE
optimize ~Own<T,D>, Maybe<T> for noexcept ~T case

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1298,7 +1298,11 @@ public:
       noexcept(noexcept(instance<T&>().~T()))
 #endif
   {
-    destroy();
+    if constexpr (noexcept(instance<T&>().~T())) {
+      if (isSet) { dtor(value); }
+    } else {
+      destroy();
+    }
   }
 
   inline T& operator*() & { return value; }
@@ -1507,7 +1511,11 @@ public:
       noexcept(noexcept(instance<T&>().~T()))
 #endif
   {
-    destroy();
+    if constexpr (noexcept(instance<T&>().~T())) {
+      if (!isNone(value)) { dtor(value); }
+    } else {
+      destroy();
+    }
   }
 
   inline T& operator*() & { return value; }

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -191,7 +191,7 @@ private:
   };
 
   struct StorageDisposer {
-    static void dispose(Storage* storage) { delete storage; }
+    static void dispose(Storage* storage) noexcept { delete storage; }
   };
 
   kj::Own<Storage, StorageDisposer> storage { new Storage() };

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -417,7 +417,14 @@ public:
   }
   inline explicit Own(T* ptr) noexcept: ptr(ptr) {}
 
-  ~Own() noexcept(false) { dispose(); }
+  ~Own() noexcept(false) {
+    if constexpr (noexcept(StaticDisposer::dispose(kj::instance<T*>()))) {
+      // dispose doesn't throw, we can be more optimal.
+      StaticDisposer::dispose(ptr);
+    } else {
+      dispose();
+    }
+  }
 
   inline Own& operator=(Own&& other) {
     // Move-assignnment operator.


### PR DESCRIPTION
Compiler is not smart enough and doesn't eliminate null assignment.

Results in measurable performance improvements: https://gist.github.com/mikea/257b904577aba452d70e3c45b25968ac

bm_Promise_Fib10 is a top winner (-1.1%), bm_Http_OverCapnpFullRPC clocks at -0.5%