### PR TITLE
[nfc] async benchmark for throw performance

### DIFF
--- a/c++/src/kj/async-bench.c++
+++ b/c++/src/kj/async-bench.c++
@@ -25,6 +25,7 @@
 
 #include <kj/async.h>
 #include <kj/debug.h>
+#include <kj/test.h>
 
 // kj::READY_NOW is in its own performance class
 
@@ -271,5 +272,46 @@ static void bm_Coro_Fib10(benchmark::State &state) {
 }
 
 BENCHMARK(bm_Coro_Fib10);
+
+/////////////////////////////////////////////////////////////////
+// Exception handling benchmarks
+// Exceptions are supposed to be rare, and we mostly care about happy path performance.
+// It is still curious to measure the exception handling overhead.
+
+kj::Promise<void> promiseThrow() {
+  return immediatePromise().then([] (auto x) -> kj::Promise<void> {
+    throw KJ_EXCEPTION(FAILED, "test exception");
+  });
+}
+
+static void bm_Promise_Throw(benchmark::State &state) {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  for (auto _ : state) {
+    auto promise = promiseThrow();
+    KJ_EXPECT_THROW(FAILED, promise.wait(waitScope));
+  }
+}
+
+BENCHMARK(bm_Promise_Throw);
+
+kj::Promise<void> coroThrow() {
+  co_await immediatePromise();
+  throw KJ_EXCEPTION(FAILED, "test exception");
+}
+
+
+static void bm_Coro_Throw(benchmark::State &state) {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  for (auto _ : state) {
+    auto promise = coroThrow();
+    KJ_EXPECT_THROW(FAILED, promise.wait(waitScope));
+  }
+}
+
+BENCHMARK(bm_Coro_Throw);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
I was simply curious how slow it is:

```
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
bm_Promise_ReadyNow                      18.3 ns         18.3 ns       100000
bm_Promise_Immediate                     30.4 ns         30.4 ns       100000
bm_Coro_Immediate                        35.6 ns         35.3 ns       100000
bm_Promise_ImmediatePromise_Then         48.1 ns         48.2 ns       100000
bm_Coro_CoAwait_ImmediatePromise          123 ns          123 ns       100000
bm_Coro_CoAwait_ImmediateCoroutine        109 ns          109 ns       100000
bm_Promise_Pow2_20                        393 ns          393 ns       100000
bm_Coro_Pow2_20                          1204 ns         1204 ns       100000
bm_Promise_Shift_20                       537 ns          537 ns       100000
bm_Coro_Shift_20                         1179 ns         1177 ns       100000
bm_Promise_Fib10                         1119 ns         1118 ns       100000
bm_Coro_Fib10                             815 ns          814 ns       100000
bm_Promise_Throw                         7231 ns         7230 ns       100000
bm_Coro_Throw                            6362 ns         6361 ns       100000
```

Number are worse than I expected. Seems to be _at least_ two orders of magnitute of overhead.