### PR TITLE
Fix RpcFlowController to fulfill blocked senders with DISCONNECTED on destruction

### DIFF
--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -2691,6 +2691,52 @@ KJ_TEST("AdaptiveFlowController: minimum window is enforced") {
   KJ_EXPECT(estimatedWindow >= 64 * 1024, estimatedWindow);
 }
 
+KJ_TEST("AdaptiveFlowController: destroying with blocked senders fulfills them") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+  TestClock clock;
+  auto fc = RpcFlowController::newAdaptiveController(256 * 1024, clock);
+
+  // Send a 256KB message to fill most of the window. The ack never arrives (NEVER_DONE),
+  // simulating a dead follower.
+  auto msg1 = kj::heap<MockMessage>(256 * 1024);
+  fc->send(kj::mv(msg1), kj::NEVER_DONE).poll(waitScope);
+
+  // Second send blocks — window is full since the first ack never arrived.
+  auto msg2 = kj::heap<MockMessage>(256 * 1024);
+  auto blockedPromise = fc->send(kj::mv(msg2), kj::NEVER_DONE);
+  KJ_EXPECT(!blockedPromise.poll(waitScope));
+
+  // Destroy the flow controller while a sender is blocked.
+  fc = nullptr;
+
+  // The blocked promise should be fulfilled (not rejected).
+  blockedPromise.wait(waitScope);
+}
+
+KJ_TEST("WindowFlowController: destroying with blocked senders fulfills them") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+  auto fc = RpcFlowController::newFixedWindowController(256 * 1024);
+
+  // Send a 256KB message to fill most of the window. The ack never arrives,
+  // simulating a dead follower.
+  auto msg1 = kj::heap<MockMessage>(256 * 1024);
+  fc->send(kj::mv(msg1), kj::NEVER_DONE).poll(waitScope);
+
+  // Second send blocks — window is full since the first ack never arrived.
+  auto msg2 = kj::heap<MockMessage>(256 * 1024);
+  auto blockedPromise = fc->send(kj::mv(msg2), kj::NEVER_DONE);
+  KJ_EXPECT(!blockedPromise.poll(waitScope));
+
+  // Destroy the flow controller while a sender is blocked.
+  fc = nullptr;
+
+  // The blocked promise should be fulfilled (not rejected).
+  blockedPromise.wait(waitScope);
+}
+
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -4728,6 +4728,20 @@ public:
     state.init<Running>();
   }
 
+  ~WindowFlowController() noexcept(false) {
+    KJ_IF_SOME(blockedSends, state.tryGet<Running>()) {
+      // Without this, the default destructor would destroy the fulfillers, causing KJ to
+      // reject them with a hardcoded FAILED exception ("PromiseFulfiller was destroyed without
+      // fulfilling the promise"). Fulfilling is safe because the send() promise resolving only
+      // means "now is a good time to send the next message", not that the message was delivered.
+      // The caller's next send will fail with the actual root cause error from the connection
+      // layer.
+      for (auto& fulfiller: blockedSends) {
+        fulfiller->fulfill();
+      }
+    }
+  }
+
   kj::Promise<void> send(kj::Own<OutgoingRpcMessage> message, kj::Promise<void> ack) override {
     auto size = message->sizeInWords() * sizeof(capnp::word);
     maxMessageSize = kj::max(size, maxMessageSize);
@@ -4869,6 +4883,20 @@ public:
   AdaptiveFlowController(size_t initialWindowSize, const kj::MonotonicClock& clock)
       : window(initialWindowSize), clock(clock), tasks(*this) {
     state.init<Running>();
+  }
+
+  ~AdaptiveFlowController() noexcept(false) {
+    KJ_IF_SOME(blockedSends, state.tryGet<Running>()) {
+      // Without this, the default destructor would destroy the fulfillers, causing KJ to
+      // reject them with a hardcoded FAILED exception ("PromiseFulfiller was destroyed without
+      // fulfilling the promise"). Fulfilling is safe because the send() promise resolving only
+      // means "now is a good time to send the next message", not that the message was delivered.
+      // The caller's next send will fail with the actual root cause error from the connection
+      // layer.
+      for (auto& fulfiller: blockedSends) {
+        fulfiller->fulfill();
+      }
+    }
   }
 
   kj::Promise<void> send(kj::Own<OutgoingRpcMessage> message, kj::Promise<void> ack) override {


### PR DESCRIPTION
When an AdaptiveFlowController or WindowFlowController is destroyed while senders are blocked waiting for window space, the pending PromiseFulfillers were being destroyed without being fulfilled or rejected. This caused KJ's WeakFulfillerBase::disposeImpl to reject the corresponding promises with a hardcoded FAILED exception type ("PromiseFulfiller was destroyed without fulfilling the promise"), regardless of the actual cause.

A flow controller being destroyed while senders are blocked means the underlying connection is going away — this is a disconnection, not a logic bug. The FAILED exception type is misleading and causes callers that distinguish between exception types to mishandle the error. Add explicit destructors to both AdaptiveFlowController and WindowFlowController that reject any pending blocked-sender fulfillers with DISCONNECTED before the implicit member destruction runs. This matches the semantics already used by taskFailed() when an ack promise fails.

Also make StreamSimulator accept an optional RpcFlowController parameter so it can be used to test any flow controller implementation.