### PR TITLE
Cloneable<T> and clone() method in basic structures

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -29,6 +29,17 @@
 namespace kj {
 namespace {
 
+struct CloneableElement {
+  int clone() const { return 123; }
+};
+
+struct NonCloneableElement {};
+
+static_assert(Cloneable<Array<CloneableElement>>);
+static_assert(Cloneable<ArrayPtr<CloneableElement>>);
+static_assert(!Cloneable<Array<NonCloneableElement>>);
+static_assert(!Cloneable<ArrayPtr<NonCloneableElement>>);
+
 struct TestObject {
   TestObject() {
     index = count;
@@ -402,6 +413,27 @@ TEST(Array, HeapCopy) {
     EXPECT_EQ(3u, copy.size());
     EXPECT_EQ(kj::str(copy.first(3)), "baz"_kj);
   }
+}
+
+KJ_TEST("ArrayPtr clone") {
+  StringPtr values[] = {"foo", "bar"};
+  ArrayPtr<const StringPtr> original(values);
+  Array<String> cloned = original.clone();
+  ASSERT_EQ(2u, cloned.size());
+  EXPECT_EQ(cloned[0], "foo");
+  EXPECT_EQ(cloned[1], "bar");
+  EXPECT_NE(cloned[0].begin(), original[0].begin());
+  EXPECT_NE(cloned[1].begin(), original[1].begin());
+}
+
+KJ_TEST("Array clone") {
+  Array<const StringPtr> original = heapArray<const StringPtr>({"baz", "qux"});
+  Array<String> cloned = original.clone();
+  ASSERT_EQ(2u, cloned.size());
+  EXPECT_EQ(cloned[0], "baz");
+  EXPECT_EQ(cloned[1], "qux");
+  EXPECT_NE(cloned[0].begin(), original[0].begin());
+  EXPECT_NE(cloned[1].begin(), original[1].begin());
 }
 
 TEST(Array, OwnConst) {

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -272,6 +272,10 @@ public:
   // Syntax sugar for invoking asImpl(U*, const Array&).
   // Used to chain conversion calls rather than wrap with function.
 
+  auto clone() const requires Cloneable<T>;
+  // Deep-clone to a new heap array by cloning every element.
+  // Returns Array<decltype(t.clone())>
+
   inline bool hasNullDisposer() const {return disposer == &NullArrayDisposer::instance; }
   // Returns true if array uses NullArrayDisposer, intended for use with string literal
   // ConstStrings.
@@ -947,6 +951,21 @@ heapArray(Iterator begin, Iterator end) {
 template <typename T>
 inline Array<T> heapArray(std::initializer_list<T> init) {
   return heapArray<T>(init.begin(), init.end());
+}
+
+template <typename T>
+inline auto ArrayPtr<T>::clone() const requires Cloneable<T> {
+  using U = decltype(instance<const T&>().clone());
+  auto builder = heapArrayBuilder<U>(size());
+  for (auto& value: *this) {
+    builder.add(value.clone());
+  }
+  return builder.finish();
+}
+
+template <typename T>
+inline auto Array<T>::clone() const requires Cloneable<T> {
+  return asPtr().clone();
 }
 
 template <typename T, typename... Params>

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -29,6 +29,16 @@
 namespace kj {
 namespace {
 
+struct ClonesToInt { int clone() const { return 123; } };
+struct ClonesToStringPtr { StringPtr clone() const { return "foo"; } };
+struct NoClone {};
+struct NonConstClone { int clone() { return 123; } };
+
+static_assert(Cloneable<ClonesToInt>);
+static_assert(Cloneable<ClonesToStringPtr>);
+static_assert(!Cloneable<NoClone>);
+static_assert(!Cloneable<NonConstClone>);
+
 KJ_ASSERT_CAN_MEMCPY(char);
 KJ_ASSERT_CAN_MEMCPY(byte);
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1250,6 +1250,10 @@ concept ConstructibleFrom = requires(U&& u) { T(kj::fwd<U>(u)); };
 }  // namespace _ (private)
 
 template <typename T>
+concept Cloneable = requires(const T& value) { value.clone(); };
+// Concept: T has a `const clone()` member.
+
+template <typename T>
 concept NicheOptimizable = _::HasAnyNicheMember<T>;
 // Concept for types that support niche optimization in Maybe<T>.
 // Matches when ANY niche member is defined, so the niche-optimized specialization is selected.
@@ -2124,6 +2128,17 @@ public:
     }
   }
 
+  auto clone() const requires Cloneable<T> {
+    // Clones the value if it is not none.
+    // Returns Maybe<decltype(t.clone())>
+    using U = decltype(ptr->clone());
+    if (ptr == nullptr) {
+      return Maybe<U>(kj::none);
+    } else {
+      return Maybe<U>(ptr->clone());
+    }
+  }
+
   template <typename Func>
   auto map(Func&& f) & -> Maybe<decltype(f(instance<T&>()))> {
     // See KJ_MAP for a more ergonomic interface.
@@ -2245,6 +2260,16 @@ public:
       return defaultValue;
     } else {
       return *ptr;
+    }
+  }
+
+  auto clone() const requires Cloneable<T> {
+    // Clones the value (not a reference) if reference is not none.
+    using U = decltype(ptr->clone());
+    if (ptr == nullptr) {
+      return Maybe<U>(kj::none);
+    } else {
+      return Maybe<U>(ptr->clone());
     }
   }
 
@@ -2596,6 +2621,10 @@ public:
   inline auto as() const { return asImpl((U*)nullptr, *this); }
   // Syntax sugar for invoking asImpl(U*, const ArrayPtr&).
   // Used to chain conversion calls rather than wrap with function.
+
+  auto clone() const requires Cloneable<T>;
+  // Deep-clone into heap-owned array.
+  // Returns Array<decltype(t.clone())>
 
   inline void fill(T t) {
     // Fill the area by copying t over every element.

--- a/c++/src/kj/maybe-test.c++
+++ b/c++/src/kj/maybe-test.c++
@@ -20,7 +20,9 @@
 // THE SOFTWARE.
 
 #include "common.h"
+#include "array.h"
 #include "memory.h"
+#include "string.h"
 #include "test.h"
 #include <stdexcept>
 
@@ -48,6 +50,17 @@ struct CopyOrMove {
 
   int i;
 };
+
+struct CloneableMaybeValue {
+  int clone() const { return 123; }
+};
+
+struct NonCloneableMaybeValue {};
+
+static_assert(Cloneable<Maybe<CloneableMaybeValue>>);
+static_assert(Cloneable<Maybe<CloneableMaybeValue&>>);
+static_assert(!Cloneable<Maybe<NonCloneableMaybeValue>>);
+static_assert(!Cloneable<Maybe<NonCloneableMaybeValue&>>);
 
 // =======================================================================================
 
@@ -730,6 +743,68 @@ KJ_TEST("Maybe") {
     KJ_EXPECT(m1 != m4);
     KJ_EXPECT(m4 == m5);
     KJ_EXPECT(m4 != m1);
+  }
+
+  {
+    Maybe<ConstString> m = ConstString(kj::str("foo"));
+    auto cloned = m.clone();
+    KJ_EXPECT(cloned != kj::none);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned).cStr() != KJ_ASSERT_NONNULL(m).cStr());
+
+    Maybe<ConstString> empty = kj::none;
+    KJ_EXPECT(empty.clone() == kj::none);
+  }
+
+  {
+    // cloned value can be of different type
+    Maybe<StringPtr> m = StringPtr("foo");
+    Maybe<String> cloned = m.clone();
+    KJ_EXPECT(cloned != kj::none);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned) == "foo");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned).cStr() != KJ_ASSERT_NONNULL(m).begin());
+  }
+
+  {
+    // references are cloned into values
+    StringPtr str = "bar";
+    Maybe<StringPtr&> m = str;
+    Maybe<String> cloned = m.clone();
+    KJ_EXPECT(cloned != kj::none);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned) == "bar");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned).cStr() != KJ_ASSERT_NONNULL(m).begin());
+  }
+
+  {
+    Maybe<String> m = kj::str("baz");
+    Maybe<String> cloned = m.clone();
+    KJ_EXPECT(cloned != kj::none);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned) == "baz");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned).cStr() != KJ_ASSERT_NONNULL(m).cStr());
+  }
+
+  {
+    // clone is deep
+    StringPtr values[] = {"one", "two"};
+    Maybe<ArrayPtr<const StringPtr>> m = ArrayPtr<const StringPtr>(values);
+    Maybe<Array<String>> cloned = m.clone();
+    KJ_EXPECT(cloned != kj::none);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned).size() == 2);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[0] == "one");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[1] == "two");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[0].begin() != KJ_ASSERT_NONNULL(m)[0].begin());
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[1].begin() != KJ_ASSERT_NONNULL(m)[1].begin());
+  }
+
+  {
+    // clone can change multiple types
+    Maybe<Array<const StringPtr>> m = heapArray<const StringPtr>({"three", "four"});
+    Maybe<Array<String>> cloned = m.clone();
+    KJ_EXPECT(cloned != kj::none);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned).size() == 2);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[0] == "three");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[1] == "four");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[0].begin() != KJ_ASSERT_NONNULL(m)[0].begin());
+    KJ_EXPECT(KJ_ASSERT_NONNULL(cloned)[1].begin() != KJ_ASSERT_NONNULL(m)[1].begin());
   }
 
   {

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -31,6 +31,10 @@ namespace kj {
 namespace _ {  // private
 namespace {
 
+static_assert(Cloneable<String>);
+static_assert(Cloneable<ConstString>);
+static_assert(Cloneable<StringPtr>);
+
 TEST(String, Str) {
   EXPECT_EQ("foobar", str("foo", "bar"));
   EXPECT_EQ("1 2 3 4", str(1, " ", 2u, " ", 3l, " ", 4ll));
@@ -397,6 +401,25 @@ KJ_TEST("ConstString clone") {
   // still valid after original string gets deallocated
   heapConst = nullptr;
   KJ_EXPECT(heapClone == "bar");
+}
+
+KJ_TEST("StringPtr clone") {
+  kj::StringPtr original = "foo";
+  kj::String cloned = original.clone();
+
+  KJ_EXPECT(cloned == "foo");
+  KJ_EXPECT(cloned.begin() != original.begin());
+}
+
+KJ_TEST("String clone") {
+  kj::String original = kj::str("bar");
+  kj::String cloned = original.clone();
+
+  KJ_EXPECT(cloned == "bar");
+  KJ_EXPECT(cloned.begin() != original.begin());
+
+  original = nullptr;
+  KJ_EXPECT(cloned == "bar");
 }
 
 KJ_TEST("StringPtr find") {

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -158,6 +158,9 @@ public:
   // Syntax sugar for invoking asImpl(T*, const StringPtr&).
   // Used to chain conversion calls rather than wrap with function.
 
+  inline String clone() const;
+  // Clones the string into heap-owning storage.
+
 private:
   inline explicit constexpr StringPtr(ArrayPtr<const char> content): content(content) {}
   friend constexpr StringPtr (::operator ""_kj)(const char* str, size_t n);
@@ -314,6 +317,9 @@ public:
   inline auto as() const { return asImpl((T*)nullptr, *this); }
   // Syntax sugar for invoking asImpl(T*, const String&).
   // Used to chain conversion calls rather than wrap with function.
+
+  inline String clone() const;
+  // Clones the string into heap-owning storage.
 
 private:
   Array<char> content;
@@ -783,6 +789,14 @@ inline ConstString ConstString::clone() const {
   } else {
     return ConstString(heapArray<char>(content));
   }
+}
+
+inline String StringPtr::clone() const {
+  return heapString(begin(), size());
+}
+
+inline String String::clone() const {
+  return heapString(begin(), size());
 }
 
 inline String::String(Array<char> buffer): content(kj::mv(buffer)) {


### PR DESCRIPTION
- StringPtr, String
- ArrayPtr, Array
- Maybe

Supports only types with explicit clone() for now. I'll address primitive T in followups.