### PR TITLE
TransformPromiseNode::getImpl micro optimization

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -663,14 +663,27 @@ private:
     // Derive return type from DepT to reduce templating.
     typedef _::FixVoid<_::ReturnType<Func, _DepT>> T;
     typedef _::FixVoid<_DepT> DepT;
-    ExceptionOr<DepT> depResult;
-    getDepResult(depResult);
-    KJ_IF_SOME(depException, depResult.exception) {
-      output.as<T>() = handle<T>(
-          MaybeVoidCaller<Exception, FixVoid<ReturnType<ErrorFunc, Exception>>>::apply(
-              errorHandler, kj::mv(depException)));
-    } else KJ_IF_SOME(depValue, depResult.value) {
-      output.as<T>() = handle(MaybeVoidCaller<DepT, T>::apply(func, kj::mv(depValue)));
+
+    kj::Maybe<DepT> depValue;
+
+    {
+      ExceptionOr<DepT> depResult;
+      getDepResult(depResult);
+
+      KJ_IF_SOME(depException, depResult.exception) {
+        output.as<T>() = handle<T>(
+            MaybeVoidCaller<Exception, FixVoid<ReturnType<ErrorFunc, Exception>>>::apply(
+                errorHandler, kj::mv(depException)));
+        return;
+      }
+
+      KJ_IF_SOME(value, depResult.value) {
+        depValue.emplaceInit(kj::mv(value));
+      }
+    }
+
+    KJ_IF_SOME(value, depValue) {
+      output.as<T>() = handle(MaybeVoidCaller<DepT, T>::apply(func, kj::mv(value)));
     }
   }
 };
@@ -702,12 +715,25 @@ private:
   void getImpl(ExceptionOrValue& output) override {
     typedef _::FixVoid<_::ReturnType<Func, _DepT>> T;
     typedef _::FixVoid<_DepT> DepT;
-    ExceptionOr<DepT> depResult;
-    getDepResult(depResult);
-    KJ_IF_SOME(depException, depResult.exception) {
-      output.as<T>() = ExceptionOr<T>(false, kj::mv(depException));
-    } else KJ_IF_SOME(depValue, depResult.value) {
-      output.as<T>() = handle(MaybeVoidCaller<DepT, T>::apply(func, kj::mv(depValue)));
+
+    kj::Maybe<DepT> depValue;
+
+    {
+      ExceptionOr<DepT> depResult;
+      getDepResult(depResult);
+
+      KJ_IF_SOME(depException, depResult.exception) {
+        output.as<T>() = ExceptionOr<T>(false, kj::mv(depException));
+        return;
+      }
+
+      KJ_IF_SOME(value, depResult.value) {
+        depValue.emplaceInit(kj::mv(value));
+      }
+    }
+
+    KJ_IF_SOME(value, depValue) {
+      output.as<T>() = handle(MaybeVoidCaller<DepT, T>::apply(func, kj::mv(value)));
     }
   }
 };


### PR DESCRIPTION
I was hunting down cases of missed optimization opportunities related to ~Exception, which are uncovered by making it inline.

This one stood out. If you take a look at v2 decompiled code: https://gist.github.com/mikea/1c5ef39c5c0d1b70a4ade15b70bd5cfe

there's ~Exception branch present.

This change is the smallest transformation of existing code I was able to find that eliminates the branch: https://gist.github.com/mikea/d7e4d0a1293c1d6fe1b8130048eb7310

It does this by strictly limiting Exception scope.

This change has some minor performance improvement for Promise_Fib10 benchmark (-0.2%) that uses this code path a lot. This optimization becomes even more important if you remove NOINLINE for ~kj::Exception.

https://gist.github.com/mikea/409bf964945f43d80b85e7cf47b37097

As well as landing this I'm curious if we can identify some code patterns/helpers that could make this more elegant?