### PR TITLE
kj::isNoThrowMoveConstructible

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -22,6 +22,7 @@
 #include "common.h"
 #include "test.h"
 #include <inttypes.h>
+#include <type_traits>
 #include <kj/compat/gtest.h>
 #include <span>
 #include "thread.h"
@@ -168,6 +169,50 @@ TEST(Common, CanConvert) {
 
   static_assert(canConvert<void*, const void*>(), "failure");
   static_assert(!canConvert<const void*, void*>(), "failure");
+}
+
+KJ_TEST("isNoThrowMoveConstructible") {
+  static_assert(isNoThrowMoveConstructible<int>());
+  static_assert(isNoThrowMoveConstructible<int&>());
+  static_assert(isNoThrowMoveConstructible<int*>());
+
+  struct ImplicitMove {};
+  static_assert(isNoThrowMoveConstructible<ImplicitMove>());
+
+  struct ExplicitNoThrowMove {
+    ExplicitNoThrowMove() = default;
+    ExplicitNoThrowMove(ExplicitNoThrowMove&&) noexcept = default;
+  };
+  static_assert(isNoThrowMoveConstructible<ExplicitNoThrowMove>());
+
+  struct ExplicitThrowingMove {
+    ExplicitThrowingMove() = default;
+    ExplicitThrowingMove(ExplicitThrowingMove&&) noexcept(false) {}
+  };
+  static_assert(!isNoThrowMoveConstructible<ExplicitThrowingMove>());
+  static_assert(isNoThrowMoveConstructible<ExplicitThrowingMove&>());
+  static_assert(isNoThrowMoveConstructible<ExplicitThrowingMove*>());
+
+  struct CopyOnlyNoThrow {
+    CopyOnlyNoThrow() = default;
+    CopyOnlyNoThrow(const CopyOnlyNoThrow&) noexcept {}
+  };
+  static_assert(isNoThrowMoveConstructible<CopyOnlyNoThrow>());
+
+  struct CopyOnlyThrowing {
+    CopyOnlyThrowing() = default;
+    CopyOnlyThrowing(const CopyOnlyThrowing&) noexcept(false) {}
+  };
+  static_assert(!isNoThrowMoveConstructible<CopyOnlyThrowing>());
+
+  struct ThrowingDestructor {
+    ThrowingDestructor() = default;
+    ThrowingDestructor(ThrowingDestructor&&) noexcept = default;
+    ~ThrowingDestructor() noexcept(false) {}
+  };
+  // this is where we intentionally differ from std
+  static_assert(isNoThrowMoveConstructible<ThrowingDestructor>());
+  static_assert(!std::is_nothrow_move_constructible_v<ThrowingDestructor>);
 }
 
 TEST(Common, ArrayAsBytes) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1066,6 +1066,13 @@ inline void dtor(T& location) {
   location.~T();
 }
 
+template <typename T>
+constexpr bool isNoThrowMoveConstructible() {
+  // like std::is_nothrow_move_constructible but that ignores noexcept(false) destructors
+  if constexpr (isReference<T>()) return true;
+  else return noexcept(new ((void*)nullptr, _::PlacementNew()) T(instance<T&&>()));
+}
+
 // =======================================================================================
 // Maybe
 //


### PR DESCRIPTION
std::is_nothrow_move_constructible also checks for noexcept destructor which is never true for us. Our implementation considers only move constructor.

The plan is to use it inside ExceptionOr and other places for safety.