### PR TITLE
non-const Cloneable<T>

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -33,10 +33,20 @@ struct CloneableElement {
   int clone() const { return 123; }
 };
 
+struct NonConstCloneableElement {
+  int clone() { return 123; }
+};
+
 struct NonCloneableElement {};
 
 static_assert(Cloneable<Array<CloneableElement>>);
+static_assert(Cloneable<const Array<CloneableElement>>);
 static_assert(Cloneable<ArrayPtr<CloneableElement>>);
+static_assert(Cloneable<const ArrayPtr<CloneableElement>>);
+static_assert(Cloneable<Array<NonConstCloneableElement>>);
+static_assert(!Cloneable<const Array<NonConstCloneableElement>>);
+static_assert(Cloneable<ArrayPtr<NonConstCloneableElement>>);
+static_assert(!Cloneable<const ArrayPtr<NonConstCloneableElement>>);
 static_assert(!Cloneable<Array<NonCloneableElement>>);
 static_assert(!Cloneable<ArrayPtr<NonCloneableElement>>);
 

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -272,7 +272,8 @@ public:
   // Syntax sugar for invoking asImpl(U*, const Array&).
   // Used to chain conversion calls rather than wrap with function.
 
-  auto clone() const requires Cloneable<T>;
+  auto clone() requires Cloneable<T>;
+  auto clone() const requires Cloneable<const T>;
   // Deep-clone to a new heap array by cloning every element.
   // Returns Array<decltype(t.clone())>
 
@@ -954,17 +955,22 @@ inline Array<T> heapArray(std::initializer_list<T> init) {
 }
 
 template <typename T>
-inline auto ArrayPtr<T>::clone() const requires Cloneable<T> {
-  using U = decltype(instance<const T&>().clone());
-  auto builder = heapArrayBuilder<U>(size());
-  for (auto& value: *this) {
-    builder.add(value.clone());
-  }
-  return builder.finish();
+inline auto ArrayPtr<T>::clone() requires Cloneable<T> {
+  return KJ_MAP(value, *this) { return value.clone(); };
 }
 
 template <typename T>
-inline auto Array<T>::clone() const requires Cloneable<T> {
+inline auto ArrayPtr<T>::clone() const requires Cloneable<const T> {
+  return KJ_MAP(value, *this) { return value.clone(); };
+}
+
+template <typename T>
+inline auto Array<T>::clone() requires Cloneable<T> {
+  return asPtr().clone();
+}
+
+template <typename T>
+inline auto Array<T>::clone() const requires Cloneable<const T> {
   return asPtr().clone();
 }
 

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -38,7 +38,8 @@ struct NonConstClone { int clone() { return 123; } };
 static_assert(Cloneable<ClonesToInt>);
 static_assert(Cloneable<ClonesToStringPtr>);
 static_assert(!Cloneable<NoClone>);
-static_assert(!Cloneable<NonConstClone>);
+static_assert(Cloneable<NonConstClone>);
+static_assert(!Cloneable<const NonConstClone>);
 
 KJ_ASSERT_CAN_MEMCPY(char);
 KJ_ASSERT_CAN_MEMCPY(byte);

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1264,8 +1264,8 @@ constexpr bool isNoThrowMoveConstructible() {
 }
 
 template <typename T>
-concept Cloneable = requires(const T& value) { value.clone(); };
-// Concept: T has a `const clone()` member.
+concept Cloneable = requires(T& value) { value.clone(); };
+// Concept: T has a `clone()` member callable on a `T&`.
 
 template <typename T>
 concept NicheOptimizable = _::HasAnyNicheMember<T>;
@@ -2142,10 +2142,21 @@ public:
     }
   }
 
-  auto clone() const requires Cloneable<T> {
+  auto clone() requires Cloneable<T> {
     // Clones the value if it is not none.
     // Returns Maybe<decltype(t.clone())>
-    using U = decltype(ptr->clone());
+    using U = decltype(instance<T&>().clone());
+    if (ptr == nullptr) {
+      return Maybe<U>(kj::none);
+    } else {
+      return Maybe<U>(ptr->clone());
+    }
+  }
+
+  auto clone() const requires Cloneable<const T> {
+    // Clones the value if it is not none.
+    // Returns Maybe<decltype(t.clone())>
+    using U = decltype(instance<const T&>().clone());
     if (ptr == nullptr) {
       return Maybe<U>(kj::none);
     } else {
@@ -2277,13 +2288,24 @@ public:
     }
   }
 
-  auto clone() const requires Cloneable<T> {
+  auto clone() requires Cloneable<T> {
     // Clones the value (not a reference) if reference is not none.
-    using U = decltype(ptr->clone());
+    using U = decltype(instance<T&>().clone());
     if (ptr == nullptr) {
       return Maybe<U>(kj::none);
     } else {
       return Maybe<U>(ptr->clone());
+    }
+  }
+
+  auto clone() const requires Cloneable<const T> {
+    // Clones the value (not a reference) if reference is not none.
+    using U = decltype(instance<const T&>().clone());
+    if (ptr == nullptr) {
+      return Maybe<U>(kj::none);
+    } else {
+      const T& ref = *ptr;
+      return Maybe<U>(ref.clone());
     }
   }
 
@@ -2636,7 +2658,8 @@ public:
   // Syntax sugar for invoking asImpl(U*, const ArrayPtr&).
   // Used to chain conversion calls rather than wrap with function.
 
-  auto clone() const requires Cloneable<T>;
+  auto clone() requires Cloneable<T>;
+  auto clone() const requires Cloneable<const T>;
   // Deep-clone into heap-owned array.
   // Returns Array<decltype(t.clone())>
 

--- a/c++/src/kj/maybe-test.c++
+++ b/c++/src/kj/maybe-test.c++
@@ -55,10 +55,20 @@ struct CloneableMaybeValue {
   int clone() const { return 123; }
 };
 
+struct NonConstCloneableMaybeValue {
+  int clone() { return 123; }
+};
+
 struct NonCloneableMaybeValue {};
 
 static_assert(Cloneable<Maybe<CloneableMaybeValue>>);
+static_assert(Cloneable<const Maybe<CloneableMaybeValue>>);
 static_assert(Cloneable<Maybe<CloneableMaybeValue&>>);
+static_assert(Cloneable<const Maybe<CloneableMaybeValue&>>);
+static_assert(Cloneable<Maybe<NonConstCloneableMaybeValue>>);
+static_assert(!Cloneable<const Maybe<NonConstCloneableMaybeValue>>);
+static_assert(Cloneable<Maybe<NonConstCloneableMaybeValue&>>);
+static_assert(!Cloneable<const Maybe<NonConstCloneableMaybeValue&>>);
 static_assert(!Cloneable<Maybe<NonCloneableMaybeValue>>);
 static_assert(!Cloneable<Maybe<NonCloneableMaybeValue&>>);
 

--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -20,10 +20,12 @@
 // THE SOFTWARE.
 
 #include "refcount.h"
+#include "array.h"
 #include <kj/compat/gtest.h>
 
 namespace kj {
 
+namespace _ {
 struct SetTrueInDestructor: public Refcounted {
   SetTrueInDestructor(bool* ptr): ptr(ptr) {}
   ~SetTrueInDestructor() { *ptr = true; }
@@ -32,6 +34,15 @@ struct SetTrueInDestructor: public Refcounted {
 
   bool* ptr;
 };
+
+static_assert(Cloneable<Rc<SetTrueInDestructor>>);
+static_assert(!Cloneable<const Rc<SetTrueInDestructor>>);
+static_assert(Cloneable<Maybe<Rc<SetTrueInDestructor>>>);
+static_assert(!Cloneable<const Maybe<Rc<SetTrueInDestructor>>>);
+static_assert(Cloneable<Array<Rc<SetTrueInDestructor>>>);
+static_assert(!Cloneable<const Array<Rc<SetTrueInDestructor>>>);
+static_assert(Cloneable<ArrayPtr<Rc<SetTrueInDestructor>>>);
+static_assert(!Cloneable<const ArrayPtr<Rc<SetTrueInDestructor>>>);
 
 TEST(Refcount, Basic) {
   bool b = false;
@@ -95,6 +106,52 @@ KJ_TEST("Rc") {
   EXPECT_TRUE(b);
 }
 
+KJ_TEST("Rc clone") {
+  bool b = false;
+
+  auto ref1 = kj::rc<SetTrueInDestructor>(&b);
+  auto ref2 = ref1.clone();
+
+  EXPECT_TRUE(ref1 == ref2);
+
+  ref1 = nullptr;
+  EXPECT_FALSE(b);
+
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+}
+
+KJ_TEST("Rc container clone") {
+  bool b = false;
+
+  {
+    auto ref = kj::rc<SetTrueInDestructor>(&b);
+
+    Maybe<Rc<SetTrueInDestructor>> maybe = ref.addRef();
+    auto maybeClone = maybe.clone();
+    ASSERT_TRUE(maybeClone != kj::none);
+    EXPECT_TRUE(KJ_ASSERT_NONNULL(maybe) == KJ_ASSERT_NONNULL(maybeClone));
+
+    ArrayBuilder<Rc<SetTrueInDestructor>> builder = heapArrayBuilder<Rc<SetTrueInDestructor>>(2);
+    builder.add(ref.addRef());
+    builder.add(ref.addRef());
+    auto array = builder.finish();
+
+    auto arrayPtr = array.asPtr();
+    auto arrayPtrClone = arrayPtr.clone();
+    ASSERT_EQ(2u, arrayPtrClone.size());
+    EXPECT_TRUE(arrayPtrClone[0] == array[0]);
+    EXPECT_TRUE(arrayPtrClone[1] == array[1]);
+
+    auto arrayClone = array.clone();
+    ASSERT_EQ(2u, arrayClone.size());
+    EXPECT_TRUE(arrayClone[0] == array[0]);
+    EXPECT_TRUE(arrayClone[1] == array[1]);
+  }
+
+  EXPECT_TRUE(b);
+}
+
 KJ_TEST("Rc Own interop") {
     bool b = false;
 
@@ -121,7 +178,7 @@ KJ_TEST("Rc inheritance") {
 
   // up casting works automatically
   kj::Rc<SetTrueInDestructor> parent = child.addRef();
-  
+
   auto down = parent.downcast<Child>();
   EXPECT_TRUE(parent == nullptr);
   EXPECT_TRUE(down != nullptr);
@@ -240,6 +297,9 @@ struct AtomicSetTrueInDestructor: public AtomicRefcounted {
   bool* ptr;
 };
 
+static_assert(Cloneable<Arc<AtomicSetTrueInDestructor>>);
+static_assert(Cloneable<const Arc<AtomicSetTrueInDestructor>>);
+
 KJ_TEST("Arc") {
   bool b = false;
 
@@ -265,6 +325,22 @@ KJ_TEST("Arc") {
 
   EXPECT_FALSE(b);
   ref4 = nullptr;
+  EXPECT_TRUE(b);
+}
+
+KJ_TEST("Arc clone") {
+  bool b = false;
+
+  auto ref1 = kj::arc<AtomicSetTrueInDestructor>(&b);
+  const auto& cref = ref1;
+  auto ref2 = cref.clone();
+
+  EXPECT_TRUE(ref1 == ref2);
+
+  ref1 = nullptr;
+  EXPECT_FALSE(b);
+
+  ref2 = nullptr;
   EXPECT_TRUE(b);
 }
 
@@ -320,4 +396,5 @@ KJ_TEST("Arc disown / reown") {
   KJ_EXPECT(b == true);
 }
 
+}  // namespace _
 }  // namespace kj

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -189,6 +189,10 @@ public:
     }
   }
 
+  kj::Rc<T> clone() {
+    return addRef();
+  }
+
   Rc& operator=(decltype(nullptr)) {
     own = nullptr;
     return *this;
@@ -442,6 +446,10 @@ public:
     } else {
       return kj::Arc<T>();
     }
+  }
+
+  kj::Arc<T> clone() const {
+    return addRef();
   }
 
   // Surrenders ownership of the underlying object to the caller. Unlike Own<T>::disown(), there


### PR DESCRIPTION
This removes const requirement from clone() method and adds corresponding const overrides to containers.

Adds clone() to Rc and Arc to demonstrate the feature (in Rc case)