### PR TITLE
static disposer for kj::Rc

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -175,9 +175,12 @@ KJ_TEST("Rc inheritance") {
   bool b = false;
 
   auto child = kj::rc<Child>(&b);
+  KJ_ASSERT(!child->isShared());
 
   // up casting works automatically
   kj::Rc<SetTrueInDestructor> parent = child.addRef();
+  KJ_ASSERT(child->isShared());
+  KJ_ASSERT(parent->isShared());
 
   auto down = parent.downcast<Child>();
   EXPECT_TRUE(parent == nullptr);

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -172,7 +172,7 @@ public:
   inline Rc(Rc&& other) noexcept = default;
 
   template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
-  inline Rc(Rc<U>&& other) noexcept : own(kj::mv(other.own)) { }
+  inline Rc(Rc<U>&& other) noexcept : own(other.own.template disown<Rc<U>>()) { }
 
   kj::Own<T> toOwn() {
     // Convert Rc<T> to Own<T>.
@@ -202,7 +202,9 @@ public:
 
   template <typename U>
   Rc<U> downcast() {
-    return Rc<U>(own.template downcast<U>());
+    T* t = own.template disown<Rc>();
+    U* u = &kj::downcast<U>(*t);
+    return Rc<U>(u);
   }
 
   inline bool operator==(const Rc<T>& other) const { return own.get() == other.own.get(); }
@@ -215,12 +217,21 @@ public:
   inline const T* get() const { return own.get(); }
 
 private:
-  Rc(T* t) : own(t, *t) { }
-  Rc(Own<T>&& t) : own(kj::mv(t)) { }
+  Rc(T* t) : own(t) { }
+  Rc(Own<T, Rc>&& t) : own(kj::mv(t)) { }
 
-  Own<T> own;
+  Own<T, Rc> own;
+  // Rc is its own disposer.
+
+  inline static void dispose(T* t) {
+    if (--t->refcount == 0) delete t;
+  };
 
   friend class Refcounted;
+
+  // dispose access
+  friend class Own<T, Rc>;
+  friend class _::StaticDisposerAdapter<T, Rc>;
 
   template <typename>
   friend class Rc;


### PR DESCRIPTION
Makes no sense to go through virtual calls.
If this works well I'll convert Arc too.