### PR TITLE
ArrayPtr::split()

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -778,6 +778,78 @@ KJ_TEST("Array::slice(start) const") {
 #endif
 }
 
+KJ_TEST("ArrayPtr::split") {
+  {
+    const char text[] = "foo,,bar,";
+    StringPtr expected[] = {"foo", "", "bar", ""};
+
+    size_t i = 0;
+    for (auto part: kj::arrayPtr(text, sizeof(text) - 1).split(',')) {
+      ASSERT_LT(i, kj::size(expected));
+      KJ_EXPECT(part == expected[i], i, part, expected[i]);
+      ++i;
+    }
+
+    KJ_EXPECT(i == kj::size(expected));
+  }
+
+  {
+    const char text[] = "foobar";
+    size_t i = 0;
+    for (auto part: kj::arrayPtr(text, sizeof(text) - 1).split(',')) {
+      KJ_EXPECT(i == 0);
+      KJ_EXPECT(part == "foobar"_kj);
+      ++i;
+    }
+
+    KJ_EXPECT(i == 1);
+  }
+
+  {
+    size_t i = 0;
+    for (auto part: kj::ArrayPtr<const char>().split(',')) {
+      KJ_EXPECT(i == 0);
+      KJ_EXPECT(part == ""_kj);
+      ++i;
+    }
+
+    KJ_EXPECT(i == 1);
+  }
+}
+
+KJ_TEST("ArrayPtr::split mutable") {
+  int values[] = {1, 0, 2, 3, 0, 4};
+  int expectedFirst[] = {11, 12, 14};
+
+  size_t i = 0;
+  for (auto part: kj::arrayPtr(values).split(0)) {
+    if (part.size() > 0) {
+      ASSERT_LT(i, kj::size(expectedFirst));
+      part[0] += 10;
+      KJ_EXPECT(part[0] == expectedFirst[i]);
+    }
+    ++i;
+  }
+
+  KJ_EXPECT(i == 3);
+  KJ_EXPECT(kj::ArrayPtr<const int>(values) == kj::arr(11, 0, 12, 3, 0, 14));
+}
+
+KJ_TEST("ArrayPtr::split const") {
+  const int values[] = {1, 0, 2};
+  const auto split = kj::arrayPtr(values).split(0);
+  static_assert(kj::isSameType<decltype(*split.begin()), kj::ArrayPtr<const int>>());
+
+  size_t i = 0;
+  for (auto part: split) {
+    KJ_ASSERT(i < 2);
+    KJ_EXPECT(part == kj::arr(i == 0 ? 1 : 2));
+    ++i;
+  }
+
+  KJ_EXPECT(i == 2);
+}
+
 KJ_TEST("FixedArray::fill") {
   FixedArray<int64_t, 10> arr;
   arr.fill(42);

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2452,6 +2452,16 @@ struct Mapper<Maybe<T>> {
 template <typename T>
 class Array;
 
+namespace _ {  // private
+class SplitIteratorEnd;
+
+template <typename T>
+class SplitIterator;
+
+template <typename T>
+class SplitIterable;
+}  // namespace _ (private)
+
 template <typename T>
 class ArrayPtr: public DisallowConstCopyIfNotConst<T> {
   // A pointer to an array.  Includes a size.  Like any pointer, it doesn't own the target data,
@@ -2597,6 +2607,10 @@ public:
     return kj::none;
   }
 
+  inline auto split(T delim) { return _::SplitIterable<T>(*this, kj::mv(delim)); }
+  inline auto split(T delim) const { return _::SplitIterable<const T>(asConst(), kj::mv(delim)); }
+  // Returns iterator of segments (ArrayPtr<T>)
+
   constexpr ArrayPtr<PropagateConst<T, byte>> asBytes() const {
     // Reinterpret the array as a byte array. This is explicitly legal under C++ aliasing
     // rules.
@@ -2733,6 +2747,65 @@ private:
     return begin() < other.end() && other.begin() < end();
   }
 };
+
+namespace _ {  // private
+
+class SplitIteratorEnd {};
+
+template <typename T>
+class SplitIterator {
+public:
+  inline SplitIterator(ArrayPtr<T> array, T delim) : array(array), end(0), delim(kj::mv(delim)) {
+    nextSegment();
+  }
+
+  inline ArrayPtr<T> operator*() { return array.first(end); }
+
+  inline SplitIterator& operator++() {
+    if (end == array.size()) {
+      end = array.size() + 1;
+    } else {
+      array = array.slice(end + 1);
+      nextSegment();
+    }
+    return *this;
+  }
+
+  inline bool operator==(const SplitIterator& other) const {
+    return array == other.array && end == other.end;
+  }
+  inline bool operator==(SplitIteratorEnd) const { return end == array.size() + 1; }
+
+private:
+  ArrayPtr<T> array;
+  // The remaining suffix starting at the current segment.
+  size_t end;
+  // Delimiter index, array.size() for the final segment, or array.size() + 1 when exhausted.
+  
+  const T delim;
+
+  inline void nextSegment() {
+    KJ_IF_SOME(index, array.findFirst(delim)) {
+      end = index;
+    } else {
+      end = array.size();
+    }
+  }
+};
+
+template <typename T>
+class SplitIterable {
+public:
+  inline SplitIterable(ArrayPtr<T> array, T&& delim) : array(array), delim(kj::mv(delim)) {}
+  inline SplitIterator<T> begin() const { return SplitIterator<T>(array, delim); }
+  inline SplitIteratorEnd end() const { return SplitIteratorEnd(); }
+
+private:
+  ArrayPtr<T> array;
+  const T delim;
+};
+
+}  // namespace _ (private)
 
 template <>
 inline Maybe<size_t> ArrayPtr<const char>::findFirst(const char& c) const {


### PR DESCRIPTION
Non-allocating version returning an iterator.

Supercedes https://github.com/capnproto/capnproto/pull/2050