### PR TITLE
Replace c++/LICENSE.txt symlink with real file

### DIFF
--- a/c++/LICENSE.txt
+++ b/c++/LICENSE.txt
@@ -1,1 +1,24 @@
-../LICENSE
+Copyright (c) 2013-2017 Sandstorm Development Group, Inc.; Cloudflare, Inc.;
+and other contributors. Each commit is copyright by its respective author or
+author's employer.
+
+Licensed under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+


### PR DESCRIPTION
## Problem
`c++/LICENSE.txt` is a symlink to `../LICENSE`. This breaks tools that extract only the `c++/` subtree via `strip_prefix`, as the symlink target resolves outside the extracted directory.

## Solution
- Replace the symlink with a real copy of the file.