### PR TITLE
Fix bare includes in ez-rpc.h

### DIFF
--- a/c++/src/capnp/ez-rpc.h
+++ b/c++/src/capnp/ez-rpc.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include "rpc.h"
-#include "message.h"
+#include <capnp/rpc.h>
+#include <capnp/message.h>
 
 CAPNP_BEGIN_HEADER
 

--- a/c++/src/capnp/ez-rpc.h
+++ b/c++/src/capnp/ez-rpc.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <capnp/rpc.h>
+#include "rpc.h"
 #include <capnp/message.h>
 
 CAPNP_BEGIN_HEADER


### PR DESCRIPTION
Bare includes in `ez-rpc.h` break builds with sandboxed include paths. See #1942.