### PR TITLE
kj: tolerate ERROR_INVALID_FUNCTION from GetFileInformationByHandleEx on Wine

### DIFF
--- a/c++/src/kj/filesystem-disk-win32.c++
+++ b/c++/src/kj/filesystem-disk-win32.c++
@@ -380,6 +380,11 @@ public:
       case ERROR_CALL_NOT_IMPLEMENTED:
         // Probably WINE.
       	break;
+      case ERROR_INVALID_FUNCTION:
+        // Also WINE: NtQueryInformationFile returns STATUS_NOT_IMPLEMENTED for
+        // unsupported FileInfoClass values, which RtlNtStatusToDosError maps to
+        // ERROR_INVALID_FUNCTION (not ERROR_CALL_NOT_IMPLEMENTED).
+        break;
       case ERROR_INVALID_PARAMETER:
         // Probably VeraCrypt. See https://github.com/capnproto/capnproto/issues/2176
         break;


### PR DESCRIPTION
I tested this patch as part of cross-compile-then-run-in-wine PR: https://github.com/bitcoin-core/libmultiprocess/pull/272.

However, I didn't check the (LLM generated) reasoning in the commit message.