### PR TITLE
Add cap.debugInfo() to dump the type of a capability.

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -29,6 +29,10 @@
 #include <kj/vector.h>
 #include "generated-header-support.h"
 
+#if !KJ_NO_RTTI
+#include <typeinfo>
+#endif
+
 namespace capnp {
 
 namespace _ {
@@ -79,6 +83,12 @@ kj::Promise<kj::Maybe<int>> Capability::Client::getFd() {
   } else {
     return kj::Maybe<int>(kj::none);
   }
+}
+
+kj::String Capability::Client::debugInfo() {
+  kj::Vector<kj::ConstString> vec;
+  hook->debugInfo(vec);
+  return kj::strArray(vec, ":");
 }
 
 kj::Maybe<kj::Promise<Capability::Client>> Capability::Server::shortenPath() {
@@ -463,6 +473,15 @@ public:
     }
   }
 
+  void debugInfo(kj::Vector<kj::ConstString>& chain) override {
+    KJ_IF_SOME(r, redirect) {
+      chain.add("resolved"_kjc);
+      r->debugInfo(chain);
+    } else {
+      chain.add("promise"_kjc);
+    }
+  }
+
 private:
   typedef kj::ForkedPromise<kj::Own<ClientHook>> ClientHookPromiseFork;
 
@@ -733,6 +752,24 @@ public:
       return s->getFd();
     } else {
       return kj::none;
+    }
+  }
+
+  void debugInfo(kj::Vector<kj::ConstString>& chain) override {
+    KJ_IF_SOME(e, brokenException) {
+      chain.add("broken"_kjc);
+      chain.add(kj::str(e));
+    } else KJ_IF_SOME(r, resolved) {
+      chain.add("shortened"_kjc);
+      r->debugInfo(chain);
+    } else KJ_IF_SOME(s, server) {
+      chain.add("local"_kjc);
+#if !KJ_NO_RTTI
+      auto& ref = *s;
+      chain.add(kj::str(typeid(ref).name()));
+#endif
+    } else {
+      chain.add("revoked"_kjc);
     }
   }
 
@@ -1060,6 +1097,11 @@ public:
 
   kj::Maybe<int> getFd() override {
     return kj::none;
+  }
+
+  void debugInfo(kj::Vector<kj::ConstString>& chain) override {
+    chain.add("broken"_kjc);
+    chain.add(kj::str(exception));
   }
 
 private:

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -288,6 +288,10 @@ public:
   // The file descriptor will remain open at least as long as the Capability::Client remains alive.
   // If you need it to last longer, you will need to `dup()` it.
 
+  kj::String debugInfo();
+  // For debugging purposes, return what kind of capability this is, including layers of wrapping
+  // (promises, membranes, etc.). This is suitable for debug logging only; do NOT parse this.
+
   // TODO(someday):  method(s) for Join
 
 protected:
@@ -870,6 +874,10 @@ public:
   virtual kj::Maybe<int> getFd() = 0;
   // Implements Capability::Client::getFd(). If this returns null but whenMoreResolved() returns
   // non-null, then Capability::Client::getFd() waits for resolution and tries again.
+
+  virtual void debugInfo(kj::Vector<kj::ConstString>& chain);
+  // For debugging purposes, follows the chain of ClientHooks appending information about each
+  // to `chain`.
 
   static kj::Own<ClientHook> from(Capability::Client client) { return kj::mv(client.hook); }
 

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -28,6 +28,9 @@
 
 #if !CAPNP_LITE
 #include "capability.h"
+#if !KJ_NO_RTTI
+#include <typeinfo>
+#endif  // !KJ_NO_RTTI
 #endif  // !CAPNP_LITE
 
 namespace capnp {
@@ -65,6 +68,19 @@ static BrokenCapFactory* readGlobalBrokenCapFactoryForLayoutCpp() {
 const uint ClientHook::NULL_CAPABILITY_BRAND = 0;
 const uint ClientHook::BROKEN_CAPABILITY_BRAND = 0;
 // Defined here rather than capability.c++ so that we can safely call isNull() in this file.
+
+void ClientHook::debugInfo(kj::Vector<kj::ConstString>& chain) {
+  // Defined here rather than capability.c++ because when compiling in UBSAN mode specifically,
+  // the compiler emits references to the type info block for ClientHook in some translation units
+  // that #include capability.h even if they don't explicitly use ClientHook, so we need it to be
+  // emitted as part of libcapnp rather than libcapnp-rpc.
+
+#if KJ_NO_RTTI
+  chain.add("unknown"_kjc);
+#else
+  chain.add(kj::str(typeid(*this).name()));
+#endif
+}
 
 namespace _ {  // private
 

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -22,6 +22,10 @@
 #include "membrane.h"
 #include <kj/debug.h>
 
+#if !KJ_NO_RTTI
+#include <typeinfo>
+#endif
+
 namespace capnp {
 
 namespace {
@@ -534,6 +538,14 @@ public:
     }
     return kj::none;
   }
+
+#if !KJ_NO_RTTI
+  void debugInfo(kj::Vector<kj::ConstString>& chain) override {
+    auto& policyRef = *policy;  // avoid stupid compiler warning about side effects
+    chain.add(kj::str(typeid(policyRef).name()));
+    inner->debugInfo(chain);
+  }
+#endif
 
 private:
   kj::Own<ClientHook> inner;

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -1394,6 +1394,11 @@ private:
       }
     }
 
+    void debugInfo(kj::Vector<kj::ConstString>& chain) override {
+      chain.add("rpcPromise"_kjc);
+      cap->debugInfo(chain);
+    }
+
   private:
     kj::Own<ClientHook> cap;
 


### PR DESCRIPTION
This dumps info about the whole chain. For membranes, it dumps the membrane policy type as well as the wrapped capability.

I've very commonly found myself wishing for this while debugging things. Really should have done this sooner.