### PR TITLE
Fix the trouble with Tribbles.

### DIFF
--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -1356,6 +1356,81 @@ KJ_TEST("embargos block CapabilityServerSet") {
   KJ_EXPECT(unwrappedAt >= 3, unwrappedAt);
 }
 
+KJ_TEST("TribbleRaceBlocker blocks CapabilityServerSet unwrap") {
+  TestContext context;
+
+  capnp::CapabilityServerSet<test::TestCallOrder> capSet;
+
+  auto client = context.connect().getTestMoreStuffRequest().send().getCap();
+
+  TestCallOrderImpl* ptr;
+  auto ownCap = kj::heap<TestCallOrderImpl>();
+  ptr = ownCap;
+  auto cap = capSet.add(kj::mv(ownCap));
+
+  auto echoRequest = client.echoRequest();
+  echoRequest.setCap(cap);
+  auto echo = echoRequest.send();
+
+  auto pipeline = echo.getCap();
+
+  auto echoAgainRequest = client.echoRequest();
+  echoAgainRequest.setCap(pipeline);
+  auto echoAgain = echoAgainRequest.send();
+
+  auto roundTripCap = echoAgain.getCap();
+
+  echo.wait(context.waitScope);
+  echoAgain.wait(context.waitScope);
+
+  auto& roundTripObj = KJ_ASSERT_NONNULL(capSet.getLocalServer(roundTripCap).wait(
+      context.waitScope));
+  KJ_EXPECT(&roundTripObj == ptr);
+}
+
+KJ_TEST("TribbleRaceBlocker preserves order for reflected promise") {
+  TestContext context;
+
+  auto client = context.connect().getTestMoreStuffRequest().send().getCap();
+
+  auto cap = test::TestCallOrder::Client(kj::heap<TestCallOrderImpl>());
+
+  auto echoRequest = client.echoRequest();
+  echoRequest.setCap(cap);
+  auto echo = echoRequest.send();
+
+  auto pipeline = echo.getCap();
+
+  auto echoAgainRequest = client.echoRequest();
+  echoAgainRequest.setCap(pipeline);
+  auto echoAgain = echoAgainRequest.send();
+
+  auto& aliceToBob = KJ_ASSERT_NONNULL(
+      context.alice.vatNetwork.getConnectionTo(context.bob.vatNetwork));
+  aliceToBob.block();
+
+  auto roundTripCap = echoAgain.getCap();
+  auto call0 = getCallSequence(pipeline, 0);
+
+  echo.wait(context.waitScope);
+  echoAgain.wait(context.waitScope);
+
+  auto& bobToAlice = KJ_ASSERT_NONNULL(
+      context.bob.vatNetwork.getConnectionTo(context.alice.vatNetwork));
+  bobToAlice.block();
+  aliceToBob.unblock();
+
+  auto call1 = getCallSequence(roundTripCap, 1);
+
+  KJ_EXPECT(!call0.poll(context.waitScope));
+  KJ_EXPECT(!call1.poll(context.waitScope));
+
+  bobToAlice.unblock();
+
+  KJ_EXPECT(call0.wait(context.waitScope).getN() == 0);
+  KJ_EXPECT(call1.wait(context.waitScope).getN() == 1);
+}
+
 template <typename T>
 void expectPromiseThrows(kj::Promise<T>&& promise, kj::WaitScope& waitScope) {
   KJ_EXPECT(promise.then([](T&&) { return false; }, [](kj::Exception&&) { return true; })

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -546,6 +546,9 @@ public:
 
       exports.forEach([&](ExportId id, Export& exp) {
         clientsToRelease.add(kj::mv(exp.clientHook));
+        KJ_IF_SOME(resolveHook, exp.resolveHook) {
+          clientsToRelease.add(kj::mv(resolveHook));
+        }
         KJ_IF_SOME(op, exp.resolveOp) {
           resolveOpsToRelease.add(kj::mv(op));
         }
@@ -730,6 +733,12 @@ private:
     // `exportsByCap[clientHook]` points to this entry.
 
     kj::Own<ClientHook> clientHook;
+
+    kj::Maybe<kj::Own<ClientHook>> resolveHook;
+    // If non-null, use this hook rather than `clientHook` when a `receiverHosted` descriptor
+    // refers to this export. `clientHook` remains the pinned message target for calls addressed
+    // directly to the export, but `resolveHook` retains the original resolution path so promise
+    // shortening can continue when this export is itself used to resolve another promise.
 
     kj::Maybe<kj::Promise<void>> resolveOp = kj::none;
     // If this export is a promise (not a settled capability), the `resolveOp` represents the
@@ -1924,6 +1933,7 @@ private:
         KJ_ASSERT(exportsByCap.erase(exp.clientHook));
       }
       exp.clientHook = kj::mv(resolution);
+      exp.resolveHook = kj::none;
 
       // The export now points to `resolution`, but it is not necessarily the canonical export
       // for `resolution`. The export itself still represents the promise that ended up resolving
@@ -1975,7 +1985,10 @@ private:
         // was for the temporary destination for pipelined calls. To resolve the Tribble 4-way
         // race condition, we must make sure our existing export table entry permanently points
         // strictly to the pipeline, not the promise.
+        exp2.resolveHook = exp2.clientHook->addRef();
         exp2.clientHook = writeDescResult.described.addRef();
+      } else {
+        exp2.resolveHook = kj::none;
       }
 
       return kj::READY_NOW;
@@ -2093,28 +2106,35 @@ private:
     //    `PromiseClient` from recognizing the capability as being remote, so it instead treats it
     //    as local. That causes it to set up an embargo as desired.
     //
-    //    The wrapper still presents itself as a promise resolving to `inner`, so code like
-    //    `CapabilityServerSet` can keep following the resolution chain. The important bit is only
-    //    that `getResolved()` does not reveal `inner` until the `whenMoreResolved()` promise
-    //    actually resolves.
-    //
-    // TODO(perf): This still doesn't fully shorten the path for ordinary calls when `inner` is
-    //   itself another promise that later resolves back over the connection. Messages sent through
-    //   this export continue to route through `inner` to preserve Tribble ordering. A more complete
-    //   optimization would be to put a special export-table entry here that separately handles
-    //   incoming messages to the export and use of the export as the subject of a `Resolve`.
+    //    The wrapper has separate views: calls are sent to `callTarget`, preserving the pinned
+    //    path required by the Tribble rule, while `whenMoreResolved()` resolves to
+    //    `resolutionTarget`, allowing a promise that resolves to this capability to keep
+    //    shortening once its embargo clears. The important bit is only that `getResolved()` does
+    //    not reveal `resolutionTarget` until the `whenMoreResolved()` promise actually resolves.
     //
   public:
-    TribbleRaceBlocker(kj::Own<ClientHook> inner): inner(kj::mv(inner)) {}
+    TribbleRaceBlocker(kj::Own<ClientHook> inner)
+        : ClientHook(getBrand()), callTarget(inner->addRef()), resolutionTarget(kj::mv(inner)) {}
+
+    TribbleRaceBlocker(kj::Own<ClientHook> callTarget, kj::Own<ClientHook> resolutionTarget)
+        : ClientHook(getBrand()),
+          callTarget(kj::mv(callTarget)), resolutionTarget(kj::mv(resolutionTarget)) {}
+
+    static const void* getBrand() {
+      static const int brand = 0;
+      return &brand;
+    }
+
+    ClientHook& getCallTarget() { return *callTarget; }
 
     Request<AnyPointer, AnyPointer> newCall(
         uint64_t interfaceId, uint16_t methodId, kj::Maybe<MessageSize> sizeHint,
         CallHints hints) override {
-      return inner->newCall(interfaceId, methodId, sizeHint, hints);
+      return callTarget->newCall(interfaceId, methodId, sizeHint, hints);
     }
     VoidPromiseAndPipeline call(uint64_t interfaceId, uint16_t methodId,
                                 kj::Own<CallContextHook>&& context, CallHints hints) override {
-      return inner->call(interfaceId, methodId, kj::mv(context), hints);
+      return callTarget->call(interfaceId, methodId, kj::mv(context), hints);
     }
     kj::Maybe<ClientHook&> getResolved() override {
       return resolved.map([](kj::Own<ClientHook>& r) -> ClientHook& { return *r; });
@@ -2123,7 +2143,7 @@ private:
       KJ_IF_SOME(r, resolved) {
         return kj::Promise<kj::Own<ClientHook>>(r->addRef());
       } else {
-        return kj::evalLater([this,result = inner->addRef()]() mutable {
+        return kj::evalLater([this,result = resolutionTarget->addRef()]() mutable {
           resolved = result->addRef();
           return kj::mv(result);
         }).attach(kj::addRef(*this));
@@ -2133,11 +2153,12 @@ private:
       return kj::addRef(*this);
     }
     kj::Maybe<int> getFd() override {
-      return inner->getFd();
+      return callTarget->getFd();
     }
 
   private:
-    kj::Own<ClientHook> inner;
+    kj::Own<ClientHook> callTarget;
+    kj::Own<ClientHook> resolutionTarget;
     kj::Maybe<kj::Own<ClientHook>> resolved;
   };
 
@@ -2175,7 +2196,10 @@ private:
                   vineConnection, capnp::clone(*contact), kj::mv(vine));
             }
           }
-          if (unwrapIfSameConnection(*result) != kj::none) {
+          KJ_IF_SOME(resolveHook, exp.resolveHook) {
+            result = kj::refcounted<TribbleRaceBlocker>(
+                kj::mv(result), resolveHook->addRef());
+          } else if (unwrapIfSameConnection(*result) != kj::none) {
             result = kj::refcounted<TribbleRaceBlocker>(kj::mv(result));
           }
           return kj::mv(result);
@@ -3058,7 +3082,12 @@ private:
       ClientHook* ptr = original.get();
       for (;;) {
         if (ptr == resolution.returnedCap.get()) {
-          return kj::mv(resolution.unwrapped);
+          if (resolution.unwrapped.get() == resolution.returnedCap.get()) {
+            return kj::mv(resolution.unwrapped);
+          } else {
+            return kj::refcounted<TribbleRaceBlocker>(
+                kj::mv(resolution.unwrapped), kj::mv(resolution.returnedCap));
+          }
         } else KJ_IF_SOME(r, ptr->getResolved()) {
           ptr = &r;
         } else {
@@ -4234,6 +4263,29 @@ private:
     }
   }
 
+  kj::Promise<kj::Own<ClientHook>> whenMessageTargetResolved(kj::Own<ClientHook> target) {
+    // Resolve a target for the purpose of forwarding a message or disembargo. A
+    // `TribbleRaceBlocker` has a separate call target and resolution target; for this path we must
+    // follow the call target to preserve the Tribble ordering rule.
+    for (;;) {
+      if (target->isBrand(TribbleRaceBlocker::getBrand())) {
+        target = kj::downcast<TribbleRaceBlocker>(*target).getCallTarget().addRef();
+      } else KJ_IF_SOME(r, target->getResolved()) {
+        target = r.addRef();
+      } else {
+        break;
+      }
+    }
+
+    KJ_IF_SOME(p, target->whenMoreResolved()) {
+      return p.attach(kj::mv(target)).then([this](kj::Own<ClientHook>&& resolved) {
+        return whenMessageTargetResolved(kj::mv(resolved));
+      });
+    } else {
+      return kj::mv(target);
+    }
+  }
+
   void handleDisembargo(const rpc::Disembargo::Reader& disembargo) {
     auto context = disembargo.getContext();
     switch (context.which()) {
@@ -4252,22 +4304,17 @@ private:
         // Alice. Alice then *also* sends a Disembargo to Bob. The Alice -> Bob Disembargo might
         // arrive at Bob before the Bob -> Carol Disembargo has resolved, in which case the
         // Disembargo is delivered to a promise capability.
-        auto promise = target->whenResolved()
-            .then([]() {
+        auto promise = whenMessageTargetResolved(kj::mv(target))
+            .then([this](kj::Own<ClientHook>&& target) mutable {
           // We also need to insert yieldUntilQueueEmpty() here to make sure that any pending calls
           // towards this cap have had time to find their way through the event loop.
-          return kj::yieldUntilQueueEmpty();
+          return kj::yieldUntilQueueEmpty()
+              .then([this,target = kj::mv(target)]() mutable {
+            return whenMessageTargetResolved(kj::mv(target));
+          });
         });
 
-        tasks.add(promise.then([this, embargoId, target = kj::mv(target)]() mutable {
-          for (;;) {
-            KJ_IF_SOME(r, target->getResolved()) {
-              target = r.addRef();
-            } else {
-              break;
-            }
-          }
-
+        tasks.add(promise.then([this, embargoId](kj::Own<ClientHook>&& target) mutable {
           KJ_REQUIRE(unwrapIfSameConnection(*target) != kj::none,
                     "'Disembargo' of type 'senderLoopback' sent to an object that does not point "
                     "back to the sender.") {

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -2093,13 +2093,17 @@ private:
     //    `PromiseClient` from recognizing the capability as being remote, so it instead treats it
     //    as local. That causes it to set up an embargo as desired.
     //
-    // TODO(perf): This actually blocks further promise resolution in the case where the
-    //   ImportClient or PipelineClient itself ends up being yet another promise that resolves
-    //   back over the connection again. What we probably really need to do here is, instead of
-    //   placing `ImportClient` or `PipelineClient` on the export table, place a special type there
-    //   that both knows what to do with future incoming messages to that export ID, but also knows
-    //   what to do when that export is the subject of a `Resolve`.
-
+    //    The wrapper still presents itself as a promise resolving to `inner`, so code like
+    //    `CapabilityServerSet` can keep following the resolution chain. The important bit is only
+    //    that `getResolved()` does not reveal `inner` until the `whenMoreResolved()` promise
+    //    actually resolves.
+    //
+    // TODO(perf): This still doesn't fully shorten the path for ordinary calls when `inner` is
+    //   itself another promise that later resolves back over the connection. Messages sent through
+    //   this export continue to route through `inner` to preserve Tribble ordering. A more complete
+    //   optimization would be to put a special export-table entry here that separately handles
+    //   incoming messages to the export and use of the export as the subject of a `Resolve`.
+    //
   public:
     TribbleRaceBlocker(kj::Own<ClientHook> inner): inner(kj::mv(inner)) {}
 
@@ -2113,14 +2117,17 @@ private:
       return inner->call(interfaceId, methodId, kj::mv(context), hints);
     }
     kj::Maybe<ClientHook&> getResolved() override {
-      // We always wrap either PipelineClient or ImportClient, both of which return null for this
-      // anyway.
-      return kj::none;
+      return resolved.map([](kj::Own<ClientHook>& r) -> ClientHook& { return *r; });
     }
     kj::Maybe<kj::Promise<kj::Own<ClientHook>>> whenMoreResolved() override {
-      // We always wrap either PipelineClient or ImportClient, both of which return null for this
-      // anyway.
-      return kj::none;
+      KJ_IF_SOME(r, resolved) {
+        return kj::Promise<kj::Own<ClientHook>>(r->addRef());
+      } else {
+        return kj::evalLater([this,result = inner->addRef()]() mutable {
+          resolved = result->addRef();
+          return kj::mv(result);
+        }).attach(kj::addRef(*this));
+      }
     }
     kj::Own<ClientHook> addRef() override {
       return kj::addRef(*this);
@@ -2131,6 +2138,7 @@ private:
 
   private:
     kj::Own<ClientHook> inner;
+    kj::Maybe<kj::Own<ClientHook>> resolved;
   };
 
   kj::Maybe<kj::Own<ClientHook>> receiveCap(rpc::CapDescriptor::Reader descriptor,


### PR DESCRIPTION
TribbleRaceBlocker had a TODO describing a case where it blocks promise resolution. It described this as TODO(perf). But it's actually a correctness issue when combined with CapabilityServerSet, which needs all promises to resolve in order to unwrap a local capability.

Two tests are added, one to cover the bug that is fixed, and another than verifies the general TribbleRaceBlocker behvaior, because I noticed that removing it entirely didn't break any tests.

This was written entirely by GPT 5.5, which can also take credit for figuring out that this bug was manifesting in an obscure case in production in the Cloudflare Workers Runtime.

The first commit was GPT's first attempt to fix the specific bug, which specifically solved the CapabilityServerSet issue but not the broader performance issue. I then pushed it to actually fully solve the issue, which produced the second commit.

**I HAVE NOT REVIEWED THIS YET.** I honestly have not yet been able to fully remember WTF is going on here. This is THE most complicated part of Cap'n Proto. When I get a chance (definitely before asking anyone else to review) I'm going to spend an hour or two paging this all back into my head and decide if this fix is actually the fix I want...