### PR TITLE
KJ: Make Windows CA store import best-effort

### DIFF
--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -98,9 +98,22 @@ void updateOpenSSLCAStoreWithWindowsCertificates(SSL_CTX* ctx) {
   if (store == nullptr) {
     throwOpensslError();
   }
-  HCERTSTORE hStore;
-  KJ_WIN32(hStore = CertOpenSystemStoreA(NULL, "ROOT"));
-  KJ_DEFER(KJ_WIN32(CertCloseStore(hStore, 0)));
+  HCERTSTORE hStore = CertOpenSystemStoreA(NULL, "ROOT");
+  DWORD currentUserError = hStore == nullptr ? GetLastError() : ERROR_SUCCESS;
+  if (hStore == nullptr) {
+    hStore = CertOpenStore(CERT_STORE_PROV_SYSTEM_A, 0, 0,
+        CERT_SYSTEM_STORE_LOCAL_MACHINE | CERT_STORE_READONLY_FLAG, "ROOT");
+  }
+  DWORD localMachineError = hStore == nullptr ? GetLastError() : ERROR_SUCCESS;
+  if (hStore == nullptr) {
+    // Service accounts may not have a loadable current-user certificate store. Treat the
+    // Windows CA import as best-effort; SSL_CTX_set_default_verify_paths() has already run,
+    // and callers may still provide explicit trusted certificates.
+    KJ_LOG(WARNING, "unable to open Windows ROOT certificate store; skipping Windows CA import",
+        currentUserError, localMachineError);
+    return;
+  }
+  KJ_DEFER(CertCloseStore(hStore, 0));
   PCCERT_CONTEXT pContext = nullptr;
   KJ_DEFER(CertFreeCertificateContext(pContext));
   while ((pContext = CertEnumCertificatesInStore(hStore, pContext))) {


### PR DESCRIPTION
---

**Disclaimer: This PR was AI-assisted (GPT 5.5), and is my first contribution to the codebase. I’ve included the observed failure, stack trace, and reasoning below to make the proposed behavior easy to validate.**

---

This makes importing Windows root certificates into OpenSSL best-effort.

Currently, `TlsContext` on Windows calls `CertOpenSystemStoreA(NULL, "ROOT")` while initializing the system trust store. Under some service identities, such as IIS application pool or other non-interactive service accounts, the current-user certificate store may not be loadable. In that case, KJ treats the failed `CertOpenSystemStoreA()` call as fatal and aborts TLS context construction.

This change:

- Tries the current-user `ROOT` store first.
- Falls back to `LocalMachine\ROOT` if the current-user store is unavailable.
- Logs a warning and skips Windows CA import if neither store can be opened.

Callers may still provide explicit trusted certificates, and the Windows CA import no longer makes process startup depend on a loadable current-user certificate store.

## Reproducer / Motivation

This was observed when running `workerd` under an IIS-hosted service account. The process failed during startup with only:

```text
*** std::terminate() called with no exception
stack: ...
FATAL: workerd backend failed during startup: Error: workerd exited before sockets became ready: aborted
```

There was no actionable warning or error message indicating that Windows certificate store access had failed.

A first-chance dump with [matching symbols](https://github.com/lofcz/workerd/commit/8f945b2115a362c53f67aca77a8ec39c90850b28#diff-acf2a617ec46e1b14414cdd16c378cfca4173c8bef1ef5937840e81f19f63bf5) showed the process was aborting while creating the default TLS-enabled network service:

```text
kj::ExceptionCallback::RootExceptionCallback::onFatalException()
kj::throwFatalException()
kj::_::Debug::Fault::fatal()
updateOpenSSLCAStoreWithWindowsCertificates()
kj::TlsContext::TlsContext()
workerd::server::Server::startServices()
```

<img width="2558" height="1373" alt="image" src="https://github.com/user-attachments/assets/a22adb4e-8d2f-4b08-b1f5-dd106de82cb6" />

The failing call was:

```cpp
KJ_WIN32(hStore = CertOpenSystemStoreA(NULL, "ROOT"));
```

After [applying this change](https://github.com/lofcz/workerd/commit/34222005fc7106680b4eaedf83aaaa8fa7b36f2c), the same `workerd` binary was able to start and serve successfully under the service identity.