### PR TITLE
fix ArrayPtr::find methods for empty array

### DIFF
--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -817,6 +817,13 @@ KJ_TEST("ArrayPtr::split") {
   }
 }
 
+KJ_TEST("ArrayPtr::findFirst empty optimized types") {
+  KJ_EXPECT(kj::ArrayPtr<const char>().findFirst(',') == kj::none);
+  KJ_EXPECT(kj::ArrayPtr<char>().findFirst(',') == kj::none);
+  KJ_EXPECT(kj::ArrayPtr<const byte>().findFirst(byte{123}) == kj::none);
+  KJ_EXPECT(kj::ArrayPtr<byte>().findFirst(byte{123}) == kj::none);
+}
+
 KJ_TEST("ArrayPtr::split mutable") {
   int values[] = {1, 0, 2, 3, 0, 4};
   int expectedFirst[] = {11, 12, 14};

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2810,6 +2810,7 @@ private:
 
 template <>
 inline Maybe<size_t> ArrayPtr<const char>::findFirst(const char& c) const {
+  if (size_ == 0) return kj::none;
   const char* pos = reinterpret_cast<const char*>(memchr(ptr, c, size_));
   if (pos == nullptr) {
     return kj::none;
@@ -2820,6 +2821,7 @@ inline Maybe<size_t> ArrayPtr<const char>::findFirst(const char& c) const {
 
 template <>
 inline Maybe<size_t> ArrayPtr<char>::findFirst(const char& c) const {
+  if (size_ == 0) return kj::none;
   char* pos = reinterpret_cast<char*>(memchr(ptr, c, size_));
   if (pos == nullptr) {
     return kj::none;
@@ -2830,6 +2832,7 @@ inline Maybe<size_t> ArrayPtr<char>::findFirst(const char& c) const {
 
 template <>
 inline Maybe<size_t> ArrayPtr<const byte>::findFirst(const byte& c) const {
+  if (size_ == 0) return kj::none;
   const byte* pos = reinterpret_cast<const byte*>(memchr(ptr, c, size_));
   if (pos == nullptr) {
     return kj::none;
@@ -2840,6 +2843,7 @@ inline Maybe<size_t> ArrayPtr<const byte>::findFirst(const byte& c) const {
 
 template <>
 inline Maybe<size_t> ArrayPtr<byte>::findFirst(const byte& c) const {
+  if (size_ == 0) return kj::none;
   byte* pos = reinterpret_cast<byte*>(memchr(ptr, c, size_));
   if (pos == nullptr) {
     return kj::none;


### PR DESCRIPTION
memchr has first argument annotated as non-null and UBSAN complains.