### PR TITLE
use kj::ArrayPtr<const char> for statusText

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-bench.c++
+++ b/c++/src/capnp/compat/http-over-capnp-bench.c++
@@ -261,7 +261,7 @@ public:
     kj::HttpHeaders responseHeaders(headerTable);
     responseHeaders.setPtr(kj::HttpHeaderId::CONTENT_TYPE, "text/plain");
     responseHeaders.setPtr(customHeaderId, "foobar"_kj);
-    auto stream = response.send(200, "OK", responseHeaders);
+    auto stream = response.send(200, "OK"_kj, responseHeaders);
     auto promise = stream->write(HELLO_WORLD.asBytes());
     return promise.attach(kj::mv(stream));
   }
@@ -306,7 +306,7 @@ private:
   VectorOutputStream responseBody;
 
   kj::Own<kj::AsyncOutputStream> send(
-      kj::uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers,
+      kj::uint statusCode, kj::ArrayPtr<const char> statusText, const kj::HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
     KJ_ASSERT(statusCode == 200);
     KJ_ASSERT(statusText == "OK"_kj);

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -686,7 +686,7 @@ public:
       kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& io,
       kj::HttpService::ConnectResponse& response,
       kj::HttpConnectSettings settings) override {
-    response.accept(200, "OK", kj::HttpHeaders(headerTable));
+    response.accept(200, "OK"_kj, kj::HttpHeaders(headerTable));
     return io.write("test"_kjb).then([&io]() mutable {
       io.shutdownWrite();
     });
@@ -711,7 +711,7 @@ public:
       kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& io,
       kj::HttpService::ConnectResponse& response,
       kj::HttpConnectSettings settings) override {
-    response.accept(200, "OK", kj::HttpHeaders(headerTable));
+    response.accept(200, "OK"_kj, kj::HttpHeaders(headerTable));
     // TODO(later): `io.pumpTo(io).ignoreResult;` doesn't work here,
     // it causes startTls to come back in a loop. The below avoids this.
     auto buffer = kj::heapArray<byte>(4096);
@@ -748,7 +748,7 @@ public:
       kj::StringPtr host, const kj::HttpHeaders& headers, kj::AsyncIoStream& io,
       kj::HttpService::ConnectResponse& response,
       kj::HttpConnectSettings settings) override {
-    auto body = response.reject(500, "Internal Server Error", kj::HttpHeaders(headerTable), 5);
+    auto body = response.reject(500, "Internal Server Error"_kj, kj::HttpHeaders(headerTable), 5);
     return body->write("Error"_kjb).attach(kj::mv(body));
   }
 
@@ -782,7 +782,8 @@ KJ_TEST("HTTP-over-Cap'n-Proto Connect with close") {
     kj::Own<kj::PromiseFulfiller<kj::HttpClient::ConnectRequest::Status>> fulfiller;
     ResponseImpl(kj::Own<kj::PromiseFulfiller<kj::HttpClient::ConnectRequest::Status>> fulfiller)
       : fulfiller(kj::mv(fulfiller)) {}
-    void accept(uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+    void accept(uint statusCode, kj::ArrayPtr<const char> statusText,
+                const kj::HttpHeaders& headers) override {
       KJ_REQUIRE(statusCode >= 200 && statusCode < 300, "the statusCode must be 2xx for accept");
       fulfiller->fulfill(
         kj::HttpClient::ConnectRequest::Status(
@@ -796,7 +797,7 @@ KJ_TEST("HTTP-over-Cap'n-Proto Connect with close") {
 
     kj::Own<kj::AsyncOutputStream> reject(
         uint statusCode,
-        kj::StringPtr statusText,
+        kj::ArrayPtr<const char> statusText,
         const kj::HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize) override {
       KJ_UNREACHABLE;
@@ -857,17 +858,18 @@ KJ_TEST("HTTP-over-Cap'n-Proto Connect Reject") {
     kj::Own<kj::PromiseFulfiller<kj::Own<kj::AsyncInputStream>>> fulfiller;
     ResponseImpl(kj::Own<kj::PromiseFulfiller<kj::Own<kj::AsyncInputStream>>> fulfiller)
       : fulfiller(kj::mv(fulfiller)) {}
-    void accept(uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+    void accept(uint statusCode, kj::ArrayPtr<const char> statusText,
+                const kj::HttpHeaders& headers) override {
       KJ_UNREACHABLE;
     }
 
     kj::Own<kj::AsyncOutputStream> reject(
         uint statusCode,
-        kj::StringPtr statusText,
+        kj::ArrayPtr<const char> statusText,
         const kj::HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize) override {
       KJ_ASSERT(statusCode == 500);
-      KJ_ASSERT(statusText == "Internal Server Error");
+      KJ_ASSERT(statusText == "Internal Server Error"_kj);
       KJ_ASSERT(expectedBodySize.orDefault(5));
       auto pipe = kj::newOneWayPipe();
       fulfiller->fulfill(kj::mv(pipe.in));

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -691,7 +691,7 @@ public:
         clientContext(kj::mv(clientContext)) {}
 
   kj::Own<kj::AsyncOutputStream> send(
-      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers,
+      uint statusCode, kj::ArrayPtr<const char> statusText, const kj::HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
     KJ_REQUIRE(!responseSent, "already called send() or acceptWebSocket()");
     responseSent = true;
@@ -705,7 +705,7 @@ public:
 
     auto rpcResponse = req.initResponse();
     rpcResponse.setStatusCode(statusCode);
-    rpcResponse.setStatusText(statusText);
+    rpcResponse.initStatusText(statusText.size()).asArray().copyFrom(statusText);
     rpcResponse.adoptHeaders(factory.headersToCapnp(
         headers, Orphanage::getForMessageContaining(rpcResponse)));
     bool hasBody = true;
@@ -790,13 +790,14 @@ public:
       capnp::HttpService::ConnectClientRequestContext::Client context) :
       context(context), factory(factory) {}
 
-  void accept(uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+  void accept(uint statusCode, kj::ArrayPtr<const char> statusText,
+              const kj::HttpHeaders& headers) override {
     KJ_REQUIRE(replyTask == kj::none, "already called accept() or reject()");
 
     auto req = context.startConnectRequest();
     auto rpcResponse = req.initResponse();
     rpcResponse.setStatusCode(statusCode);
-    rpcResponse.setStatusText(statusText);
+    rpcResponse.initStatusText(statusText.size()).asArray().copyFrom(statusText);
     rpcResponse.adoptHeaders(factory.headersToCapnp(
         headers, Orphanage::getForMessageContaining(rpcResponse)));
 
@@ -805,7 +806,7 @@ public:
 
   kj::Own<kj::AsyncOutputStream> reject(
       uint statusCode,
-      kj::StringPtr statusText,
+      kj::ArrayPtr<const char> statusText,
       const kj::HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
     KJ_REQUIRE(replyTask == kj::none, "already called accept() or reject()");
@@ -814,7 +815,7 @@ public:
     auto req = context.startErrorRequest();
     auto rpcResponse = req.initResponse();
     rpcResponse.setStatusCode(statusCode);
-    rpcResponse.setStatusText(statusText);
+    rpcResponse.initStatusText(statusText.size()).asArray().copyFrom(statusText);
     rpcResponse.adoptHeaders(factory.headersToCapnp(
         headers, Orphanage::getForMessageContaining(rpcResponse)));
 

--- a/c++/src/kj/compat/http-bench.c++
+++ b/c++/src/kj/compat/http-bench.c++
@@ -42,7 +42,7 @@ public:
                             Response &response) override {
     responseHeaders.clear();
     responseHeaders.setPtr(HttpHeaderId::CONTENT_TYPE, "text/plain");
-    auto stream = response.send(200, "OK", responseHeaders);
+    auto stream = response.send(200, "OK"_kj, responseHeaders);
     co_await stream->write("OK"_kjb);
   }
 

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -2633,7 +2633,7 @@ public:
     }
 
     if (url == "/return-error") {
-      response.send(404, "Not Found", responseHeaders, uint64_t(0));
+      response.send(404, "Not Found"_kj, responseHeaders, uint64_t(0));
       return kj::READY_NOW;
     } else if (url == "/websocket") {
       auto ws = response.acceptWebSocket(responseHeaders);
@@ -4481,23 +4481,23 @@ public:
     // In a real error handler, you should redact `protocolError.rawContent`.
     auto message = kj::str("Saw protocol error: ", protocolError.description, "; rawContent = ",
         encodeCEscape(protocolError.rawContent));
-    return sendError(400, "Bad Request", kj::mv(message), response);
+    return sendError(400, "Bad Request"_kj, kj::mv(message), response);
   }
 
   kj::Promise<void> handleApplicationError(
       kj::Exception exception, kj::Maybe<kj::HttpService::Response&> response) override {
-    return sendError(500, "Internal Server Error",
+    return sendError(500, "Internal Server Error"_kj,
         kj::str("Saw application error: ", exception.getDescription()), response);
   }
 
   kj::Promise<void> handleNoResponse(kj::HttpService::Response& response) override {
-    return sendError(500, "Internal Server Error", kj::str("Saw no response."), response);
+    return sendError(500, "Internal Server Error"_kj, kj::str("Saw no response."), response);
   }
 
   static TestErrorHandler instance;
 
 private:
-  kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText, String message,
+  kj::Promise<void> sendError(uint statusCode, kj::ArrayPtr<const char> statusText, String message,
       Maybe<HttpService::Response&> response) {
     KJ_IF_SOME(r, response) {
       HttpHeaderTable headerTable;
@@ -4610,7 +4610,7 @@ public:
     return requestBody.readAllBytes()
         .then([this,&response](kj::Array<byte>&&) -> kj::Promise<void> {
       HttpHeaders headers(table);
-      auto body = response.send(200, "OK", headers, 32);
+      auto body = response.send(200, "OK"_kj, headers, 32);
       auto promise = body->write("foo"_kjb);
       return promise.attach(kj::mv(body)).then([]() -> kj::Promise<void> {
         return KJ_EXCEPTION(FAILED, "failed");
@@ -4659,7 +4659,7 @@ public:
     return requestBody.readAllBytes()
         .then([this,&response](kj::Array<byte>&&) -> kj::Promise<void> {
       HttpHeaders headers(table);
-      auto body = response.send(200, "OK", headers, 32);
+      auto body = response.send(200, "OK"_kj, headers, 32);
       auto promise = body->write("foo"_kjb);
       return promise.attach(kj::mv(body));
     });
@@ -4724,7 +4724,7 @@ public:
         .then([this,&response](kj::Array<byte>&&) -> kj::Promise<void> {
       HttpHeaders headers(table);
       kj::StringPtr text = "Hello, World!";
-      auto body = response.send(200, "OK", headers, text.size());
+      auto body = response.send(200, "OK"_kj, headers, text.size());
 
       auto stream = kj::heap<SimpleInputStream>(text);
       auto promise = stream->pumpTo(*body);
@@ -4870,7 +4870,7 @@ private:
 
     // Send response.
     HttpHeaders responseHeaders(*table);
-    response.send(200, "OK", responseHeaders);
+    response.send(200, "OK"_kj, responseHeaders);
     return requestBody.readAllBytes().ignoreResult();
   }
 
@@ -5199,7 +5199,7 @@ KJ_TEST("HttpServer::listenHttpCleanDrain() factory-created services outlive req
           // This KJ_EXPECT here is the entire point of this test.
           KJ_EXPECT(serviceCount == 1)
           HttpHeaders responseHeaders(table);
-          response.send(200, "OK", responseHeaders);
+          response.send(200, "OK"_kj, responseHeaders);
           return requestBody.readAllBytes().ignoreResult();
         });
       }
@@ -5518,7 +5518,7 @@ public:
   kj::Promise<void> request(
       HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override {
-    auto stream = response.send(200, "OK", HttpHeaders(table), expectedLength);
+    auto stream = response.send(200, "OK"_kj, HttpHeaders(table), expectedLength);
     auto promise = stream->write("foo"_kjb);
     return promise.attach(kj::mv(stream)).then([this]() {
       return kj::mv(paf.promise);
@@ -5818,7 +5818,7 @@ public:
       }
 
       auto body = kj::str(headers.get(HttpHeaderId::HOST).orDefault("null"), ":", url);
-      auto stream = response.send(200, "OK", HttpHeaders(headerTable), body.size());
+      auto stream = response.send(200, "OK"_kj, HttpHeaders(headerTable), body.size());
       auto promises = kj::heapArrayBuilder<kj::Promise<void>>(2);
       promises.add(stream->write(body.asBytes()));
       promises.add(requestBody.readAllBytes().ignoreResult());
@@ -6231,7 +6231,7 @@ KJ_TEST("HttpClient releaseSlotOnHeadersReceived") {
         co_await ws->receive();
       } else {
         auto body = kj::str("body:", url);
-        auto stream = response.send(200, "OK", HttpHeaders(headerTable), body.size());
+        auto stream = response.send(200, "OK"_kj, HttpHeaders(headerTable), body.size());
         co_await stream->write(body.asBytes());
         co_await requestBody.readAllBytes();
       }
@@ -6244,7 +6244,7 @@ KJ_TEST("HttpClient releaseSlotOnHeadersReceived") {
                               kj::HttpConnectSettings settings) override {
       KJ_ASSERT(nextGate < gates.size(), "no gate available for incoming CONNECT");
       co_await gates[nextGate++];
-      response.accept(200, "OK", HttpHeaders(headerTable));
+      response.accept(200, "OK"_kj, HttpHeaders(headerTable));
       co_await connection.pumpTo(connection);
     }
   };
@@ -6457,7 +6457,7 @@ KJ_TEST("HttpClient releaseSlotOnHeadersReceived immediate path") {
         co_await ws->receive();
       } else {
         auto body = "ok"_kjb;
-        auto stream = response.send(200, "OK", HttpHeaders(headerTable), body.size());
+        auto stream = response.send(200, "OK"_kj, HttpHeaders(headerTable), body.size());
         co_await stream->write(body);
         co_await requestBody.readAllBytes();
       }
@@ -6468,7 +6468,7 @@ KJ_TEST("HttpClient releaseSlotOnHeadersReceived immediate path") {
                               kj::AsyncIoStream& connection,
                               ConnectResponse& response,
                               kj::HttpConnectSettings settings) override {
-      response.accept(200, "OK", HttpHeaders(headerTable));
+      response.accept(200, "OK"_kj, HttpHeaders(headerTable));
       co_await connection.pumpTo(connection);
     }
   };
@@ -6755,10 +6755,10 @@ public:
           .then([]() -> kj::Promise<void> { return kj::NEVER_DONE; })
           .exclusiveJoin(timer.afterDelay(1 * kj::MILLISECONDS))
           .then([this, &responseSender]() {
-        responseSender.send(408, "Request Timeout", kj::HttpHeaders(headerTable), uint64_t(0));
+        responseSender.send(408, "Request Timeout"_kj, kj::HttpHeaders(headerTable), uint64_t(0));
       });
     } else {
-      responseSender.send(200, "OK", kj::HttpHeaders(headerTable), uint64_t(0));
+      responseSender.send(200, "OK"_kj, kj::HttpHeaders(headerTable), uint64_t(0));
       return kj::READY_NOW;
     }
   }
@@ -7095,7 +7095,7 @@ KJ_TEST("HttpServer handles disconnected exception for clients disconnecting aft
     kj::Promise<void> request(
         HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
         kj::AsyncInputStream& requestBody, Response& responseSender) override {
-      return responseSender.sendError(404, "Not Found", headerTable);
+      return responseSender.sendError(404, "Not Found"_kj, headerTable);
     }
 
   private:
@@ -7245,7 +7245,7 @@ public:
                             ConnectResponse& response,
                             kj::HttpConnectSettings settings) override {
     connectCount++;
-    response.accept(statusCodeToSend, "OK", HttpHeaders(headerTable));
+    response.accept(statusCodeToSend, "OK"_kj, HttpHeaders(headerTable));
     return connection.pumpTo(connection).ignoreResult();
   }
 
@@ -7304,7 +7304,7 @@ public:
                             kj::AsyncIoStream& connection,
                             ConnectResponse& response,
                             kj::HttpConnectSettings settings) override {
-    response.accept(200, "OK", HttpHeaders(headerTable));
+    response.accept(200, "OK"_kj, HttpHeaders(headerTable));
     // Return an immediately resolved promise and drop the connection
     return kj::READY_NOW;
   }
@@ -7331,7 +7331,7 @@ public:
                             kj::AsyncIoStream& connection,
                             ConnectResponse& response,
                             kj::HttpConnectSettings settings) override {
-    response.accept(200, "OK", HttpHeaders(headerTable));
+    response.accept(200, "OK"_kj, HttpHeaders(headerTable));
     auto promise KJ_UNUSED = connection.write("hello"_kjb);
     // Return an immediately resolved promise and drop the io
     return kj::READY_NOW;
@@ -7362,7 +7362,7 @@ private:
                             kj::AsyncIoStream& connection,
                             ConnectResponse& response,
                             kj::HttpConnectSettings settings) override {
-    response.accept(200, "OK", HttpHeaders(tunneledService.table));
+    response.accept(200, "OK"_kj, HttpHeaders(tunneledService.table));
     return server.listenHttp(kj::Own<kj::AsyncIoStream>(&connection, kj::NullDisposer::instance));
   }
 
@@ -7402,7 +7402,7 @@ public:
                             kj::AsyncIoStream& connection,
                             ConnectResponse& response,
                             kj::HttpConnectSettings settings) override {
-    response.accept(200, "OK", HttpHeaders(headerTable));
+    response.accept(200, "OK"_kj, HttpHeaders(headerTable));
     connection.shutdownWrite();
     return kj::READY_NOW;
   }
@@ -7933,13 +7933,14 @@ KJ_TEST("CONNECT pipelined via an adapter") {
   struct ResponseImpl final: public HttpService::ConnectResponse {
     bool& acceptCalled;
     ResponseImpl(bool& acceptCalled) : acceptCalled(acceptCalled) {}
-    void accept(uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+    void accept(uint statusCode, kj::ArrayPtr<const char> statusText,
+                const HttpHeaders& headers) override {
       acceptCalled = true;
     }
 
     kj::Own<kj::AsyncOutputStream> reject(
         uint statusCode,
-        kj::StringPtr statusText,
+        kj::ArrayPtr<const char> statusText,
         const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize) override {
       KJ_UNREACHABLE;
@@ -8001,13 +8002,14 @@ KJ_TEST("CONNECT pipelined via an adapter (reject)") {
     ResponseImpl(bool& rejectCalled)
         : rejectCalled(rejectCalled),
           pipe(kj::newOneWayPipe()) {}
-    void accept(uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+    void accept(uint statusCode, kj::ArrayPtr<const char> statusText,
+                const HttpHeaders& headers) override {
       KJ_UNREACHABLE;
     }
 
     kj::Own<kj::AsyncOutputStream> reject(
         uint statusCode,
-        kj::StringPtr statusText,
+        kj::ArrayPtr<const char> statusText,
         const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize) override {
       rejectCalled = true;

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1083,7 +1083,7 @@ kj::String HttpHeaders::serializeConnectRequest(
 }
 
 kj::String HttpHeaders::serializeResponse(
-    uint statusCode, kj::StringPtr statusText,
+    uint statusCode, kj::ArrayPtr<const char> statusText,
     kj::ArrayPtr<const kj::StringPtr> connectionHeaders) const {
   auto statusCodeStr = kj::toCharSequence(statusCode);
 
@@ -7124,7 +7124,7 @@ private:
     }
 
     kj::Own<kj::AsyncOutputStream> send(
-        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers,
+        uint statusCode, kj::ArrayPtr<const char> statusText, const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
       // The caller of HttpClient is allowed to assume that the statusText and headers remain
       // valid until the body stream is dropped, but the HttpService implementation is allowed to
@@ -7272,7 +7272,7 @@ private:
     }
 
     kj::Own<kj::AsyncOutputStream> send(
-        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers,
+        uint statusCode, kj::ArrayPtr<const char> statusText, const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
       // The caller of HttpClient is allowed to assume that the statusText and headers remain
       // valid until the body stream is dropped, but the HttpService implementation is allowed to
@@ -7355,14 +7355,15 @@ private:
       }
     }
 
-    void accept(uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+    void accept(uint statusCode, kj::ArrayPtr<const char> statusText,
+                const HttpHeaders& headers) override {
       KJ_REQUIRE(statusCode >= 200 && statusCode < 300, "the statusCode must be 2xx for accept");
       respond(statusCode, statusText, headers);
     }
 
     kj::Own<kj::AsyncOutputStream> reject(
         uint statusCode,
-        kj::StringPtr statusText,
+        kj::ArrayPtr<const char> statusText,
         const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
       KJ_REQUIRE(statusCode < 200 || statusCode >= 300,
@@ -7425,7 +7426,7 @@ private:
     }
 
     void respond(uint statusCode,
-                 kj::StringPtr statusText,
+                 kj::ArrayPtr<const char> statusText,
                  const HttpHeaders& headers,
                  kj::Maybe<kj::Own<kj::AsyncInputStream>> errorBody = kj::none) {
       if (errorBody == kj::none) {
@@ -7582,14 +7583,14 @@ kj::Own<HttpService> newHttpService(HttpClient& client) {
 // =======================================================================================
 
 kj::Promise<void> HttpService::Response::sendError(
-    uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) {
+    uint statusCode, kj::ArrayPtr<const char> statusText, const HttpHeaders& headers) {
   auto stream = send(statusCode, statusText, headers, statusText.size());
   auto promise = stream->write(statusText.asBytes());
   return promise.attach(kj::mv(stream));
 }
 
 kj::Promise<void> HttpService::Response::sendError(
-    uint statusCode, kj::StringPtr statusText, const HttpHeaderTable& headerTable) {
+    uint statusCode, kj::ArrayPtr<const char> statusText, const HttpHeaderTable& headerTable) {
   return sendError(statusCode, statusText, HttpHeaders(headerTable));
 }
 
@@ -8084,7 +8085,7 @@ private:
   }
 
   kj::Own<kj::AsyncOutputStream> send(
-      uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers,
+      uint statusCode, kj::ArrayPtr<const char> statusText, const HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize) override {
     auto method = KJ_REQUIRE_NONNULL(currentMethod, "already called send()");
     currentMethod = kj::none;
@@ -8237,7 +8238,7 @@ private:
     currentMethod = kj::none;
 
     httpOutput.writeHeaders(headers.serializeResponse(
-        101, "Switching Protocols", connectionHeaders));
+        101, "Switching Protocols"_kj, connectionHeaders));
 
     upgraded = true;
     // We need to give the WebSocket an Own<AsyncIoStream>, but we only have a reference. This is
@@ -8321,7 +8322,8 @@ private:
         kj::mv(paf.promise));
   }
 
-  void accept(uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+  void accept(uint statusCode, kj::ArrayPtr<const char> statusText,
+              const HttpHeaders& headers) override {
     auto method = KJ_REQUIRE_NONNULL(currentMethod, "already called send()");
     currentMethod = kj::none;
     KJ_ASSERT(method.is<HttpConnectMethod>(), "only use accept() with CONNECT requests");
@@ -8338,7 +8340,7 @@ private:
 
   kj::Own<kj::AsyncOutputStream> reject(
       uint statusCode,
-      kj::StringPtr statusText,
+      kj::ArrayPtr<const char> statusText,
       const HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize) override {
     auto method = KJ_REQUIRE_NONNULL(currentMethod, "already called send()");
@@ -8544,15 +8546,15 @@ kj::Promise<void> HttpServerErrorHandler::handleApplicationError(
     if (exception.getType() == kj::Exception::Type::OVERLOADED) {
       errorMessage = kj::str(
           "ERROR: The server is temporarily unable to handle your request. Details:\n\n", exception);
-      body = r.send(503, "Service Unavailable", headers, errorMessage.size());
+      body = r.send(503, "Service Unavailable"_kj, headers, errorMessage.size());
     } else if (exception.getType() == kj::Exception::Type::UNIMPLEMENTED) {
       errorMessage = kj::str(
           "ERROR: The server does not implement this operation. Details:\n\n", exception);
-      body = r.send(501, "Not Implemented", headers, errorMessage.size());
+      body = r.send(501, "Not Implemented"_kj, headers, errorMessage.size());
     } else {
       errorMessage = kj::str(
           "ERROR: The server threw an exception. Details:\n\n", exception);
-      body = r.send(500, "Internal Server Error", headers, errorMessage.size());
+      body = r.send(500, "Internal Server Error"_kj, headers, errorMessage.size());
     }
 
     return body->write(errorMessage.asBytes()).attach(kj::mv(errorMessage), kj::mv(body));
@@ -8573,7 +8575,7 @@ kj::Promise<void> HttpServerErrorHandler::handleNoResponse(kj::HttpService::Resp
   headers.setPtr(HttpHeaderId::CONTENT_TYPE, "text/plain");
 
   constexpr auto errorMessage = "ERROR: The HttpService did not generate a response."_kj;
-  auto body = response.send(500, "Internal Server Error", headers, errorMessage.size());
+  auto body = response.send(500, "Internal Server Error"_kj, headers, errorMessage.size());
 
   return body->write(errorMessage.asBytes()).attach(kj::mv(body));
 }

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -450,7 +450,7 @@ public:
                               kj::ArrayPtr<const kj::StringPtr> connectionHeaders = nullptr) const;
   kj::String serializeConnectRequest(kj::StringPtr authority,
                               kj::ArrayPtr<const kj::StringPtr> connectionHeaders = nullptr) const;
-  kj::String serializeResponse(uint statusCode, kj::StringPtr statusText,
+  kj::String serializeResponse(uint statusCode, kj::ArrayPtr<const char> statusText,
                                kj::ArrayPtr<const kj::StringPtr> connectionHeaders = nullptr) const;
   // **Most applications will not use these methods; they are called by the HTTP client and server
   // implementations.**
@@ -932,7 +932,7 @@ public:
   class Response {
   public:
     virtual kj::Own<kj::AsyncOutputStream> send(
-        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers,
+        uint statusCode, kj::ArrayPtr<const char> statusText, const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize = kj::none) = 0;
     // Begin the response.
     //
@@ -955,9 +955,9 @@ public:
     // `acceptWebSocket()` may only be called a single time. Calling it a second time will cause an
     // exception to be thrown.
 
-    kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText,
+    kj::Promise<void> sendError(uint statusCode, kj::ArrayPtr<const char> statusText,
                                 const HttpHeaders& headers);
-    kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText,
+    kj::Promise<void> sendError(uint statusCode, kj::ArrayPtr<const char> statusText,
                                 const HttpHeaderTable& headerTable);
     // Convenience wrapper around send() which sends a basic error. A generic error page specifying
     // the error code is sent as the body.
@@ -993,13 +993,13 @@ public:
   public:
     virtual void accept(
         uint statusCode,
-        kj::StringPtr statusText,
+        kj::ArrayPtr<const char> statusText,
         const HttpHeaders& headers) = 0;
     // Signals acceptance of the CONNECT tunnel.
 
     virtual kj::Own<kj::AsyncOutputStream> reject(
         uint statusCode,
-        kj::StringPtr statusText,
+        kj::ArrayPtr<const char> statusText,
         const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize = kj::none) = 0;
     // Signals rejection of the CONNECT tunnel.


### PR DESCRIPTION
Rust's strings are not 0-allocated so passing statusText requires extra allocation.

@kentonv lmk if you think this is ok and I'll create downstream PRs.