### PR TITLE
Add OneOf::clone()

### DIFF
--- a/c++/src/kj/one-of-test.c++
+++ b/c++/src/kj/one-of-test.c++
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #include "one-of.h"
+#include "refcount.h"
 #include "string.h"
 #include <kj/compat/gtest.h>
 
@@ -263,6 +264,105 @@ template<unsigned int N>
 struct T {
   unsigned int n = N;
 };
+
+struct RcCloneable: public Refcounted {
+  int value;
+  RcCloneable(int v): value(v) {}
+};
+
+KJ_TEST("OneOf clone: mixed Cloneable + Copyable variants") {
+  // OneOf<int, String> is the canonical mixed-trait case. The OneOf itself is non-copyable
+  // (String is move-only), but per-variant `Cloneable<T> || Copyable<T>` lets clone() work:
+  // String is cloned, int is copied. Exercise both arms by cloning each active variant.
+
+  OneOf<int, String> textVar = kj::str("foo");
+  auto textCloned = textVar.clone();
+  static_assert(isSameType<decltype(textCloned), OneOf<int, String>>());
+  KJ_EXPECT(textCloned.get<String>() == "foo");
+  // Independent storage — mutating original doesn't disturb the clone.
+  textVar.get<String>() = kj::str("bar");
+  KJ_EXPECT(textCloned.get<String>() == "foo");
+
+  OneOf<int, String> intVar = 42;
+  auto intCloned = intVar.clone();
+  KJ_EXPECT(intCloned.get<int>() == 42);
+  intVar.get<int>() = 99;
+  KJ_EXPECT(intCloned.get<int>() == 42);
+}
+
+KJ_TEST("OneOf clone: nested Cloneable composites (Array, Maybe)") {
+  // Variants whose own types are clone()-aware composites: Array<String> deep-clones each
+  // element, Maybe<String> clones the held value if present. Verifies the per-variant
+  // clone() dispatch propagates through composite types correctly.
+
+  OneOf<Array<String>, Maybe<String>> arrayVar = arr<String>(kj::str("a"), kj::str("b"));
+  auto arrayCloned = arrayVar.clone();
+  KJ_EXPECT(arrayCloned.get<Array<String>>().size() == 2);
+  KJ_EXPECT(arrayCloned.get<Array<String>>()[0] == "a");
+  // Distinct backing storage.
+  KJ_EXPECT(arrayCloned.get<Array<String>>()[0].begin() !=
+      arrayVar.get<Array<String>>()[0].begin());
+
+  OneOf<Array<String>, Maybe<String>> maybeVar = Maybe<String>(kj::str("baz"));
+  auto maybeCloned = maybeVar.clone();
+  KJ_EXPECT(KJ_ASSERT_NONNULL(maybeCloned.get<Maybe<String>>()) == "baz");
+}
+
+KJ_TEST("OneOf clone: type-changing variants (ArrayPtr -> Array)") {
+  // ArrayPtr<T>::clone() returns Array<T>, so OneOf<ArrayPtr<int>, String>::clone() returns
+  // OneOf<Array<int>, String>. Mirrors Maybe<ArrayPtr<T>>::clone() returning Maybe<Array<T>>.
+
+  int storage[] = {1, 2, 3};
+  OneOf<ArrayPtr<int>, String> var = ArrayPtr<int>(storage);
+
+  auto cloned = var.clone();
+  static_assert(isSameType<decltype(cloned), OneOf<Array<int>, String>>());
+  KJ_EXPECT(cloned.get<Array<int>>().size() == 3);
+  KJ_EXPECT(cloned.get<Array<int>>()[0] == 1);
+}
+
+KJ_TEST("OneOf clone: non-const overload supports Rc<T>") {
+  // kj::Rc<T>::clone() is non-const (it mutates the refcount), so Cloneable<const Rc<T>>
+  // is false and the const clone() overload is SFINAE'd out for OneOf<Rc<T>, ...>. The
+  // non-const overload exists precisely to support this case; verify it works and that the
+  // refcount semantics carry through (both originals share the same underlying object).
+
+  OneOf<int, Rc<RcCloneable>> var = kj::rc<RcCloneable>(42);
+  auto cloned = var.clone();
+  KJ_EXPECT(cloned.get<Rc<RcCloneable>>()->value == 42);
+  KJ_EXPECT(var.get<Rc<RcCloneable>>().get() == cloned.get<Rc<RcCloneable>>().get());
+}
+
+KJ_TEST("OneOf clone: default-constructed source produces default-constructed clone") {
+  // A default-constructed OneOf has no active variant (tag == 0). Cloning skips every
+  // variant arm of the fold expression and returns a fresh default-constructed result.
+  // Mirrors the behavior already documented for the copy ctor at the top of TEST(OneOf,
+  // Copy).
+  OneOf<int, String> var;
+  KJ_EXPECT(!var.is<int>());
+  KJ_EXPECT(!var.is<String>());
+
+  auto cloned = var.clone();
+  KJ_EXPECT(!cloned.is<int>());
+  KJ_EXPECT(!cloned.is<String>());
+}
+
+KJ_TEST("OneOf clone: moved-from source still clonable, produces moved-from-equivalent clone") {
+  // OneOf doesn't reset its tag during move construction (see TEST(OneOf, Basic) above:
+  // `kj::mv(var); var.get<String>() == ""` is the existing documented behavior). So a
+  // moved-from OneOf still has tag == String with a moved-from String inside. clone() is
+  // therefore well-defined on a moved-from source: it clones whatever the moved-from
+  // variant currently holds — which for kj::String is empty content.
+  OneOf<int, String> var = kj::str("payload");
+  OneOf<int, String> moved KJ_UNUSED = kj::mv(var);
+
+  KJ_EXPECT(var.is<String>());
+  KJ_EXPECT(var.get<String>() == "");
+
+  auto cloned = var.clone();
+  KJ_EXPECT(cloned.is<String>());
+  KJ_EXPECT(cloned.get<String>() == "");
+}
 
 TEST(OneOf, MaxVariants) {
   kj::OneOf<

--- a/c++/src/kj/one-of.h
+++ b/c++/src/kj/one-of.h
@@ -389,6 +389,35 @@ public:
   }
   // Copy/move from a value that matches one of the individual types in the OneOf.
 
+  // Deep-clone or copy each variant. For variants that are Cloneable, use `clone()`; for
+  // variants that are only Copyable, use copy. Mirrors `kj::Array<T>::clone()`.
+  //
+  // The result type is `OneOf<decltype(_::copyOrClone(v))...>` — for variants where `clone()`
+  // returns a different type than the variant itself (e.g. `ArrayPtr<T>::clone()` returns
+  // `Array<T>`), the cloned OneOf has the corresponding cloned-element types.
+  //
+  // Unlike `Maybe<T>::clone()` which only requires `Cloneable<T>` (because `Maybe<T>` is
+  // already copyable when `T` is copyable, making `clone()` redundant for that case),
+  // `OneOf<...>` is non-copyable as soon as any one variant is non-copyable. So `clone()`
+  // here accepts the dual `Cloneable<T> || Copyable<T>` per variant — clone the cloneable
+  // variants and copy the copyable ones — to support the mixed-trait case (e.g.
+  // `OneOf<int, kj::String>::clone()`).
+  //
+  // Both `&` and `const&` overloads are provided so types whose `clone()` is non-const (e.g.
+  // `kj::Rc<T>::clone()` mutates a refcount) work in non-const contexts.
+  auto clone() requires ((Cloneable<Variants> || Copyable<Variants>) && ...) {
+    using Result = OneOf<decltype(_::copyOrClone(instance<Variants&>()))...>;
+    Result result;
+    (cloneVariantInto<Variants>(result), ...);
+    return result;
+  }
+  auto clone() const requires ((Cloneable<const Variants> || Copyable<const Variants>) && ...) {
+    using Result = OneOf<decltype(_::copyOrClone(instance<const Variants&>()))...>;
+    Result result;
+    (cloneVariantInto<Variants>(result), ...);
+    return result;
+  }
+
   ~OneOf() { destroy(); }
 
   OneOf& operator=(const OneOf& other) { if (tag != 0) destroy(); copyFrom(other); return *this; }
@@ -536,6 +565,23 @@ private:
     // is invalid.
     tag = other.tag;
     doAll(copyVariantFrom<Variants>(other)...);
+  }
+
+  template <typename T, typename Result>
+  inline bool cloneVariantInto(Result& result) {
+    if (this->template is<T>()) {
+      using U = decltype(_::copyOrClone(instance<T&>()));
+      result.template init<U>(_::copyOrClone(this->template get<T>()));
+    }
+    return false;
+  }
+  template <typename T, typename Result>
+  inline bool cloneVariantInto(Result& result) const {
+    if (this->template is<T>()) {
+      using U = decltype(_::copyOrClone(instance<const T&>()));
+      result.template init<U>(_::copyOrClone(this->template get<T>()));
+    }
+    return false;
   }
 
   template <typename T>


### PR DESCRIPTION
Mirrors the existing `kj::Array<T>::clone()` (and `kj::Maybe<T>::clone()`) APIs: returns a deep-cloned OneOf with each variant cloned (via clone()) or copied (via copy ctor), depending on which trait the variant satisfies.

Per-variant requires `Cloneable<T> || Copyable<T>`. Unlike `Maybe<T>::clone()` which accepts only `Cloneable<T>` — because a `Maybe<T>` for copyable T is itself copyable, making clone() redundant — OneOf can be non-copyable (when at least one variant is non-copyable) even when other variants are copyable. Supporting `Copyable` per variant lets the mixed-trait case (e.g. `OneOf<int, kj::String>::clone()`) work: int copied, String cloned.

Both `&` and `const&` overloads are provided so types whose clone() is non-const (e.g. `kj::Rc<T>::clone()` mutates a refcount) can be cloned in non-const contexts.

Result type is `OneOf<decltype(_::copyOrClone(v))...>`, so type-changing clones work: `OneOf<ArrayPtr<T>>::clone()` returns `OneOf<Array<T>>`.