### PR TITLE
Auto-roll capnp-cpp MODULE.bazel version in release.sh

### DIFF
--- a/c++/MODULE.bazel
+++ b/c++/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "capnp-cpp",
-    version = "1.1.0",
+    version = "1.5.0",
 )
 
 bazel_dep(name = "platforms", version = "0.0.11")

--- a/c++/MODULE.bazel
+++ b/c++/MODULE.bazel
@@ -1,5 +1,6 @@
 module(
     name = "capnp-cpp",
+    version = "1.5-dev",
 )
 
 bazel_dep(name = "platforms", version = "1.1.0")

--- a/release.sh
+++ b/release.sh
@@ -40,6 +40,7 @@ update_version() {
   local OLD_REGEX=${OLD//./[.]}
   doit sed -i -e "s/$OLD_REGEX/$NEW/g" c++/configure.ac
   doit sed -i -e "s/set(VERSION.*)/set(VERSION $NEW)/g" c++/CMakeLists.txt
+  doit sed -i -re "s/^( *version = )\"[^\"]*\",/\1\"$NEW\",/" c++/MODULE.bazel
 
   local NEW_NOTAG=${NEW%%-*}
   declare -a NEW_ARR=(${NEW_NOTAG//./ })


### PR DESCRIPTION
Bump capnp-cpp module version in c++/MODULE.bazel from 1.1.0 to 1.5-dev to match the in-progress mainline version.
Updated release.sh to automate this.
#2649 did remove the version number but AFAICT the Bazel Central Registry would need a patch that adds it if not already set.
The version number could be omitted if `publish-to-bcr` is added to the release flow.
https://github.com/bazel-contrib/publish-to-bcr
