### PR TITLE
Fix wrong common header value check in http-over-capnp

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #include "http-over-capnp.h"
+#include <capnp/message.h>
 #include <kj/test.h>
 
 #ifndef TEST_PEER_OPTIMIZATION_LEVEL
@@ -28,6 +29,38 @@
 
 namespace capnp {
 namespace {
+
+KJ_TEST("HttpOverCapnpFactory::capnpToKj rejects out of range common values") {
+  MallocMessageBuilder message;
+  auto orphanage = message.getOrphanage();
+
+  kj::HttpHeaderTable::Builder headerBuilder;
+
+  ByteStreamFactory streamFactory;
+  HttpOverCapnpFactory factory(streamFactory, headerBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+
+  auto headerTable = headerBuilder.build();
+
+  {
+    auto invalidName = orphanage.newOrphan<List<HttpHeader>>(1);
+    auto invalidNameHeader = invalidName.get()[0];
+    auto common = invalidNameHeader.initCommon();
+    common.setName(static_cast<CommonHeaderName>(999));
+    common.setValue("value");
+
+    KJ_EXPECT_THROW_MESSAGE("unknown common header name", factory.capnpToKj(invalidName.get()));
+  }
+
+  {
+    auto invalidValue = orphanage.newOrphan<List<HttpHeader>>(1);
+    auto invalidValueHeader = invalidValue.get()[0];
+    auto common = invalidValueHeader.initCommon();
+    common.setName(CommonHeaderName::ACCEPT_CHARSET);
+    common.setCommonValue(static_cast<CommonHeaderValue>(999));
+
+    KJ_EXPECT_THROW_MESSAGE("unknown common header value", factory.capnpToKj(invalidValue.get()));
+  }
+}
 
 KJ_TEST("KJ and RPC HTTP method enums match") {
 #define EXPECT_MATCH(METHOD) \

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -1070,7 +1070,7 @@ kj::HttpHeaders HttpOverCapnpFactory::capnpToKj(
         switch (nv.which()) {
           case capnp::HttpHeader::Common::COMMON_VALUE: {
             auto cvInt = static_cast<uint>(nv.getCommonValue());
-            KJ_REQUIRE(nameInt < valueCapnpToKj.size(),
+            KJ_REQUIRE(cvInt < valueCapnpToKj.size(),
                 "unknown common header value", nv.getCommonValue());
             result.setPtr(nameCapnpToKj[nameInt], valueCapnpToKj[cvInt]);
             break;


### PR DESCRIPTION
Adds associated tests for the expected exceptions as well.