### PR TITLE
Rc<T> without inheritance

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -895,7 +895,7 @@ public:
 
     class EofDetector final: public kj::AsyncOutputStream {
     public:
-      EofDetector(kj::Own<kj::AsyncIoStream> inner)
+      EofDetector(kj::Rc<kj::AsyncIoStream> inner)
           : inner(kj::mv(inner)) {}
       ~EofDetector() {
         inner->shutdownWrite();
@@ -918,29 +918,27 @@ public:
         return inner->whenWriteDisconnected();
       }
     private:
-      kj::Own<kj::AsyncIoStream> inner;
+      kj::Rc<kj::AsyncIoStream> inner;
     };
 
     auto stream = factory.streamFactory.capnpToKjExplicitEnd(context.getParams().getDown());
 
     // We want to keep the stream alive even after EofDetector is destroyed, so we need to create
     // a refcounted AsyncIoStream.
-    auto refcounted = kj::refcountedWrapper(kj::mv(pipe.ends[1]));
-    kj::Own<kj::AsyncIoStream> ref1 = refcounted->addWrappedRef();
-    kj::Own<kj::AsyncIoStream> ref2 = refcounted->addWrappedRef();
+    kj::Rc<kj::AsyncIoStream> refcounted(kj::mv(pipe.ends[1]));
 
     // We write to the `down` pipe.
-    auto pumpTask = ref1->pumpTo(*stream)
+    auto pumpTask = refcounted->pumpTo(*stream)
           .then([&stream = *stream](uint64_t) mutable {
       return stream.end();
-    }).then([httpProxyStream = kj::mv(ref1), stream = kj::mv(stream)]() mutable
+    }).then([httpProxyStream = refcounted.addRef(), stream = kj::mv(stream)]() mutable
         -> kj::Promise<void> {
       return kj::NEVER_DONE;
     });
 
     {
       PipelineBuilder<ConnectResults> pb;
-      auto eofWrapper = kj::heap<EofDetector>(kj::mv(ref2));
+      auto eofWrapper = kj::heap<EofDetector>(refcounted.addRef());
       auto up = factory.streamFactory.kjToCapnp(kj::mv(eofWrapper), kj::mv(tlsStarter));
       pb.setUp(kj::cp(up));
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -696,6 +696,14 @@ template<typename T> constexpr T cp(T& t) noexcept { return T(t); }
 template<typename T> constexpr T cp(const T& t) noexcept { return T(t); }
 // Useful to force a copy, particularly to pass into a function that expects T&&.
 
+template <typename T>
+void swp(T& a, T& b) {
+  // Swap two values. Similar to std::swap. Using kj::swap collides with libc++ sources.
+  T tmp = kj::mv(a);
+  a = kj::mv(b);
+  b = kj::mv(tmp);
+}
+
 template <typename T, typename U, bool takeT, bool uOK = true> struct ChooseType_;
 template <typename T, typename U> struct ChooseType_<T, U, true, true> { typedef T Type; };
 template <typename T, typename U> struct ChooseType_<T, U, true, false> { typedef T Type; };

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -6525,15 +6525,15 @@ public:
     if (!connectSettings.useTls) {
       KJ_IF_SOME(wrapper, settings.tlsContext) {
         KJ_IF_SOME(tlsStarter, connectSettings.tlsStarter) {
-          auto transitConnectionRef = kj::refcountedWrapper(
+          kj::Rc<TransitionaryAsyncIoStream> transitConnectionRef(
               kj::heap<TransitionaryAsyncIoStream>(kj::mv(connection)));
           Function<kj::Promise<void>(kj::StringPtr)> cb =
-              [&wrapper, ref1 = transitConnectionRef->addWrappedRef()](
+              [&wrapper, ref1 = transitConnectionRef.addRef()](
               kj::StringPtr expectedServerHostname) mutable {
             ref1->startTls(&wrapper, expectedServerHostname);
             return kj::READY_NOW;
           };
-          connection = transitConnectionRef->addWrappedRef();
+          connection = transitConnectionRef.addRef().toOwn();
           tlsStarter = kj::mv(cb);
         }
       }

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -85,6 +85,8 @@ class AtomicRefcounted;
 class Refcounted;
 
 namespace _ {  // private
+template <typename T>
+concept IsPolymorphic = _kj_internal_isPolymorphic((T*)nullptr);
 
 template <typename T, typename U>
 concept DerivedFrom = requires(const T* t) { static_cast<const U*>(t); };

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -85,8 +85,6 @@ class AtomicRefcounted;
 class Refcounted;
 
 namespace _ {  // private
-template <typename T>
-concept IsPolymorphic = _kj_internal_isPolymorphic((T*)nullptr);
 
 template <typename T, typename U>
 concept DerivedFrom = requires(const T* t) { static_cast<const U*>(t); };

--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -269,6 +269,24 @@ KJ_TEST("Rc Own interop") {
     EXPECT_TRUE(b);
 }
 
+KJ_TEST("Rc wraps Own of refcounted types") {
+  bool b = false;
+
+  Own<SetTrueInDestructor> own = kj::refcounted<SetTrueInDestructor>(&b);
+
+  Rc<SetTrueInDestructor> ref(kj::mv(own));
+  EXPECT_TRUE(own.get() == nullptr);
+  EXPECT_TRUE(ref != nullptr);
+
+  Rc<SetTrueInDestructor> ref2 = ref.addRef();
+  EXPECT_TRUE(ref.get() == ref2.get());
+
+  ref = nullptr;
+  EXPECT_FALSE(b);
+
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+}
 
 struct SetTrueInDestructor2 {
   // Like SetTrueInDestructor but doesn't inherit Refcounted.
@@ -327,6 +345,29 @@ KJ_TEST("Rc wraps Own of non-refcounted types") {
   EXPECT_TRUE(b);
 }
 
+KJ_TEST("Rc wraps attached Own") {
+  bool b = false;
+  bool attached = false;
+
+  Own<SetTrueInDestructor> own = kj::refcounted<SetTrueInDestructor>(&b)
+      .attachToThisReference(kj::heap<SetTrueInDestructor2>(&attached));
+  Rc<SetTrueInDestructor> ref(kj::mv(own));
+  EXPECT_TRUE(own.get() == nullptr);
+  EXPECT_TRUE(ref != nullptr);
+  EXPECT_FALSE(b);
+  EXPECT_FALSE(attached);
+
+  Rc<SetTrueInDestructor> ref2 = ref.addRef();
+
+  ref = nullptr;
+  EXPECT_FALSE(b);
+  EXPECT_FALSE(attached);
+
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+  EXPECT_TRUE(attached);
+}
+
 KJ_TEST("Rc<String>") {
   Rc<String> ref1 = kj::rc<String>(kj::str("hello"));
   EXPECT_TRUE(ref1 != nullptr);
@@ -359,6 +400,39 @@ struct Concrete final: public Abstract {
   void use() override {}
   bool* ptr;
 };
+
+struct AbstractRefcounted: public Refcounted {
+  virtual void use() = 0;
+};
+
+struct ConcreteRefcounted final: public Abstract, public AbstractRefcounted {
+  ConcreteRefcounted(bool* ptr): ptr(ptr) {}
+  ~ConcreteRefcounted() { *ptr = true; }
+  void use() override {}
+
+  bool* ptr;
+};
+
+KJ_TEST("Rc wraps Own of abstract refcounted types") {
+  bool b = false;
+
+  Own<AbstractRefcounted> own = kj::refcounted<ConcreteRefcounted>(&b);
+
+  Rc<AbstractRefcounted> ref(kj::mv(own));
+  EXPECT_TRUE(own.get() == nullptr);
+  EXPECT_TRUE(ref != nullptr);
+
+  ref->use();
+
+  Rc<AbstractRefcounted> ref2 = ref.addRef();
+  EXPECT_TRUE(ref.get() == ref2.get());
+
+  ref = nullptr;
+  EXPECT_FALSE(b);
+
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+}
 
 KJ_TEST("Rc<Abstract>") {
   bool b = false;

--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -21,6 +21,7 @@
 
 #include "refcount.h"
 #include "array.h"
+#include "string.h"
 #include <kj/compat/gtest.h>
 
 namespace kj {
@@ -43,6 +44,104 @@ static_assert(Cloneable<Array<Rc<SetTrueInDestructor>>>);
 static_assert(!Cloneable<const Array<Rc<SetTrueInDestructor>>>);
 static_assert(Cloneable<ArrayPtr<Rc<SetTrueInDestructor>>>);
 static_assert(!Cloneable<const ArrayPtr<Rc<SetTrueInDestructor>>>);
+
+struct IncompleteDeclaredRefcounted;
+static_assert(sizeof(Rc<IncompleteDeclaredRefcounted>) == 2 * sizeof(void*));
+
+struct IncompleteDeclaredRefcounted: public Refcounted {
+  IncompleteDeclaredRefcounted(bool* ptr): ptr(ptr) {}
+  ~IncompleteDeclaredRefcounted() { *ptr = true; }
+
+  bool* ptr;
+};
+
+struct IncompleteDeclaredNotRefcounted;
+static_assert(sizeof(Rc<IncompleteDeclaredNotRefcounted>) == 2 * sizeof(void*));
+
+struct IncompleteDeclaredNotRefcounted {
+  IncompleteDeclaredNotRefcounted(bool* ptr): ptr(ptr) {}
+  ~IncompleteDeclaredNotRefcounted() { *ptr = true; }
+
+  bool* ptr;
+};
+
+struct IncompleteInnerDeclaredRefcounted {
+private:
+  struct Inner;
+  static_assert(sizeof(Rc<Inner>) == 2 * sizeof(void*));
+
+public:
+  static void test();
+};
+
+struct IncompleteInnerDeclaredRefcounted::Inner: public Refcounted {
+  Inner(bool* ptr): ptr(ptr) {}
+  ~Inner() { *ptr = true; }
+
+  bool* ptr;
+};
+
+void IncompleteInnerDeclaredRefcounted::test() {
+  bool b = false;
+  Rc<Inner> ref = kj::rc<Inner>(&b);
+  KJ_EXPECT(!b);
+  ref = nullptr;
+  KJ_EXPECT(b);
+}
+
+struct IncompleteInnerDeclaredNotRefcounted {
+private:
+  struct Inner;
+  static_assert(sizeof(Rc<Inner>) == 2 * sizeof(void*));
+
+public:
+  static void test();
+};
+
+struct IncompleteInnerDeclaredNotRefcounted::Inner {
+  Inner(bool* ptr): ptr(ptr) {}
+  ~Inner() { *ptr = true; }
+
+  bool* ptr;
+};
+
+void IncompleteInnerDeclaredNotRefcounted::test() {
+  bool b = false;
+  Rc<Inner> ref = kj::rc<Inner>(&b);
+  KJ_EXPECT(!b);
+  auto ref2 = ref.addRef();
+  ref = nullptr;
+  KJ_EXPECT(!b);
+  ref2 = nullptr;
+  KJ_EXPECT(b);
+}
+
+KJ_TEST("Rc incomplete declared refcounted types") {
+  {
+    bool b = false;
+    Rc<IncompleteDeclaredRefcounted> ref = kj::rc<IncompleteDeclaredRefcounted>(&b);
+    KJ_EXPECT(!b);
+    ref = nullptr;
+    KJ_EXPECT(b);
+  }
+
+  IncompleteInnerDeclaredRefcounted::test();
+}
+
+KJ_TEST("Rc incomplete declared non-refcounted types") {
+  {
+    bool b = false;
+    Rc<IncompleteDeclaredNotRefcounted> ref = kj::rc<IncompleteDeclaredNotRefcounted>(&b);
+    KJ_EXPECT(!b);
+    auto ref2 = ref.addRef();
+    ref = nullptr;
+    KJ_EXPECT(!b);
+    ref2 = nullptr;
+    KJ_EXPECT(b);
+  }
+
+  IncompleteInnerDeclaredNotRefcounted::test();
+}
 
 TEST(Refcount, Basic) {
   bool b = false;
@@ -170,6 +269,161 @@ KJ_TEST("Rc Own interop") {
     EXPECT_TRUE(b);
 }
 
+
+struct SetTrueInDestructor2 {
+  // Like SetTrueInDestructor but doesn't inherit Refcounted.
+
+  SetTrueInDestructor2(bool* ptr): ptr(ptr) {}
+  ~SetTrueInDestructor2() { *ptr = true; }
+
+  bool* ptr;
+};
+
+KJ_TEST("Rc wraps non-refcounted types") {
+  bool b = false;
+
+  Rc<SetTrueInDestructor2> ref1 = kj::rc<SetTrueInDestructor2>(&b);
+  EXPECT_TRUE(ref1 != nullptr);
+  EXPECT_FALSE(ref1 == nullptr);
+  EXPECT_TRUE(&*ref1 == ref1.get());
+  const auto& cref1 = ref1;
+  EXPECT_TRUE(&*cref1 == ref1.get());
+
+  Rc<SetTrueInDestructor2> ref2 = ref1.addRef();
+  EXPECT_TRUE(ref1 == ref2);
+  EXPECT_TRUE(ref1.get() == ref2.get());
+
+  EXPECT_FALSE(b);
+  Own<SetTrueInDestructor2> own = ref1.toOwn();
+  EXPECT_TRUE(ref1 == nullptr);
+  EXPECT_TRUE(own.get() == ref2.get());
+  EXPECT_FALSE(b);
+  own = nullptr;
+  EXPECT_FALSE(b);
+
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+}
+
+KJ_TEST("Rc wraps Own of non-refcounted types") {
+  bool b = false;
+
+  Rc<SetTrueInDestructor2> ref1(kj::heap<SetTrueInDestructor2>(&b));
+  EXPECT_TRUE(ref1 != nullptr);
+  EXPECT_FALSE(b);
+
+  Rc<SetTrueInDestructor2> ref2 = ref1.addRef();
+  EXPECT_TRUE(ref1 == ref2);
+  EXPECT_TRUE(ref1.get() == ref2.get());
+
+  Own<SetTrueInDestructor2> own = ref1.toOwn();
+  EXPECT_TRUE(ref1 == nullptr);
+  EXPECT_TRUE(own.get() == ref2.get());
+
+  own = nullptr;
+  EXPECT_FALSE(b);
+
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+}
+
+KJ_TEST("Rc<String>") {
+  Rc<String> ref1 = kj::rc<String>(kj::str("hello"));
+  EXPECT_TRUE(ref1 != nullptr);
+  EXPECT_TRUE(ref1->asPtr() == "hello");
+
+  Rc<String> ref2 = ref1.addRef();
+  EXPECT_TRUE(ref1 == ref2);
+  EXPECT_TRUE(ref1.get() == ref2.get());
+
+  (*ref2)[0] = 'H';
+  EXPECT_TRUE(ref1->asPtr() == "Hello");
+
+  Own<String> own = ref1.toOwn();
+  EXPECT_TRUE(ref1 == nullptr);
+  EXPECT_TRUE(own.get() == ref2.get());
+  EXPECT_TRUE(own->asPtr() == "Hello");
+
+  own = nullptr;
+  EXPECT_TRUE(ref2->asPtr() == "Hello");
+}
+
+struct Abstract {
+  virtual ~Abstract() noexcept(false) = default;
+  virtual void use() = 0;
+};
+
+struct Concrete final: public Abstract {
+  Concrete(bool* ptr): ptr(ptr) {}
+  ~Concrete() { *ptr = true; }
+  void use() override {}
+  bool* ptr;
+};
+
+KJ_TEST("Rc<Abstract>") {
+  bool b = false;
+
+  Rc<Abstract> ref(kj::heap<Concrete>(&b));
+  EXPECT_TRUE(ref != nullptr);
+  EXPECT_FALSE(b);
+  EXPECT_TRUE(&*ref == ref.get());
+  const auto& cref = ref;
+  EXPECT_TRUE(&*cref == ref.get());
+
+  ref->use();
+
+  auto ref2 = ref.addRef();
+  EXPECT_TRUE(ref == ref2);
+  EXPECT_TRUE(ref.get() == ref2.get());
+
+  Own<Abstract> own2 = ref.toOwn();
+  EXPECT_TRUE(ref == nullptr);
+  own2->use();
+  EXPECT_FALSE(b);
+  own2 = nullptr;
+  EXPECT_FALSE(b);
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+}
+
+KJ_TEST("Rc<Concrete>") {
+  bool b = false;
+
+  Rc<Concrete> ref = kj::rc<Concrete>(&b);
+  EXPECT_TRUE(ref != nullptr);
+  EXPECT_FALSE(b);
+  EXPECT_TRUE(&*ref == ref.get());
+  const auto& cref = ref;
+  EXPECT_TRUE(&*cref == ref.get());
+
+  auto own = ref.toOwn();
+  EXPECT_TRUE(ref == nullptr);
+  EXPECT_TRUE(own.get() != nullptr);
+  EXPECT_FALSE(b);
+  own = nullptr;
+  EXPECT_TRUE(b);
+}
+
+KJ_TEST("Rc polymorphic upcast") {
+  bool b = false;
+
+  Rc<Concrete> ref = kj::rc<Concrete>(&b);
+  Rc<Concrete> ref2 = ref.addRef();
+
+  Rc<Abstract> abstract = kj::mv(ref);
+  EXPECT_TRUE(ref == nullptr);
+  EXPECT_TRUE(abstract.get() == ref2.get());
+
+  abstract->use();
+  EXPECT_FALSE(b);
+
+  abstract = nullptr;
+  EXPECT_FALSE(b);
+
+  ref2 = nullptr;
+  EXPECT_TRUE(b);
+}
+
 struct Child: public SetTrueInDestructor {
   Child(bool* ptr): SetTrueInDestructor(ptr) {}
 };
@@ -211,15 +465,6 @@ KJ_TEST("Refcounted::addRefToThis") {
   ref2 = nullptr;
   EXPECT_TRUE(b);
 }
-
-struct SetTrueInDestructor2 {
-  // Like above but doesn't inherit Refcounted.
-
-  SetTrueInDestructor2(bool* ptr): ptr(ptr) {}
-  ~SetTrueInDestructor2() { *ptr = true; }
-
-  bool* ptr;
-};
 
 KJ_TEST("RefcountedWrapper") {
   {

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -37,6 +37,16 @@ namespace kj {
 template<typename T>
 class Rc;
 
+template <typename T, typename... Params>
+Rc<T> rc(Params&&... params);
+
+namespace _ {  // private
+
+template <typename T> class RcWrapper;
+template <typename T> class RcOwnWrapper;
+
+}  // namespace _ (private)
+
 class Refcounted: private Disposer {
   // Subclass this to create a class that contains a reference count. Then, use
   // `kj::refcounted<T>()` to allocate a new refcounted pointer.
@@ -102,6 +112,9 @@ private:
 
   template <typename T>
   friend class Rc;
+
+  template <typename T> friend class _::RcWrapper;
+  template <typename T> friend class _::RcOwnWrapper;
 };
 
 template <typename T, typename... Params>
@@ -110,14 +123,6 @@ inline Own<T> refcounted(Params&&... params) {
   // initial reference to the object.  More references can be created with `kj::addRef()`.
 
   return Refcounted::addRefInternal(new T(kj::fwd<Params>(params)...));
-}
-
-template <typename T, typename... Params>
-inline Rc<T> rc(Params&&... params) {
-  // Allocate a new refcounted instance of T, passing `params` to its constructor.
-  // Returns smart pointer that can be used to manage references.
-
-  return Refcounted::addRcRefInternal(new T(kj::fwd<Params>(params)...));
 }
 
 template <typename T>
@@ -142,91 +147,194 @@ Rc<T> Refcounted::addRcRefInternal(T* object) {
   static_assert(kj::canConvert<T&, Refcounted&>());
   Refcounted* refcounted = object;
   ++refcounted->refcount;
-  return Rc<T>(object);
+  return Rc<T>(refcounted, object);
 }
+
+namespace _ {  // private
+
+template <typename T>
+class RcWrapper final: public Refcounted {
+public:
+  template <typename... Params>
+  explicit RcWrapper(Params &&...params) : wrapped(kj::fwd<Params>(params)...) { ++refcount; }
+  T* getWrappedPtr() { return &wrapped; }
+  const T *getWrappedPtr() const { return &wrapped; }
+
+private:
+  T wrapped;
+};
+
+template <typename T>
+class RcOwnWrapper final: public Refcounted {
+public:
+  explicit RcOwnWrapper(Own<T> &&wrapped) : wrapped(kj::mv(wrapped)) { ++refcount; }
+  T* getWrappedPtr() { return wrapped.get(); }
+  const T *getWrappedPtr() const { return wrapped.get(); }
+
+private:
+  Own<T> wrapped;
+};
+
+}  // namespace _ (private)
 
 template<typename T>
 class Rc {
-  // Smart pointer for reference counted objects.
+  // Rc<T> is a smart pointer providing reference counting capabilities for all kinds of Ts.
   //
-  // There are only three ways to obtain new Rc instances:
-  // - use kj::rc<T>(...) function to create new T.
-  // - use kj::Rc::addRef() and the existing Rc instance.
+  // The primary way to obtain new `Rc<T>` instance is ot use `kj::rc<T>(...)` function that will
+  // allocates new T on the heap. Depending on T nature:
+  // - T extends Refcounted. In such case T's `refcount` field is used for counting. 1 allocation.
+  // - T does not extend Refcounted and is not polymorphic. `kj::rc` will over-allocate 
+  //   `RcWrapper<T>` to provide a `refcount`. 1 allocation.
+  // - T extends Refcounted and is polymorphic. `RcOwnWrapper<T>` is used. 2 allocations.
+  //
+  // Rc<T> can also be constructed from:
+  // - kj::Own<T> for all types of T. Always allocates.
+  // - T for non-polymorphic non-`Refcounted` Ts with move constructor. Always allocates.
+  //
+  // Once you have `Rc<T>` you can `addRef` or `clone` it to increment the refcount and obtain new
+  // smart pointer.
   //
   // Suggested usage patterns are:
   // - return kj::Rc as value from factory functions:
-  //     kj::Rc<MyService> createMyService();
-  // - pass kj::Rc as rvalue to functions that need to extend T's lifetime:
-  //     void setMyService(kj::Rc<MyService>&& service)
+  //     `kj::Rc<MyService> createMyService();`
+  // - pass kj::Rc as value to functions that need to extend T's lifetime:
+  //     void setMyService(kj::Rc<MyService> service)
   // - store kj::Rc as data member:
   //     struct MyComputation { kj::Rc<MyService> service; };
   // - use toOwn to convert kj::Rc<T> instance to kj::Own<T> and use it
   //     without being concerned of reference counting behavior.
   //     To improve the transparency of the code, kj::Own<T> shouldn't be used
   //     to call addRef() without kj::Rc.
-
+  // - convert kj::Own<T> to kj::Rc<T> to wrap an object into refcounted hold.
 public:
   KJ_DISALLOW_COPY(Rc);
   Rc() { }
   Rc(decltype(nullptr)) { }
-  inline Rc(Rc&& other) noexcept = default;
-
-  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
-  inline Rc(Rc<U>&& other) noexcept : own(kj::mv(other.own)) { }
-
-  kj::Own<T> toOwn() {
-    // Convert Rc<T> to Own<T>.
-    // Nullifies the original Rc<T>.
-    return kj::mv(own);
+  inline Rc(Rc&& other) noexcept : refcounted(other.refcounted), ptr(other.ptr) {
+    other.refcounted = nullptr;
+    other.ptr = nullptr;
   }
 
-  kj::Rc<T> addRef() {
-    T* refcounted = own.get();
-    if (refcounted != nullptr) {
-      return Refcounted::addRcRefInternal(refcounted);
+  ~Rc() noexcept(false) { dispose(); }
+
+  template <typename U = T, typename = EnableIf<canConvert<U*, T*>()>>
+  inline Rc(Rc<U>&& other) noexcept : refcounted(other.refcounted), ptr(other.ptr) {
+    other.refcounted = nullptr;
+    other.ptr = nullptr;
+  }
+
+  template <typename U, typename = EnableIf<isSameType<U, T>()>>
+  inline Rc(U t) noexcept {
+    // This and below do not use concepts, but templates and static_asserts.
+    // Concepts require T to be fully defined, but Rc<T> is often used with forward-declared T.
+    // This function is declared as template to help msvc in polymorphic base class case.
+    static_assert(!canConvert<T*, Refcounted*>());
+    auto wrapper = new _::RcWrapper<U>(mv(t));
+    refcounted = wrapper;
+    ptr = wrapper->getWrappedPtr();
+  }
+
+  inline Rc(Own<T> t) noexcept {
+    static_assert(!canConvert<T*, Refcounted*>());
+    if (t.get() == nullptr) return;
+    auto wrapper = new _::RcOwnWrapper<T>(mv(t));
+    this->refcounted = wrapper;
+    ptr = wrapper->getWrappedPtr();
+  }
+
+  Own<T> toOwn() {
+    // Convert Rc<T> to Own<T>.
+    // Nullifies the original Rc<T>.
+    if (ptr == nullptr) return Own<T>();
+    auto result = Own<T>(ptr, *refcounted);
+    refcounted = nullptr;
+    ptr = nullptr;
+    return result;
+  }
+
+  Rc<T> addRef() {
+    if (ptr != nullptr) {
+      ++refcounted->refcount;
+      return Rc(refcounted, ptr);
     } else {
-      return kj::Rc<T>();
+      return Rc<T>();
     }
   }
 
-  kj::Rc<T> clone() {
+  Rc<T> clone() {
     return addRef();
   }
 
   Rc& operator=(decltype(nullptr)) {
-    own = nullptr;
+    dispose();
     return *this;
   }
 
-  Rc& operator=(Rc&& other) = default;
+  Rc& operator=(Rc&& other) {
+    if (this == &other) return *this;
+    swp(refcounted, other.refcounted);
+    swp(ptr, other.ptr);
+    other.dispose();
+    return *this;
+  }
 
   template <typename U>
   Rc<U> downcast() {
-    return Rc<U>(own.template downcast<U>());
+    Rc<U> result(refcounted, &kj::downcast<U>(*ptr));
+    refcounted = nullptr;
+    ptr = nullptr;
+    return result;
   }
 
-  inline bool operator==(const Rc<T>& other) const { return own.get() == other.own.get(); }
-  inline bool operator==(decltype(nullptr)) const { return own.get() == nullptr; }
+  inline bool operator==(const Rc<T>& other) const { return ptr == other.ptr; }
+  inline bool operator==(decltype(nullptr)) const { return ptr == nullptr; }
 
-  inline T* operator->() { return own.get(); }
-  inline const T* operator->() const { return own.get(); }
-  inline T& operator*() { return *own; }
-  inline const T& operator*() const { return *own; }
+  inline T* operator->() { KJ_IREQUIRE(ptr != nullptr, "null Rc<> dereference"); return ptr; }
+  inline const T* operator->() const { KJ_IREQUIRE(ptr != nullptr, "null Rc<> dereference"); return ptr; }
+  inline T& operator*() { KJ_IREQUIRE(ptr != nullptr, "null Rc<> dereference"); return *ptr; }
+  inline const T& operator*() const { KJ_IREQUIRE(ptr != nullptr, "null Rc<> dereference"); return *ptr; }
 
-  inline T* get() { return own.get(); }
-  inline const T* get() const { return own.get(); }
+  inline T* get() { return ptr; }
+  inline const T* get() const { return ptr; }
 
 private:
-  Rc(T* t) : own(t, *t) { }
-  Rc(Own<T>&& t) : own(kj::mv(t)) { }
+  Rc(Refcounted *wrapper, T *ptr) : refcounted(wrapper), ptr(ptr) {}
+  void dispose() {
+    if (ptr == nullptr) return;
+    auto ptrCopy = ptr;
+    auto wrapperCopy = refcounted;
+    refcounted = nullptr;
+    ptr = nullptr;
+    wrapperCopy->dispose(const_cast<RemoveConst<T>*>(ptrCopy));
+  }
 
-  Own<T> own;
+  Refcounted* refcounted = nullptr;
+  T* ptr = nullptr;
 
   friend class Refcounted;
+
+  template <typename U, typename... Params>
+  friend Rc<U> rc(Params&&... params);
 
   template <typename>
   friend class Rc;
 };
+
+template <typename T, typename... Params>
+inline Rc<T> rc(Params&&... params) {
+  // Allocate a new refcounted instance of T, passing `params` to its constructor.
+  // Returns smart pointer that can be used to manage references.
+
+  if constexpr (canConvert<T*, Refcounted*>()) {
+    return Refcounted::addRcRefInternal(new T(fwd<Params>(params)...));
+  } else if constexpr (_::IsPolymorphic<T>) {
+    return Rc<T>(heap<T>(fwd<Params>(params)...));
+  } else {
+    auto wrapper = new _::RcWrapper<T>(fwd<Params>(params)...);
+    return Rc<T>(wrapper, wrapper->getWrappedPtr());
+  }
+}
 
 template <typename T>
 class RefcountedWrapper: public Refcounted {

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -181,16 +181,13 @@ template<typename T>
 class Rc {
   // Rc<T> is a smart pointer providing reference counting capabilities for all kinds of Ts.
   //
-  // The primary way to obtain new `Rc<T>` instance is ot use `kj::rc<T>(...)` function that will
-  // allocates new T on the heap. Depending on T nature:
-  // - T extends Refcounted. In such case T's `refcount` field is used for counting. 1 allocation.
-  // - T does not extend Refcounted and is not polymorphic. `kj::rc` will over-allocate 
-  //   `RcWrapper<T>` to provide a `refcount`. 1 allocation.
-  // - T extends Refcounted and is polymorphic. `RcOwnWrapper<T>` is used. 2 allocations.
+  // The primary way to obtain new `Rc<T>` instance is to use `kj::rc<T>(...)`, which allocates
+  // a new T on the heap. If T extends Refcounted, T's `refcount` field is used for counting.
+  // Otherwise, `kj::rc` allocates `RcWrapper<T>` to provide a `refcount`.
   //
   // Rc<T> can also be constructed from:
-  // - kj::Own<T> for all types of T. Always allocates.
-  // - T for non-polymorphic non-`Refcounted` Ts with move constructor. Always allocates.
+  // - kj::Own<T> for all types of T. Allocates a wrapper.
+  // - T for non-`Refcounted` Ts with move constructor. Allocates a wrapper.
   //
   // Once you have `Rc<T>` you can `addRef` or `clone` it to increment the refcount and obtain new
   // smart pointer.
@@ -236,10 +233,9 @@ public:
   }
 
   inline Rc(Own<T> t) noexcept {
-    static_assert(!canConvert<T*, Refcounted*>());
     if (t.get() == nullptr) return;
     auto wrapper = new _::RcOwnWrapper<T>(mv(t));
-    this->refcounted = wrapper;
+    refcounted = wrapper;
     ptr = wrapper->getWrappedPtr();
   }
 
@@ -302,11 +298,11 @@ private:
   Rc(Refcounted *wrapper, T *ptr) : refcounted(wrapper), ptr(ptr) {}
   void dispose() {
     if (ptr == nullptr) return;
-    auto ptrCopy = ptr;
-    auto wrapperCopy = refcounted;
+    auto refcountedCopy = refcounted;
     refcounted = nullptr;
     ptr = nullptr;
-    wrapperCopy->dispose(const_cast<RemoveConst<T>*>(ptrCopy));
+    // refcounted dispose ignores the pointer
+    refcountedCopy->dispose(static_cast<Refcounted*>(nullptr));
   }
 
   Refcounted* refcounted = nullptr;
@@ -328,8 +324,6 @@ inline Rc<T> rc(Params&&... params) {
 
   if constexpr (canConvert<T*, Refcounted*>()) {
     return Refcounted::addRcRefInternal(new T(fwd<Params>(params)...));
-  } else if constexpr (_::IsPolymorphic<T>) {
-    return Rc<T>(heap<T>(fwd<Params>(params)...));
   } else {
     auto wrapper = new _::RcWrapper<T>(fwd<Params>(params)...);
     return Rc<T>(wrapper, wrapper->getWrappedPtr());


### PR DESCRIPTION
Wraps into rc counted object and provides same interface without extra allocations.

The only thing that is missing when T does not extend Refcounted is `addRefToThis` which most Ts do not nead.
Makes possible to write `kj::Rc<String>` directly.