### PR TITLE
[release-1.3.0] backport HTTP body-size overflow fixes (CVE-2026-32239 + CVE-2026-32240)

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -4038,6 +4038,70 @@ KJ_TEST("HttpServer invalid method") {
   KJ_EXPECT(expectedResponse == response, expectedResponse, response);
 }
 
+KJ_TEST("HttpServer rejects negative Content-Length") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  HttpHeaderTable table;
+  BrokenHttpService service;
+  HttpServer server(timer, table, service, {
+    .canceledUploadGraceBytes = 1024 * 1024,
+  });
+
+  auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+  auto msg =
+      "POST / HTTP/1.1\r\n"
+      "Content-Length: -1\r\n"
+      "\r\n"
+      "foo"_kj.asBytes();
+
+  auto writePromise = pipe.ends[1]->write(msg.begin(), msg.size());
+  auto response = pipe.ends[1]->readAllText().wait(waitScope);
+
+  // The server should reject the negative Content-Length. The KJ_FAIL_REQUIRE in getEntityBody()
+  // gets caught by the server loop and turned into a 500 error.
+  KJ_EXPECT(response.startsWith("HTTP/1.1 500 Internal Server Error"), response);
+
+  KJ_EXPECT(writePromise.poll(waitScope));
+  writePromise.catch_([](kj::Exception&&) {}).wait(waitScope);
+}
+
+KJ_TEST("HttpServer rejects chunked body with overflowing chunk size") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  HttpHeaderTable table;
+  BrokenHttpService service;
+  HttpServer server(timer, table, service, {
+    .canceledUploadGraceBytes = 1024 * 1024,
+  });
+
+  auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+  // 17 hex digits: 0x10000000000000000 = 2^64, which overflows uint64_t.
+  auto msg =
+      "POST / HTTP/1.1\r\n"
+      "Transfer-Encoding: chunked\r\n"
+      "\r\n"
+      "10000000000000000\r\n"
+      "x\r\n"
+      "0\r\n"
+      "\r\n"_kj.asBytes();
+
+  auto writePromise = pipe.ends[1]->write(msg.begin(), msg.size());
+  auto response = pipe.ends[1]->readAllText().wait(waitScope);
+
+  // The chunk size overflow causes a KJ_REQUIRE failure during body reading, which the server
+  // catches and turns into a 500 error.
+  KJ_EXPECT(response.startsWith("HTTP/1.1 500 Internal Server Error"), response);
+
+  KJ_EXPECT(writePromise.poll(waitScope));
+  writePromise.catch_([](kj::Exception&&) {}).wait(waitScope);
+}
+
 // Ensure that HttpServerSettings can continue to be constexpr.
 KJ_UNUSED static constexpr HttpServerSettings STATIC_CONSTEXPR_SETTINGS {};
 

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1406,16 +1406,20 @@ public:
 
       uint64_t value = 0;
       for (char c: text) {
+        uint64_t digit;
         if ('0' <= c && c <= '9') {
-          value = value * 16 + (c - '0');
+          digit = c - '0';
         } else if ('a' <= c && c <= 'f') {
-          value = value * 16 + (c - 'a' + 10);
+          digit = c - 'a' + 10;
         } else if ('A' <= c && c <= 'F') {
-          value = value * 16 + (c - 'A' + 10);
+          digit = c - 'A' + 10;
         } else {
           KJ_FAIL_REQUIRE("invalid HTTP chunk size", text, text.asBytes()) { break; }
           return value;
         }
+        KJ_REQUIRE(value <= (uint64_t(kj::maxValue) >> 4),
+            "HTTP chunk size overflow", text, text.asBytes()) { break; }
+        value = value * 16 + digit;
       }
 
       return value;
@@ -1942,7 +1946,15 @@ kj::Own<kj::AsyncInputStream> HttpInputStreamImpl::getEntityBody(
       // Body elided.
       kj::Maybe<uint64_t> length;
       KJ_IF_MAYBE(cl, headers.get(HttpHeaderId::CONTENT_LENGTH)) {
-        length = strtoull(cl->cStr(), nullptr, 10);
+        // Validate that the Content-Length is a non-negative integer. Note that strtoull() accepts
+        // leading '-' signs and silently converts negative values to large unsigned values, so we
+        // must explicitly check for a leading digit.
+        char* end;
+        uint64_t parsedValue = strtoull(cl->cStr(), &end, 10);
+        if ((*cl)[0] >= '0' && (*cl)[0] <= '9' && end > cl->begin() && *end == '\0') {
+          length = parsedValue;
+        }
+        // If invalid, we just leave `length` as nullptr, since the body is elided anyway.
       } else if (headers.get(HttpHeaderId::TRANSFER_ENCODING) == nullptr) {
         // HACK: Neither Content-Length nor Transfer-Encoding header in response to HEAD
         //   request. Propagate this fact with a 0 expected body length.
@@ -1991,12 +2003,16 @@ kj::Own<kj::AsyncInputStream> HttpInputStreamImpl::getEntityBody(
     //   "Content-Length: 5, 5, 5". Hopefully no one actually does that...
     char* end;
     uint64_t length = strtoull(cl->cStr(), &end, 10);
-    if (end > cl->begin() && *end == '\0') {
+    // Note that strtoull() accepts leading '-' signs and silently converts negative values to
+    // large unsigned values, so we must explicitly check for a leading digit.
+    if ((*cl)[0] >= '0' && (*cl)[0] <= '9' && end > cl->begin() && *end == '\0') {
       // #5
       return kj::heap<HttpFixedLengthEntityReader>(*this, length);
     } else {
       // #4 (bad content-length)
-      KJ_FAIL_REQUIRE("invalid Content-Length header value", *cl);
+      KJ_FAIL_REQUIRE("invalid Content-Length header value", *cl) { break; }
+      // To pass the -fno-exceptions test (but KJ-HTTP is really not safe to use in that mode).
+      return kj::heap<HttpNullEntityReader>(*this, uint64_t(0));
     }
   }
 


### PR DESCRIPTION
backports `2744b3c012b4` onto release-1.3.0 — the http body-size overflow hardening isn't on this branch yet. one commit covers both CVE-ids:

- CVE-2026-32239: the content-length parser in `HttpInputStreamImpl::getEntityBody` runs the header through strtoull without a leading-digit check, so `Content-Length: -1` silently becomes 18446744073709551615 — a smuggling primitive through a buggy proxy.
- CVE-2026-32240: the chunked path truncates a chunk size >= 2^64 to a 64-bit value instead of rejecting it.

i pulled both parsers out and ran them either side of the commit: pre-fix `Content-Length: -1` is accepted as 2^64-1 and a 17-digit `f` chunk size truncates to 2^64-1; post-fix both are rejected. clean cherry-pick.

upstream: https://github.com/capnproto/capnproto/commit/2744b3c012b4
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-32239 / https://nvd.nist.gov/vuln/detail/CVE-2026-32240

didn't run the full test suite — change is the parser guards only. if you'd rather pull it in yourselves that's fine, just flagging the gap.