### PR TITLE
Reject more invalid HTTP common names and values

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -52,11 +52,31 @@ KJ_TEST("HttpOverCapnpFactory::capnpToKj rejects out of range common values") {
   }
 
   {
+    auto invalidName = orphanage.newOrphan<List<HttpHeader>>(1);
+    auto invalidNameHeader = invalidName.get()[0];
+    auto common = invalidNameHeader.initCommon();
+    common.setName(CommonHeaderName::INVALID);
+    common.setValue("value");
+
+    KJ_EXPECT_THROW_MESSAGE("unknown common header name", factory.capnpToKj(invalidName.get()));
+  }
+
+  {
     auto invalidValue = orphanage.newOrphan<List<HttpHeader>>(1);
     auto invalidValueHeader = invalidValue.get()[0];
     auto common = invalidValueHeader.initCommon();
     common.setName(CommonHeaderName::ACCEPT_CHARSET);
     common.setCommonValue(static_cast<CommonHeaderValue>(999));
+
+    KJ_EXPECT_THROW_MESSAGE("unknown common header value", factory.capnpToKj(invalidValue.get()));
+  }
+  
+  {
+    auto invalidValue = orphanage.newOrphan<List<HttpHeader>>(1);
+    auto invalidValueHeader = invalidValue.get()[0];
+    auto common = invalidValueHeader.initCommon();
+    common.setName(CommonHeaderName::ACCEPT_CHARSET);
+    common.setCommonValue(CommonHeaderValue::INVALID);
 
     KJ_EXPECT_THROW_MESSAGE("unknown common header value", factory.capnpToKj(invalidValue.get()));
   }

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -1065,12 +1065,12 @@ kj::HttpHeaders HttpOverCapnpFactory::capnpToKj(
       case capnp::HttpHeader::COMMON: {
         auto nv = header.getCommon();
         auto nameInt = static_cast<uint>(nv.getName());
-        KJ_REQUIRE(nameInt < nameCapnpToKj.size(), "unknown common header name", nv.getName());
+        KJ_REQUIRE(nameInt > 0 && nameInt < nameCapnpToKj.size(), "unknown common header name", nv.getName());
 
         switch (nv.which()) {
           case capnp::HttpHeader::Common::COMMON_VALUE: {
             auto cvInt = static_cast<uint>(nv.getCommonValue());
-            KJ_REQUIRE(cvInt < valueCapnpToKj.size(),
+            KJ_REQUIRE(cvInt > 0 && cvInt < valueCapnpToKj.size(),
                 "unknown common header value", nv.getCommonValue());
             result.setPtr(nameCapnpToKj[nameInt], valueCapnpToKj[cvInt]);
             break;


### PR DESCRIPTION
0 is invalid too, but we don't check that. Now it throws the same error as values far out of range.