### PR TITLE
Clamp rpc Exception type enum.

### DIFF
--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -1721,6 +1721,43 @@ KJ_TEST("abort") {
   KJ_EXPECT(conn->receiveIncomingMessage().wait(context.waitScope) == kj::none);
 }
 
+KJ_TEST("abort with invalid exception type") {
+  // Regression test: a peer sends an abort message with an out-of-range Exception::type.
+  // Cap'n Proto enums are raw UInt16 on the wire, so any value 0-65535 is possible.
+  // The server must handle this gracefully (clamp to FAILED) rather than crashing
+  // due to an out-of-bounds array access in KJ_STRINGIFY(Exception::Type).
+
+  TestContext context;
+
+  MallocMessageBuilder refMessage(128);
+  auto hostId = refMessage.initRoot<test::TestSturdyRefHostId>();
+  hostId.setHost("bob");
+
+  auto conn = KJ_ASSERT_NONNULL(context.alice.vatNetwork.connect(hostId));
+  conn->setIdle(false);
+
+  {
+    // Send an abort with an out-of-range exception type (0xFFFF).
+    auto msg = conn->newOutgoingMessage(128);
+    auto abort = msg->getBody().initAs<rpc::Message>().initAbort();
+    abort.setReason("malformed type test");
+    abort.setType(static_cast<rpc::Exception::Type>(0xFFFF));
+    msg->send();
+  }
+
+  // The server should handle the malformed abort without crashing. It disconnects and
+  // sends its own abort back (with the clamped exception type).
+  auto reply = KJ_ASSERT_NONNULL(conn->receiveIncomingMessage().wait(context.waitScope));
+  KJ_EXPECT(reply->getBody().getAs<rpc::Message>().which() == rpc::Message::ABORT);
+
+  // Verify the abort response has a valid (clamped) exception type.
+  auto responseException = reply->getBody().getAs<rpc::Message>().getAbort();
+  KJ_EXPECT(responseException.getType() == rpc::Exception::Type::FAILED);
+
+  // Connection should then close.
+  KJ_EXPECT(conn->receiveIncomingMessage().wait(context.waitScope) == kj::none);
+}
+
 KJ_TEST("handles exceptions thrown during disconnect") {
   // This is similar to the earlier "abort" test, but throws an exception on
   // connection shutdown, to exercise the RpcConnectionState error handler.

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -123,8 +123,18 @@ kj::Exception toException(const rpc::Exception::Reader& exception) {
     }
   }();
 
-  kj::Exception result(static_cast<kj::Exception::Type>(exception.getType()),
-      "(remote)", 0, kj::mv(reason));
+  // Cap'n Proto enums are encoded as raw UInt16 on the wire, so a peer can send any value 0-65535.
+  // We must clamp to valid kj::Exception::Type values to avoid undefined behavior (e.g. out-of-
+  // bounds array access when stringifying the exception type).
+  kj::Exception::Type type = kj::Exception::Type::FAILED;
+  switch (exception.getType()) {
+    case rpc::Exception::Type::FAILED:        type = kj::Exception::Type::FAILED; break;
+    case rpc::Exception::Type::OVERLOADED:    type = kj::Exception::Type::OVERLOADED; break;
+    case rpc::Exception::Type::DISCONNECTED:  type = kj::Exception::Type::DISCONNECTED; break;
+    case rpc::Exception::Type::UNIMPLEMENTED: type = kj::Exception::Type::UNIMPLEMENTED; break;
+  }
+
+  kj::Exception result(type, "(remote)", 0, kj::mv(reason));
   if (exception.hasTrace()) {
     result.setRemoteTrace(kj::str(exception.getTrace()));
   }

--- a/c++/src/kj/exception-test.c++
+++ b/c++/src/kj/exception-test.c++
@@ -644,6 +644,32 @@ KJ_TEST("Maybe<Exception> niche optimization") {
   }
 }
 
+KJ_TEST("KJ_STRINGIFY(Exception::Type) handles out-of-range values") {
+  // Valid types stringify correctly.
+  KJ_EXPECT(kj::str(kj::Exception::Type::FAILED) == "failed");
+  KJ_EXPECT(kj::str(kj::Exception::Type::OVERLOADED) == "overloaded");
+  KJ_EXPECT(kj::str(kj::Exception::Type::DISCONNECTED) == "disconnected");
+  KJ_EXPECT(kj::str(kj::Exception::Type::UNIMPLEMENTED) == "unimplemented");
+
+  // Out-of-range type must not crash; should return "failed".
+  auto bogus = static_cast<kj::Exception::Type>(99);
+  KJ_EXPECT(kj::str(bogus) == "failed");
+
+  // Maximum uint16 value (worst-case wire input from capnp enum).
+  auto maxBogus = static_cast<kj::Exception::Type>(0xFFFF);
+  KJ_EXPECT(kj::str(maxBogus) == "failed");
+}
+
+KJ_TEST("Exception with out-of-range type stringifies safely") {
+  // Constructing a kj::Exception with an invalid type (e.g. from an unchecked wire cast)
+  // must not crash when the exception is stringified.
+  kj::Exception e(static_cast<kj::Exception::Type>(0xFFFF),
+                  "test.c++", 42, kj::heapString("bogus type test"));
+  auto s = kj::str(e);
+  KJ_ASSERT(strstr(s.cStr(), "failed") != nullptr, s);
+  KJ_ASSERT(strstr(s.cStr(), "bogus type test") != nullptr, s);
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -942,7 +942,11 @@ StringPtr KJ_STRINGIFY(Exception::Type type) {
     "unimplemented"
   };
 
-  return TYPE_STRINGS[static_cast<uint>(type)];
+  uint i = static_cast<uint>(type);
+  if (i >= kj::size(TYPE_STRINGS)) {
+    i = 0;
+  }
+  return TYPE_STRINGS[i];
 }
 
 String KJ_STRINGIFY(const Exception& e) {


### PR DESCRIPTION
It's possible to construct an exception type which doesn't match the values allowed by the `rpc::Exception::Type` enum, then send it over the wire. This can lead to a out of bounds array access when stringifying the exception type.

This PR fixes this and includes tests which reproduce it.

### Test Plan

Verified that this passes:

```
bazel test --config=asan //src/kj:exception-test //src/capnp:rpc-test
```

Verified that we get an ASAN trigger without the fix in our test:

```
[ TEST ] exception-test.c++:647: KJ_STRINGIFY(Exception::Type) handles out-of-range values
=================================================================
==15625==ERROR: AddressSanitizer: global-buffer-overflow on address 0x0001023c9ff8 at pc 0x0001023467bc bp 0x00016db08210 sp 0x00016db08208
    #0 0x0001023467b8 in kj::operator*(kj::_::Stringifier, kj::Exception::Type)+0x54 (exception-test:arm64+0x1000527b8)
    #1 0x00010232af74 in kj::_::(anonymous namespace)::TestCase647::run()+0xa70 (exception-test:arm64+0x100036f74)
...
```