### PR TITLE
ArrayPtr::slice(0, l) linter

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -129,7 +129,7 @@ jobs:
             export CLANG_TIDY=clang-tidy-${{ matrix.clang }}
             cd c++ 
             bazel build --config=ci //...
-            find src/kj src/capnp -name "*.c++" | parallel $CLANG_TIDY {}
+            find src/kj src/capnp -name "*.c++" | parallel $CLANG_TIDY --experimental-custom-checks {}
   MacOS:
     runs-on: macos-latest
     strategy:

--- a/c++/.clang-tidy
+++ b/c++/.clang-tidy
@@ -2,7 +2,35 @@
 # We prefer to enable useful checks one by one.
 Checks: >
   -*,
-  modernize-use-nullptr
+  modernize-use-nullptr,
+  custom-arrayptr-slice-zero
+
+####
+# Custom checks.
+#
+# These checks enforce custom KJ code style and idiomatic code. We recommend to enable these
+# in all projects that use KJ.
+#
+# Requires clang-tidy's --experimental-custom-checks flag.
+#
+# References:
+# - https://clang.llvm.org/extra/clang-tidy/QueryBasedCustomChecks.html
+# - https://clang.llvm.org/docs/LibASTMatchersReference.html
+CustomChecks:
+  - Name: arrayptr-slice-zero
+    Query: |
+      match cxxMemberCallExpr(
+        callee(cxxMethodDecl(
+          hasName("slice"),
+          ofClass(classTemplateSpecializationDecl(hasName("::kj::ArrayPtr")))
+        )),
+        argumentCountIs(2),
+        hasArgument(0, ignoringParenImpCasts(integerLiteral(equals(0))))
+      ).bind("call")
+    Diagnostic:
+      - BindName: call
+        Message: "use first() instead of slice(0, ...)"
+        Level: Warning
 
 HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2570,14 +2570,16 @@ public:
     return ArrayPtr(ptr + start, size_ - start);
   }
   inline constexpr bool startsWith(const ArrayPtr<const T>& other) const {
-    return other.size() <= size_ && slice(0, other.size()) == other;
+    return other.size() <= size_ && first(other.size()) == other;
   }
   inline constexpr bool endsWith(const ArrayPtr<const T>& other) const {
     return other.size() <= size_ && slice(size_ - other.size(), size_) == other;
   }
 
+  // NOLINTBEGIN(*-arrayptr-slice-zero)
   inline constexpr ArrayPtr first(size_t count) { return slice(0, count); }
   inline constexpr ArrayPtr<const T> first(size_t count) const { return slice(0, count); }
+  // NOLINTEND(*-arrayptr-slice-zero)
 
   inline Maybe<size_t> findFirst(const T& match) const {
     for (size_t i = 0; i < size_; i++) {

--- a/c++/src/kj/io.c++
+++ b/c++/src/kj/io.c++
@@ -199,7 +199,7 @@ BufferedOutputStreamWrapper::~BufferedOutputStreamWrapper() noexcept(false) {
 
 void BufferedOutputStreamWrapper::flush() {
   if (bufferPos > buffer.begin()) {
-    inner.write(buffer.slice(0, bufferPos - buffer.begin()));
+    inner.write(buffer.first(bufferPos - buffer.begin()));
     bufferPos = buffer.begin();
   }
 }
@@ -231,7 +231,7 @@ void BufferedOutputStreamWrapper::write(ArrayPtr<const byte> src) {
       bufferPos = buffer.begin() + size;
     } else {
       // Writing so much data that we might as well write directly to avoid a copy.
-      inner.write(buffer.slice(0, bufferPos - buffer.begin()));
+      inner.write(buffer.first(bufferPos - buffer.begin()));
       bufferPos = buffer.begin();
       inner.write(src.first(size));
     }


### PR DESCRIPTION
I want to experiment with linters suggesting more compact code similar to the way clippy does it.
The plan is to enable these checks downstream too.