### PR TITLE
http: add support for informational (1xx) responses

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1703,6 +1703,40 @@ KJ_TEST("HttpInputStream responses") {
   KJ_EXPECT(!input->awaitNextMessage().wait(waitScope));
 }
 
+KJ_TEST("HttpInputStream reads 1xx response") {
+  KJ_HTTP_TEST_SETUP_IO;
+
+  kj::HttpHeaderTable table;
+
+  auto pipe = kj::newOneWayPipe();
+  auto input = newHttpInputStream(*pipe.in, table);
+
+  // Queue the write without waiting: the pipe blocks writes until a reader is active,
+  // so reads and writes must run concurrently on the event loop.
+  kj::Promise<void> writeTask = pipe.out->write(
+      "HTTP/1.1 103 Early Hints\r\n"
+      "\r\n"
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 0\r\n"
+      "\r\n"_kjb).then([&]() { pipe.out = nullptr; });
+
+  KJ_ASSERT(input->awaitNextMessage().wait(waitScope));
+  auto resp = input->readResponse(HttpMethod::GET).wait(waitScope);
+  KJ_EXPECT(resp.statusCode == 103);
+  KJ_EXPECT(resp.statusText == "Early Hints");
+  auto body = resp.body->readAllText().wait(waitScope);
+  KJ_EXPECT(body == "");
+
+  // Verify the stream is correctly positioned for the following final response.
+  KJ_ASSERT(input->awaitNextMessage().wait(waitScope));
+  auto resp2 = input->readResponse(HttpMethod::GET).wait(waitScope);
+  KJ_EXPECT(resp2.statusCode == 200);
+  resp2.body->readAllText().wait(waitScope);
+
+  writeTask.wait(waitScope);
+  KJ_EXPECT(!input->awaitNextMessage().wait(waitScope));
+}
+
 KJ_TEST("HttpInputStream bare messages") {
   KJ_HTTP_TEST_SETUP_IO;
 
@@ -8209,6 +8243,294 @@ KJ_TEST("Range header parsing") {
       }
     }
   }
+}
+
+KJ_TEST("HttpServer sendInformational sends 1xx before final response") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  HttpHeaderTable table;
+
+  class EarlyHintsService final: public HttpService {
+  public:
+    EarlyHintsService(HttpHeaderTable& table) : table(table) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      HttpHeaders hints(table);
+      hints.addPtrPtr("Link", "</style.css>; rel=preload; as=style");
+      return response.sendInformational(103, "Early Hints", hints)
+          .then([this, &response]() {
+        HttpHeaders responseHeaders(table);
+        auto body = response.send(200, "OK", responseHeaders, uint64_t(0));
+        kj::ArrayPtr<const kj::StringPtr> empty;
+        return writeEach(*body, empty).attach(kj::mv(body));
+      });
+    }
+
+  private:
+    HttpHeaderTable& table;
+  };
+
+  EarlyHintsService service(table);
+  HttpServer server(timer, table, service);
+  auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+  pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb).wait(waitScope);
+  pipe.ends[1]->shutdownWrite();
+
+  expectRead(*pipe.ends[1],
+      "HTTP/1.1 103 Early Hints\r\n"
+      "Link: </style.css>; rel=preload; as=style\r\n"
+      "\r\n"
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 0\r\n"
+      "\r\n").wait(waitScope);
+
+  listenTask.wait(waitScope);
+}
+
+KJ_TEST("HttpServer sendInformational multiple 1xx before final response") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  HttpHeaderTable table;
+
+  class MultiHintsService final: public HttpService {
+  public:
+    MultiHintsService(HttpHeaderTable& table) : table(table) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      HttpHeaders hints1(table);
+      hints1.addPtrPtr("Link", "</style.css>; rel=preload; as=style");
+      return response.sendInformational(103, "Early Hints", hints1)
+          .then([this, &response]() {
+        HttpHeaders hints2(table);
+        hints2.addPtrPtr("Link", "</script.js>; rel=preload; as=script");
+        return response.sendInformational(103, "Early Hints", hints2);
+      }).then([this, &response]() {
+        HttpHeaders responseHeaders(table);
+        auto body = response.send(200, "OK", responseHeaders, uint64_t(0));
+        kj::ArrayPtr<const kj::StringPtr> empty;
+        return writeEach(*body, empty).attach(kj::mv(body));
+      });
+    }
+
+  private:
+    HttpHeaderTable& table;
+  };
+
+  MultiHintsService service(table);
+  HttpServer server(timer, table, service);
+  auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+  pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb).wait(waitScope);
+  pipe.ends[1]->shutdownWrite();
+
+  expectRead(*pipe.ends[1],
+      "HTTP/1.1 103 Early Hints\r\n"
+      "Link: </style.css>; rel=preload; as=style\r\n"
+      "\r\n"
+      "HTTP/1.1 103 Early Hints\r\n"
+      "Link: </script.js>; rel=preload; as=script\r\n"
+      "\r\n"
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 0\r\n"
+      "\r\n").wait(waitScope);
+
+  listenTask.wait(waitScope);
+}
+
+KJ_TEST("HttpServer sendInformational rejects non-1xx status code") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  HttpHeaderTable table;
+
+  class BadStatusService final: public HttpService {
+  public:
+    BadStatusService(HttpHeaderTable& table) : table(table) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      HttpHeaders h(table);
+      KJ_EXPECT_THROW_MESSAGE("non-1xx",
+          response.sendInformational(200, "OK", h));
+      auto body = response.send(200, "OK", h, uint64_t(0));
+      kj::ArrayPtr<const kj::StringPtr> empty;
+      return writeEach(*body, empty).attach(kj::mv(body));
+    }
+
+  private:
+    HttpHeaderTable& table;
+  };
+
+  BadStatusService service(table);
+  HttpServer server(timer, table, service);
+  auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+  pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb).wait(waitScope);
+  pipe.ends[1]->shutdownWrite();
+
+  expectRead(*pipe.ends[1],
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 0\r\n"
+      "\r\n").wait(waitScope);
+
+  listenTask.wait(waitScope);
+}
+
+KJ_TEST("HttpServer sendInformational rejects call after send()") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  HttpHeaderTable table;
+
+  class AfterSendService final: public HttpService {
+  public:
+    AfterSendService(HttpHeaderTable& table) : table(table) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      HttpHeaders h(table);
+      auto body = response.send(200, "OK", h, uint64_t(0));
+      KJ_EXPECT_THROW_MESSAGE("after calling send()",
+          response.sendInformational(103, "Early Hints", h));
+      kj::ArrayPtr<const kj::StringPtr> empty;
+      return writeEach(*body, empty).attach(kj::mv(body));
+    }
+
+  private:
+    HttpHeaderTable& table;
+  };
+
+  AfterSendService service(table);
+  HttpServer server(timer, table, service);
+  auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+  pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb).wait(waitScope);
+  pipe.ends[1]->shutdownWrite();
+
+  expectRead(*pipe.ends[1],
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 0\r\n"
+      "\r\n").wait(waitScope);
+
+  listenTask.wait(waitScope);
+}
+
+KJ_TEST("HttpClient reads past 103 to get final response") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  auto serverTask = expectRead(*pipe.ends[1], "GET / HTTP/1.1\r\n\r\n").then([&]() {
+    return pipe.ends[1]->write(
+        "HTTP/1.1 103 Early Hints\r\n"
+        "Link: </style.css>; rel=preload; as=style\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 3\r\n"
+        "\r\n"
+        "foo"_kjb);
+  }).then([&]() -> kj::Promise<void> {
+    pipe.ends[1]->shutdownWrite();
+    return kj::NEVER_DONE;
+  });
+
+  HttpHeaderTable table;
+  auto client = newHttpClient(table, *pipe.ends[0]);
+  HttpHeaders headers(table);
+  auto req = client->request(HttpMethod::GET, "/", headers, uint64_t(0));
+  req.body = nullptr;
+
+  auto clientTask = req.response.then([](HttpClient::Response&& response) {
+    KJ_EXPECT(response.statusCode == 200);
+    KJ_EXPECT(response.statusText == "OK");
+    auto promise = response.body->readAllText();
+    return promise.attach(kj::mv(response.body));
+  }).then([](kj::String body) {
+    KJ_EXPECT(body == "foo");
+  });
+
+  serverTask.exclusiveJoin(kj::mv(clientTask)).wait(waitScope);
+}
+
+KJ_TEST("HttpClient does not read past 101") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  // A nonsense request/response pair (proper usage would go `openWebsocket`),
+  // but the client has to be able to handle a server sending anything.
+  auto serverTask = expectRead(*pipe.ends[1], "GET / HTTP/1.1\r\n\r\n").then([&]() {
+    return writeA(*pipe.ends[1], asBytes(WEBSOCKET_RESPONSE_HANDSHAKE));
+  }).then([&]() -> kj::Promise<void> {
+    pipe.ends[1]->shutdownWrite();
+    return kj::NEVER_DONE;
+  });
+
+  HttpHeaderTable table;
+  auto client = newHttpClient(table, *pipe.ends[0]);
+  HttpHeaders headers(table);
+  auto req = client->request(HttpMethod::GET, "/", headers, uint64_t(0));
+  req.body = nullptr;
+
+  auto clientTask = req.response.then([](HttpClient::Response&& response) {
+    KJ_EXPECT(response.statusCode == 101);
+    KJ_EXPECT(response.statusText == "Switching Protocols");
+    auto promise = response.body->readAllText();
+    return promise.attach(kj::mv(response.body));
+  }).then([](kj::String body) {
+    KJ_EXPECT(body == "");
+  });
+
+  serverTask.exclusiveJoin(kj::mv(clientTask)).wait(waitScope);
+}
+
+KJ_TEST("newHttpClient from HttpService: sendInformational ignored by adapter") {
+  KJ_HTTP_TEST_SETUP_IO;
+
+  HttpHeaderTable table;
+
+  class InformationalService final: public HttpService {
+  public:
+    InformationalService(HttpHeaderTable& table) : table(table) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      HttpHeaders hints(table);
+      hints.addPtrPtr("Link", "</style.css>; rel=preload; as=style");
+      return response.sendInformational(103, "Early Hints", hints)
+          .then([this, &response]() {
+        HttpHeaders responseHeaders(table);
+        auto body = response.send(200, "OK", responseHeaders, uint64_t(0));
+        kj::ArrayPtr<const kj::StringPtr> empty;
+        return writeEach(*body, empty).attach(kj::mv(body));
+      });
+    }
+
+  private:
+    HttpHeaderTable& table;
+  };
+
+  InformationalService service(table);
+  auto client = newHttpClient(service);
+  HttpHeaders headers(table);
+  auto req = client->request(HttpMethod::GET, "/", headers, uint64_t(0));
+  req.body = nullptr;
+
+  auto resp = req.response.wait(waitScope);
+  KJ_EXPECT(resp.statusCode == 200);
+  KJ_EXPECT(resp.statusText == "OK");
 }
 
 }  // namespace

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1635,6 +1635,29 @@ public:
     KJ_UNREACHABLE;
   }
 
+  kj::Promise<HttpHeaders::ResponseOrProtocolError> readResponseHeadersSkippingInformational() {
+    // Like readResponseHeaders(), but automatically skips any informational
+    // responses. These are 1xx responses except for 101 Switching Protocols,
+    // which has the unique behavior of terminating HTTP/1 on the connection.
+    // That response needs to be surfaced to callers in order for them to
+    // properly react to this change in connection state.
+    while (true) {
+      auto headersOrError = co_await readResponseHeaders();
+      KJ_SWITCH_ONEOF(headersOrError) {
+        KJ_CASE_ONEOF(response, HttpHeaders::Response) {
+          if (response.statusCode >= 100 && response.statusCode < 200 && response.statusCode != 101) {
+            finishRead();
+            continue;
+          }
+          co_return kj::mv(headersOrError);
+        }
+        KJ_CASE_ONEOF(protocolError, HttpHeaders::ProtocolError) {
+          co_return kj::mv(headersOrError);
+        }
+      }
+    }
+  }
+
   inline const HttpHeaders& getHeaders() const { return headers; }
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) {
@@ -2268,7 +2291,7 @@ kj::Own<kj::AsyncInputStream> HttpInputStreamImpl::getEntityBody(
       return kj::heap<HttpNullEntityReader>(*this, length);
     } else if (isConnectRequest && statusCode >= 200 && statusCode < 300) {
       KJ_FAIL_ASSERT("a CONNECT response with a 2xx status does not have an entity body to get");
-    } else if (statusCode == 204 || statusCode == 304) {
+    } else if ((statusCode >= 100 && statusCode < 200) || statusCode == 204 || statusCode == 304) {
       // No body.
       return kj::heap<HttpNullEntityReader>(*this, uint64_t(0));
     }
@@ -5592,7 +5615,7 @@ public:
 
     auto id = ++counter;
 
-    auto responsePromise = httpInput.readResponseHeaders().then(
+    auto responsePromise = httpInput.readResponseHeadersSkippingInformational().then(
         [this,method,id](HttpHeaders::ResponseOrProtocolError&& responseOrProtocolError)
             -> HttpClient::Response {
       KJ_SWITCH_ONEOF(responseOrProtocolError) {
@@ -7581,6 +7604,11 @@ kj::Own<HttpService> newHttpService(HttpClient& client) {
 
 // =======================================================================================
 
+kj::Promise<void> HttpService::Response::sendInformational(
+    uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) {
+  return kj::READY_NOW;
+}
+
 kj::Promise<void> HttpService::Response::sendError(
     uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) {
   auto stream = send(statusCode, statusText, headers, statusText.size());
@@ -8081,6 +8109,15 @@ private:
         co_return BREAK_LOOP_CONN_ERR;
       }
     }
+  }
+
+  kj::Promise<void> sendInformational(
+      uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+    KJ_REQUIRE(statusCode >= 100 && statusCode < 200, "can't call sendInformational() with a non-1xx statusCode");
+    KJ_REQUIRE(currentMethod != kj::none, "can't call sendInformational() after calling send()");
+    httpOutput.writeHeaders(headers.serializeResponse(statusCode, statusText));
+    httpOutput.finishBody();
+    return httpOutput.flush();
   }
 
   kj::Own<kj::AsyncOutputStream> send(

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -955,6 +955,18 @@ public:
     // `acceptWebSocket()` may only be called a single time. Calling it a second time will cause an
     // exception to be thrown.
 
+    virtual kj::Promise<void> sendInformational(
+        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers);
+    // Sends a 1xx informational response. May be called any number of times before send() or
+    // acceptWebSocket(). `statusText` and `headers` need only remain valid until
+    // sendInformational() returns. Returns a promise that resolves once the response has been
+    // written; the caller should typically await this before making further calls.
+    //
+    // Calling sendInformational() after send() or acceptWebSocket() throws an exception.
+    //
+    // The default implementation is a no-op (returns kj::READY_NOW), which is appropriate for
+    // adapters that cannot forward informational responses.
+
     kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText,
                                 const HttpHeaders& headers);
     kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText,


### PR DESCRIPTION
Ref: https://github.com/cloudflare/workerd/discussions/761

In HTTP, informational (1xx) responses are intermediate responses that typically do not terminate an HTTP response stream. That is to say, an HTTP response may present zero or more informational responses before presenting a terminal response with status code >= 200. (I say "typically" in that a 101 Switching Protocols response, as in WebSocket handshakes, does terminate the HTTP aspect of the response, though the stream does live on.)

So, informational responses change the "arity" of HTTP responses, from 1 to n, requiring API support from HTTP implementations. Because informational responses are niche, many implementations get away without exposing them to callers, either on the sending side by just not allowing them to be sent, or even on the receiving side by silently consuming them and continuing onward. Until now, KJ has been in this state.

Unfortunately, the standardization of 103 Early Hints as a mechanism to optimize asset loading in dynamic web sites means that informational responses are not as niche as they used to be. Browser support for consuming preload Link headers in early hints responses is widespread, so web servers implemented in KJ can benefit from being able to send early hints responses.

So:
- Add a new `HttpService::Response::sendInformational`, which allows sending any informational response without concluding the response.
- This method has a default no-op implementation, both because to do otherwise would be a breaking API change, and because I spotted many implementations in tests or in workerd that ought not have to care.
- Add support for "reading through" 1xx responses to HttpClient (except 101 Switching Protocols - see commentary). I believe that until now, any response streams containing informational responses were not correctly handled by it, in that HttpClient would give callers the first informational response, with no further access to subsequent responses.
- I have not added support for exposing those "read-through" informational responses to the caller: I could not find an API that preserved compatibility while also not feeling mediocre and bolted on. I am also not sure that support is necessary: in a library like KJ, sending informational responses is a plausible application-level concern, but I'm not sure receiving them is.  Given KJ's current scope, informational responses are useless trivia that applications can't do anything with. And if they do want that, they can use the lower-level HttpInputStream.
- On that note, set body length to 0 when reading an informational response entity, like in HttpInputStream.