### PR TITLE
Address compiler errors when building against OpenSSL 4.0

### DIFF
--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -1125,13 +1125,13 @@ kj::String TlsPeerIdentity::getCommonName() {
     KJ_FAIL_REQUIRE("client did not provide a certificate") { return nullptr; }
   }
 
-  X509_NAME* subj = X509_get_subject_name(reinterpret_cast<X509*>(cert));
+  const X509_NAME* subj = X509_get_subject_name(reinterpret_cast<X509*>(cert));
 
   int index = X509_NAME_get_index_by_NID(subj, NID_commonName, -1);
   KJ_ASSERT(index != -1, "certificate has no common name?");
-  X509_NAME_ENTRY* entry = X509_NAME_get_entry(subj, index);
+  const X509_NAME_ENTRY* entry = X509_NAME_get_entry(subj, index);
   KJ_ASSERT(entry != nullptr);
-  ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
+  const ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
   KJ_ASSERT(data != nullptr);
 
   unsigned char* out = nullptr;

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -1127,7 +1127,8 @@ kj::String TlsPeerIdentity::getCommonName() {
 
   const X509_NAME* subj = X509_get_subject_name(reinterpret_cast<X509*>(cert));
 
-  int index = X509_NAME_get_index_by_NID(subj, NID_commonName, -1);
+  // Cast away const for compatibility with older OpenSSL versions
+  int index = X509_NAME_get_index_by_NID(const_cast<X509_NAME*>(subj), NID_commonName, -1);
   KJ_ASSERT(index != -1, "certificate has no common name?");
   const X509_NAME_ENTRY* entry = X509_NAME_get_entry(subj, index);
   KJ_ASSERT(entry != nullptr);


### PR DESCRIPTION
Hi, this is a super-minor patch required to address compiler warnings when building against OpenSSL 4.0.  It still builds against 3.x and has been applied to the Debian [capnproto package](https://tracker.debian.org/pkg/capnproto).   Reference https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1137594

Below are the compiler errors before the patch:
```
| libtool: compile:  g++ -DHAVE_CONFIG_H -I. -Wdate-time -D_FORTIFY_SOURCE=2 -I./src -I./src -DKJ_HEADER_WARNINGS -DCAPNP_HEADER_WARNINGS -DCAPNP_INCLUDE_DIR=\"/usr/include\" -g -O2 -ffile-prefix-map=/build/reproducible-path/capnproto-1.4.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -DNDEBUG -DKJ_HAS_ZLIB -DKJ_HAS_OPENSSL -DKJ_USE_FIBERS -c src/kj/compat/tls.c++  -fPIC -DPIC -o src/kj/compat/.libs/tls.o
| src/kj/compat/tls.c++: In member function 'kj::String kj::TlsPeerIdentity::getCommonName()':
| src/kj/compat/tls.c++:1131:42: error: invalid conversion from 'const X509_NAME*' {aka 'const X509_name_st*'} to 'X509_NAME*' {aka 'X509_name_st*'} [-fpermissive]
|  1131 |   X509_NAME* subj = X509_get_subject_name(reinterpret_cast<X509*>(cert));
|       |                     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|       |                                          |
|       |                                          const X509_NAME* {aka const X509_name_st*}
| src/kj/compat/tls.c++:1135:47: error: invalid conversion from 'const X509_NAME_ENTRY*' {aka 'const X509_name_entry_st*'} to 'X509_NAME_ENTRY*' {aka 'X509_name_entry_st*'} [-fpermissive]
|  1135 |   X509_NAME_ENTRY* entry = X509_NAME_get_entry(subj, index);
|       |                            ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
|       |                                               |
|       |                                               const X509_NAME_ENTRY* {aka const X509_name_entry_st*}
| src/kj/compat/tls.c++:1137:47: error: invalid conversion from 'const ASN1_STRING*' {aka 'const asn1_string_st*'} to 'ASN1_STRING*' {aka 'asn1_string_st*'} [-fpermissive]
|  1137 |   ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
|       |                       ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
|       |                                               |
|       |                                               const ASN1_STRING* {aka const asn1_string_st*}
| make[3]: *** [Makefile:2354: src/kj/compat/tls.lo] Error 1
```



