### PR TITLE
ArrayPtr::write

### DIFF
--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -397,6 +397,72 @@ TEST(Common, ArrayAsBytes) {
   }
 }
 
+KJ_TEST("ArrayPtr write") {
+  int raw[] = {0, 0, 0, 0, 0};
+  ArrayPtr<int> head = raw;
+
+  int first[] = {1, 2};
+  head.write(arrayPtr(first));
+
+  int expectedAfterFirst[] = {1, 2, 0, 0, 0};
+  KJ_EXPECT(arrayPtr(raw) == arrayPtr(expectedAfterFirst));
+  KJ_EXPECT(head.begin() == raw + 2);
+  KJ_EXPECT(head.size() == 3);
+
+  int second[] = {3, 4, 5};
+  head.write(arrayPtr(second));
+
+  int expectedAfterSecond[] = {1, 2, 3, 4, 5};
+  KJ_EXPECT(arrayPtr(raw) == arrayPtr(expectedAfterSecond));
+  KJ_EXPECT(head.begin() == raw + 5);
+  KJ_EXPECT(head.size() == 0);
+}
+
+KJ_TEST("ArrayPtr write bounds check") {
+  int raw[] = {9, 9, 9};
+  ArrayPtr<int> head = raw;
+  int source[] = {1, 2, 3, 4};
+
+  KJ_EXPECT_THROW_MESSAGE("Out-of-bounds", head.write(arrayPtr(source)));
+
+  int expected[] = {9, 9, 9};
+  KJ_EXPECT(arrayPtr(raw) == arrayPtr(expected));
+  KJ_EXPECT(head.begin() == raw);
+  KJ_EXPECT(head.size() == 3);
+}
+
+KJ_TEST("ArrayPtr write pieces") {
+  int raw[] = {0, 0, 0, 0, 0, 0};
+  ArrayPtr<int> head = raw;
+  int first[] = {1, 2};
+  int second[] = {3};
+  int third[] = {4, 5};
+  ArrayPtr<const int> pieces[] = {arrayPtr(first), arrayPtr(second), arrayPtr(third)};
+
+  head.write(arrayPtr(pieces));
+
+  int expected[] = {1, 2, 3, 4, 5, 0};
+  KJ_EXPECT(arrayPtr(raw) == arrayPtr(expected));
+  KJ_EXPECT(head.begin() == raw + 5);
+  KJ_EXPECT(head.size() == 1);
+}
+
+KJ_TEST("ArrayPtr write pieces bounds check") {
+  int raw[] = {9, 9, 9, 9};
+  ArrayPtr<int> head = raw;
+  int first[] = {1, 2};
+  int second[] = {3, 4, 5};
+  int third[] = {6};
+  ArrayPtr<const int> pieces[] = {arrayPtr(first), arrayPtr(second), arrayPtr(third)};
+
+  KJ_EXPECT_THROW_MESSAGE("Out-of-bounds", head.write(arrayPtr(pieces)));
+
+  int expected[] = {1, 2, 9, 9};
+  KJ_EXPECT(arrayPtr(raw) == arrayPtr(expected));
+  KJ_EXPECT(head.begin() == raw + 2);
+  KJ_EXPECT(head.size() == 2);
+}
+
 enum TestOrdering {
   UNORDERED,
   EQUAL,

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2725,6 +2725,21 @@ public:
     for (size_t s = size_, i = 0; i < s; i++) { dst[i] = src[i]; }
   }
 
+  inline void write(kj::ArrayPtr<const T> other) {
+    // Copy data to the head of this pointer, then advance past the copied data.
+    // Out-of-bounds exception is raised is data does not fit.
+    first(other.size()).copyFrom(other); // first will do a bounds check
+    ptr += other.size();
+    size_ -= other.size();
+  }
+
+  inline void write(kj::ArrayPtr<const kj::ArrayPtr<const T>> pieces) {
+    // Copy pieces of data to the head of this pointer, then advancing past the copied data.
+    // Pieces are bound-checked individually, i.e. the data can be partially written when raising
+    // an out-of-bounds exception.
+    for (auto piece: pieces) { write(piece); }
+  }
+
 private:
   T* ptr;
   size_t size_;


### PR DESCRIPTION
Writing to array ptr and advancing head is extremely common operation. This change enables using arrayptr as buffer directly and is a great shorthand for `ptr.first(size).copyFrom(data)`.

The other design option would be to make write() immutable and return tail, but I am not sure if that is better. Writing is a mutable operation afterall.