### PR TITLE
fix payload length shift in websocket frame header

### DIFF
--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -3286,7 +3286,7 @@ private:
         bytes[2] = static_cast<byte>(payloadLen >> 56);
         bytes[3] = static_cast<byte>(payloadLen >> 48);
         bytes[4] = static_cast<byte>(payloadLen >> 40);
-        bytes[5] = static_cast<byte>(payloadLen >> 42);
+        bytes[5] = static_cast<byte>(payloadLen >> 32);
         bytes[6] = static_cast<byte>(payloadLen >> 24);
         bytes[7] = static_cast<byte>(payloadLen >> 16);
         bytes[8] = static_cast<byte>(payloadLen >>  8);


### PR DESCRIPTION
The 8-byte extended length in Header::compose uses `payloadLen >> 42` for bytes[5], which drops bits 32-39 and leaks bits 42-49; for frames over 4 GiB the peer decodes a wrong length and desyncs. Should be `>> 32` to match the 56/48/40/32/24/16/8/0 sequence.