### PR TITLE
read http byte-range positions as 64-bit

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -8145,6 +8145,12 @@ KJ_TEST("Range header parsing") {
     {"bytes=5-"_kjc,                  2},
     // Check multiple valid ranges accepted
     {"bytes=  1-  ,6-, 10-11 "_kjc,  12, {{1,11},{6,11},{10,11}}},
+    // Check positions past 2^32 are not truncated against a 64-bit content length
+    {"bytes=5000000000-5000000001"_kjc, 8000000000, {{5000000000, 5000000001}}},
+    {"bytes=5000000000-"_kjc,           8000000000, {{5000000000, 7999999999}}},
+    {"bytes=-5000000000"_kjc,           8000000000, {{3000000000, 7999999999}}},
+    // Check a start position past the content is rejected rather than wrapping into range
+    {"bytes=4294967298-"_kjc,                    8},
 
     // ===== Suffix =====
     // Check valid ranges accepted

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -8159,6 +8159,24 @@ KJ_TEST("Range header parsing") {
     // Check start after content truncated and entire response response
     {"bytes=-7"_kjc,                  7, HttpEverythingRange {}},
     {"bytes=-10"_kjc,                 5, HttpEverythingRange {}},
+    // Check the top of the uint64 range parses without overflow, and values past uint64 max are
+    // rejected rather than wrapping. A suffix length >= content resolves to the whole resource, so
+    // each value that parses yields everything while a rejected one falls through to unsatisfiable.
+    {"bytes=-18446744073709551615"_kjc, 4, HttpEverythingRange {}},  // 2^64 - 1
+    {"bytes=-18446744073709551614"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551613"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551612"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551611"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551610"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551609"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551608"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551607"_kjc, 4, HttpEverythingRange {}},
+    {"bytes=-18446744073709551606"_kjc, 4, HttpEverythingRange {}},
+    // 2^64 and beyond must be rejected, not wrapped down into a satisfiable length
+    {"bytes=-18446744073709551616"_kjc, 4},
+    {"bytes=-18446744073709551617"_kjc, 4},
+    {"bytes=-18446744073709551620"_kjc, 4},
+    {"bytes=-99999999999999999999"_kjc, 4},
     // Check if any range returns entire response, other ranges ignored
     {"bytes=0-1,-5,2-3"_kjc,          5, HttpEverythingRange {}},
     // Check unsatisfiable empty range ignored

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -852,6 +852,30 @@ static kj::Maybe<uint> consumeNumber(char*& ptr) {
   return result;
 }
 
+static kj::Maybe<uint64_t> consumeNumber64(const char*& ptr) {
+  // Like consumeNumber(), but accumulates into a 64-bit value and rejects (rather than silently
+  // wrapping) numbers that don't fit. Used for byte-range positions, which are compared against a
+  // 64-bit content length.
+  const char* start = skipSpace(ptr);
+  const char* p = start;
+
+  uint64_t result = 0;
+
+  for (;;) {
+    const char c = *p;
+    if ('0' <= c && c <= '9') {
+      uint digit = c - '0';
+      if (result > (uint64_t(kj::maxValue) - digit) / 10) return kj::none;
+      result = result * 10 + digit;
+      ++p;
+    } else {
+      if (p == start) return kj::none;
+      ptr = p;
+      return result;
+    }
+  }
+}
+
 static kj::StringPtr consumeLine(char*& ptr) {
   char* start = skipSpace(ptr);
   char* p = start;
@@ -1186,8 +1210,8 @@ static bool consumeByteRangeUnit(const char*& ptr) {
 static kj::Maybe<HttpByteRange> consumeIntRange(const char*& ptr, uint64_t contentLength) {
   const char* p = ptr;
   p = skipSpace(p);
-  uint firstPos;
-  KJ_IF_SOME(n, consumeNumber(p)) {
+  uint64_t firstPos;
+  KJ_IF_SOME(n, consumeNumber64(p)) {
     firstPos = n;
   } else {
     return kj::none;
@@ -1195,7 +1219,7 @@ static kj::Maybe<HttpByteRange> consumeIntRange(const char*& ptr, uint64_t conte
   p = skipSpace(p);
   if (*(p++) != '-') return kj::none;
   p = skipSpace(p);
-  auto maybeLastPos = consumeNumber(p);
+  auto maybeLastPos = consumeNumber64(p);
   p = skipSpace(p);
 
   KJ_IF_SOME(lastPos, maybeLastPos) {
@@ -1218,8 +1242,8 @@ static kj::Maybe<HttpByteRange> consumeSuffixRange(const char*& ptr, uint64_t co
   p = skipSpace(p);
   if (*(p++) != '-') return kj::none;
   p = skipSpace(p);
-  uint suffixLength;
-  KJ_IF_SOME(n, consumeNumber(p)) {
+  uint64_t suffixLength;
+  KJ_IF_SOME(n, consumeNumber64(p)) {
     suffixLength = n;
   } else {
     return kj::none;

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -859,13 +859,18 @@ static kj::Maybe<uint64_t> consumeNumber64(const char*& ptr) {
   const char* start = skipSpace(ptr);
   const char* p = start;
 
+  constexpr uint64_t MAX = kj::maxValue;
+
   uint64_t result = 0;
 
   for (;;) {
     const char c = *p;
     if ('0' <= c && c <= '9') {
       uint digit = c - '0';
-      if (result > (uint64_t(kj::maxValue) - digit) / 10) return kj::none;
+      // Reject before `result * 10 + digit` would exceed a uint64. MAX / 10 and MAX % 10 are
+      // compile-time constants, so this is a couple of comparisons per digit rather than a
+      // division.
+      if (result > MAX / 10 || (result == MAX / 10 && digit > MAX % 10)) return kj::none;
       result = result * 10 + digit;
       ++p;
     } else {


### PR DESCRIPTION
Reading through tryParseHttpRangeHeader I noticed the range positions come from consumeNumber, which accumulates into a 32-bit uint and silently wraps, and firstPos/lastPos/suffixLength are uint too. But HttpByteRange and the contentLength argument are uint64_t, so any offset at or above 2^32 gets truncated. On an 8 GB resource bytes=5000000000-5000000001 comes back as {705032704,705032705}, and bytes=4294967298- against an 8-byte resource wraps the start down to 2, turning an unsatisfiable range into a satisfiable one that serves the wrong bytes.

This adds consumeNumber64 which accumulates into uint64_t and rejects values that don't fit instead of wrapping, and widens the range locals to match. Added a few range-parsing cases past 2^32.