### PR TITLE
fix off-by-one write to membersByDiscriminant in schema validator

### DIFF
--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -360,7 +360,7 @@ private:
 
         membersByDiscriminant[discriminantPos++] = index;
       } else {
-        VALIDATE_SCHEMA(nonDiscriminantPos <= fields.size(),
+        VALIDATE_SCHEMA(nonDiscriminantPos < fields.size(),
                         "discriminantCount did not match fields");
         membersByDiscriminant[nonDiscriminantPos++] = index;
       }


### PR DESCRIPTION
SchemaLoader::Validator::validate() for a struct node fills membersByDiscriminant, an arena array sized to fields.size(), in two regions: discriminant members from the front and non-discriminant members from offset discriminantCount. The guard before the non-discriminant write tests nonDiscriminantPos <= fields.size(), so a node that declares a discriminantCount larger than the number of fields actually carrying a discriminant value drives nonDiscriminantPos up to fields.size() and writes one uint16 past the end of the array, scribbling over whatever the arena placed next. The KJ_ASSERT(nonDiscriminantPos == fields.size()) a few lines down confirms fields.size() is meant to be the exclusive upper bound.

Tightening the check to nonDiscriminantPos < fields.size() rejects the malformed node before the write instead of after, mirroring the discriminantPos side which is already bounded by the unique discriminant values. The fix belongs in the validator because SchemaLoader::load() accepts schema nodes from untrusted sources (loaded schema blobs, schemas received over RPC) and validate() is the layer meant to make them safe to traverse; an invalid node is supposed to be downgraded to an empty schema, not to corrupt adjacent arena memory on its way out, so nothing observable surfaces at the API. I reproduced the overrun with an ASan harness replicating the fill loop: with discriminantCount=2 and two non-discriminant fields it reports a 2-byte heap-buffer-overflow at the membersByDiscriminant[2] write, and the tightened bound rejects the same input cleanly.