### PR TITLE
Revert "Remove Arc::disown() and Arc::reown()"

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -703,5 +703,23 @@ KJ_TEST("Arc Own interop") {
   EXPECT_TRUE(b);
 }
 
+KJ_TEST("Arc disown / reown") {
+  bool b = false;
+  const AtomicSetTrueInDestructor* ptr = nullptr;
+
+  {
+    kj::Arc<AtomicSetTrueInDestructor> ref = kj::arc<AtomicSetTrueInDestructor>(&b);
+    ptr = ref.disown();
+  }
+
+  KJ_EXPECT(b == false);
+
+  {
+    auto ref = kj::Arc<AtomicSetTrueInDestructor>::reown(ptr);
+  }
+
+  KJ_EXPECT(b == true);
+}
+
 }  // namespace _
 }  // namespace kj

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -556,6 +556,18 @@ public:
     return addRef();
   }
 
+  // Surrenders ownership of the underlying object to the caller. Unlike Own<T>::disown(), there
+  // is no need for the caller to prove they know how to dispose of the object, because the object
+  // is its own Disposer.
+  const T* disown() {
+    return own.disown(own.get());
+  }
+
+  // Assume ownership of an object without incrementing its refcount. Opposite of disown().
+  static Arc reown(const T* ptr) {
+    return Arc(ptr);
+  }
+
   Arc& operator=(decltype(nullptr)) {
     own = nullptr;
     return *this;


### PR DESCRIPTION
Reverts capnproto/capnproto#2687

I was wrong it is used in workerd-cxx. I have to fix that first before getting back to this one.