### PR TITLE
Scope testing to project (backport #2685)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project("Cap'n Proto Root" CXX)
-include(CTest)
+
+# PROJECT_IS_TOP_LEVEL was added in CMake 3.21
+if (NOT DEFINED PROJECT_IS_TOP_LEVEL OR PROJECT_IS_TOP_LEVEL)
+  include(CTest)
+endif()
 
 add_subdirectory(c++)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -6,7 +6,11 @@ set(VERSION 1.5-dev)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-include(CTest)
+# PROJECT_IS_TOP_LEVEL was added in CMake 3.21
+if (NOT DEFINED PROJECT_IS_TOP_LEVEL OR PROJECT_IS_TOP_LEVEL)
+  include(CTest)
+endif()
+
 include(CheckIncludeFileCXX)
 include(GNUInstallDirs)
 if(MSVC)


### PR DESCRIPTION
This PR is a backport of #2685.

> We were trying to fetch Cap'n Proto via `FetchContent` in a C++ project and ran into the issue that we couldn't disable the tests due to unconditional calls to `include(CTest)`. The proposed changes should fix this.
> 
> It would also be possible to define a, say, `CAPNPROTO_BUILD_TESTS` option that defaults to `PROJECT_IS_TOP_LEVEL`. This would make the configuration more configurable.