### PR TITLE
fix offset overflow in schema loader struct validation

### DIFF
--- a/c++/src/capnp/schema-loader-test.c++
+++ b/c++/src/capnp/schema-loader-test.c++
@@ -234,6 +234,31 @@ TEST(SchemaLoader, Incompatible) {
       loadUnderAlternateTypeId<test::TestAllTypes>(loader, typeId<test::TestListDefaults>()));
 }
 
+TEST(SchemaLoader, OutOfBoundsFieldOffset) {
+  // A field's offset is a UInt32 taken straight from the schema node. The validator must reject
+  // offsets that don't fit within the struct's declared data section, because the layout code
+  // (StructBuilder::setDataField) trusts the offset and does no bounds check of its own. An offset
+  // near 2^32 used to slip through, because the bounds check evaluated (offset + 1) * bits in
+  // 32-bit arithmetic, which wraps around to a small value.
+  SchemaLoader loader;
+
+  MallocMessageBuilder builder;
+  builder.setRoot(Schema::from<test::TestAllTypes>().getProto());
+  auto node = builder.getRoot<schema::Node>();
+
+  bool found = false;
+  for (auto field: node.getStruct().getFields()) {
+    if (field.isSlot() && field.getSlot().getType().isUint64()) {
+      field.getSlot().setOffset(0xffffffffu);
+      found = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(found);
+
+  EXPECT_NONFATAL_FAILURE(loader.load(node));
+}
+
 TEST(SchemaLoader, Enumerate) {
   SchemaLoader loader;
   loader.loadCompiledTypeAndDependencies<TestAllTypes>();

--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -326,8 +326,9 @@ private:
       VALIDATE_SCHEMA(structNode.getDiscriminantCount() <= fields.size(),
                       "struct can't have more union fields than total fields");
 
-      VALIDATE_SCHEMA((structNode.getDiscriminantOffset() + 1) * 16 <= dataSizeInBits,
-                      "union discriminant is out-of-bounds");
+      VALIDATE_SCHEMA(
+          (static_cast<uint64_t>(structNode.getDiscriminantOffset()) + 1) * 16 <= dataSizeInBits,
+          "union discriminant is out-of-bounds");
     }
 
     membersByDiscriminant = loader.arena.allocateArray<uint16_t>(fields.size());
@@ -372,10 +373,11 @@ private:
           uint fieldBits = 0;
           bool fieldIsPointer = false;
           validate(slot.getType(), slot.getDefaultValue(), &fieldBits, &fieldIsPointer);
-          VALIDATE_SCHEMA(fieldBits * (slot.getOffset() + 1) <= dataSizeInBits &&
-                          fieldIsPointer * (slot.getOffset() + 1) <= pointerCount,
+          uint64_t offset = slot.getOffset();
+          VALIDATE_SCHEMA(fieldBits * (offset + 1) <= dataSizeInBits &&
+                          fieldIsPointer * (offset + 1) <= pointerCount,
                           "field offset out-of-bounds",
-                          slot.getOffset(), dataSizeInBits, pointerCount);
+                          offset, dataSizeInBits, pointerCount);
 
           break;
         }


### PR DESCRIPTION
SchemaLoader::Validator::validate() checks each slot field's position with `fieldBits * (slot.getOffset() + 1) <= dataSizeInBits`, and the union discriminant with `(getDiscriminantOffset() + 1) * 16 <= dataSizeInBits`. Those offsets are UInt32 values copied straight from the schema node, but the `+ 1` and the multiply run in 32-bit arithmetic, so an offset near 2^32 (0xffffffff being the easy one) wraps the product back down to a small number and the out-of-range field passes validation.

This is the layer that has to get it right: StructBuilder::setDataField()/getDataField() index the data section straight from the offset with no bounds check of their own, on the assumption that the loader already rejected anything that does not fit, so a node accepted here becomes an out-of-bounds read or write the moment a message is built or read against it. I widened the offset arithmetic to 64 bit at the three affected sites so the comparison can no longer wrap; legitimate schemas are unaffected because their offsets are tiny. The added test loads TestAllTypes after setting a UInt64 field offset to 0xffffffff and confirms the loader now rejects it, where previously the malformed node loaded cleanly.
