### PR TITLE
OSS-Fuzz: Add new json fuzzer

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -512,6 +512,7 @@ else !LITE_MODE
 check_PROGRAMS = capnp-test capnp-evolution-test capnp-afl-testcase
 if HAS_FUZZING_ENGINE
     check_PROGRAMS += capnp-llvm-fuzzer-testcase
+    check_PROGRAMS += capnp-json-fuzzer-testcase
 endif
 heavy_tests =                                                  \
   src/kj/async-test.c++                                        \
@@ -618,6 +619,9 @@ if HAS_FUZZING_ENGINE
     capnp_llvm_fuzzer_testcase_LDADD = libcapnp-test.a libcapnp-rpc.la libcapnp.la libkj.la libkj-async.la
     capnp_llvm_fuzzer_testcase_SOURCES = src/capnp/llvm-fuzzer-testcase.c++
     capnp_llvm_fuzzer_testcase_LDFLAGS = $(LIB_FUZZING_ENGINE)
+    capnp_json_fuzzer_testcase_LDADD = libcapnp-test.a libcapnp-rpc.la libcapnp-json.la libcapnp.la libkj.la libkj-async.la
+    capnp_json_fuzzer_testcase_SOURCES = src/capnp/json-fuzzer-testcase.c++
+    capnp_json_fuzzer_testcase_LDFLAGS = $(LIB_FUZZING_ENGINE)
 endif
 endif !LITE_MODE
 

--- a/c++/src/capnp/json-fuzzer-testcase.c++
+++ b/c++/src/capnp/json-fuzzer-testcase.c++
@@ -1,0 +1,27 @@
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <capnp/dynamic.h>
+#include <capnp/test.capnp.h>
+#include <kj/exception.h>
+#include <kj/array.h>
+#include <kj/string.h>
+
+/* libFuzzer entry point fuzzing Cap'n Proto's JSON decoder
+ * (text JSON -> Cap'n Proto message). Cap'n Proto throws kj exceptions on
+ * malformed input; those are expected, not bugs, so we swallow them via
+ * kj::runCatchingExceptions.
+ */
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
+  kj::runCatchingExceptions([&]() {
+    capnp::JsonCodec json;
+    capnp::MallocMessageBuilder mb;
+    auto root = mb.initRoot<capnproto_test::capnp::test::TestAllTypes>();
+
+    json.decode(kj::arrayPtr(reinterpret_cast<const char*>(Data), Size), root);
+
+    // Re-encode to exercise the encoder over whatever was successfully decoded.
+    kj::String reencoded = json.encode(root.asReader());
+    (void)reencoded;
+  });
+  return 0;
+}


### PR DESCRIPTION
This PR creates a new fuzzer for OSS-Fuzz targets JSON parsing. This fuzzer will be activate once this and the OSS-Fuzz changes is merged in (https://github.com/google/oss-fuzz/pull/15644).