### PR TITLE
fix segment size overflow in message readers

### DIFF
--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -139,7 +139,7 @@ kj::Promise<void> AsyncMessageReader::readAfterFirstWord(kj::AsyncInputStream& i
 
 kj::Promise<void> AsyncMessageReader::readSegments(kj::AsyncInputStream& inputStream,
                                                    kj::ArrayPtr<word> scratchSpace) {
-  size_t totalWords = segment0Size();
+  uint64_t totalWords = segment0Size();
 
   if (segmentCount() > 1) {
     for (uint i = 0; i < segmentCount() - 1; i++) {

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -76,7 +76,7 @@ void FlatArrayMessageReader::init(kj::ArrayPtr<const word> array) {
   {
     uint segmentSize = table[1].get();
 
-    KJ_REQUIRE(array.size() >= offset + segmentSize,
+    KJ_REQUIRE(array.size() - offset >= segmentSize,
                "Message ends prematurely in first segment.") {
       return;
     }
@@ -91,7 +91,7 @@ void FlatArrayMessageReader::init(kj::ArrayPtr<const word> array) {
     for (uint i = 1; i < segmentCount; i++) {
       uint segmentSize = table[i + 1].get();
 
-      KJ_REQUIRE(array.size() >= offset + segmentSize, "Message ends prematurely.") {
+      KJ_REQUIRE(array.size() - offset >= segmentSize, "Message ends prematurely.") {
         moreSegments = nullptr;
         return;
       }
@@ -209,7 +209,7 @@ InputStreamMessageReader::InputStreamMessageReader(
   uint segmentCount = firstWord[0].get() + 1;
   uint segment0Size = firstWord[1].get();
 
-  size_t totalWords = segment0Size;
+  uint64_t totalWords = segment0Size;
 
   // Reject messages with too many segments for security reasons.
   // Use firstWord[0].get() here instead of segmentCount to catch overflow. The actual limit


### PR DESCRIPTION
1. the message segment table carries an untrusted uint32 word count per segment; InputStreamMessageReader and AsyncMessageReader sum those into a `size_t totalWords`, which wraps on a 32-bit build and slips past the `totalWords <= traversalLimitInWords` check meant to bound the allocation.
2. FlatArrayMessageReader::init vets each segment with `array.size() >= offset + segmentSize`, where the addition wraps the same way.
3. ArrayPtr::slice only bounds-checks under KJ_IREQUIRE, which is compiled out of release builds, so once a check is bypassed the reader hands back segment pointers past the buffer and they get read during traversal.

Sum the words in uint64_t and write the bound as `array.size() - offset >= segmentSize` so neither can overflow. 64-bit builds are unaffected; this removes an out-of-bounds read on 32-bit deployments fed a hostile message.
