### PR TITLE
[build] Add gcc CI job

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -18,12 +18,12 @@ env:
   INSTALL_DEPS: |
     install_deps() {
       local clang=$1
-      if [ "$clang" -ge 22 ]; then
+      if [ "$clang" -ge 23 ]; then
         . /etc/os-release
         wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
         echo "deb http://apt.llvm.org/$VERSION_CODENAME/ llvm-toolchain-$VERSION_CODENAME-$clang main" | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
       fi
-      export DEBIAN_FRONTEND=noninteractive && sudo apt-get update && sudo apt-get install --no-upgrade --no-install-recommends -y clang-$clang libc++-$clang-dev libc++abi-$clang-dev libclang-rt-$clang-dev lld-$clang llvm-$clang clang-tidy-$clang parallel
+      export DEBIAN_FRONTEND=noninteractive && sudo apt-get update && sudo apt-get install --no-upgrade --no-install-recommends -y clang-$clang libc++-$clang-dev libc++abi-$clang-dev libunwind-$clang-dev libclang-rt-$clang-dev lld-$clang llvm-$clang clang-tidy-$clang parallel
     }
 
 jobs:
@@ -39,8 +39,18 @@ jobs:
         run: apk add autoconf automake bash build-base cmake libtool libucontext-dev linux-headers openssl-dev clang20 libc++-dev llvm-libunwind-dev
       - name: super-test
         run: ./super-test.sh quick clang-20
+  Linux-gcc:
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: install dependencies
+        run: eval "$INSTALL_DEPS" && install_deps 20 && sudo apt-get install --no-upgrade --no-install-recommends -y gcc-15
+      - name: test
+        run: |
+          export CC=gcc-15
+          cd c++ && bazel test --config=ci --config=gcc //...
   Linux-clang:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +71,7 @@ jobs:
             export CXX=clang++-${{ matrix.clang }}
             ${{ matrix.run-test }}
   Linux-clang-opt:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -73,12 +83,11 @@ jobs:
       - name: test
         run: |
             export CC=clang-${{ matrix.clang }}
-            export CXX=clang++-${{ matrix.clang }}
             export LD=lld-${{ matrix.clang }}
             export AR=llvm-ar-${{ matrix.clang }}
             cd c++ && bazel test --config=ci --config=opt //...
   Linux-clang-arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +106,7 @@ jobs:
             export CXX=clang++-${{ matrix.clang }}
             ${{ matrix.run-test }}
   Linux-clang-sanitizers:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -110,10 +119,9 @@ jobs:
       - name: test
         run: |
             export CC=clang-${{ matrix.clang }}
-            export CXX=clang++-${{ matrix.clang }}
             cd c++ && bazel test --config=ci --config=${{ matrix.config }} //...
   Linux-clang-tidy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -125,7 +133,6 @@ jobs:
       - name: test
         run: |
             export CC=clang-${{ matrix.clang }}
-            export CXX=clang++-${{ matrix.clang }}
             export CLANG_TIDY=clang-tidy-${{ matrix.clang }}
             cd c++ 
             bazel build --config=ci //...

--- a/c++/.bazelrc
+++ b/c++/.bazelrc
@@ -33,6 +33,10 @@ build:thin-lto --dynamic_mode=off
 
 build:profile --config=opt
 
+# Build options for compatibility with GCC
+build:gcc --cxxopt=-Wno-maybe-musttail-local-addr
+build:gcc --cxxopt=-Wno-maybe-uninitialized
+
 build:unix --cxxopt='-std=c++23' --host_cxxopt='-std=c++23' --force_pic
 build:unix --cxxopt='-Wall'
 build:unix --cxxopt='-Wextra'
@@ -50,21 +54,22 @@ build:unix --per_file_copt='external@-w'
 # enable libdl integration for stacktrace symbolization
 build:unix --//src/kj:libdl=True
 
-# I needed these magic spells to build locally with clang-11 and clang-12 on Ubuntu. clang-13 and up
-# work out-of-the-box.
-# TODO(2.0): Remove this when we support g++ again.
-build:linux --cxxopt=-stdlib=libc++ --host_cxxopt=-stdlib=libc++
-build:linux --linkopt='-stdlib=libc++' --host_linkopt='-stdlib=libc++'
+# Build using libc++. This should no longer be required with recent clang versions, but may still be
+# desirable to closer match the downstream build.
+# TODO(someday): We can't default-enable this since GCC does not accept the stdlib flag, even if we
+# try to revert it later. Is there a workaround so we can enable this in clang builds?
+# build:libcpp --cxxopt=-stdlib=libc++ --host_cxxopt=-stdlib=libc++
+# build:libcpp --linkopt='-stdlib=libc++' --host_linkopt='-stdlib=libc++'
 # Drop default link flags, which include libstdc++ for Linux
-build:linux --features=-default_link_libs --host_features=-default_link_libs
-build:linux --linkopt='-lc++' --linkopt='-lm'
-build:linux --host_linkopt='-lc++' --host_linkopt='-lm'
+# build:libcpp --features=-default_link_libs --host_features=-default_link_libs
+# build:libcpp --linkopt='-lc++' --linkopt='-lm'
+# build:libcpp --host_linkopt='-lc++' --host_linkopt='-lm'
 
 # Limit recursive header includes within libc++. This improves compliance with IWYU, helps avoid
 # errors with downstream projects that implicitly define this already and reduces total include size.
 https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html
-build:unix --cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
-build:unix --host_cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
+build:libcpp --cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
+build:libcpp --host_cxxopt=-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES
 
 build:linux --config=unix
 build:macos --config=unix

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -1077,7 +1077,7 @@ KJ_TEST("HTTP-over-Cap'n-Proto Connect with startTls") {
   auto request = frontCapnpHttpClient->connect(
       "https://example.org"_kj, kj::HttpHeaders(*table), settings);
 
-  KJ_ASSERT_NONNULL(*tlsStarter);
+  KJ_ASSERT(*tlsStarter != kj::none);
 
   request.status.then(
       [io=kj::mv(request.connection), &tlsStarter](auto status) mutable {

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -241,7 +241,7 @@ public:
     return result;
   }
 
-  inline bool operator==(decltype(nullptr)) const { return size_ == 0; }
+  inline constexpr bool operator==(decltype(nullptr)) const { return size_ == 0; }
 
   inline Array& operator=(decltype(nullptr)) {
     dispose();

--- a/c++/src/kj/async-bench.c++
+++ b/c++/src/kj/async-bench.c++
@@ -91,6 +91,8 @@ static void bm_Promise_ImmediatePromise_Then(benchmark::State &state) {
 
 BENCHMARK(bm_Promise_ImmediatePromise_Then);
 
+// GCC gets compilation errors with promise continuations in lambdas
+#if !(__GNUC__ && !__clang__)
 static void bm_Coro_CoAwait_ImmediatePromise(benchmark::State &state) {
   // Benchmark coro that co_awaits an immediate coroutine
   kj::EventLoop loop;
@@ -118,6 +120,7 @@ static void bm_Coro_CoAwait_ImmediateCoroutine(benchmark::State &state) {
 }
 
 BENCHMARK(bm_Coro_CoAwait_ImmediateCoroutine);
+#endif  // !(__GNUC__ && !__clang__)
 
 ///////////////////////////////
 // Pow benchmarks mean to benchmark promise evaluation when the start of the

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -203,6 +203,8 @@ KJ_TEST("Exceptions propagate through layered coroutines") {
   KJ_EXPECT_THROW_RECOVERABLE(FAILED, simpleCoroutine(kj::mv(throwy)).wait(waitScope));
 }
 
+// GCC gets compilation errors with promise continuations in lambdas
+#if !(__GNUC__ && !__clang__)
 KJ_TEST("Exceptions before the first co_await don't escape, but reject the promise") {
   EventLoop loop;
   WaitScope waitScope(loop);
@@ -878,6 +880,7 @@ KJ_TEST("KJ_TRY/KJ_CATCH inside try/catch with promise rejection in coroutines")
   auto result = testCoro().wait(waitScope);
   KJ_EXPECT(result == "kj:caught std:not-caught");
 }
+#endif  // !(__GNUC__ && !__clang__)
 
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -3657,11 +3657,15 @@ KJ_TEST("Calling abortRead() after tryRead() raised exception") {
     virtual kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
       numCalls++;
       KJ_FAIL_REQUIRE("This stream never works");
+#if __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
+#endif
       // clang-18 thinks this line is unnecessary
       co_return 0;
+#if __clang__
 #pragma clang diagnostic pop
+#endif
     }
 
     uint numCalls = 0;

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -608,6 +608,8 @@ TEST(Async, ForkMaybeRef) {
   EXPECT_EQ(789, branch2.wait(waitScope));
 }
 
+// GCC gets compilation errors with promise continuations in lambdas
+#if !(__GNUC__ && !__clang__)
 KJ_TEST("addBranchForCoAwait") {
   EventLoop loop;
   WaitScope waitScope(loop);
@@ -623,6 +625,7 @@ KJ_TEST("addBranchForCoAwait") {
 
   KJ_EXPECT(coro().wait(waitScope) == 123);
 }
+#endif  // !(__GNUC__ && !__clang__)
 
 TEST(Async, Split) {
   EventLoop loop;

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1474,7 +1474,7 @@ private:
     }
   };
 
-  bool isSet;
+  bool isSet = false;
 
 #if _MSC_VER && !defined(__clang__)
 #pragma warning(push)

--- a/c++/src/kj/tuple.h
+++ b/c++/src/kj/tuple.h
@@ -55,7 +55,15 @@ struct TypeByIndex_<index, First, Rest...>
     : public TypeByIndex_<index - 1, Rest...> {};
 template <size_t index>
 struct TypeByIndex_<index> {
+// GCC 15 (possibly earlier versions too) issues a warning for this
+#if __GNUC__ && !__clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+#endif
   static_assert(index != index, "Index out-of-range.");
+#if __GNUC__ && !__clang__
+#pragma GCC diagnostic pop
+#endif
 };
 template <size_t index, typename... T>
 using TypeByIndex = typename TypeByIndex_<index, T...>::Type;

--- a/doc/install.md
+++ b/doc/install.md
@@ -21,15 +21,15 @@ This package is licensed under the [MIT License](http://opensource.org/licenses/
 Cap'n Proto makes extensive use of C++20 language features. As a result, it requires a relatively
 new version of a well-supported compiler. The minimum versions are:
 
-* GCC 10.0*
-* Clang 14.0
+* GCC 14.3*
+* Clang 16.0
 * Visual C++ 2022
 
-*: Cap'n Proto 2.0 and above cannot currently compile with GCC due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102051
+*: Cap'n Proto 2.0 and above require a fairly recent GCC that includes a fix for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102051
 
 If your system's default compiler is older that the above, you will need to install a newer
 compiler and set the `CXX` environment variable before trying to build Cap'n Proto. For example,
-after installing GCC 10, you could set `CXX=g++-10` to use this compiler.
+after installing GCC 14, you could set `CXX=g++-14` to use this compiler.
 
 ### Supported Operating Systems
 


### PR DESCRIPTION
GCC 15 is widely available now. Fix the GCC build and add a CI job so that it does not regress again. clang/LLVM remains our primary toolchain.