### PR TITLE
opt Ptr<T>

### DIFF
--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -1364,7 +1364,61 @@ KJ_TEST("kj::Pin<T> moved with active ptrs crashes") {
     kj::Pin<Obj> obj2(kj::mv(obj));
   });
 }
-#endif  
+#else
+KJ_TEST("kj::Ptr<T> expires when Pin<T> is destroyed in opt mode") {
+  kj::Maybe<kj::Ptr<Obj>> maybePtr;
+
+  {
+    kj::Pin<Obj> obj("b");
+    maybePtr = obj.asPtr();
+
+    KJ_IF_SOME(ptr, maybePtr) {
+      KJ_EXPECT(ptr == obj);
+      KJ_EXPECT(ptr->name == "b"_kj);
+    } else {
+      KJ_FAIL_EXPECT("expected Maybe<Ptr<T>> to contain a pointer");
+    }
+  }
+
+  KJ_IF_SOME(ptr, maybePtr) {
+    KJ_EXPECT(ptr == nullptr);
+    KJ_EXPECT_THROW_MESSAGE("null Ptr<> dereference", (void)ptr->name);
+    KJ_EXPECT_THROW_MESSAGE("null Ptr<> dereference", (void)ptr.asRef());
+
+    kj::Weak<Obj> weak = ptr.asWeak();
+    KJ_EXPECT(weak == nullptr);
+    KJ_EXPECT(weak.upgrade() == kj::none);
+  } else {
+    KJ_FAIL_EXPECT("expected Maybe<Ptr<T>> to contain an expired pointer");
+  }
+}
+
+KJ_TEST("kj::Ptr<T> expires when Pin<T> is moved in opt mode") {
+  kj::Maybe<kj::Ptr<Obj>> maybePtr;
+
+  {
+    kj::Pin<Obj> obj("b");
+    maybePtr = obj.asPtr();
+    kj::Pin<Obj> obj2(kj::mv(obj));
+
+    KJ_IF_SOME(ptr, maybePtr) {
+      KJ_EXPECT(ptr == nullptr);
+      KJ_EXPECT(!(ptr == obj2));
+      KJ_EXPECT_THROW_MESSAGE("null Ptr<> dereference", (void)ptr->name);
+
+      kj::Weak<Obj> weak = ptr.asWeak();
+      KJ_EXPECT(weak == nullptr);
+      KJ_EXPECT(weak.upgrade() == kj::none);
+    } else {
+      KJ_FAIL_EXPECT("expected Maybe<Ptr<T>> to contain an expired pointer");
+    }
+
+    auto newPtr = obj2.asPtr();
+    KJ_EXPECT(newPtr == obj2);
+    KJ_EXPECT(newPtr->name == "b"_kj);
+  }
+}
+#endif
 
 } // namespace 
 

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -36,11 +36,15 @@
 #endif
 
 // KJ_ASSERT_PTR_COUNTERS == 1 keeps track of active Ptr<T> instances and asserts validity
-// of their ownership.
-// Matches KJ_DEBUG_MEMORY by default.
+// of their ownership. Ptr<T> always counts in debug builds; optimized builds represent Ptr<T>
+// using Weak<T> instead.
 #if !defined(KJ_ASSERT_PTR_COUNTERS)
-#define KJ_ASSERT_PTR_COUNTERS KJ_DEBUG_MEMORY
-#endif // KJ_ASSERT_PTR_COUNTERS
+#if defined(KJ_DEBUG)
+#define KJ_ASSERT_PTR_COUNTERS 1
+#else
+#define KJ_ASSERT_PTR_COUNTERS 0
+#endif
+#endif
 
 #if KJ_ASSERT_PTR_COUNTERS
 #include <atomic>
@@ -274,6 +278,7 @@ public:
   inline void assertEmpty() {
     ptrCounter.assertEmpty();
   }
+
 #else
   inline void inc() {}
   inline void dec() {}
@@ -717,8 +722,8 @@ class Pin {
   // allocated on the heap.
   // Pin<T> is integrated with Ptr<T> and Weak<T>. It is legal to move/destroy only when there are
   // no active Ptr<T>s; outstanding Weak<T>s are nulled instead.
-  // When KJ_ASSERT_PTR_COUNTERS is defined, pointers are tracked and validity of these
-  // operations are asserted.
+  // Debug builds track pointers and abort if these operations violate Ptr<T>'s lifetime
+  // constraint.
   // Weak<T> support adds one pointer of overhead to Pin<T>, and allocates a shared cell lazily when
   // the first weak reference is created.
 
@@ -729,13 +734,13 @@ public:
 
   inline Pin(Pin<T>&& other): t(kj::mv(other.t)) {
     // Move T's ownership.
-    // Undefined behavior when live pointers exist, asserted when KJ_ASSERT_PTR_COUNTERS is defined.
+    // Undefined behavior when live pointers exist, asserted in debug builds.
     other.control.dispose();
   }
 
   inline ~Pin() {
     // Destroy a Pin with underlying object.
-    // Undefined behavior when live pointers exist, asserted when KJ_ASSERT_PTR_COUNTERS is defined.
+    // Undefined behavior when live pointers exist, asserted in debug builds.
     control.dispose();
   }
 
@@ -936,18 +941,29 @@ struct MaybeTraits<Weak<T>> {
 // =======================================================================================
 // Ptr<T>
 
+#if KJ_ASSERT_PTR_COUNTERS
+
+// Ptr<T> is a smart alternative to T&. 
+//
+// New instances of Ptr<T> are obtained from Pin<T> which provides inline T storage and provides all
+// the necessary machinery for Ptr<T> contract enforcement.
+//
+// The contract demands that T exists while Ptr<T> does, i.e. destroying T while there are active
+// Ptr<T> instances pointing to it is undefined behavior.
+// 
+// In debug builds, destroying or moving Pin<T> while there are outstanding Ptr<T> aborts the 
+// program.
+// In release builds Ptr<T> is implemented as Weak<T> with automatic non-null checks on dereference.
+// This technically implements a weaker contract, but still provides a protection against uaf.
+
 template <typename T>
 class Ptr {
-  // Ptr<T> is a smart alternative to T&.
-  //
-  // When used together with Pin<T> it keeps track of active pointers.
-  // Asserts lifetime constraints when KJ_ASSERT_PTR_COUNTERS is defined.
-  // Ptr<T> stores a pointer to Pin<T>'s control block so it can produce weak refs.
+  // Debug builds count active pointers and abort if a Pin<T> is destroyed or moved while any
+  // Ptr<T> still exists.
 
 public:
   inline ~Ptr() {
     if (ptr == nullptr) {
-      // the value was moved out
       return;
     }
     control->dec();
@@ -964,7 +980,6 @@ public:
     other.control = nullptr;
   }
 
-// Ptr<T> can be freely copied.
   Ptr(const Ptr& other) : ptr(other.ptr), control(other.control) {
     if (ptr != nullptr) {
       control->inc();
@@ -986,8 +1001,8 @@ public:
     }
   }
 
-  inline T* operator->() { return get(); }
-  inline const T* operator->() const { return get(); }
+  inline T* operator->() { return getLive(); }
+  inline const T* operator->() const { return getLive(); }
 
   inline bool operator==(const Pin<T>& other) const { return get() == other.get(); }
   inline bool operator==(const Ptr<T>& other) const { return get() == other.get(); }
@@ -999,11 +1014,8 @@ public:
   template <typename U>
   inline bool operator==(const Ptr<U>& other) const { return get() == other.get(); }
 
-  inline T& asRef() { return *get(); }
-  // Obtain a `T&` reference.
-  // This is an unsafe operation and should be avoided unless absolutely necessary.
-  // It is undefined behavior to use the reference after the object managed by this Ptr<T>
-  // ceased to exist.
+  inline T& asRef() { return *getLive(); }
+  // Obtain a `T&` reference, checking that this Ptr<T> is not null.
 
   inline Weak<T> asWeak() {
     if (ptr == nullptr) {
@@ -1034,6 +1046,15 @@ private:
   inline T* get() { return ptr; }
   inline const T* get() const { return ptr; }
 
+  inline T* getLive() {
+    KJ_IREQUIRE(ptr != nullptr, "null Ptr<> dereference");
+    return ptr;
+  }
+  inline const T* getLive() const {
+    KJ_IREQUIRE(ptr != nullptr, "null Ptr<> dereference");
+    return ptr;
+  }
+
   template <typename>
   friend class Ptr;
   template <typename>
@@ -1043,20 +1064,114 @@ private:
   friend struct MaybeTraits<Ptr<T>>;
 };
 
-// MaybeTraits specialization for Ptr<T>.
-// This enables niche optimization: Maybe<Ptr<T>> uses ptr == nullptr as "none".
+// Maybe<Ptr<T>> niche optimization.
 template <typename T>
 struct MaybeTraits<Ptr<T>> {
   static void initNone(Ptr<T>* ptr) noexcept { new (ptr, _::PlacementNew()) Ptr<T>(nullptr); }
   static bool isNone(const Ptr<T>& p) noexcept { return p.ptr == nullptr; }
 
-  // Ptr's move ctor just copies ptr/counter and sets source.ptr to nullptr. Moving a null Ptr is
-  // safe when the null state is constructed via initNone().
+  // Ptr's move ctor leaves the source null. Moving a null Ptr is safe when the null state is
+  // constructed via initNone().
   static constexpr bool noneIsMoveSafe = true;
 
   // Allow `Maybe<Ptr<T>>` to be constructed from types convertible to `Ptr<T>`, like `Ptr<U>`.
   static constexpr bool convertingConstructor = true;
 };
+
+#else
+
+template <typename T>
+class Ptr {
+  // Optimized builds keep Ptr<T> as a checked Weak<T> wrapper. Dereferencing checks that the
+  // referent is still live, but no strong-count upgrade is performed.
+
+public:
+  inline ~Ptr() = default;
+
+  Ptr(Ptr&& other) noexcept: weak(kj::mv(other.weak)) {}
+
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  Ptr(Ptr<U>&& other) noexcept: weak(kj::mv(other.weak)) {}
+
+  Ptr(const Ptr& other): weak(other.weak) {}
+
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  Ptr(const Ptr<U>& other): weak(other.weak) {}
+
+  inline void operator=(decltype(nullptr)) {
+    weak = nullptr;
+  }
+
+  inline T* operator->() { return getLive(); }
+  inline const T* operator->() const { return getLive(); }
+
+  inline bool operator==(const Pin<T>& other) const { return get() == other.get(); }
+  inline bool operator==(const Ptr<T>& other) const { return get() == other.get(); }
+  inline bool operator==(const T* const other) const { return get() == other; }
+
+  template <typename U>
+  inline bool operator==(const Pin<U>& other) const { return get() == other.get(); }
+
+  template <typename U>
+  inline bool operator==(const Ptr<U>& other) const { return get() == other.get(); }
+
+  inline T& asRef() { return *getLive(); }
+  // Obtain a `T&` reference, checking that the referent is still live.
+
+  inline Weak<T> asWeak() { return weak; }
+  // Convert this pointer to a weak pointer.
+
+private:
+  inline explicit Ptr(decltype(nullptr)) noexcept: weak(nullptr) {}
+
+  inline Ptr(Pin<T>* pin) : weak(pin) {}
+
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  inline Ptr(Pin<U>* pin) : weak(pin->get(), pin->getWeakCell()) {}
+
+  inline Ptr(T* ptr, _::WeakCell* cell) : weak(ptr, cell) {}
+
+  Weak<T> weak;
+
+  inline T* get() { return weak.get(); }
+  inline const T* get() const { return weak.get(); }
+
+  inline T* getLive() {
+    T* result = get();
+    KJ_IREQUIRE(result != nullptr, "null Ptr<> dereference");
+    return result;
+  }
+  inline const T* getLive() const {
+    const T* result = get();
+    KJ_IREQUIRE(result != nullptr, "null Ptr<> dereference");
+    return result;
+  }
+
+  template <typename>
+  friend class Ptr;
+  template <typename>
+  friend class Pin;
+  template <typename>
+  friend class Weak;
+  friend struct MaybeTraits<Ptr<T>>;
+};
+
+// Maybe<Ptr<T>> niche optimization.
+template <typename T>
+struct MaybeTraits<Ptr<T>> {
+  static void initNone(Ptr<T>* ptr) noexcept { new (ptr, _::PlacementNew()) Ptr<T>(nullptr); }
+  static bool isNone(const Ptr<T>& p) noexcept { return MaybeTraits<Weak<T>>::isNone(p.weak); }
+
+  // Ptr's move ctor leaves the source null. Moving a null Ptr is safe when the null state is
+  // constructed via initNone().
+  static constexpr bool noneIsMoveSafe = true;
+
+  // Allow `Maybe<Ptr<T>>` to be constructed from types convertible to `Ptr<T>`, like `Ptr<U>`.
+  static constexpr bool convertingConstructor = true;
+};
+
+#endif // KJ_ASSERT_PTR_COUNTERS
+
 
 template <typename T>
 inline Weak<T>::Weak(Ptr<T>& ptr): Weak(ptr.asWeak()) {}

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -789,6 +789,151 @@ private:
 };
 
 // =======================================================================================
+// Weak<T>
+
+template <typename T>
+class Weak {
+  // Weak<T> is a smart alternative to T& with expiration detection.
+  //
+  // Weak<T> is obtained from Pin<T>::addWeak(). It does not keep the Pin alive and does not prevent
+  // the Pin from moving; it expires when the Pin is moved or destroyed.
+  // Common usage:
+  // - KJ_IF_SOME on Weak<T> upgrades to Ptr<T>
+  // - assertLive() obtains T& and throws on expired Weak<T>
+  // - tryGet() obtains Maybe<T&> directly.
+  // - upgrade() method upgrades to Maybe<Ptr<T>>
+
+public:
+  inline Weak(decltype(nullptr)) noexcept: cell(nullptr), ptr(nullptr) {}
+
+  inline ~Weak() { dispose(); }
+
+  Weak(Weak&& other) noexcept {
+    kj::swp(cell, other.cell);
+    kj::swp(ptr, other.ptr);
+  }
+
+  Weak(const Weak& other): cell(other.cell), ptr(other.ptr) {
+    if (cell != nullptr) {
+      cell->addRef();
+    }
+  }
+
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  Weak(Weak<U>&& other) noexcept: ptr(other.ptr) {
+    kj::swp(cell, other.cell);
+    other.ptr = nullptr;
+  }
+
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  Weak(const Weak<U>& other): cell(other.cell), ptr(other.ptr) {
+    if (cell != nullptr) {
+      cell->addRef();
+    }
+  }
+
+  inline Weak(Ptr<T>& ptr);
+  inline Weak(Ptr<T>&& ptr);
+
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  inline Weak(Ptr<U>& ptr);
+  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
+  inline Weak(Ptr<U>&& ptr);
+
+  inline Weak& operator=(decltype(nullptr)) {
+    dispose();
+    return *this;
+  }
+
+  inline bool operator==(const Pin<T>& other) const { return get() == other.get(); }
+  inline bool operator==(const Weak<T>& other) const { return get() == other.get(); }
+  inline bool operator==(const T* const other) const { return get() == other; }
+
+  template <typename U>
+  inline bool operator==(const Pin<U>& other) const { return get() == other.get(); }
+
+  template <typename U>
+  inline bool operator==(const Weak<U>& other) const { return get() == other.get(); }
+
+  inline T& assertLive() {
+    // Obtain a `T&` reference, checking that the referent is still alive.
+    T* ptr = get();
+    KJ_IREQUIRE(ptr != nullptr, "null Weak<> dereference");
+    return *ptr;
+  }
+
+  inline const T& assertLive() const {
+    // Obtain a `const T&` reference, checking that the referent is still alive.
+    const T* ptr = get();
+    KJ_IREQUIRE(ptr != nullptr, "null Weak<> dereference");
+    return *ptr;
+  }
+
+  inline Maybe<T&> tryGet() { return get(); }
+  // Obtain a reference if the referent is still alive, otherwise return none.
+
+  inline Maybe<const T&> tryGet() const { return get(); }
+  // Obtain a const reference if the referent is still alive, otherwise return none.
+
+  inline Maybe<Ptr<T>> upgrade();
+  // Obtain a strong pointer if the referent is still alive, otherwise return none.
+
+  inline Maybe<Ptr<const T>> upgrade() const;
+  // Obtain a const strong pointer if the referent is still alive, otherwise return none.
+
+private:
+  _::WeakCell* cell = nullptr;
+  T* ptr = nullptr;
+
+  inline Weak(Pin<T>* pin): cell(pin->getWeakCell()), ptr(pin->get()) {
+    cell->addRef();
+  }
+
+  inline Weak(T* ptr, _::WeakCell* cell): cell(cell), ptr(ptr) {
+    if (cell != nullptr) {
+      cell->addRef();
+    }
+  }
+
+  inline void dispose() {
+    if (cell != nullptr) {
+      cell->decRef();
+      cell = nullptr;
+      ptr = nullptr;
+    }
+  }
+
+  inline T* get() const {
+    if (cell == nullptr || cell->ptr == nullptr) {
+      return nullptr;
+    }
+    return ptr;
+  }
+
+  template <typename>
+  friend class Pin;
+  template <typename>
+  friend class Ptr;
+  template <typename>
+  friend class Weak;
+  friend struct MaybeTraits<Weak<T>>;
+};
+
+// MaybeTraits specialization for Weak<T>.
+// This enables niche optimization: Maybe<Weak<T>> uses cell == nullptr as "none".
+template <typename T>
+struct MaybeTraits<Weak<T>> {
+  static void initNone(Weak<T>* ptr) noexcept { new (ptr, _::PlacementNew()) Weak<T>(nullptr); }
+  static bool isNone(const Weak<T>& p) noexcept { return p.cell == nullptr; }
+
+  // Weak's move ctor copies cell and sets source.cell to nullptr. Moving a null Weak is safe.
+  static constexpr bool noneIsMoveSafe = true;
+
+  // Allow `Maybe<Weak<T>>` to be constructed from types convertible to `Weak<T>`, like `Weak<U>`.
+  static constexpr bool convertingConstructor = true;
+};
+
+// =======================================================================================
 // Ptr<T>
 
 template <typename T>
@@ -913,163 +1058,36 @@ struct MaybeTraits<Ptr<T>> {
   static constexpr bool convertingConstructor = true;
 };
 
-// =======================================================================================
-// Weak<T>
+template <typename T>
+inline Weak<T>::Weak(Ptr<T>& ptr): Weak(ptr.asWeak()) {}
+template <typename T>
+inline Weak<T>::Weak(Ptr<T>&& ptr): Weak(ptr.asWeak()) {}
 
 template <typename T>
-class Weak {
-  // Weak<T> is a smart alternative to T& with expiration detection.
-  //
-  // Weak<T> is obtained from Pin<T>::addWeak(). It does not keep the Pin alive and does not prevent
-  // the Pin from moving; it expires when the Pin is moved or destroyed.
-  // Common usage:
-  // - KJ_IF_SOME on Weak<T> upgrades to Ptr<T>
-  // - assertLive() obtains T& and throws on expired Weak<T>
-  // - tryGet() obtains Maybe<T&> directly.
-  // - upgrade() method upgrades to Maybe<Ptr<T>>
+template <typename U, typename>
+inline Weak<T>::Weak(Ptr<U>& ptr): Weak(ptr.asWeak()) {}
+template <typename T>
+template <typename U, typename>
+inline Weak<T>::Weak(Ptr<U>&& ptr): Weak(ptr.asWeak()) {}
 
-public:
-  inline Weak(decltype(nullptr)) noexcept: cell(nullptr), ptr(nullptr) {}
-
-  inline ~Weak() { dispose(); }
-
-  Weak(Weak&& other) noexcept {
-    kj::swp(cell, other.cell);
-    kj::swp(ptr, other.ptr);
+template <typename T>
+inline Maybe<Ptr<T>> Weak<T>::upgrade() {
+  if (get() == nullptr) {
+    return kj::none;
   }
+  return Ptr<T>(ptr, cell);
+}
 
-  Weak(const Weak& other): cell(other.cell), ptr(other.ptr) {
-    if (cell != nullptr) {
-      cell->addRef();
-    }
+template <typename T>
+inline Maybe<Ptr<const T>> Weak<T>::upgrade() const {
+  if (get() == nullptr) {
+    return kj::none;
   }
-
-  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
-  Weak(Weak<U>&& other) noexcept: ptr(other.ptr) {
-    kj::swp(cell, other.cell);
-    other.ptr = nullptr;
-  }
-
-  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
-  Weak(const Weak<U>& other): cell(other.cell), ptr(other.ptr) {
-    if (cell != nullptr) {
-      cell->addRef();
-    }
-  }
-
-  inline Weak(Ptr<T>& ptr): Weak(ptr.asWeak()) {}
-  inline Weak(Ptr<T>&& ptr): Weak(ptr.asWeak()) {}
-
-  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
-  inline Weak(Ptr<U>& ptr): Weak(ptr.asWeak()) {}
-  template <typename U, typename = EnableIf<canConvert<U*, T*>()>>
-  inline Weak(Ptr<U>&& ptr): Weak(ptr.asWeak()) {}
-
-  inline Weak& operator=(decltype(nullptr)) {
-    dispose();
-    return *this;
-  }
-
-  inline bool operator==(const Pin<T>& other) const { return get() == other.get(); }
-  inline bool operator==(const Weak<T>& other) const { return get() == other.get(); }
-  inline bool operator==(const T* const other) const { return get() == other; }
-
-  template <typename U>
-  inline bool operator==(const Pin<U>& other) const { return get() == other.get(); }
-
-  template <typename U>
-  inline bool operator==(const Weak<U>& other) const { return get() == other.get(); }
-
-  inline T& assertLive() {
-    // Obtain a `T&` reference, checking that the referent is still alive.
-    T* ptr = get();
-    KJ_IREQUIRE(ptr != nullptr, "null Weak<> dereference");
-    return *ptr;
-  }
-
-  inline const T& assertLive() const {
-    // Obtain a `const T&` reference, checking that the referent is still alive.
-    const T* ptr = get();
-    KJ_IREQUIRE(ptr != nullptr, "null Weak<> dereference");
-    return *ptr;
-  }
-
-  inline Maybe<T&> tryGet() { return get(); }
-  // Obtain a reference if the referent is still alive, otherwise return none.
-
-  inline Maybe<const T&> tryGet() const { return get(); }
-  // Obtain a const reference if the referent is still alive, otherwise return none.
-
-  inline Maybe<Ptr<T>> upgrade() {
-    // Obtain a strong pointer if the referent is still alive, otherwise return none.
-    if (get() == nullptr) {
-      return kj::none;
-    }
-    return Ptr<T>(ptr, cell);
-  }
-
-  inline Maybe<Ptr<const T>> upgrade() const {
-    // Obtain a const strong pointer if the referent is still alive, otherwise return none.
-    if (get() == nullptr) {
-      return kj::none;
-    }
-    return Ptr<const T>(ptr, cell);
-  }
-
-private:
-  _::WeakCell* cell = nullptr;
-  T* ptr = nullptr;
-
-  inline Weak(Pin<T>* pin): cell(pin->getWeakCell()), ptr(pin->get()) {
-    cell->addRef();
-  }
-
-  inline Weak(T* ptr, _::WeakCell* cell): cell(cell), ptr(ptr) {
-    if (cell != nullptr) {
-      cell->addRef();
-    }
-  }
-
-  inline void dispose() {
-    if (cell != nullptr) {
-      cell->decRef();
-      cell = nullptr;
-      ptr = nullptr;
-    }
-  }
-
-  inline T* get() const {
-    if (cell == nullptr || cell->ptr == nullptr) {
-      return nullptr;
-    }
-    return ptr;
-  }
-
-  template <typename>
-  friend class Pin;
-  template <typename>
-  friend class Ptr;
-  template <typename>
-  friend class Weak;
-  friend struct MaybeTraits<Weak<T>>;
-};
+  return Ptr<const T>(ptr, cell);
+}
 
 template <typename T, typename U>
 inline bool operator==(const Pin<T>& pin, const Weak<U>& weak) { return weak == pin; }
-
-// MaybeTraits specialization for Weak<T>.
-// This enables niche optimization: Maybe<Weak<T>> uses cell == nullptr as "none".
-template <typename T>
-struct MaybeTraits<Weak<T>> {
-  static void initNone(Weak<T>* ptr) noexcept { new (ptr, _::PlacementNew()) Weak<T>(nullptr); }
-  static bool isNone(const Weak<T>& p) noexcept { return p.cell == nullptr; }
-
-  // Weak's move ctor copies cell and sets source.cell to nullptr. Moving a null Weak is safe.
-  static constexpr bool noneIsMoveSafe = true;
-
-  // Allow `Maybe<Weak<T>>` to be constructed from types convertible to `Weak<T>`, like `Weak<U>`.
-  static constexpr bool convertingConstructor = true;
-};
 
 namespace _ {  // private
 


### PR DESCRIPTION
Since crashing in opt mode is a no-go and throwing at ~T point cannot protect Ptr<T>, this PR keeps existing crashing behavior in debug mode for eaiser contract debugging, but replaces Ptr<T> with checked Weak<T> in opt , thus making it safe to replace T& with Ptr<T> and always get additional security guarantee.

I've split Weak<T> textual move to a separate commit for easier review. There's no new logic, opt Ptr<T> simply wraps Weak<Y>.