### PR TITLE
doc: list capngodo (GDScript / Godot) under Serialization only

### DIFF
--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -28,6 +28,7 @@ project's documentation for details.
 * [C](https://github.com/opensourcerouting/c-capnproto) by [OpenSourceRouting](https://www.opensourcerouting.org/) / [@eqvinox](https://github.com/eqvinox) (originally by [@jmckaskill](https://github.com/jmckaskill)) (no longer maintained)
     * [Forked and maintained](https://gitlab.com/dkml/ext/c-capnproto) by [@jonahbeckford](https://github.com/jonahbeckford)
 * [D](https://github.com/capnproto/capnproto-dlang) by [@ThomasBrixLarsen](https://github.com/ThomasBrixLarsen)
+* [GDScript (Godot)](https://github.com/plaught-armor/capngodo) by [@plaught-armor](https://github.com/plaught-armor)
 * [Java](https://github.com/capnproto/capnproto-java/) by [@dwrensha](https://github.com/dwrensha)
 * [JavaScript](https://github.com/capnp-js/plugin/) by [@popham](https://github.com/popham)
 * [JavaScript](https://github.com/jscheid/capnproto-js) (older, abandoned) by [@jscheid](https://github.com/jscheid)


### PR DESCRIPTION
This adds [capngodo](https://github.com/plaught-armor/capngodo) to the Other Languages page under **Serialization only** (alphabetical, between D and Java).

capngodo is a pure-GDScript Cap'n Proto implementation for the [Godot](https://godotengine.org/) game engine (4.6+). It is serialization-only (no RPC).

It satisfies the two stated expectations on the page:

- **It does not implement its own schema parser.** It ships a `capnpc-gdscript` compiler plugin driven by `capnp compile -o gdscript`, exactly as recommended, plus a standalone runtime wire codec.
- **It is tested via `capnp` encode/decode interop.** Generated readers decode real `capnp`-encoded messages, and generated builders produce bytes `capnp decode` reads back. The GUT suite is 166 tests / ~29k assertions, plus the bidirectional interop check against the reference `capnp` tool.

The full wire format is covered (structs, all list types, packed, multi-segment + far pointers, default-XOR), with codegen for structs/enums/unions/groups/defaults/consts, interface fields, cross-file references, and generics. It also ships alloc-free lazy iterators for `List(struct)` fields (one reused element reader/builder per step). The decoder is fuzzed against 800 malformed/hostile buffers (random, byte-flipped, truncated, hand-crafted adversarial) — it never crashes, hangs, or OOMs on untrusted bytes. MIT licensed.

Would be the first GDScript/Godot implementation listed. Thanks!
