### PR TITLE
Allow embedder to control inlining of dispose

### DIFF
--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -753,7 +753,8 @@ struct ArrayDisposer::Dispose_ {
 };
 
 template <typename T>
-void ArrayDisposer::dispose(T* firstElement, size_t elementCount, size_t capacity) const {
+KJ_DISPOSE_ATTR void ArrayDisposer::dispose(
+    T* firstElement, size_t elementCount, size_t capacity) const {
   if constexpr (KJ_HAS_TRIVIAL_DESTRUCTOR(T)) {
     disposeImpl(const_cast<RemoveConst<T>*>(firstElement),
                          sizeof(T), elementCount, capacity, nullptr);

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -281,7 +281,7 @@ public:
     return sizeof(T) <= sizeof(PromiseArena) && alignof(T) <= alignof(void*);
   }
 
-  static void dispose(PromiseArenaMember* node) {
+  static KJ_DISPOSE_ATTR void dispose(PromiseArenaMember* node) {
     PromiseArena* arena = node->arena;
     // Defer the `delete` to protect against exception in `destroy()`.
     // Reminder: `delete` automatically ignores null pointers

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -224,6 +224,20 @@ typedef unsigned char byte;
 #define KJ_NOINLINE __attribute__((noinline))
 #endif
 
+#ifndef KJ_DISPOSE_ATTR
+#define KJ_DISPOSE_ATTR
+// Attribute applied to KJ's type-erased object-teardown dispatch helpers: Disposer::dispose(),
+// ArrayDisposer::dispose(), and PromiseDisposer::dispose(). By default this expands to nothing, so
+// these remain ordinary inlinable functions and existing embedders see no change.
+//
+// An embedder whose build instantiates these helpers at a very large number of call sites may
+// define KJ_DISPOSE_ATTR (typically to KJ_NOINLINE) to force the dispatch out-of-line. Because the
+// instantiations are largely identical, the linker can then fold them (e.g. via ICF) into a small
+// number of shared copies, substantially reducing code size on teardown paths -- at the cost of a
+// non-inlined call per disposal. Defining it does not change the meaning of the program, only
+// inlining/codegen.
+#endif
+
 #if defined(_MSC_VER) && !__clang__
 #define KJ_NORETURN(prototype) __declspec(noreturn) prototype
 #define KJ_UNUSED

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -1155,7 +1155,7 @@ inline NullableValue<Ptr<T>> readMaybe(Weak<T>&& weak) { return readMaybe(weak.u
 // Inline implementation details
 
 template <typename T>
-void Disposer::dispose(T* object) const {
+KJ_DISPOSE_ATTR void Disposer::dispose(T* object) const {
   if constexpr (_kj_internal_isPolymorphic((T*)nullptr)) {
     // Note that dynamic_cast<void*> does not require RTTI to be enabled, because the offset to
     // the top of the object is in the vtable -- as it obviously needs to be to correctly implement


### PR DESCRIPTION
There can be a huge number of calls to dispose,
and if they are all inlined, this can cause bloat. Allow
the embedder to control this.  By default, no change.