### PR TITLE
1.x: Fix pkgconfig bindings.

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -221,6 +221,9 @@ if(NOT MSVC)
   set(PTHREAD_CFLAGS "-pthread")
 endif()
 set(STDLIB_FLAG)  # TODO: Unsupported
+if(WIN32)
+  set(ASYNC_LIBS "-lws2_32")
+endif()
 set(CAPNP_PKG_CONFIG_FILES
   pkgconfig/kj.pc
   pkgconfig/capnp.pc
@@ -233,10 +236,15 @@ if(NOT CAPNP_LITE)
     pkgconfig/kj-gzip.pc
     pkgconfig/kj-http.pc
     pkgconfig/kj-test.pc
-    pkgconfig/kj-tls.pc
     pkgconfig/capnp-rpc.pc
     pkgconfig/capnp-websocket.pc
     pkgconfig/capnp-json.pc
+  )
+endif()
+
+if(WITH_OPENSSL)
+  list(APPEND CAPNP_PKG_CONFIG_FILES
+    pkgconfig/kj-tls.pc
   )
 endif()
 

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -229,7 +229,13 @@ AS_IF([test "$with_openssl" = check], [
 ])
 AS_IF([test "$with_openssl" != no], [
   CXXFLAGS="$CXXFLAGS -DKJ_HAS_OPENSSL"
-  CAPNP_PKG_CONFIG_FILES="$CAPNP_PKG_CONFIG_FILES pkgconfig/kj-tls.pc"
+  # Note: CAPNP_PKG_CONFIG_FILES is both an m4 macro (defined above) and a
+  # substituted shell variable. We must bracket-quote the whole assignment so
+  # m4 doesn't expand the bare CAPNP_PKG_CONFIG_FILES tokens into the file list.
+  [CAPNP_PKG_CONFIG_FILES="$CAPNP_PKG_CONFIG_FILES pkgconfig/kj-tls.pc"]
+  # Only generate kj-tls.pc when TLS is enabled, so the set of generated files
+  # matches the set we install (see pkgconfig_DATA in Makefile.am).
+  AC_CONFIG_FILES([pkgconfig/kj-tls.pc])
 ])
 AM_CONDITIONAL([BUILD_KJ_TLS], [test "$with_openssl" != no])
 
@@ -301,5 +307,5 @@ AC_SUBST(_WITH_LIBUCONTEXT, NO)
 
 AM_CONDITIONAL([HAS_FUZZING_ENGINE], [test "x$LIB_FUZZING_ENGINE" != "x"])
 
-AC_CONFIG_FILES([Makefile] CAPNP_PKG_CONFIG_FILES pkgconfig/kj-tls.pc CAPNP_CMAKE_CONFIG_FILES)
+AC_CONFIG_FILES([Makefile] CAPNP_PKG_CONFIG_FILES CAPNP_CMAKE_CONFIG_FILES)
 AC_OUTPUT

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -163,7 +163,6 @@ AC_DEFUN([CAPNP_PKG_CONFIG_FILES], [ \
   pkgconfig/kj-async.pc \
   pkgconfig/kj-http.pc \
   pkgconfig/kj-gzip.pc \
-  pkgconfig/kj-tls.pc \
   pkgconfig/kj-test.pc \
 ])
 AC_DEFUN([CAPNP_CMAKE_CONFIG_FILES], [ \
@@ -230,6 +229,7 @@ AS_IF([test "$with_openssl" = check], [
 ])
 AS_IF([test "$with_openssl" != no], [
   CXXFLAGS="$CXXFLAGS -DKJ_HAS_OPENSSL"
+  CAPNP_PKG_CONFIG_FILES="$CAPNP_PKG_CONFIG_FILES pkgconfig/kj-tls.pc"
 ])
 AM_CONDITIONAL([BUILD_KJ_TLS], [test "$with_openssl" != no])
 
@@ -301,5 +301,5 @@ AC_SUBST(_WITH_LIBUCONTEXT, NO)
 
 AM_CONDITIONAL([HAS_FUZZING_ENGINE], [test "x$LIB_FUZZING_ENGINE" != "x"])
 
-AC_CONFIG_FILES([Makefile] CAPNP_PKG_CONFIG_FILES CAPNP_CMAKE_CONFIG_FILES)
+AC_CONFIG_FILES([Makefile] CAPNP_PKG_CONFIG_FILES pkgconfig/kj-tls.pc CAPNP_CMAKE_CONFIG_FILES)
 AC_OUTPUT

--- a/c++/pkgconfig/kj-async.pc.in
+++ b/c++/pkgconfig/kj-async.pc.in
@@ -8,4 +8,4 @@ Description: Basic utility library called KJ (async part)
 Version: @VERSION@
 Libs: -L${libdir} -lkj-async @ASYNC_LIBS@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
 Requires: kj = @VERSION@
-Cflags: -I${includedir} @ASYNC_LIBS@ @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@
+Cflags: -I${includedir} @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@

--- a/c++/pkgconfig/kj-tls.pc.in
+++ b/c++/pkgconfig/kj-tls.pc.in
@@ -8,4 +8,5 @@ Description: Basic utility library called KJ (TLS part)
 Version: @VERSION@
 Libs: -L${libdir} -lkj-tls @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
 Requires: kj-async = @VERSION@
+Requires.private: openssl
 Cflags: -I${includedir} @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@

--- a/super-test.sh
+++ b/super-test.sh
@@ -24,6 +24,39 @@ function test_samples() {
   rm -f /tmp/capnp-calculator-example-$$
 }
 
+# libkj-tls and its pkg-config file must be installed as a unit: both present
+# when OpenSSL is available, both absent otherwise. #2726 fixed the case where
+# kj-tls.pc was installed even when OpenSSL was absent and libkj-tls was never
+# built (a .pc advertising a missing library); while iterating on that fix, the
+# opposite briefly slipped in -- libkj-tls installed with no kj-tls.pc. The
+# install samples don't use TLS, so they exercise neither case. Check both,
+# under whatever prefix the (autotools or CMake) build installed into.
+function check_kj_tls_packaging() {
+  local prefix=$1
+  local tls_lib tls_pc pc_dir
+  # Capture find's full output; piping to `head` can SIGPIPE under `pipefail`.
+  tls_lib=$(find "$prefix" -name 'libkj-tls.*' 2>/dev/null)
+  tls_pc=$(find "$prefix" -name 'kj-tls.pc' 2>/dev/null)
+
+  if [ -n "$tls_lib" ]; then
+    # libkj-tls was built, so kj-tls.pc must be installed and fully resolvable,
+    # including its private OpenSSL dependency.
+    if [ -z "$tls_pc" ]; then
+      echo "error: libkj-tls was built but kj-tls.pc was not installed" >&2
+      exit 1
+    fi
+    pc_dir=$(dirname "${tls_pc%%$'\n'*}")  # first match, in case there are several
+    PKG_CONFIG_PATH="$pc_dir${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" \
+        doit pkg-config --exists --print-errors kj-tls
+    PKG_CONFIG_PATH="$pc_dir${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" \
+        doit pkg-config --cflags --libs --static kj-tls
+  elif [ -n "$tls_pc" ]; then
+    # libkj-tls was not built, so kj-tls.pc must not be installed.
+    echo "error: kj-tls.pc was installed but libkj-tls was not built" >&2
+    exit 1
+  fi
+}
+
 QUICK=
 CPP_FEATURES=
 WERROR="-Werror"
@@ -279,6 +312,8 @@ while [ $# -gt 0 ]; do
       # Build and install
       doit make -j$PARALLEL install
 
+      check_kj_tls_packaging "$WORKSPACE/inst"
+
       # Configure, build, and execute the samples.
       cd $WORKSPACE/build-samples
       doit cmake $SOURCE_DIR/samples -G "Unix Makefiles" -DCMAKE_PREFIX_PATH="$WORKSPACE/inst" \
@@ -464,6 +499,8 @@ doit make install
 
 test "x$(which capnp)" = "x$STAGING/bin/capnp"
 test "x$(which capnpc-c++)" = "x$STAGING/bin/capnpc-c++"
+
+check_kj_tls_packaging "$STAGING"
 
 cd samples
 


### PR DESCRIPTION
* Don't pass ASYNC_LIBS (typically -lws2_32 or -lucontext) to the C compiler.
* Don't install kj-tls.pc when TLS is disabled.
* Add missing dependency on OpenSSL for kj-tls.pc.

This was first (partially) reported in https://github.com/microsoft/vcpkg/pull/52845 so @xiaozhuai deserves some credit. Some parts of this change were written by GPT 5.6-Sol.

After this change the following examples succeed on Windows (both TLS on and off).

CMakeLists.txt:

```
cmake_minimum_required(VERSION 3.20)
project(capnproto_consumer LANGUAGES CXX)
set(CMAKE_CXX_STANDARD 17)
set(CMAKE_CXX_STANDARD_REQUIRED ON)
if(USE_TLS)
  set(source tls.cpp)
else()
  set(source core.cpp)
endif()
add_executable(consumer "${source}")
find_package(PkgConfig REQUIRED)
if(USE_TLS)
  pkg_check_modules(CAPNP REQUIRED IMPORTED_TARGET kj-tls)
else()
  pkg_check_modules(CAPNP REQUIRED IMPORTED_TARGET capnp)
endif()
target_link_libraries(consumer PRIVATE PkgConfig::CAPNP)
```

core.cpp:

```
#include <capnp/message.h>
#include <kj/string.h>

int main() {
  capnp::MallocMessageBuilder message;
  auto text = kj::str("capnproto-", 15);
  return text == "capnproto-15" ? 0 : 1;
}
```

tls.cpp:

```
#include <kj/compat/tls.h>

int main() {
  kj::TlsContext::Options options;
  options.verifyClients = false;
  kj::TlsContext context(kj::mv(options));
  return 0;
}
```