### PR TITLE
change Refcounted to start count from 1

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -46,6 +46,16 @@ static_assert(!Cloneable<const Array<Rc<SetTrueInDestructor>>>);
 static_assert(Cloneable<ArrayPtr<Rc<SetTrueInDestructor>>>);
 static_assert(!Cloneable<const ArrayPtr<Rc<SetTrueInDestructor>>>);
 
+struct WeakInConstructor: public Refcounted {
+  // Captures a weak reference to itself from within its constructor, exercising addWeakToThis()
+  // before kj::rc()/kj::refcounted() has incremented the refcount.
+  WeakInConstructor(bool* ptr): ptr(ptr), weak(addWeakToThis()) {}
+  ~WeakInConstructor() { *ptr = true; }
+
+  bool* ptr;
+  kj::WeakRc<WeakInConstructor> weak;
+};
+
 struct IncompleteDeclaredRefcounted;
 static_assert(sizeof(Rc<IncompleteDeclaredRefcounted>) == 2 * sizeof(void*));
 
@@ -165,9 +175,76 @@ TEST(Refcount, Basic) {
 
 #ifdef KJ_DEBUG
   b = false;
-  SetTrueInDestructor obj(&b);
-  EXPECT_ANY_THROW(addRef(obj));
+  // A Refcounted object is born with refcount == 1 and must be adopted by the Own/Rc returned from
+  // kj::refcounted()/kj::rc(). Allocating one another way (e.g. on the stack) and destroying it
+  // trips the destructor's refcount assertion, since the count never returns to zero via disposal.
+  EXPECT_ANY_THROW(SetTrueInDestructor obj(&b));
 #endif
+}
+
+struct InlineRefcounted {
+  // Holds a Refcounted object inline as a member, an allocation the destructor should reject.
+  InlineRefcounted(bool* ptr): inner(ptr) {}
+  SetTrueInDestructor inner;
+};
+
+#ifdef KJ_DEBUG
+KJ_TEST("Refcounted rejects stack/inline allocation") {
+  // A Refcounted object is born with refcount == 1 and only reaches its destructor with refcount 0
+  // after being adopted by (and disposed through) an Own<T>/Rc<T>. Allocating it any other way
+  // leaves the initial reference stranded, so destruction trips the assertion. This assertion is
+  // KJ_DASSERT (debug-only), so this test only runs under KJ_DEBUG.
+
+  bool b = false;
+
+  // Directly on the stack.
+  KJ_EXPECT_THROW_MESSAGE("Refcounted object deleted with non-zero refcount", SetTrueInDestructor obj(&b));
+
+  // Inline as a member of another object.
+  KJ_EXPECT_THROW_MESSAGE("Refcounted object deleted with non-zero refcount", InlineRefcounted obj(&b));
+
+  // On the heap via plain `new`/`delete` rather than kj::refcounted(). The initial reference is
+  // still stranded, so deleting it (which invokes ~Refcounted() with refcount == 1, and not during
+  // an unwind) trips the assertion.
+  KJ_EXPECT_THROW_MESSAGE("Refcounted object deleted with non-zero refcount",
+      delete new SetTrueInDestructor(&b));
+}
+#endif
+
+struct ThrowInConstructor: public Refcounted {
+  // Throws from its constructor body, after the Refcounted base subobject has been fully
+  // constructed (with refcount == 1). During the resulting stack unwind, ~Refcounted() runs while
+  // refcount is still non-zero; the destructor's assertion must NOT fire spuriously in this case,
+  // because we are unwinding due to an exception rather than leaking a stranded reference.
+  ThrowInConstructor() {
+    KJ_FAIL_ASSERT("throw from Refcounted constructor");
+  }
+};
+
+KJ_TEST("Refcounted constructor that throws does not trip destructor assertion") {
+  // The exception that propagates must be the constructor's, not a secondary failure from the
+  // destructor's refcount assertion (which, if it fired while already unwinding, would terminate).
+  KJ_EXPECT_THROW_MESSAGE("throw from Refcounted constructor",
+      kj::refcounted<ThrowInConstructor>());
+}
+
+struct ThrowAfterPublishingWeak: public Refcounted {
+  ThrowAfterPublishingWeak(WeakRc<ThrowAfterPublishingWeak>& published) {
+    published = addWeakToThis();
+    KJ_FAIL_ASSERT("throw after publishing weak reference");
+  }
+};
+
+KJ_TEST("WeakRc published by throwing constructor expires") {
+  WeakRc<ThrowAfterPublishingWeak> weak = nullptr;
+
+  KJ_EXPECT_THROW_MESSAGE("throw after publishing weak reference",
+      kj::rc<ThrowAfterPublishingWeak>(weak));
+
+  // A failed construction has ended the referent's lifetime, so the published weak reference must
+  // not retain the stale pointer or attempt to read the freed Refcounted object while upgrading.
+  KJ_EXPECT(weak == nullptr);
+  KJ_EXPECT(weak.upgrade() == kj::none);
 }
 
 KJ_TEST("Rc") {
@@ -385,15 +462,15 @@ KJ_TEST("Rc wraps attached Own") {
   bool b = false;
   bool attached = false;
 
-  Own<SetTrueInDestructor> own = kj::refcounted<SetTrueInDestructor>(&b)
-      .attachToThisReference(kj::heap<SetTrueInDestructor2>(&attached));
-  Rc<SetTrueInDestructor> ref(kj::mv(own));
+  Own<SetTrueInDestructor2> own = kj::heap<SetTrueInDestructor2>(&b)
+      .attach(kj::heap<SetTrueInDestructor2>(&attached));
+  Rc<SetTrueInDestructor2> ref(kj::mv(own));
   EXPECT_TRUE(own.get() == nullptr);
   EXPECT_TRUE(ref != nullptr);
   EXPECT_FALSE(b);
   EXPECT_FALSE(attached);
 
-  Rc<SetTrueInDestructor> ref2 = ref.addRef();
+  Rc<SetTrueInDestructor2> ref2 = ref.addRef();
 
   ref = nullptr;
   EXPECT_FALSE(b);
@@ -436,39 +513,6 @@ struct Concrete final: public Abstract {
   void use() override {}
   bool* ptr;
 };
-
-struct AbstractRefcounted: public Refcounted {
-  virtual void use() = 0;
-};
-
-struct ConcreteRefcounted final: public Abstract, public AbstractRefcounted {
-  ConcreteRefcounted(bool* ptr): ptr(ptr) {}
-  ~ConcreteRefcounted() { *ptr = true; }
-  void use() override {}
-
-  bool* ptr;
-};
-
-KJ_TEST("Rc wraps Own of abstract refcounted types") {
-  bool b = false;
-
-  Own<AbstractRefcounted> own = kj::refcounted<ConcreteRefcounted>(&b);
-
-  Rc<AbstractRefcounted> ref(kj::mv(own));
-  EXPECT_TRUE(own.get() == nullptr);
-  EXPECT_TRUE(ref != nullptr);
-
-  ref->use();
-
-  Rc<AbstractRefcounted> ref2 = ref.addRef();
-  EXPECT_TRUE(ref.get() == ref2.get());
-
-  ref = nullptr;
-  EXPECT_FALSE(b);
-
-  ref2 = nullptr;
-  EXPECT_TRUE(b);
-}
 
 KJ_TEST("Rc<Abstract>") {
   bool b = false;
@@ -899,6 +943,30 @@ KJ_TEST("Refcounted::addWeakToThis") {
   }
 
   EXPECT_FALSE(ref->isShared());
+  ref = nullptr;
+  EXPECT_TRUE(b);
+  EXPECT_TRUE(weak == nullptr);
+}
+
+KJ_TEST("Refcounted::addWeakToThis in constructor") {
+  bool b = false;
+
+  auto ref = kj::rc<WeakInConstructor>(&b);
+
+  // The weak reference captured during construction is valid and refers to the object.
+  EXPECT_TRUE(ref->weak == ref);
+  EXPECT_FALSE(ref->isShared());
+
+  KJ_IF_SOME(strong, ref->weak.upgrade()) {
+    EXPECT_TRUE(strong == ref);
+  } else {
+    KJ_FAIL_EXPECT("expected WeakRc captured in constructor to upgrade while referent is alive");
+  }
+
+  // Grab an independent weak reference before dropping the object; it must observe expiration once
+  // the last strong reference is gone.
+  WeakRc<WeakInConstructor> weak = ref->weak.clone();
+
   ref = nullptr;
   EXPECT_TRUE(b);
   EXPECT_TRUE(weak == nullptr);

--- a/c++/src/kj/refcount.c++
+++ b/c++/src/kj/refcount.c++
@@ -35,7 +35,21 @@ namespace kj {
 // Non-atomic (thread-unsafe) refcounting
 
 Refcounted::~Refcounted() noexcept(false) {
-  KJ_ASSERT(refcount == 0, "Refcounted object deleted with non-zero refcount.");
+  // A Refcounted object is born with a refcount of 1, so if a subclass constructor throws, the
+  // object is destroyed while refcount is still non-zero. Any weak references created and
+  // published by the constructor must observe that the referent has expired, just as they do when
+  // the last strong reference is dropped normally.
+  if (refcount != 0 && weakCell != nullptr) {
+    weakCell->refcounted = nullptr;
+    weakCell->decRef();
+    weakCell = nullptr;
+  }
+
+  // Suppress the assertion when we're unwinding due to a constructor exception. This is a
+  // debug-only assertion so that release builds do not do expensive unwinding checks.
+  KJ_DASSERT(refcount == 0 || UnwindDetector::uncaughtExceptionCount() > 0,
+      "Refcounted object deleted with non-zero refcount; it appears to have "
+      "been allocated without using kj::rc.");
 }
 
 void Refcounted::disposeImpl(void* pointer) const {

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -120,7 +120,11 @@ protected:
   }
 
 private:
-  mutable uint refcount = 0;
+  mutable uint refcount = 1;
+  // A Refcounted object is born with a reference count of 1: it always comes into existence owned
+  // by exactly one strong reference (the Own<T>/Rc<T> returned by kj::refcounted()/kj::rc()). This
+  // means the object is in a valid, fully-counted state throughout its constructor, so addRefToThis()
+  // and addWeakToThis() may be called from within the constructor.
   // "mutable" because disposeImpl() is const.  Bleh.
 
   mutable _::RcWeakCell* weakCell = nullptr;
@@ -172,8 +176,8 @@ template <typename T, typename... Params>
 inline Own<T> refcounted(Params&&... params) {
   // Allocate a new refcounted instance of T, passing `params` to its constructor.  Returns an
   // initial reference to the object.  More references can be created with `kj::addRef()`.
-
-  return Refcounted::addRefInternal(new T(kj::fwd<Params>(params)...));
+  T* object = new T(kj::fwd<Params>(params)...);
+  return Own<T>(object, *static_cast<Refcounted*>(object));
 }
 
 template <typename T>
@@ -207,7 +211,7 @@ template <typename T>
 class RcWrapper final: public Refcounted {
 public:
   template <typename... Params>
-  explicit RcWrapper(Params &&...params) : wrapped(kj::fwd<Params>(params)...) { ++refcount; }
+  explicit RcWrapper(Params &&...params) : wrapped(kj::fwd<Params>(params)...) {}
   T* getWrappedPtr() { return &wrapped; }
   const T *getWrappedPtr() const { return &wrapped; }
 
@@ -218,7 +222,7 @@ private:
 template <typename T>
 class RcOwnWrapper final: public Refcounted {
 public:
-  explicit RcOwnWrapper(Own<T> &&wrapped) : wrapped(kj::mv(wrapped)) { ++refcount; }
+  explicit RcOwnWrapper(Own<T> &&wrapped) : wrapped(kj::mv(wrapped)) {}
   T* getWrappedPtr() { return wrapped.get(); }
   const T *getWrappedPtr() const { return wrapped.get(); }
 
@@ -402,7 +406,8 @@ inline Rc<T> rc(Params&&... params) {
   // Returns smart pointer that can be used to manage references.
 
   if constexpr (canConvert<T*, Refcounted*>()) {
-    return Refcounted::addRcRefInternal(new T(fwd<Params>(params)...));
+    T* object = new T(fwd<Params>(params)...);
+    return Rc<T>(static_cast<Refcounted*>(object), object);
   } else {
     auto wrapper = new _::RcWrapper<T>(fwd<Params>(params)...);
     return Rc<T>(wrapper, wrapper->getWrappedPtr());


### PR DESCRIPTION
This has 2 positive effects:

- makes building and accesing weak pointers and constructor easy and straightforward (main reason why I am doing this)
- allows us to detect on-the-stack allocation.