### PR TITLE
EventLoop::Id

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -1473,6 +1473,33 @@ KJ_TEST("Maximum turn count during wait scope poll is enforced") {
   KJ_ASSERT(count == 0);
 }
 
+KJ_TEST("EventLoop::Id") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  auto id1 = EventLoop::Id::current();
+  id1.assertCurrentEventLoop();
+
+  auto id2 = EventLoop::Id::current();
+  KJ_ASSERT(id2 == id1);
+
+  KJ_ASSERT(loop.id() == id1);
+
+  Thread thread([&]() {
+    EventLoop loop2;
+    WaitScope waitScope2(loop2);
+
+    auto id3 = EventLoop::Id::current();
+    id3.assertCurrentEventLoop();
+    KJ_ASSERT(id1 != id3);
+    KJ_ASSERT(id2 != id3);
+    KJ_ASSERT(loop2.id() == id3);
+    KJ_ASSERT(loop.id() != id3);
+
+    KJ_EXPECT_THROW_MESSAGE("loop->loopId == id", id1.assertCurrentEventLoop());
+  });
+}
+
 KJ_TEST("exclusiveJoin both events complete simultaneously") {
   // Previously, if both branches of an exclusiveJoin() completed simultaneously, then the parent
   // event could be armed twice. This is an error, but the exact results of this error depend on

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1750,8 +1750,14 @@ void EventPort::wake() const {
       "cross-thread wake() not implemented by this EventPort implementation"));
 }
 
+namespace {
+std::atomic<size_t> nextEventLoopId(0);
+// Global counter used to assign a unique id to each EventLoop.
+}  // namespace
+
 EventLoop::EventLoop(kj::Maybe<EventLoopObserver&> observer)
-    : observer(observer), daemons(kj::heap<TaskSet>(_::LoggingErrorHandler::instance)) {
+    : loopId(nextEventLoopId.fetch_add(1, std::memory_order_relaxed)),
+      observer(observer), daemons(kj::heap<TaskSet>(_::LoggingErrorHandler::instance)) {
   auto link = [](_::Event& prev, _::Event& next) {
     prev.next = &next;
     next.prev = &prev.next;
@@ -1882,6 +1888,15 @@ void EventLoop::setRunnable(bool runnable) {
 void EventLoop::enterScope() {
   KJ_REQUIRE(threadLocalEventLoop == nullptr, "This thread already has an EventLoop.");
   threadLocalEventLoop = this;
+}
+
+EventLoop::Id EventLoop::id() const { return Id(loopId); }
+
+EventLoop::Id EventLoop::Id::current() { return currentEventLoop().id(); }
+
+void EventLoop::Id::assertCurrentEventLoop() const {
+  EventLoop* loop = threadLocalEventLoop;
+  KJ_ASSERT(loop != nullptr && loop->loopId == id);
 }
 
 void EventLoop::leaveScope() {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1364,6 +1364,31 @@ public:
   // Same as WaitScope::cancelAllDetached(). Sometimes it's easier to call on the EventLoop. (A
   // WaitScope still must exist, i.e., this EventLoop must be current.)
 
+  class Id {
+    // Unique event loop identifier.
+    // Implemented as a monotonically increasing counter value assigned to each EventLoop on
+    // construction, so it stays unique even after an EventLoop is destroyed and its memory reused.
+
+  public:
+    static Id current();
+    // Obtain the id of the EventLoop currently running on this thread. Requires that an EventLoop
+    // is running on the current thread.
+
+    inline bool operator==(const Id& other) const = default;
+
+    void assertCurrentEventLoop() const;
+    // KJ_ASSERTs that the current thread's EventLoop matches this identifier.
+
+  private:
+    inline explicit Id(size_t id): id(id) {}
+    size_t id;
+
+    friend class EventLoop;
+  };
+
+  Id id() const;
+  // Returns the unique identifier of this EventLoop.
+
 private:
   inline _::Event* head() const {
     _::Event* event = headSentinel.next;
@@ -1389,6 +1414,10 @@ private:
     Maybe<Own<_::Event>> fire() override { KJ_UNREACHABLE; }
     void traceEvent(_::TraceBuilder& builder) override { KJ_UNREACHABLE; }
   };
+
+  size_t loopId;
+  // Unique identifier for this EventLoop, assigned from a global atomic counter on construction.
+  // See id().
 
   kj::Maybe<EventPort&> port;
   // If null, this thread doesn't receive I/O events from the OS. It can potentially receive


### PR DESCRIPTION
Similar to ThreadId it can be used to eforce objects belonging to a single event loop. (e.g. Promise)