### PR TITLE
Report WebSocket overloads with close 1013

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -643,6 +643,56 @@ void runWebSocketTests(kj::HttpHeaderTable& headerTable,
   }
 }
 
+void runWebSocketOverloadTest(kj::HttpHeaderTable& headerTable,
+                              HttpOverCapnpFactory& clientFactory,
+                              HttpOverCapnpFactory& serverFactory,
+                              kj::WaitScope& waitScope) {
+  enum class Scenario { IDLE, PENDING_WRITE, CLOSED };
+  for (auto scenario: {Scenario::IDLE, Scenario::PENDING_WRITE, Scenario::CLOSED}) {
+    auto wsPaf = kj::newPromiseAndFulfiller<kj::Own<kj::WebSocket>>();
+    auto donePaf = kj::newPromiseAndFulfiller<void>();
+
+    auto back = serverFactory.kjToCapnp(kj::heap<WebSocketAccepter>(
+        headerTable, kj::mv(wsPaf.fulfiller), kj::mv(donePaf.promise)));
+    auto front = clientFactory.capnpToKj(back);
+    auto client = kj::newHttpClient(*front);
+
+    auto resp = client->openWebSocket("/ws", kj::HttpHeaders(headerTable)).wait(waitScope);
+    KJ_ASSERT(resp.webSocketOrBody.is<kj::Own<kj::WebSocket>>());
+
+    auto clientWs = kj::mv(resp.webSocketOrBody.get<kj::Own<kj::WebSocket>>());
+    auto serverWs = wsPaf.promise.wait(waitScope);
+    if (scenario == Scenario::PENDING_WRITE) {
+      auto send = serverWs->send("message before overload"_kj);
+      KJ_EXPECT(!send.poll(waitScope));
+      donePaf.fulfiller->reject(KJ_EXCEPTION(OVERLOADED, "backend overloaded"));
+
+      auto message = clientWs->receive().wait(waitScope);
+      KJ_ASSERT(message.is<kj::String>());
+      KJ_EXPECT(message.get<kj::String>() == "message before overload");
+      send.wait(waitScope);
+      KJ_EXPECT_THROW(DISCONNECTED, clientWs->receive().wait(waitScope));
+    } else if (scenario == Scenario::CLOSED) {
+      auto close = serverWs->close(1234, "closed before overload"_kj);
+      auto message = clientWs->receive().wait(waitScope);
+      KJ_ASSERT(message.is<kj::WebSocket::Close>());
+      KJ_EXPECT(message.get<kj::WebSocket::Close>().code == 1234);
+      KJ_EXPECT(message.get<kj::WebSocket::Close>().reason == "closed before overload");
+      close.wait(waitScope);
+
+      donePaf.fulfiller->reject(KJ_EXCEPTION(OVERLOADED, "backend overloaded"));
+      KJ_EXPECT_THROW(DISCONNECTED, clientWs->receive().wait(waitScope));
+    } else {
+      donePaf.fulfiller->reject(KJ_EXCEPTION(OVERLOADED, "backend overloaded"));
+
+      auto message = clientWs->receive().wait(waitScope);
+      KJ_ASSERT(message.is<kj::WebSocket::Close>());
+      KJ_EXPECT(message.get<kj::WebSocket::Close>().code == 1013);
+      KJ_EXPECT(message.get<kj::WebSocket::Close>().reason == "Service overloaded; retry later.");
+    }
+  }
+}
+
 KJ_TEST("HTTP-over-Cap'n Proto WebSocket, no path shortening") {
   kj::EventLoop eventLoop;
   kj::WaitScope waitScope(eventLoop);
@@ -667,6 +717,20 @@ KJ_TEST("HTTP-over-Cap'n Proto WebSocket, with path shortening") {
   auto headerTable = tableBuilder.build();
 
   runWebSocketTests(*headerTable, factory, factory, waitScope);
+}
+
+KJ_TEST("HTTP-over-Cap'n Proto WebSocket reports overload") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory streamFactory1;
+  ByteStreamFactory streamFactory2;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory1(streamFactory1, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  HttpOverCapnpFactory factory2(streamFactory2, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  auto headerTable = tableBuilder.build();
+
+  runWebSocketOverloadTest(*headerTable, factory1, factory2, waitScope);
 }
 
 // =======================================================================================

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -150,6 +150,23 @@ public:
     });
   }
 
+  enum class OverloadCloseStatus { READY, WRITE_IN_PROGRESS, CLOSED };
+
+  // Reports whether it's safe to send an overload Close frame. The caller (ClientRequestContextImpl)
+  // performs the close/abort itself because it, not this adapter, owns the underlying WebSocket.
+  OverloadCloseStatus prepareForOverloadClose() {
+    if (webSocket == kj::none) {
+      return OverloadCloseStatus::CLOSED;
+    }
+    if (activeWriteCount > 0) {
+      return OverloadCloseStatus::WRITE_IN_PROGRESS;
+    }
+
+    // Prevent any later RPCs from starting another write while the context sends the Close frame.
+    webSocket = kj::none;
+    return OverloadCloseStatus::READY;
+  }
+
 private:
   kj::Maybe<kj::WebSocket&> webSocket;  // becomes none when canceled
   kj::Own<kj::WebSocket> ownWebSocket;
@@ -161,6 +178,7 @@ private:
   kj::Maybe<kj::Own<kj::Exception>> error;
 
   bool shortened = false;
+  uint activeWriteCount = 0;
 
   kj::WebSocket& getWebSocket() {
     return KJ_REQUIRE_NONNULL(webSocket, "request canceled");
@@ -172,9 +190,12 @@ private:
       kj::throwFatalException(e->clone());
     }
 
+    ++activeWriteCount;
+
     // Detect cancellation (of the operation) and mark the object broken in this case.
     bool done = false;
     KJ_DEFER({
+      --activeWriteCount;
       if (!done && error == kj::none) {
         error = kj::heap(KJ_EXCEPTION(FAILED,
             "a write was canceled before completing, breaking the WebSocket"));
@@ -356,11 +377,23 @@ public:
     auto upWrapper = kj::heap<KjToCapnpWebSocketAdapter>(
         kj::none, params.getUpSocket(), kj::mv(shorteningPaf.fulfiller));
     responsePumpTask = webSocket->pumpTo(*upWrapper).attach(kj::mv(upWrapper))
-        .catch_([&webSocket=*webSocket](kj::Exception&& e) -> kj::Promise<void> {
+        .catch_([this, &webSocket=*webSocket](kj::Exception&& e) -> kj::Promise<void> {
       // The pump in the client -> server direction failed. The error may have originated from
       // either the client or the server. In case it came from the server, we want to call .abort()
       // to propagate the problem back to the client. If the error came from the client, then
       // .abort() probably is a noop.
+      if (e.getType() == kj::Exception::Type::OVERLOADED) {
+        if (closingForOverload) {
+          return kj::mv(e);
+        }
+
+        // Send a Close frame to the client before propagating, rather than aborting into a raw
+        // disconnect.
+        return closeWebSocketForOverload()
+            .then([e = kj::mv(e)]() mutable -> kj::Promise<void> {
+          return kj::mv(e);
+        });
+      }
       webSocket.abort();
       return kj::mv(e);
     });
@@ -406,6 +439,39 @@ public:
     return sentResponse;
   }
 
+  bool hasStartedWebSocket() {
+    return ownWebSocket != kj::none;
+  }
+
+  kj::Promise<void> closeWebSocketForOverload() {
+    if (closingForOverload) {
+      return finishPump().catch_([](kj::Exception&&) {});
+    }
+
+    closingForOverload = true;
+    auto& webSocket = *KJ_ASSERT_NONNULL(ownWebSocket);
+    KJ_IF_SOME(adapter, maybeWebSocket) {
+      switch (adapter.prepareForOverloadClose()) {
+        case CapnpToKjWebSocketAdapter::OverloadCloseStatus::READY:
+          break;
+        case CapnpToKjWebSocketAdapter::OverloadCloseStatus::WRITE_IN_PROGRESS:
+          webSocket.abort();
+          return kj::READY_NOW;
+        case CapnpToKjWebSocketAdapter::OverloadCloseStatus::CLOSED:
+          return kj::READY_NOW;
+      }
+    } else {
+      webSocket.abort();
+      return kj::READY_NOW;
+    }
+
+    // 1013 ("Try Again Later") is the WebSocket protocol's standard signal to retry later.
+    return webSocket.close(1013, "Service overloaded; retry later.")
+        .catch_([&webSocket](kj::Exception&&) {
+      webSocket.abort();
+    });
+  }
+
 private:
   HttpOverCapnpFactory& factory;
   kj::Maybe<kj::Own<kj::WebSocket>> ownWebSocket;
@@ -414,10 +480,14 @@ private:
 
   kj::HttpService::Response& kjResponse;
   bool sentResponse = false;
+  bool closingForOverload = false;
 
   kj::Promise<void> finishPumpInner() {
     KJ_IF_SOME(r, responsePumpTask) {
-      return kj::mv(r);
+      auto promise = kj::mv(r);
+      // Null out the task so a second call can't await the moved-from (null) promise.
+      responsePumpTask = kj::none;
+      return promise;
     } else {
       return kj::READY_NOW;
     }
@@ -580,7 +650,18 @@ public:
 
     // Wait for the server to indicate completion. Meanwhile, if the
     // promise is canceled from the client side, we propagate cancellation naturally.
-    co_await pipeline.ignoreResult();
+    KJ_TRY {
+      co_await pipeline.ignoreResult();
+    } KJ_CATCH(exception) {
+      if (exception.getType() == kj::Exception::Type::OVERLOADED &&
+          context.hasStartedWebSocket()) {
+        // Keep the upgraded transport alive until the Close frame has been written.
+        auto originalException = kj::mv(exception);
+        co_await context.closeWebSocketForOverload();
+        kj::throwFatalException(kj::mv(originalException));
+      }
+      kj::throwFatalException(kj::mv(exception));
+    }
 
     // Once the server indicates it is done, then we can cancel pumping the request, because
     // obviously the server won't use it. We should not cancel pumping the response since there


### PR DESCRIPTION
Report overloaded failures on WebSockets as a 1013 close frame rather than a raw 1006 disconnect