### PR TITLE
Initial impl of tryReadSync/tryWriteSync

### DIFF
--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -81,6 +81,25 @@ private:
 
 kj::Promise<bool> AsyncMessageReader::read(kj::AsyncInputStream& inputStream,
                                            kj::ArrayPtr<word> scratchSpace) {
+  // Fast path: read the first word synchronously if it is already buffered. The subsequent reads
+  // in readAfterFirstWord() / readSegments() use AsyncInputStream::read(), which has its own
+  // synchronous fast path, so a message whose bytes are all buffered avoids suspending entirely.
+  KJ_IF_SOME(n, inputStream.tryReadSync(
+      kj::arrayPtr(reinterpret_cast<kj::byte*>(firstWord), sizeof(firstWord)),
+      sizeof(firstWord))) {
+    if (n == 0) {
+      return false;
+    } else if (n < sizeof(firstWord)) {
+      // EOF in first word.
+      return kj::evalNow([]() -> kj::Promise<bool> {
+        kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED, "Premature EOF."));
+        return false;
+      });
+    }
+
+    return readAfterFirstWord(inputStream, scratchSpace).then([]() { return true; });
+  }
+
   return inputStream.tryRead(firstWord, sizeof(firstWord), sizeof(firstWord))
       .then([this,&inputStream,KJ_CPCAP(scratchSpace)](size_t n) mutable -> kj::Promise<bool> {
     if (n == 0) {

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -2297,6 +2297,507 @@ KJ_TEST("Userland pipe BlockedRead gets empty tryPumpFrom") {
   KJ_EXPECT(kj::StringPtr(buffer, 3) == "foo");
 }
 
+KJ_TEST("tryReadSync/tryWriteSync default implementations") {
+  class MinimalInputStream final: public AsyncInputStream {
+  public:
+    Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+      return size_t(0);
+    }
+  };
+  class MinimalOutputStream final: public AsyncOutputStream {
+  public:
+    Promise<void> write(ArrayPtr<const byte> buffer) override { return READY_NOW; }
+    Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+      return READY_NOW;
+    }
+    Promise<void> whenWriteDisconnected() override { return NEVER_DONE; }
+  };
+
+  MinimalInputStream input;
+  MinimalOutputStream output;
+
+  byte buf[16];
+  KJ_EXPECT(input.tryReadSync(arrayPtr(buf), 1) == kj::none);
+  KJ_EXPECT(!output.tryWriteSync("foo"_kjb));
+
+  ArrayPtr<const byte> pieces[2] = {"foo"_kjb, "bar"_kjb};
+  KJ_EXPECT(!output.tryWriteSync(arrayPtr(pieces)));
+}
+
+KJ_TEST("NullStream tryReadSync/tryWriteSync") {
+  NullStream stream;
+
+  byte buf[16];
+  KJ_EXPECT(KJ_ASSERT_NONNULL(stream.tryReadSync(arrayPtr(buf), 1)) == 0);
+  KJ_EXPECT(stream.tryWriteSync("foo"_kjb));
+
+  ArrayPtr<const byte> pieces[2] = {"foo"_kjb, "bar"_kjb};
+  KJ_EXPECT(stream.tryWriteSync(arrayPtr(pieces)));
+}
+
+KJ_TEST("Userland pipe tryReadSync from blocked write") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  byte buf[8]{};
+
+  // Nothing written yet: no data is available synchronously.
+  KJ_EXPECT(pipe.in->tryReadSync(arrayPtr(buf), 1) == kj::none);
+
+  auto promise = pipe.out->write("foobar"_kjb);
+  KJ_EXPECT(!promise.poll(ws));
+
+  // Read part of the blocked write synchronously.
+  KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf).first(4), 1)) == 4);
+  KJ_EXPECT(arrayPtr(buf).first(4) == "foob"_kjb);
+
+  // The write is still blocked: two bytes remain.
+  KJ_EXPECT(!promise.poll(ws));
+
+  // Read the rest synchronously; this completes the write.
+  KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf), 1)) == 2);
+  KJ_EXPECT(arrayPtr(buf).first(2) == "ar"_kjb);
+  KJ_EXPECT(promise.poll(ws));
+  promise.wait(ws);
+
+  // No more data.
+  KJ_EXPECT(pipe.in->tryReadSync(arrayPtr(buf), 1) == kj::none);
+
+  // A zero-byte read always completes synchronously.
+  KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf), 0)) == 0);
+}
+
+KJ_TEST("Userland pipe tryReadSync from blocked gather write") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  ArrayPtr<const byte> pieces[2] = {"foo"_kjb, "bar"_kjb};
+  auto promise = pipe.out->write(arrayPtr(pieces));
+
+  byte buf[8]{};
+
+  // Not enough buffered data to satisfy minBytes: refused, with no side effects.
+  KJ_EXPECT(pipe.in->tryReadSync(arrayPtr(buf), 7) == kj::none);
+  KJ_EXPECT(!promise.poll(ws));
+
+  // Read across both pieces synchronously.
+  KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf).first(6), 6)) == 6);
+  KJ_EXPECT(arrayPtr(buf).first(6) == "foobar"_kjb);
+  promise.wait(ws);
+}
+
+KJ_TEST("Userland pipe tryReadSync insufficient data has no side effects") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  auto promise = pipe.out->write("ab"_kjb);
+
+  byte buf[8]{};
+  KJ_EXPECT(pipe.in->tryReadSync(arrayPtr(buf), 3) == kj::none);
+  KJ_EXPECT(!promise.poll(ws));
+
+  // Fall back to the async path with the same arguments, like a real caller would.
+  auto readPromise = pipe.in->tryRead(buf, 3, 8);
+  KJ_EXPECT(promise.poll(ws));       // "ab" was consumed, unblocking the write...
+  KJ_EXPECT(!readPromise.poll(ws));  // ...but the read still needs one more byte.
+
+  auto promise2 = pipe.out->write("c"_kjb);
+  KJ_EXPECT(readPromise.wait(ws) == 3);
+  KJ_EXPECT(arrayPtr(buf).first(3) == "abc"_kjb);
+  promise2.wait(ws);
+}
+
+KJ_TEST("Userland pipe tryReadSync during pending read returns none") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  byte buf[4]{};
+  auto readPromise = pipe.in->tryRead(buf, 3, 4);
+
+  byte buf2[4]{};
+  KJ_EXPECT(pipe.in->tryReadSync(arrayPtr(buf2), 1) == kj::none);
+
+  pipe.out->write("foo"_kjb).wait(ws);
+  KJ_EXPECT(readPromise.wait(ws) == 3);
+}
+
+KJ_TEST("Userland pipe tryReadSync/tryWriteSync in terminal states") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  {
+    // Write end dropped: EOF is a valid synchronous answer.
+    auto pipe = newOneWayPipe();
+    pipe.out = nullptr;
+    byte buf[4]{};
+    KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf), 1)) == 0);
+  }
+
+  {
+    // Read end dropped: stream is in an errored state, tryWriteSync() throws.
+    auto pipe = newOneWayPipe();
+    pipe.in = nullptr;
+    KJ_EXPECT_THROW_MESSAGE("abortRead() has been called", pipe.out->tryWriteSync("foo"_kjb));
+
+    // Empty writes still succeed (the pipe shortcuts them before consulting state).
+    KJ_EXPECT(pipe.out->tryWriteSync(""_kjb));
+  }
+}
+
+KJ_TEST("Userland pipe tryWriteSync to blocked read") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  // No reader waiting: can't write synchronously.
+  KJ_EXPECT(!pipe.out->tryWriteSync("foo"_kjb));
+
+  byte buf[6]{};
+  auto readPromise = pipe.in->tryRead(buf, 6, 6);
+
+  // Write directly into the waiting reader's buffer. The read is not yet complete.
+  KJ_EXPECT(pipe.out->tryWriteSync("foo"_kjb));
+  KJ_EXPECT(!readPromise.poll(ws));
+
+  // Complete the read with a second synchronous write.
+  KJ_EXPECT(pipe.out->tryWriteSync("bar"_kjb));
+  KJ_EXPECT(readPromise.wait(ws) == 6);
+  KJ_EXPECT(arrayPtr(buf) == "foobar"_kjb);
+}
+
+KJ_TEST("Userland pipe tryWriteSync exactly filling read buffer") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  byte buf[3]{};
+  auto readPromise = pipe.in->tryRead(buf, 1, 3);
+
+  KJ_EXPECT(pipe.out->tryWriteSync("foo"_kjb));
+  KJ_EXPECT(readPromise.wait(ws) == 3);
+  KJ_EXPECT(arrayPtr(buf) == "foo"_kjb);
+}
+
+KJ_TEST("Userland pipe tryWriteSync larger than read buffer returns false") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  byte buf[3]{};
+  auto readPromise = pipe.in->tryRead(buf, 1, 3);
+
+  // All-or-nothing: the reader can only accept 3 bytes.
+  KJ_EXPECT(!pipe.out->tryWriteSync("foobar"_kjb));
+  KJ_EXPECT(!readPromise.poll(ws));  // no side effects
+
+  // The async path handles the split.
+  auto writePromise = pipe.out->write("foobar"_kjb);
+  KJ_EXPECT(readPromise.wait(ws) == 3);
+  KJ_EXPECT(arrayPtr(buf) == "foo"_kjb);
+  KJ_EXPECT(!writePromise.poll(ws));
+
+  byte buf2[3]{};
+  KJ_EXPECT(pipe.in->tryRead(buf2, 3, 3).wait(ws) == 3);
+  KJ_EXPECT(arrayPtr(buf2) == "bar"_kjb);
+  writePromise.wait(ws);
+}
+
+KJ_TEST("Userland pipe tryWriteSync during pending write returns false") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  auto writePromise = pipe.out->write("foobar"_kjb);
+  KJ_EXPECT(!pipe.out->tryWriteSync("baz"_kjb));
+
+  expectRead(*pipe.in, "foobar").wait(ws);
+  writePromise.wait(ws);
+}
+
+KJ_TEST("Userland pipe tryWriteSync gather write to blocked read") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  {
+    byte buf[6]{};
+    auto readPromise = pipe.in->tryRead(buf, 6, 6);
+
+    ArrayPtr<const byte> pieces[2] = {"foo"_kjb, "bar"_kjb};
+    KJ_EXPECT(pipe.out->tryWriteSync(arrayPtr(pieces)));
+    KJ_EXPECT(readPromise.wait(ws) == 6);
+    KJ_EXPECT(arrayPtr(buf) == "foobar"_kjb);
+  }
+
+  {
+    // Exactly filling the reader's buffer with a trailing empty piece still succeeds.
+    byte buf[3]{};
+    auto readPromise = pipe.in->tryRead(buf, 1, 3);
+
+    ArrayPtr<const byte> pieces[2] = {"foo"_kjb, ""_kjb};
+    KJ_EXPECT(pipe.out->tryWriteSync(arrayPtr(pieces)));
+    KJ_EXPECT(readPromise.wait(ws) == 3);
+    KJ_EXPECT(arrayPtr(buf) == "foo"_kjb);
+  }
+
+  {
+    // All-or-nothing: refused if the total doesn't fit in the reader's buffer.
+    byte buf[4]{};
+    auto readPromise = pipe.in->tryRead(buf, 1, 4);
+
+    ArrayPtr<const byte> pieces[2] = {"foo"_kjb, "bar"_kjb};
+    KJ_EXPECT(!pipe.out->tryWriteSync(arrayPtr(pieces)));
+    KJ_EXPECT(!readPromise.poll(ws));  // no side effects
+
+    // The async path handles the split.
+    auto writePromise = pipe.out->write(arrayPtr(pieces));
+    KJ_EXPECT(readPromise.wait(ws) == 4);
+    KJ_EXPECT(arrayPtr(buf) == "foob"_kjb);
+
+    byte buf2[2]{};
+    KJ_EXPECT(pipe.in->tryRead(buf2, 2, 2).wait(ws) == 2);
+    KJ_EXPECT(arrayPtr(buf2) == "ar"_kjb);
+    writePromise.wait(ws);
+  }
+
+  {
+    // Gather writes consisting only of empty pieces always succeed, mirroring write().
+    ArrayPtr<const byte> pieces[2] = {""_kjb, ""_kjb};
+    KJ_EXPECT(pipe.out->tryWriteSync(arrayPtr(pieces)));
+  }
+}
+
+KJ_TEST("Userland pipe tryWriteSync gather write through pumpTo") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  auto pipe2 = newOneWayPipe();
+  auto pumpPromise = pipe.in->pumpTo(*pipe2.out, 6);
+
+  byte buf[6]{};
+  auto readPromise = pipe2.in->tryRead(buf, 6, 6);
+
+  ArrayPtr<const byte> pieces[2] = {"foo"_kjb, "bar"_kjb};
+  KJ_EXPECT(pipe.out->tryWriteSync(arrayPtr(pieces)));
+  KJ_EXPECT(readPromise.wait(ws) == 6);
+  KJ_EXPECT(arrayPtr(buf) == "foobar"_kjb);
+
+  // The pump completed synchronously as part of the write.
+  KJ_EXPECT(pumpPromise.wait(ws) == 6);
+}
+
+KJ_TEST("Userland pipe tryWriteSync through pumpTo") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  auto pipe2 = newOneWayPipe();
+  auto pumpPromise = pipe.in->pumpTo(*pipe2.out);
+
+  // Downstream has no waiting reader: the write can't complete synchronously.
+  KJ_EXPECT(!pipe.out->tryWriteSync("foo"_kjb));
+
+  byte buf[3]{};
+  auto readPromise = pipe2.in->tryRead(buf, 3, 3);
+
+  // Now the write passes through the pump directly into the downstream reader's buffer.
+  KJ_EXPECT(pipe.out->tryWriteSync("foo"_kjb));
+  KJ_EXPECT(readPromise.wait(ws) == 3);
+  KJ_EXPECT(arrayPtr(buf) == "foo"_kjb);
+
+  // The unbounded pump is still running.
+  KJ_EXPECT(!pumpPromise.poll(ws));
+}
+
+KJ_TEST("Userland pipe tryWriteSync completes bounded pumpTo") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  auto pipe2 = newOneWayPipe();
+
+  {
+    auto pumpPromise = pipe.in->pumpTo(*pipe2.out, 3);
+
+    byte buf[3]{};
+    auto readPromise = pipe2.in->tryRead(buf, 3, 3);
+
+    KJ_EXPECT(pipe.out->tryWriteSync("foo"_kjb));
+    KJ_EXPECT(readPromise.wait(ws) == 3);
+    KJ_EXPECT(arrayPtr(buf) == "foo"_kjb);
+
+    // The pump completed synchronously as part of the write.
+    KJ_EXPECT(pumpPromise.wait(ws) == 3);
+  }
+
+  {
+    // A write that would extend past the end of the pump is refused.
+    auto pumpPromise = pipe.in->pumpTo(*pipe2.out, 2);
+
+    byte buf[4]{};
+    auto readPromise = pipe2.in->tryRead(buf, 1, 4);
+
+    KJ_EXPECT(!pipe.out->tryWriteSync("foo"_kjb));
+    KJ_EXPECT(!readPromise.poll(ws));  // no side effects
+
+    // The async path handles the pump boundary.
+    auto writePromise = pipe.out->write("foo"_kjb);
+    KJ_EXPECT(readPromise.wait(ws) == 2);
+    KJ_EXPECT(arrayPtr(buf).first(2) == "fo"_kjb);
+    KJ_EXPECT(pumpPromise.wait(ws) == 2);
+  }
+}
+
+KJ_TEST("Userland pipe tryReadSync during tryPumpFrom returns none") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  auto pipe2 = newOneWayPipe();
+  auto pumpPromise = KJ_ASSERT_NONNULL(pipe2.out->tryPumpFrom(*pipe.in));
+
+  // Even with data available from the pump source, a synchronous read is refused: the pump's
+  // completion semantics cannot be replicated synchronously.
+  auto writePromise = pipe.out->write("foo"_kjb);
+  byte buf[4]{};
+  KJ_EXPECT(pipe2.in->tryReadSync(arrayPtr(buf), 1) == kj::none);
+
+  // The async path still works.
+  KJ_EXPECT(pipe2.in->tryRead(buf, 1, 4).wait(ws) == 3);
+  writePromise.wait(ws);
+
+  // A subsequent read observes EOF, completing the pump.
+  auto readPromise = pipe2.in->readAllText();
+  pipe.out = nullptr;
+  KJ_EXPECT(pumpPromise.wait(ws) == 3);
+}
+
+KJ_TEST("Userland pipe with limit tryReadSync") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  {
+    auto pipe = newOneWayPipe(uint64_t(6));
+
+    auto promise = pipe.out->write("foobar"_kjb);
+    byte buf[8]{};
+    KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf), 1)) == 6);
+    KJ_EXPECT(arrayPtr(buf).first(6) == "foobar"_kjb);
+    promise.wait(ws);
+
+    // At the limit, EOF is returned synchronously.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf), 1)) == 0);
+  }
+
+  {
+    // EOF before the limit is reached throws, matching the async path's behavior.
+    auto pipe = newOneWayPipe(uint64_t(6));
+
+    auto promise = pipe.out->write("foo"_kjb);
+    byte buf[8]{};
+    KJ_EXPECT(KJ_ASSERT_NONNULL(pipe.in->tryReadSync(arrayPtr(buf), 1)) == 3);
+    promise.wait(ws);
+
+    pipe.out = nullptr;
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("fixed-length pipe ended prematurely", {
+      auto result KJ_UNUSED = pipe.in->tryReadSync(arrayPtr(buf), 1);
+    });
+  }
+}
+
+KJ_TEST("AsyncInputStream::read() synchronous fast path") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+
+  {
+    // A read that can be fully served from a blocked write completes without suspending.
+    auto writePromise = pipe.out->write("foobar"_kjb);
+    byte buf[6]{};
+    auto readPromise = pipe.in->read(arrayPtr(buf), 6);
+    KJ_EXPECT(readPromise.poll(ws));
+    KJ_EXPECT(readPromise.wait(ws) == 6);
+    KJ_EXPECT(arrayPtr(buf) == "foobar"_kjb);
+    writePromise.wait(ws);
+  }
+
+  {
+    // A short synchronous read (EOF) produces the standard error, as a promise rejection.
+    pipe.out = nullptr;
+    byte buf[4]{};
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("stream disconnected prematurely",
+        pipe.in->read(arrayPtr(buf), 1).wait(ws));
+  }
+}
+
+KJ_TEST("newPromisedStream tryReadSync/tryWriteSync") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  {
+    auto paf = kj::newPromiseAndFulfiller<Own<AsyncInputStream>>();
+    auto promised = newPromisedStream(kj::mv(paf.promise));
+
+    byte buf[8]{};
+
+    // Unresolved: no synchronous read possible.
+    KJ_EXPECT(promised->tryReadSync(arrayPtr(buf), 1) == kj::none);
+
+    auto pipe = newOneWayPipe();
+    auto writePromise = pipe.out->write("foo"_kjb);
+    paf.fulfiller->fulfill(kj::mv(pipe.in));
+
+    // Resolve the promised stream via an async read.
+    KJ_EXPECT(promised->tryRead(buf, 3, 3).wait(ws) == 3);
+    writePromise.wait(ws);
+
+    // Now that the stream has resolved, tryReadSync() delegates to it.
+    auto writePromise2 = pipe.out->write("bar"_kjb);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(promised->tryReadSync(arrayPtr(buf), 1)) == 3);
+    KJ_EXPECT(arrayPtr(buf).first(3) == "bar"_kjb);
+    writePromise2.wait(ws);
+  }
+
+  {
+    auto paf = kj::newPromiseAndFulfiller<Own<AsyncOutputStream>>();
+    auto promised = newPromisedStream(kj::mv(paf.promise));
+
+    // Unresolved: no synchronous write possible.
+    KJ_EXPECT(!promised->tryWriteSync("foo"_kjb));
+    ArrayPtr<const byte> pieces[2] = {"foo"_kjb, "bar"_kjb};
+    KJ_EXPECT(!promised->tryWriteSync(arrayPtr(pieces)));
+
+    auto pipe = newOneWayPipe();
+    paf.fulfiller->fulfill(kj::mv(pipe.out));
+
+    // Resolve the promised stream via an async write.
+    byte buf[3]{};
+    auto readPromise = pipe.in->tryRead(buf, 3, 3);
+    promised->write("foo"_kjb).wait(ws);
+    KJ_EXPECT(readPromise.wait(ws) == 3);
+
+    // Now that the stream has resolved, tryWriteSync() delegates to it.
+    auto readPromise2 = pipe.in->tryRead(buf, 3, 3);
+    KJ_EXPECT(promised->tryWriteSync("bar"_kjb));
+    KJ_EXPECT(readPromise2.wait(ws) == 3);
+    KJ_EXPECT(arrayPtr(buf) == "bar"_kjb);
+  }
+}
+
 constexpr static auto TEE_MAX_CHUNK_SIZE = 1 << 14;
 // AsyncTee::MAX_CHUNK_SIZE, 16k as of this writing
 
@@ -3608,6 +4109,71 @@ KJ_TEST("pump file to socket") {
   // Try with a disk file. Should use sendfile().
   auto fs = kj::newDiskFilesystem();
   doTest(fs->getCurrent().createTemporary());
+}
+
+KJ_TEST("FileInputStream/FileOutputStream tryReadSync/tryWriteSync") {
+  auto file = kj::newInMemoryFile(kj::nullClock());
+  file->writeAll("foobar"_kjb);
+
+  {
+    FileInputStream input(*file);
+    byte buf[4]{};
+    KJ_EXPECT(KJ_ASSERT_NONNULL(input.tryReadSync(arrayPtr(buf), 1)) == 4);
+    KJ_EXPECT(arrayPtr(buf) == "foob"_kjb);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(input.tryReadSync(arrayPtr(buf), 1)) == 2);
+    KJ_EXPECT(arrayPtr(buf).first(2) == "ar"_kjb);
+
+    // EOF is a valid synchronous answer.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(input.tryReadSync(arrayPtr(buf), 1)) == 0);
+  }
+
+  {
+    auto file2 = kj::newInMemoryFile(kj::nullClock());
+    FileOutputStream output(*file2);
+    KJ_EXPECT(output.tryWriteSync("foo"_kjb));
+    KJ_EXPECT(output.tryWriteSync("bar"_kjb));
+
+    ArrayPtr<const byte> pieces[2] = {"baz"_kjb, "qux"_kjb};
+    KJ_EXPECT(output.tryWriteSync(arrayPtr(pieces)));
+
+    KJ_EXPECT(file2->readAllText() == "foobarbazqux");
+  }
+}
+
+KJ_TEST("pumpTo synchronous fast path") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  {
+    // When both sides can complete synchronously, the entire pump completes without ever
+    // suspending.
+    auto file = kj::newInMemoryFile(kj::nullClock());
+    file->writeAll("foobar"_kjb);
+    auto file2 = kj::newInMemoryFile(kj::nullClock());
+
+    FileInputStream input(*file);
+    FileOutputStream output(*file2);
+    auto promise = input.pumpTo(output);
+    KJ_EXPECT(promise.poll(ws));
+    KJ_EXPECT(promise.wait(ws) == 6);
+    KJ_EXPECT(file2->readAllText() == "foobar");
+  }
+
+  {
+    // A pump large enough to exhaust the synchronous iteration budget still completes correctly
+    // (after yielding to the event loop in between).
+    auto big = bigString(300'000);  // > 64 iterations of the 4096-byte pump buffer
+
+    auto file = kj::newInMemoryFile(kj::nullClock());
+    file->writeAll(big.asBytes());
+    auto file2 = kj::newInMemoryFile(kj::nullClock());
+
+    FileInputStream input(*file);
+    FileOutputStream output(*file2);
+    KJ_EXPECT(unoptimizedPumpTo(input, output, kj::maxValue).wait(ws) == big.size());
+    // Extra parens here so that we don't write the big string to the console on failure...
+    KJ_EXPECT((file2->readAllText() == big));
+  }
 }
 
 KJ_TEST("Calling abortRead() while tryRead() is in progress") {

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -592,12 +592,13 @@ private:
       // advance that enough data is buffered to satisfy `minBytes`. (Note that any FDs or
       // streams attached to the blocked write are dropped by a plain byte read, matching
       // tryRead()'s behavior.)
-      size_t totalAvailable = writeBuffer.size();
+      // We only need to confirm that at least minBytes are available, not count the full total.
+      size_t availableChecked = writeBuffer.size();
       for (auto& piece: morePieces) {
-        if (totalAvailable >= minBytes) break;
-        totalAvailable += piece.size();
+        if (availableChecked >= minBytes) break;
+        availableChecked += piece.size();
       }
-      if (totalAvailable < minBytes) {
+      if (availableChecked < minBytes) {
         return kj::none;
       }
 
@@ -1488,6 +1489,7 @@ private:
         return false;
       }
 
+      KJ_ASSERT(pumpedSoFar <= amount);
       if (buffer.size() > amount - pumpedSoFar) {
         // Part of this write would fall past the end of the pump and would have to be delivered
         // to the pipe asynchronously, but tryWriteSync() is all-or-nothing, so we must not start.
@@ -1514,6 +1516,7 @@ private:
         return false;
       }
 
+      KJ_ASSERT(pumpedSoFar <= amount);
       size_t total = 0;
       for (auto& piece: pieces) {
         total += piece.size();

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -53,16 +53,29 @@
 namespace kj {
 
 Promise<size_t> AsyncInputStream::read(ArrayPtr<byte> buffer, size_t minBytes) {
-  return tryRead(buffer.begin(), minBytes, buffer.size()).then([=](size_t result) mutable {
-    if (result >= minBytes) {
-      return result;
-    } else {
-      kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED, "stream disconnected prematurely"));
-      // Pretend we read zeros from the input.
-      buffer.first(minBytes).slice(result).fill(0);
-      return minBytes;
-    }
-  });
+  size_t result;
+
+  // Fast path: complete the read synchronously if the data is already available, avoiding
+  // promise overhead.
+  KJ_IF_SOME(syncResult, tryReadSync(buffer, minBytes)) {
+    result = syncResult;
+  } else {
+    result = co_await tryRead(buffer.begin(), minBytes, buffer.size());
+  }
+
+  if (result >= minBytes) {
+    co_return result;
+  }
+
+  // Short read indicates EOF.
+  kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED, "stream disconnected prematurely"));
+  // Pretend we read zeros from the input.
+  buffer.first(minBytes).slice(result).fill(0);
+  co_return minBytes;
+}
+
+Maybe<size_t> AsyncInputStream::tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) {
+  return kj::none;
 }
 
 Maybe<uint64_t> AsyncInputStream::tryGetLength() { return kj::none; }
@@ -79,6 +92,9 @@ Maybe<Own<AsyncInputStream>> AsyncInputStream::tryTee(uint64_t) {
 kj::Promise<size_t> NullStream::tryRead(void* buffer, size_t minBytes, size_t maxBytes) {
   return kj::constPromise<size_t, 0>();
 }
+kj::Maybe<size_t> NullStream::tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) {
+  return size_t(0);
+}
 kj::Maybe<uint64_t> NullStream::tryGetLength() {
   return uint64_t(0);
 }
@@ -92,52 +108,69 @@ kj::Promise<void> NullStream::write(ArrayPtr<const byte> buffer) {
 kj::Promise<void> NullStream::write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) {
   return kj::READY_NOW;
 }
+bool NullStream::tryWriteSync(ArrayPtr<const byte> buffer) {
+  return true;
+}
+bool NullStream::tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) {
+  return true;
+}
 kj::Promise<void> NullStream::whenWriteDisconnected() {
   return kj::NEVER_DONE;
 }
 
 void NullStream::shutdownWrite() {}
 
-namespace {
-
-class AsyncPump {
-public:
-  AsyncPump(AsyncInputStream& input, AsyncOutputStream& output, uint64_t limit, uint64_t doneSoFar)
-      : input(input), output(output), limit(limit), doneSoFar(doneSoFar) {}
-
-  Promise<uint64_t> pump() {
-    // TODO(perf): This could be more efficient by reading half a buffer at a time and then
-    //   starting the next read concurrent with writing the data from the previous read.
-
-    uint64_t n = kj::min(limit - doneSoFar, sizeof(buffer));
-    if (n == 0) return doneSoFar;
-
-    return input.tryRead(buffer, 1, n)
-        .then([this](size_t amount) -> Promise<uint64_t> {
-      if (amount == 0) return doneSoFar;  // EOF
-      doneSoFar += amount;
-      return output.write(arrayPtr(buffer).first(amount)).then([this]() {
-        return pump();
-      });
-    });
-  }
-
-private:
-  AsyncInputStream& input;
-  AsyncOutputStream& output;
-  uint64_t limit;
-  uint64_t doneSoFar;
-  byte buffer[4096];
-};
-
-}  // namespace
-
 Promise<uint64_t> unoptimizedPumpTo(
     AsyncInputStream& input, AsyncOutputStream& output, uint64_t amount,
     uint64_t completedSoFar) {
-  auto pump = heap<AsyncPump>(input, output, amount, completedSoFar);
-  auto promise = pump->pump();
-  return promise.attach(kj::mv(pump));
+  // TODO(perf): This could be more efficient by reading half a buffer at a time and then
+  //   starting the next read concurrent with writing the data from the previous read.
+
+  // Maximum number of fully-synchronous pump iterations (tryReadSync() and tryWriteSync() both
+  // succeeding) before yielding to the event loop, so that a pump between two always-synchronous
+  // streams cannot starve other events.
+  static constexpr size_t MAX_SYNC_ITERATIONS = 64;
+
+  byte buffer[4096];
+  uint64_t doneSoFar = completedSoFar;
+
+  for (;;) {
+    // Fast path: as long as both the input can produce data and the output can accept it
+    // synchronously, pump without allocating any promises. To avoid monopolizing the event loop
+    // when both sides are always-synchronous (e.g. file-to-file pumps), we limit how much we
+    // pump this way before yielding.
+    bool exhaustedBudget = true;
+    for (size_t i = 0; i < MAX_SYNC_ITERATIONS; i++) {
+      uint64_t n = kj::min(amount - doneSoFar, sizeof(buffer));
+      if (n == 0) co_return doneSoFar;
+
+      KJ_IF_SOME(readAmount, input.tryReadSync(arrayPtr(buffer).first(n), 1)) {
+        if (readAmount == 0) co_return doneSoFar;  // EOF
+        doneSoFar += readAmount;
+        if (!output.tryWriteSync(arrayPtr(buffer).first(readAmount))) {
+          // The output needs to write asynchronously.
+          co_await output.write(arrayPtr(buffer).first(readAmount));
+          exhaustedBudget = false;
+          break;
+        }
+      } else {
+        // The input needs to read asynchronously.
+        n = kj::min(amount - doneSoFar, sizeof(buffer));
+        if (n == 0) co_return doneSoFar;
+        auto readAmount = co_await input.tryRead(buffer, 1, n);
+        if (readAmount == 0) co_return doneSoFar;  // EOF
+        doneSoFar += readAmount;
+        co_await output.write(arrayPtr(buffer).first(readAmount));
+        exhaustedBudget = false;
+        break;
+      }
+    }
+
+    if (exhaustedBudget) {
+      // Used up the synchronous budget; yield to the event loop before continuing.
+      co_await kj::evalLater([]() {});
+    }
+  }
 }
 
 Promise<uint64_t> AsyncInputStream::pumpTo(
@@ -219,6 +252,14 @@ Promise<String> AsyncInputStream::readAllText(uint64_t limit) {
   return promise.attach(kj::mv(reader));
 }
 
+bool AsyncOutputStream::tryWriteSync(ArrayPtr<const byte> buffer) {
+  return false;
+}
+
+bool AsyncOutputStream::tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) {
+  return false;
+}
+
 Maybe<Promise<uint64_t>> AsyncOutputStream::tryPumpFrom(
     AsyncInputStream& input, uint64_t amount) {
   return kj::none;
@@ -245,6 +286,17 @@ public:
       return newAdaptedPromise<ReadResult, BlockedRead>(
           *this, arrayPtr(reinterpret_cast<byte*>(buffer), maxBytes), minBytes)
           .then([](ReadResult r) { return r.byteCount; });
+    }
+  }
+
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    if (minBytes == 0) {
+      return size_t(0);
+    } else KJ_IF_SOME(s, state) {
+      return s.tryReadSync(buffer, minBytes);
+    } else {
+      // No writer is waiting, so a read cannot complete synchronously.
+      return kj::none;
     }
   }
 
@@ -322,6 +374,34 @@ public:
     } else {
       return newAdaptedPromise<void, BlockedWrite>(
           *this, pieces[0], pieces.slice(1, pieces.size()));
+    }
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    if (buffer == nullptr) {
+      // Empty writes always complete immediately, mirroring write().
+      return true;
+    } else KJ_IF_SOME(s, state) {
+      return s.tryWriteSync(buffer);
+    } else {
+      // No reader is waiting, so a write cannot complete synchronously.
+      return false;
+    }
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    while (pieces.size() > 0 && pieces[0].size() == 0) {
+      pieces = pieces.slice(1, pieces.size());
+    }
+
+    if (pieces.size() == 0) {
+      // Empty writes always complete immediately, mirroring write().
+      return true;
+    } else KJ_IF_SOME(s, state) {
+      return s.tryWriteSync(pieces);
+    } else {
+      // No reader is waiting, so a write cannot complete synchronously.
+      return false;
     }
   }
 
@@ -495,6 +575,38 @@ private:
         KJ_CASE_ONEOF(retry, Retry) {
           return pipe.tryRead(retry.buffer, retry.minBytes, retry.maxBytes)
               .then([n = retry.alreadyRead](size_t amount) { return amount + n; });
+        }
+      }
+      KJ_UNREACHABLE;
+    }
+
+    Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+      if (!canceler.isEmpty()) {
+        // A pump is already in progress; can't read synchronously.
+        return kj::none;
+      }
+
+      // tryReadImpl() cannot stop halfway: if it consumes the entire blocked write without
+      // reaching `minBytes`, it completes the write and expects the caller to continue reading
+      // from the pipe asynchronously. A synchronous read cannot do that, so we must verify in
+      // advance that enough data is buffered to satisfy `minBytes`. (Note that any FDs or
+      // streams attached to the blocked write are dropped by a plain byte read, matching
+      // tryRead()'s behavior.)
+      size_t totalAvailable = writeBuffer.size();
+      for (auto& piece: morePieces) {
+        if (totalAvailable >= minBytes) break;
+        totalAvailable += piece.size();
+      }
+      if (totalAvailable < minBytes) {
+        return kj::none;
+      }
+
+      KJ_SWITCH_ONEOF(tryReadImpl(buffer.begin(), minBytes, buffer.size())) {
+        KJ_CASE_ONEOF(done, Done) {
+          return done.result;
+        }
+        KJ_CASE_ONEOF(retry, Retry) {
+          KJ_FAIL_ASSERT("tryReadImpl() returned Retry despite sufficient buffered data");
         }
       }
       KJ_UNREACHABLE;
@@ -677,6 +789,14 @@ private:
     Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
       KJ_FAIL_REQUIRE("can't write() again until previous write() completes");
     }
+    bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+      // A write() is already in progress.
+      return false;
+    }
+    bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+      // A write() is already in progress.
+      return false;
+    }
     Promise<void> writeWithFds(ArrayPtr<const byte> data,
                               ArrayPtr<const ArrayPtr<const byte>> moreData,
                               ArrayPtr<const int> fds) override {
@@ -804,6 +924,17 @@ private:
       }, teeExceptionPromise<size_t>(fulfiller, canceler)));
     }
 
+    Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+      // In principle we could delegate to `input.tryReadSync()` here (with appropriate clamping
+      // and accounting). However, if the input were to return fewer than `minBytes` -- indicating
+      // the *input* hit EOF -- the pump would complete, but the pipe itself would not be at EOF:
+      // the read must continue waiting for a future writer. A synchronous read cannot express
+      // "here is partial data, keep waiting", and by that point the input bytes would have
+      // already been irreversibly consumed. Since we can't know in advance whether the input
+      // will hit EOF, we must not attempt a synchronous read at all.
+      return kj::none;
+    }
+
     Promise<ReadResult> tryReadWithFds(void* readBuffer, size_t minBytes, size_t maxBytes,
                                        OwnFd* fdBuffer, size_t maxFds) override {
       // Pumps drop all capabilities, so fall back to regular read. (We don't even know if the
@@ -886,6 +1017,14 @@ private:
     Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
       KJ_FAIL_REQUIRE("can't write() again until previous tryPumpFrom() completes");
     }
+    bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+      // A tryPumpFrom() is already in progress.
+      return false;
+    }
+    bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+      // A tryPumpFrom() is already in progress.
+      return false;
+    }
     Promise<void> writeWithFds(ArrayPtr<const byte> data,
                               ArrayPtr<const ArrayPtr<const byte>> moreData,
                               ArrayPtr<const int> fds) override {
@@ -942,6 +1081,10 @@ private:
     Promise<size_t> tryRead(void* readBuffer, size_t minBytes, size_t maxBytes) override {
       KJ_FAIL_REQUIRE("can't read() again until previous read() completes");
     }
+    Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+      // A read() is already in progress.
+      return kj::none;
+    }
     Promise<ReadResult> tryReadWithFds(void* readBuffer, size_t minBytes, size_t maxBytes,
                                        OwnFd* fdBuffer, size_t maxFds) override {
       KJ_FAIL_REQUIRE("can't read() again until previous read() completes");
@@ -972,6 +1115,65 @@ private:
         KJ_CASE_ONEOF(retry, Retry) {
           KJ_ASSERT(retry.moreData == nullptr);
           return pipe.write(retry.data);
+        }
+      }
+      KJ_UNREACHABLE;
+    }
+
+    bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+      if (!canceler.isEmpty()) {
+        // A tryPumpFrom() is already in progress; can't write synchronously.
+        return false;
+      }
+
+      if (buffer.size() > readBuffer.size()) {
+        // The waiting reader's buffer cannot accept the entire write. writeImpl() would complete
+        // the read and then need to deliver the remainder asynchronously, but tryWriteSync() is
+        // all-or-nothing, so we must not start.
+        return false;
+      }
+
+      KJ_SWITCH_ONEOF(writeImpl(buffer, nullptr)) {
+        KJ_CASE_ONEOF(done, Done) {
+          return true;
+        }
+        KJ_CASE_ONEOF(retry, Retry) {
+          KJ_FAIL_ASSERT("writeImpl() returned Retry despite the write fitting in the read buffer");
+        }
+      }
+      KJ_UNREACHABLE;
+    }
+
+    bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+      if (!canceler.isEmpty()) {
+        // A tryPumpFrom() is already in progress; can't write synchronously.
+        return false;
+      }
+
+      size_t total = 0;
+      for (auto& piece: pieces) {
+        total += piece.size();
+      }
+      if (total > readBuffer.size()) {
+        // The waiting reader's buffer cannot accept the entire write. writeImpl() would complete
+        // the read and then need to deliver the remainder asynchronously, but tryWriteSync() is
+        // all-or-nothing, so we must not start.
+        return false;
+      }
+
+      KJ_SWITCH_ONEOF(writeImpl(pieces[0], pieces.slice(1, pieces.size()))) {
+        KJ_CASE_ONEOF(done, Done) {
+          return true;
+        }
+        KJ_CASE_ONEOF(retry, Retry) {
+          // writeImpl() returns Retry when the reader's buffer was filled exactly; since the
+          // total fit, anything left over must be empty pieces, meaning every byte was in fact
+          // delivered, so this is success.
+          KJ_ASSERT(retry.data.size() == 0);
+          for (auto& piece: retry.moreData) {
+            KJ_ASSERT(piece.size() == 0);
+          }
+          return true;
         }
       }
       KJ_UNREACHABLE;
@@ -1229,6 +1431,10 @@ private:
     Promise<size_t> tryRead(void* readBuffer, size_t minBytes, size_t maxBytes) override {
       KJ_FAIL_REQUIRE("can't read() again until previous pumpTo() completes");
     }
+    Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+      // A pumpTo() is already in progress.
+      return kj::none;
+    }
     Promise<ReadResult> tryReadWithFds(void* readBuffer, size_t minBytes, size_t maxBytes,
                                        OwnFd* fdBuffer, size_t maxFds) override {
       KJ_FAIL_REQUIRE("can't read() again until previous pumpTo() completes");
@@ -1274,6 +1480,62 @@ private:
           return pipe.write(writeBuffer.slice(actual));
         }
       }, teeExceptionPromise<void>(fulfiller, canceler)));
+    }
+
+    bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+      if (!canceler.isEmpty()) {
+        // A write to the pump's output is already in progress.
+        return false;
+      }
+
+      if (buffer.size() > amount - pumpedSoFar) {
+        // Part of this write would fall past the end of the pump and would have to be delivered
+        // to the pipe asynchronously, but tryWriteSync() is all-or-nothing, so we must not start.
+        return false;
+      }
+
+      if (!output.tryWriteSync(buffer)) {
+        return false;
+      }
+
+      pumpedSoFar += buffer.size();
+      KJ_ASSERT(pumpedSoFar <= amount);
+      if (pumpedSoFar == amount) {
+        // Done with pump.
+        fulfiller.fulfill(kj::cp(pumpedSoFar));
+        pipe.endState(*this);
+      }
+      return true;
+    }
+
+    bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+      if (!canceler.isEmpty()) {
+        // A write to the pump's output is already in progress.
+        return false;
+      }
+
+      size_t total = 0;
+      for (auto& piece: pieces) {
+        total += piece.size();
+      }
+      if (total > amount - pumpedSoFar) {
+        // Part of this write would fall past the end of the pump and would have to be delivered
+        // to the pipe asynchronously, but tryWriteSync() is all-or-nothing, so we must not start.
+        return false;
+      }
+
+      if (!output.tryWriteSync(pieces)) {
+        return false;
+      }
+
+      pumpedSoFar += total;
+      KJ_ASSERT(pumpedSoFar <= amount);
+      if (pumpedSoFar == amount) {
+        // Done with pump.
+        fulfiller.fulfill(kj::cp(pumpedSoFar));
+        pipe.endState(*this);
+      }
+      return true;
     }
 
     Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
@@ -1433,6 +1695,9 @@ private:
     Promise<size_t> tryRead(void* readBufferPtr, size_t minBytes, size_t maxBytes) override {
       return KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called");
     }
+    Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+      kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called"));
+    }
     Promise<ReadResult> tryReadWithFds(void* readBuffer, size_t minBytes, size_t maxBytes,
                                        OwnFd* fdBuffer, size_t maxFds) override {
       return KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called");
@@ -1454,6 +1719,12 @@ private:
     }
     Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
       return KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called");
+    }
+    bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+      kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called"));
+    }
+    bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+      kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "abortRead() has been called"));
     }
     Promise<void> writeWithFds(ArrayPtr<const byte> data,
                               ArrayPtr<const ArrayPtr<const byte>> moreData,
@@ -1506,6 +1777,10 @@ private:
     Promise<size_t> tryRead(void* readBufferPtr, size_t minBytes, size_t maxBytes) override {
       return constPromise<size_t, 0>();
     }
+    Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+      // EOF is a perfectly good synchronous answer.
+      return size_t(0);
+    }
     Promise<ReadResult> tryReadWithFds(void* readBuffer, size_t minBytes, size_t maxBytes,
                                        OwnFd* fdBuffer, size_t maxFds) override {
       return ReadResult { 0, 0 };
@@ -1526,6 +1801,12 @@ private:
       KJ_FAIL_REQUIRE("shutdownWrite() has been called");
     }
     Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+      KJ_FAIL_REQUIRE("shutdownWrite() has been called");
+    }
+    bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+      KJ_FAIL_REQUIRE("shutdownWrite() has been called");
+    }
+    bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
       KJ_FAIL_REQUIRE("shutdownWrite() has been called");
     }
     Promise<void> writeWithFds(ArrayPtr<const byte> data,
@@ -1564,6 +1845,10 @@ public:
     return pipe->tryRead(buffer, minBytes, maxBytes);
   }
 
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    return pipe->tryReadSync(buffer, minBytes);
+  }
+
   Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
     return pipe->pumpTo(output, amount);
   }
@@ -1588,6 +1873,14 @@ public:
 
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
     return pipe->write(pieces);
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    return pipe->tryWriteSync(buffer);
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    return pipe->tryWriteSync(pieces);
   }
 
   Maybe<Promise<uint64_t>> tryPumpFrom(
@@ -1618,6 +1911,9 @@ public:
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
     return in->tryRead(buffer, minBytes, maxBytes);
   }
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    return in->tryReadSync(buffer, minBytes);
+  }
   Promise<ReadResult> tryReadWithFds(void* buffer, size_t minBytes, size_t maxBytes,
                                       OwnFd* fdBuffer, size_t maxFds) override {
     return in->tryReadWithFds(buffer, minBytes, maxBytes, fdBuffer, maxFds);
@@ -1639,6 +1935,12 @@ public:
   }
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
     return out->write(pieces);
+  }
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    return out->tryWriteSync(buffer);
+  }
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    return out->tryWriteSync(pieces);
   }
   Promise<void> writeWithFds(ArrayPtr<const byte> data,
                              ArrayPtr<const ArrayPtr<const byte>> moreData,
@@ -1687,6 +1989,20 @@ public:
       decreaseLimit(actual, minBytes);
       return actual;
     });
+  }
+
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    if (limit == 0) return size_t(0);
+    KJ_IF_SOME(actual, inner->tryReadSync(
+        buffer.first(kj::min(buffer.size(), limit)), kj::min(minBytes, limit))) {
+      // Note: Only update the limit if the inner read actually happened. If the inner stream
+      // returned kj::none, our state must remain untouched so that the caller can fall back to
+      // tryRead().
+      decreaseLimit(actual, minBytes);
+      return actual;
+    } else {
+      return kj::none;
+    }
   }
 
   Promise<uint64_t> pumpTo(AsyncOutputStream& output, uint64_t amount) override {
@@ -2398,6 +2714,15 @@ public:
     }
   }
 
+  kj::Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    KJ_IF_SOME(s, stream) {
+      return s->tryReadSync(buffer, minBytes);
+    } else {
+      // Promise not yet resolved.
+      return kj::none;
+    }
+  }
+
   kj::Maybe<uint64_t> tryGetLength() override {
     KJ_IF_SOME(s, stream) {
       return s->tryGetLength();
@@ -2432,6 +2757,24 @@ public:
       return promise.addBranch().then([this,pieces]() {
         return KJ_ASSERT_NONNULL(stream)->write(pieces);
       });
+    }
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    KJ_IF_SOME(s, stream) {
+      return s->tryWriteSync(buffer);
+    } else {
+      // Promise not yet resolved.
+      return false;
+    }
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    KJ_IF_SOME(s, stream) {
+      return s->tryWriteSync(pieces);
+    } else {
+      // Promise not yet resolved.
+      return false;
     }
   }
 
@@ -2536,6 +2879,24 @@ public:
     }
   }
 
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    KJ_IF_SOME(s, stream) {
+      return s->tryWriteSync(buffer);
+    } else {
+      // Promise not yet resolved.
+      return false;
+    }
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    KJ_IF_SOME(s, stream) {
+      return s->tryWriteSync(pieces);
+    } else {
+      // Promise not yet resolved.
+      return false;
+    }
+  }
+
   kj::Maybe<kj::Promise<uint64_t>> tryPumpFrom(
       kj::AsyncInputStream& input, uint64_t amount = kj::maxValue) override {
     KJ_IF_SOME(s, stream) {
@@ -2588,6 +2949,15 @@ public:
       return promise.addBranch().then([this,buffer,minBytes,maxBytes]() {
         return KJ_ASSERT_NONNULL(stream)->tryRead(buffer, minBytes, maxBytes);
       });
+    }
+  }
+
+  kj::Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    KJ_IF_SOME(s, stream) {
+      return s->tryReadSync(buffer, minBytes);
+    } else {
+      // Promise not yet resolved.
+      return kj::none;
     }
   }
 
@@ -2876,6 +3246,13 @@ Promise<size_t> FileInputStream::tryRead(void* buffer, size_t minBytes, size_t m
   return result;
 }
 
+Maybe<size_t> FileInputStream::tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) {
+  // File reads are always synchronous anyway. (See the comment in tryRead() regarding `minBytes`.)
+  size_t result = file.read(offset, buffer);
+  offset += result;
+  return result;
+}
+
 Maybe<uint64_t> FileInputStream::tryGetLength() {
   uint64_t size = file.stat().size;
   return offset < size ? size - offset : 0;
@@ -2894,6 +3271,22 @@ Promise<void> FileOutputStream::write(ArrayPtr<const ArrayPtr<const byte>> piece
     offset += piece.size();
   }
   return kj::READY_NOW;
+}
+
+bool FileOutputStream::tryWriteSync(ArrayPtr<const byte> buffer) {
+  // File writes are always synchronous anyway.
+  file.write(offset, buffer);
+  offset += buffer.size();
+  return true;
+}
+
+bool FileOutputStream::tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) {
+  // File writes are always synchronous anyway.
+  for (auto piece: pieces) {
+    file.write(offset, piece);
+    offset += piece.size();
+  }
+  return true;
 }
 
 Promise<void> FileOutputStream::whenWriteDisconnected() {

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -64,6 +64,38 @@ public:
   // Read at least `minBytes` from the stream. Performs partial read if there is not enough data.
   // Returns total number of bytes read. Return value less than `minBytes` indicates EOF.
 
+  virtual Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) KJ_WARN_UNUSED_RESULT;
+  // Attempt to perform a synchronous read, as an optimization to avoid promise overhead when data
+  // is already available (e.g. in an in-memory buffer). Returns kj::none if the read cannot be
+  // completed synchronously, in which case the caller should fall back to tryRead().
+  //
+  // Semantics match tryRead(): at least `minBytes` are read, `buffer.size()` acts as the maximum,
+  // and a return value less than `minBytes` indicates EOF. `minBytes` must not exceed
+  // `buffer.size()`.
+  //
+  // tryReadSync() returns kj::none whenever a synchronous read is not possible, for example:
+  // - Answering the read would require waiting for asynchronous I/O.
+  // An implementation MUST NOT have side effects when returning kj::none: the caller may
+  // immediately invoke tryRead() with the same arguments and must observe the same result as if
+  // tryReadSync() had never been called.
+  //
+  // Calling tryReadSync() while an asynchronous operation (tryRead() or pumpTo()) is already in
+  // progress on this stream is a programming error and may throw.
+  //
+  // An implementation may throw if the stream is in an errored state, or if a synchronous read is
+  // possible but the read itself fails (e.g. a decompression error on already-buffered data). In
+  // that case the stream state may be affected, exactly as if tryRead() had been called and the
+  // returned promise rejected.
+  //
+  // The default implementation always returns kj::none. Subclasses should override this if they
+  // can sometimes serve reads synchronously. Callers use the pattern:
+  //
+  //     KJ_IF_SOME(n, stream.tryReadSync(buffer, minBytes)) {
+  //       // ... use `n` immediately, no promise needed ...
+  //     } else {
+  //       // fall back to stream.tryRead()
+  //     }
+
   Promise<void> read(ArrayPtr<byte> buffer) {
     // Reads a complete buffer from the stream. Throws an exception if there is not enough data.
     return read(buffer, buffer.size()).ignoreResult();
@@ -121,6 +153,43 @@ public:
   virtual Promise<void> write(ArrayPtr<const byte> buffer) KJ_WARN_UNUSED_RESULT = 0;
   virtual Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces)
       KJ_WARN_UNUSED_RESULT = 0;
+
+  virtual bool tryWriteSync(ArrayPtr<const byte> buffer) KJ_WARN_UNUSED_RESULT;
+  // Attempt to perform a synchronous write, as an optimization to avoid promise overhead when the
+  // stream can accept the bytes immediately (e.g. into an in-memory buffer or a waiting reader).
+  // Returns false if the write cannot be completed synchronously, in which case the caller should
+  // fall back to write().
+  //
+  // This is all-or-nothing: either the entire buffer is written synchronously (returns true), or
+  // nothing is written at all (returns false). There is no partial-write case.
+  //
+  // tryWriteSync() returns false whenever a synchronous write is not possible, for example:
+  // - The underlying transport would need to perform asynchronous I/O.
+  // An implementation MUST NOT have side effects when returning false: the caller may immediately
+  // invoke write() with the same arguments and must observe the same result as if tryWriteSync()
+  // had never been called.
+  //
+  // Calling tryWriteSync() while an asynchronous operation (write() or tryPumpFrom()) is already
+  // in progress on this stream is a programming error and may throw.
+  //
+  // If the stream is in an errored or shut-down state, the method may throw the appropriate
+  // exception rather than returning false.
+  //
+  // An implementation may also throw if a synchronous write is possible but the write itself
+  // fails. In that case the stream state may be affected, exactly as if write() had been called
+  // and the returned promise rejected.
+  //
+  // The default implementation always returns false. Subclasses should override this if they can
+  // sometimes accept writes synchronously.
+
+  virtual bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) KJ_WARN_UNUSED_RESULT;
+  // Scatter-gather variant of tryWriteSync(). Either every byte of every piece is written
+  // synchronously (returns true), or nothing is written at all (returns false). All other rules
+  // of tryWriteSync() apply.
+  //
+  // The default implementation always returns false. Note that an implementation cannot
+  // generally be composed from repeated single-buffer tryWriteSync() calls: a refusal partway
+  // through would violate the all-or-nothing contract.
 
   virtual Maybe<Promise<uint64_t>> tryPumpFrom(
       AsyncInputStream& input, uint64_t amount = kj::maxValue);
@@ -199,11 +268,14 @@ class NullStream final: public AsyncIoStream {
   // Hint: You can also use this class when you just need an input stream or an output stream.
 public:
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+  kj::Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override;
   kj::Maybe<uint64_t> tryGetLength() override;
   kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override;
 
   kj::Promise<void> write(ArrayPtr<const byte> buffer) override;
   kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override;
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override;
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
   kj::Promise<void> whenWriteDisconnected() override;
 
   void shutdownWrite() override;
@@ -1087,6 +1159,7 @@ public:
   void seek(uint64_t newOffset) { offset = newOffset; }
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override;
   Maybe<uint64_t> tryGetLength() override;
 
   // (pumpTo() is not actually overridden here, but AsyncStreamFd's tryPumpFrom() will detect when
@@ -1118,6 +1191,8 @@ public:
 
   Promise<void> write(kj::ArrayPtr<const byte> buffer) override;
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override;
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
   Promise<void> whenWriteDisconnected() override;
 
 private:

--- a/c++/src/kj/compat/brotli-test.c++
+++ b/c++/src/kj/compat/brotli-test.c++
@@ -263,6 +263,69 @@ KJ_TEST("async brotli decompression") {
   }
 }
 
+KJ_TEST("async brotli tryReadSync") {
+  auto io = setupAsyncIo();
+
+  {
+    MockAsyncInputStream rawInput(FOOBAR_BR, kj::maxValue);
+    BrotliAsyncInputStream brotli(rawInput);
+
+    byte text[16]{};
+
+    // Nothing is buffered yet, so no synchronous read is possible.
+    KJ_EXPECT(brotli.tryReadSync(arrayPtr(text), 1) == kj::none);
+
+    // While an asynchronous read is in progress, concurrent synchronous reads are a programming
+    // error.
+    auto readPromise = brotli.tryRead(text, 3, 3);
+    KJ_EXPECT_THROW_MESSAGE("concurrent read operations not allowed",
+        brotli.tryReadSync(arrayPtr(text), 1));
+
+    // The asynchronous read buffers the entire compressed input but only decompresses what was
+    // asked for.
+    KJ_EXPECT(readPromise.wait(io.waitScope) == 3);
+    KJ_EXPECT(arrayPtr(text).first(3) == "foo"_kjb);
+
+    // minBytes > 1 cannot be guaranteed synchronously, so it is refused (with no side effects).
+    KJ_EXPECT(brotli.tryReadSync(arrayPtr(text), 2) == kj::none);
+
+    // The rest of the data can be decompressed synchronously from the buffered input.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(brotli.tryReadSync(arrayPtr(text), 1)) == 3);
+    KJ_EXPECT(arrayPtr(text).first(3) == "bar"_kjb);
+
+    // All buffered input has been consumed; EOF detection requires the async path.
+    KJ_EXPECT(brotli.tryReadSync(arrayPtr(text), 1) == kj::none);
+    KJ_EXPECT(brotli.tryRead(text, 1, sizeof(text)).wait(io.waitScope) == 0);
+  }
+
+  // Concatenated brotli streams decompress synchronously as well.
+  {
+    Vector<byte> bytes;
+    bytes.addAll(ArrayPtr<const byte>(FOOBAR_BR));
+    bytes.addAll(ArrayPtr<const byte>(FOOBAR_BR));
+    MockAsyncInputStream rawInput(bytes, kj::maxValue);
+    BrotliAsyncInputStream brotli(rawInput);
+
+    byte text[16]{};
+
+    // Buffer all compressed input with a small initial async read.
+    KJ_EXPECT(brotli.tryRead(text, 1, 1).wait(io.waitScope) == 1);
+    KJ_EXPECT(text[0] == 'f');
+
+    // The remainder of the first stream is served synchronously; the stream boundary resets the
+    // decoder.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(brotli.tryReadSync(arrayPtr(text), 1)) == 5);
+    KJ_EXPECT(arrayPtr(text).first(5) == "oobar"_kjb);
+
+    // The second stream is served synchronously too.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(brotli.tryReadSync(arrayPtr(text), 1)) == 6);
+    KJ_EXPECT(arrayPtr(text).first(6) == "foobar"_kjb);
+
+    KJ_EXPECT(brotli.tryReadSync(arrayPtr(text), 1) == kj::none);
+    KJ_EXPECT(brotli.tryRead(text, 1, sizeof(text)).wait(io.waitScope) == 0);
+  }
+}
+
 KJ_TEST("brotli compression") {
   // Normal write.
   {

--- a/c++/src/kj/compat/brotli.c++
+++ b/c++/src/kj/compat/brotli.c++
@@ -261,9 +261,66 @@ BrotliAsyncInputStream::~BrotliAsyncInputStream() noexcept(false) {
 }
 
 Promise<size_t> BrotliAsyncInputStream::tryRead(void* out, size_t minBytes, size_t maxBytes) {
-  if (maxBytes == 0) return constPromise<size_t, 0>();
+  if (maxBytes == 0) co_return 0;
+  readInProgress = true;
+  KJ_DEFER(readInProgress = false);
+  co_return co_await readImpl(reinterpret_cast<byte*>(out), minBytes, maxBytes, 0);
+}
 
-  return readImpl(reinterpret_cast<byte*>(out), minBytes, maxBytes, 0);
+Maybe<size_t> BrotliAsyncInputStream::tryReadSync(ArrayPtr<byte> out, size_t minBytes) {
+  if (out.size() == 0) return size_t(0);  // mirrors tryRead()
+  KJ_REQUIRE(!readInProgress, "concurrent read operations not allowed");
+  if (minBytes > 1) {
+    // If decompressing the buffered input were to produce more than zero but fewer than
+    // `minBytes` bytes, we would be stuck: we can neither return a short count (which would
+    // falsely signal EOF) nor undo the decompression. Since the output size of compressed data
+    // cannot be predicted, only accept reads that any nonzero amount of output can satisfy.
+    // (Performance-sensitive callers, like pump loops, use minBytes == 1.)
+    return kj::none;
+  }
+
+  while (availableIn > 0 || BrotliDecoderHasMoreOutput(ctx)) {
+    // Decompress from already-buffered compressed input, mirroring readImpl().
+    byte* nextOut = out.begin();
+    size_t availableOut = out.size();
+
+    // Check window bits
+    if (firstInput && availableIn) {
+      firstInput = false;
+      int streamWbits = getBrotliWindowBits(nextIn[0]);
+      KJ_REQUIRE(streamWbits <= windowBits,
+          "brotli window size too big", (1 << streamWbits));
+    }
+    BrotliDecoderResult result = BrotliDecoderDecompressStream(
+        ctx, &availableIn, &nextIn, &availableOut, &nextOut, nullptr);
+    // A synchronous read was possible, but the data is corrupt; throw just like the async path
+    // would have.
+    KJ_REQUIRE(result != BROTLI_DECODER_RESULT_ERROR, "brotli decompression failed",
+               BrotliDecoderErrorString(BrotliDecoderGetErrorCode(ctx)));
+
+    atValidEndpoint = result == BROTLI_DECODER_RESULT_SUCCESS;
+    if (atValidEndpoint && availableIn > 0) {
+      // There's more data available. Assume start of new content, as in readImpl().
+      BrotliDecoderDestroyInstance(ctx);
+      ctx = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
+      KJ_REQUIRE(ctx, "brotli state allocation failed");
+      firstInput = true;
+    }
+
+    size_t n = out.size() - availableOut;
+    if (n >= minBytes) {
+      return n;
+    }
+
+    // No output was produced (n == 0, since minBytes <= 1). If buffered input remains (e.g. we
+    // just reset at a stream boundary), try again; otherwise fall back to the async path.
+    //
+    // Note that having consumed buffered input without producing output is not an observable
+    // side effect: the decompressor retains that data internally, and a subsequent tryRead()
+    // will return exactly the same bytes it would have returned anyway.
+  }
+
+  return kj::none;
 }
 
 Promise<size_t> BrotliAsyncInputStream::readImpl(

--- a/c++/src/kj/compat/brotli.h
+++ b/c++/src/kj/compat/brotli.h
@@ -135,12 +135,14 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(BrotliAsyncInputStream);
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override;
 
 private:
   AsyncInputStream& inner;
   BrotliDecoderState* ctx;
   int windowBits;
   bool atValidEndpoint = false;
+  bool readInProgress = false;
 
   byte buffer[_::KJ_BROTLI_BUF_SIZE];
   const byte* nextIn;

--- a/c++/src/kj/compat/gzip-test.c++
+++ b/c++/src/kj/compat/gzip-test.c++
@@ -222,6 +222,69 @@ KJ_TEST("async gzip decompression") {
   }
 }
 
+KJ_TEST("async gzip tryReadSync") {
+  auto io = setupAsyncIo();
+
+  {
+    MockAsyncInputStream rawInput(FOOBAR_GZIP, kj::maxValue);
+    GzipAsyncInputStream gzip(rawInput);
+
+    byte text[16]{};
+
+    // Nothing is buffered yet, so no synchronous read is possible.
+    KJ_EXPECT(gzip.tryReadSync(arrayPtr(text), 1) == kj::none);
+
+    // While an asynchronous read is in progress, concurrent synchronous reads are a programming
+    // error.
+    auto readPromise = gzip.tryRead(text, 3, 3);
+    KJ_EXPECT_THROW_MESSAGE("concurrent read operations not allowed",
+        gzip.tryReadSync(arrayPtr(text), 1));
+
+    // The asynchronous read buffers the entire compressed input but only decompresses what was
+    // asked for.
+    KJ_EXPECT(readPromise.wait(io.waitScope) == 3);
+    KJ_EXPECT(arrayPtr(text).first(3) == "foo"_kjb);
+
+    // minBytes > 1 cannot be guaranteed synchronously, so it is refused (with no side effects).
+    KJ_EXPECT(gzip.tryReadSync(arrayPtr(text), 2) == kj::none);
+
+    // The rest of the data can be decompressed synchronously from the buffered input.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(gzip.tryReadSync(arrayPtr(text), 1)) == 3);
+    KJ_EXPECT(arrayPtr(text).first(3) == "bar"_kjb);
+
+    // All buffered input has been consumed; EOF detection requires the async path.
+    KJ_EXPECT(gzip.tryReadSync(arrayPtr(text), 1) == kj::none);
+    KJ_EXPECT(gzip.tryRead(text, 1, sizeof(text)).wait(io.waitScope) == 0);
+  }
+
+  // Concatenated gzip members decompress synchronously as well.
+  {
+    Vector<byte> bytes;
+    bytes.addAll(ArrayPtr<const byte>(FOOBAR_GZIP));
+    bytes.addAll(ArrayPtr<const byte>(FOOBAR_GZIP));
+    MockAsyncInputStream rawInput(bytes, kj::maxValue);
+    GzipAsyncInputStream gzip(rawInput);
+
+    byte text[16]{};
+
+    // Buffer all compressed input with a small initial async read.
+    KJ_EXPECT(gzip.tryRead(text, 1, 1).wait(io.waitScope) == 1);
+    KJ_EXPECT(text[0] == 'f');
+
+    // The remainder of the first member is served synchronously; the member boundary resets the
+    // decompressor.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(gzip.tryReadSync(arrayPtr(text), 1)) == 5);
+    KJ_EXPECT(arrayPtr(text).first(5) == "oobar"_kjb);
+
+    // The second member is served synchronously too.
+    KJ_EXPECT(KJ_ASSERT_NONNULL(gzip.tryReadSync(arrayPtr(text), 1)) == 6);
+    KJ_EXPECT(arrayPtr(text).first(6) == "foobar"_kjb);
+
+    KJ_EXPECT(gzip.tryReadSync(arrayPtr(text), 1) == kj::none);
+    KJ_EXPECT(gzip.tryRead(text, 1, sizeof(text)).wait(io.waitScope) == 0);
+  }
+}
+
 KJ_TEST("gzip compression") {
   // Normal write.
   {

--- a/c++/src/kj/compat/gzip.c++
+++ b/c++/src/kj/compat/gzip.c++
@@ -189,9 +189,60 @@ GzipAsyncInputStream::~GzipAsyncInputStream() noexcept(false) {
 }
 
 Promise<size_t> GzipAsyncInputStream::tryRead(void* out, size_t minBytes, size_t maxBytes) {
-  if (maxBytes == 0) return constPromise<size_t, 0>();
+  if (maxBytes == 0) co_return 0;
+  readInProgress = true;
+  KJ_DEFER(readInProgress = false);
+  co_return co_await readImpl(reinterpret_cast<byte*>(out), minBytes, maxBytes, 0);
+}
 
-  return readImpl(reinterpret_cast<byte*>(out), minBytes, maxBytes, 0);
+Maybe<size_t> GzipAsyncInputStream::tryReadSync(ArrayPtr<byte> out, size_t minBytes) {
+  if (out.size() == 0) return size_t(0);  // mirrors tryRead()
+  KJ_REQUIRE(!readInProgress, "concurrent read operations not allowed");
+  if (minBytes > 1) {
+    // If decompressing the buffered input were to produce more than zero but fewer than
+    // `minBytes` bytes, we would be stuck: we can neither return a short count (which would
+    // falsely signal EOF) nor undo the decompression. Since the output size of compressed data
+    // cannot be predicted, only accept reads that any nonzero amount of output can satisfy.
+    // (Performance-sensitive callers, like pump loops, use minBytes == 1.)
+    return kj::none;
+  }
+
+  while (ctx.avail_in > 0) {
+    // Decompress from already-buffered compressed input, mirroring readImpl().
+    ctx.next_out = out.begin();
+    ctx.avail_out = out.size();
+
+    auto inflateResult = inflate(&ctx, Z_NO_FLUSH);
+    atValidEndpoint = inflateResult == Z_STREAM_END;
+    if (inflateResult != Z_OK && inflateResult != Z_STREAM_END) {
+      // A synchronous read was possible, but the data is corrupt; throw just like the async path
+      // would have.
+      if (ctx.msg == nullptr) {
+        KJ_FAIL_REQUIRE("gzip decompression failed", inflateResult);
+      } else {
+        KJ_FAIL_REQUIRE("gzip decompression failed", ctx.msg);
+      }
+    }
+
+    if (atValidEndpoint && ctx.avail_in > 0) {
+      // There's more data available. Assume start of new content.
+      KJ_ASSERT(inflateReset(&ctx) == Z_OK);
+    }
+
+    size_t n = out.size() - ctx.avail_out;
+    if (n >= minBytes) {
+      return n;
+    }
+
+    // No output was produced (n == 0, since minBytes <= 1). If buffered input remains (e.g. we
+    // just reset at a member boundary), try again; otherwise fall back to the async path.
+    //
+    // Note that having consumed buffered input without producing output is not an observable
+    // side effect: the decompressor retains that data internally, and a subsequent tryRead()
+    // will return exactly the same bytes it would have returned anyway.
+  }
+
+  return kj::none;
 }
 
 Promise<size_t> GzipAsyncInputStream::readImpl(

--- a/c++/src/kj/compat/gzip.h
+++ b/c++/src/kj/compat/gzip.h
@@ -103,11 +103,13 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(GzipAsyncInputStream);
 
   Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override;
 
 private:
   AsyncInputStream& inner;
   z_stream ctx = {};
   bool atValidEndpoint = false;
+  bool readInProgress = false;
 
   kj::Array<byte> buffer = kj::heapArray<byte>(_::KJ_GZ_BUF_SIZE);
 

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1280,6 +1280,152 @@ KJ_TEST("HttpClient chunked body gather-write") {
                     "b\r\nfoo bar baz\r\n0\r\n\r\n", text);
 }
 
+KJ_TEST("HttpClient fixed-length body tryWriteSync") {
+  KJ_HTTP_TEST_SETUP_IO;
+
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  {
+    HttpHeaderTable table;
+    auto client = newHttpClient(table, *pipe.ends[0]);
+
+    auto req = client->request(HttpMethod::POST, "/", HttpHeaders(table), uint64_t(6));
+
+    // The headers are still queued and have not been flushed, so a synchronous body write is
+    // refused.
+    KJ_EXPECT(!req.body->tryWriteSync("foo"_kjb));
+
+    // Write the first part of the body asynchronously; this flushes the headers.
+    auto readHeaders = expectRead(*pipe.ends[1],
+        "POST / HTTP/1.1\r\nContent-Length: 6\r\n\r\nfoo");
+    req.body->write("foo"_kjb).wait(waitScope);
+    readHeaders.wait(waitScope);
+
+    // Now start a read on the server end, then try a synchronous write.
+    auto readBody = expectRead(*pipe.ends[1], "bar");
+    if (!req.body->tryWriteSync("bar"_kjb)) {
+#if KJ_HTTP_TEST_USE_OS_PIPE
+      // OS sockets don't support synchronous writes; fall back to the async path.
+      req.body->write("bar"_kjb).wait(waitScope);
+#else
+      KJ_FAIL_EXPECT("expected in-memory pipe to accept synchronous write");
+      req.body->write("bar"_kjb).wait(waitScope);
+#endif
+    }
+    readBody.wait(waitScope);
+    req.body = nullptr;
+
+    kj::StringPtr responseText = "HTTP/1.1 204 No Content\r\n\r\n";
+    pipe.ends[1]->write(responseText.asBytes()).wait(waitScope);
+    auto response = req.response.wait(waitScope);
+    KJ_EXPECT(response.statusCode == 204);
+
+    // A 204 response has no body; EOF is available synchronously.
+    byte buf[8]{};
+    KJ_EXPECT(KJ_ASSERT_NONNULL(response.body->tryReadSync(arrayPtr(buf), 1)) == 0);
+  }
+}
+
+KJ_TEST("HttpClient chunked body tryWriteSync") {
+  KJ_HTTP_TEST_SETUP_IO;
+
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  {
+    HttpHeaderTable table;
+    auto client = newHttpClient(table, *pipe.ends[0]);
+
+    auto req = client->request(HttpMethod::POST, "/", HttpHeaders(table));
+
+    // The headers are still queued and have not been flushed, so a synchronous body write is
+    // refused.
+    KJ_EXPECT(!req.body->tryWriteSync("foo"_kjb));
+
+    // Write the first chunk asynchronously; this flushes the headers.
+    auto readHeaders = expectRead(*pipe.ends[1],
+        "POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nfoo\r\n");
+    req.body->write("foo"_kjb).wait(waitScope);
+    readHeaders.wait(waitScope);
+
+    // A single-buffer synchronous write is delivered as one complete chunk.
+    {
+      auto readChunk = expectRead(*pipe.ends[1], "3\r\nbar\r\n");
+      if (!req.body->tryWriteSync("bar"_kjb)) {
+#if KJ_HTTP_TEST_USE_OS_PIPE
+        req.body->write("bar"_kjb).wait(waitScope);
+#else
+        KJ_FAIL_EXPECT("expected in-memory pipe to accept synchronous write");
+        req.body->write("bar"_kjb).wait(waitScope);
+#endif
+      }
+      readChunk.wait(waitScope);
+    }
+
+    // A gather synchronous write is delivered as a single chunk.
+    {
+      auto readChunk = expectRead(*pipe.ends[1], "6\r\nbazqux\r\n");
+      kj::ArrayPtr<const byte> parts[] = {"baz"_kjb, "qux"_kjb};
+      if (!req.body->tryWriteSync(kj::arrayPtr(parts, kj::size(parts)))) {
+#if KJ_HTTP_TEST_USE_OS_PIPE
+        req.body->write(kj::arrayPtr(parts, kj::size(parts))).wait(waitScope);
+#else
+        KJ_FAIL_EXPECT("expected in-memory pipe to accept synchronous write");
+        req.body->write(kj::arrayPtr(parts, kj::size(parts))).wait(waitScope);
+#endif
+      }
+      readChunk.wait(waitScope);
+    }
+
+    // Finish the body; the terminating chunk is written asynchronously via the queue.
+    auto readEnd = expectRead(*pipe.ends[1], "0\r\n\r\n");
+    req.body = nullptr;
+
+    kj::StringPtr responseText = "HTTP/1.1 204 No Content\r\n\r\n";
+    pipe.ends[1]->write(responseText.asBytes()).wait(waitScope);
+    auto response = req.response.wait(waitScope);
+    KJ_EXPECT(response.statusCode == 204);
+    readEnd.wait(waitScope);
+  }
+}
+
+KJ_TEST("HttpClient response body tryReadSync") {
+  KJ_HTTP_TEST_SETUP_IO;
+
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  HttpHeaderTable table;
+  auto client = newHttpClient(table, *pipe.ends[0]);
+
+  auto req = client->request(HttpMethod::GET, "/", HttpHeaders(table));
+  req.body = nullptr;
+
+  auto serverTask = expectRead(*pipe.ends[1], "GET / HTTP/1.1\r\n\r\n")
+      .then([&]() {
+    return pipe.ends[1]->write("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nfoo"_kjb);
+  });
+
+  auto response = req.response.wait(waitScope);
+  serverTask.wait(waitScope);
+  KJ_EXPECT(response.statusCode == 200);
+
+  byte buf[8]{};
+
+  // The body has not been fully consumed, so the reader's state machine refuses a synchronous
+  // read regardless of the transport.
+  KJ_EXPECT(response.body->tryReadSync(arrayPtr(buf), 1) == kj::none);
+
+  // Read the full 6-byte body asynchronously.
+  KJ_EXPECT(response.body->tryRead(buf, 3, 3).wait(waitScope) == 3);
+  KJ_EXPECT(arrayPtr(buf).first(3) == "foo"_kjb);
+  auto writeRest = pipe.ends[1]->write("bar"_kjb);
+  KJ_EXPECT(response.body->tryRead(buf, 3, 3).wait(waitScope) == 3);
+  KJ_EXPECT(arrayPtr(buf).first(3) == "bar"_kjb);
+  writeRest.wait(waitScope);
+
+  // The reader reached Content-Length, so EOF is now available synchronously.
+  KJ_EXPECT(KJ_ASSERT_NONNULL(response.body->tryReadSync(arrayPtr(buf), 1)) == 0);
+}
+
 KJ_TEST("HttpClient chunked body pump from fixed length stream") {
   class FixedBodyStream final: public kj::AsyncInputStream {
     Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -2038,6 +2038,17 @@ public:
     }
   }
 
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    if (finished) {
+      // Already reached the end of the entity body; EOF is a valid synchronous answer.
+      //
+      // Note that if the underlying connection went away (`weakInner` is none but `finished` is
+      // false), we return kj::none instead, so that the async path can surface the error.
+      return size_t(0);
+    }
+    return kj::none;
+  }
+
 protected:
   HttpInputStreamImpl& getInner() {
     KJ_IF_SOME(i, weakInner) {
@@ -2496,6 +2507,7 @@ public:
     writeQueue = fork.addBranch();
 
     co_await fork;
+    writeQueueDrained = true;
     co_await inner.write(buffer);
 
     // We intentionally don't use KJ_DEFER to clean this up because if an exception is thrown, we
@@ -2512,11 +2524,30 @@ public:
     writeQueue = fork.addBranch();
 
     co_await fork;
+    writeQueueDrained = true;
     co_await inner.write(pieces);
 
     // We intentionally don't use KJ_DEFER to clean this up because if an exception is thrown, we
     // want to block further writes.
     writeInProgress = false;
+  }
+
+  bool tryWriteBodyDataSync(ArrayPtr<const byte> buffer) {
+    // Synchronous counterpart to writeBodyData(): attempt to write the data via the inner
+    // stream's tryWriteSync(). Returns false if queued writes (e.g. headers or chunk boundaries)
+    // have not been observed to drain yet, or if the inner stream cannot accept the data
+    // synchronously. Concurrent writes or writing outside a body are programming errors.
+    KJ_REQUIRE(!writeInProgress, "concurrent write()s not allowed");
+    KJ_REQUIRE(inBody);
+    if (!writeQueueDrained) return false;
+    return inner.tryWriteSync(buffer);
+  }
+
+  bool tryWriteBodyDataSync(ArrayPtr<const ArrayPtr<const byte>> pieces) {
+    KJ_REQUIRE(!writeInProgress, "concurrent write()s not allowed");
+    KJ_REQUIRE(inBody);
+    if (!writeQueueDrained) return false;
+    return inner.tryWriteSync(pieces);
   }
 
   Promise<uint64_t> pumpBodyFrom(AsyncInputStream& input, uint64_t amount) {
@@ -2528,6 +2559,7 @@ public:
     writeQueue = fork.addBranch();
 
     co_await fork;
+    writeQueueDrained = true;
     auto actual = co_await input.pumpTo(inner, amount);
 
     // We intentionally don't use KJ_DEFER to clean this up because if an exception is thrown, we
@@ -2550,6 +2582,7 @@ public:
       // Cancel any writes that are still queued.
       writeQueue = KJ_EXCEPTION(FAILED,
           "previous HTTP message body incomplete; can't write more messages");
+      writeQueueDrained = false;
     }
   }
 
@@ -2562,6 +2595,7 @@ public:
     // Cancel any writes that are still queued.
     writeQueue = KJ_EXCEPTION(FAILED,
         "previous HTTP message body incomplete; can't write more messages");
+    writeQueueDrained = false;
   }
 
   kj::Promise<void> flush() {
@@ -2587,6 +2621,12 @@ private:
   // a write throws an exception or is canceled, this remains true forever. In these cases, the
   // underlying stream is in an inconsistent state and cannot be reused.
 
+  bool writeQueueDrained = true;
+  // True if `writeQueue` is known to have fully drained (i.e. it is safe to write body data
+  // directly to `inner` synchronously). We cannot inspect a promise's readiness synchronously,
+  // so this is tracked explicitly: queueWrite() clears it, and the body-write methods set it
+  // after their `co_await` of the queue completes.
+
   void queueWrite(kj::String content) {
     // We only use queueWrite() in cases where we can take ownership of the write buffer, and where
     // it is convenient if we can return `void` rather than a promise.  In particular, this is used
@@ -2599,6 +2639,7 @@ private:
       auto promise = inner.write(content.asBytes());
       return promise.attach(kj::mv(content));
     });
+    writeQueueDrained = false;
   }
 };
 
@@ -2669,6 +2710,12 @@ public:
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
     return kj::READY_NOW;
   }
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    return true;
+  }
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    return true;
+  }
   Promise<void> whenWriteDisconnected() override {
     return kj::NEVER_DONE;
   }
@@ -2700,6 +2747,33 @@ public:
 
     co_await getInner().writeBodyData(pieces);
     if (length == 0) doneWriting();
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    if (buffer == nullptr) return true;  // mirrors write()
+    if (alreadyDone()) return false;     // let the async path surface the error
+    if (buffer.size() > length) return false;  // async path will throw "overwrote Content-Length"
+
+    if (!getInner().tryWriteBodyDataSync(buffer)) return false;
+
+    length -= buffer.size();
+    if (length == 0) doneWriting();
+    return true;
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    uint64_t size = 0;
+    for (auto& piece: pieces) size += piece.size();
+
+    if (size == 0) return true;  // mirrors write()
+    if (alreadyDone()) return false;
+    if (size > length) return false;
+
+    if (!getInner().tryWriteBodyDataSync(pieces)) return false;
+
+    length -= size;
+    if (length == 0) doneWriting();
+    return true;
   }
 
   Maybe<Promise<uint64_t>> tryPumpFrom(AsyncInputStream& input, uint64_t amount) override {
@@ -2801,6 +2875,37 @@ public:
     auto parts = partsBuilder.finish();
     auto promise = getInner().writeBodyData(parts.asPtr());
     return promise.attach(kj::mv(header), kj::mv(parts));
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    if (buffer == nullptr) return true;  // mirrors write(): can't encode a zero-size chunk
+    if (alreadyDone()) return false;     // let the async path surface the error
+
+    auto header = kj::str(kj::hex(buffer.size()), "\r\n");
+    ArrayPtr<const byte> parts[3] = {header.asBytes(), buffer, "\r\n"_kjb};
+
+    // A synchronous write either completes in full immediately or does nothing, so the
+    // stack-allocated header and parts need not outlive this call.
+    return getInner().tryWriteBodyDataSync(parts);
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    uint64_t size = 0;
+    for (auto& piece: pieces) size += piece.size();
+
+    if (size == 0) return true;  // mirrors write(): can't encode a zero-size chunk
+    if (alreadyDone()) return false;
+
+    auto header = kj::str(kj::hex(size), "\r\n");
+    auto partsBuilder = kj::heapArrayBuilder<ArrayPtr<const byte>>(pieces.size() + 2);
+    partsBuilder.add(header.asBytes());
+    for (auto& piece: pieces) {
+      partsBuilder.add(piece);
+    }
+    partsBuilder.add("\r\n"_kjb);
+
+    auto parts = partsBuilder.finish();
+    return getInner().tryWriteBodyDataSync(parts.asPtr());
   }
 
   Maybe<Promise<uint64_t>> tryPumpFrom(AsyncInputStream& input, uint64_t amount) override {
@@ -4858,6 +4963,32 @@ public:
     }
   }
 
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    KJ_REQUIRE(buffer.size() >= minBytes);
+
+    if (leftover.size() >= minBytes) {
+      // Serve entirely from the leftover buffer.
+      auto bytesToCopy = kj::min(buffer.size(), leftover.size());
+      buffer.write(leftover.first(bytesToCopy));
+      leftover = leftover.slice(bytesToCopy, leftover.size());
+
+      // If we've consumed all of the data in the leftover buffer, go ahead and free it.
+      if (leftover.size() == 0) {
+        leftoverBackingBuffer = nullptr;
+      }
+
+      return bytesToCopy;
+    } else if (leftover.size() == 0) {
+      // No leftover data at all; delegate directly to the underlying stream.
+      return stream->tryReadSync(buffer, minBytes);
+    } else {
+      // There is some leftover data, but not enough to satisfy minBytes. We cannot consume the
+      // leftover and then ask the underlying stream for the rest: if the underlying stream then
+      // declined, we'd have already consumed the leftover, violating the no-side-effects rule.
+      return kj::none;
+    }
+  }
+
   Maybe<uint64_t> tryGetLength() override {
     // For a CONNECT pipe, we have no idea how much data there is going to be.
     return kj::none;
@@ -4880,6 +5011,14 @@ public:
 
   Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
     return stream->write(pieces);
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    return stream->tryWriteSync(buffer);
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    return stream->tryWriteSync(pieces);
   }
 
   Promise<void> whenWriteDisconnected() override {
@@ -4955,6 +5094,13 @@ public:
     });
   }
 
+  Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    if (readGuardReleased) {
+      return inner->tryReadSync(buffer, minBytes);
+    }
+    return kj::none;
+  }
+
   Maybe<uint64_t> tryGetLength() override {
     return kj::none;
   }
@@ -5007,6 +5153,20 @@ public:
         return inner->write(pieces);
       });
     }
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    if (writeGuardReleased) {
+      return inner->tryWriteSync(buffer);
+    }
+    return false;
+  }
+
+  bool tryWriteSync(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    if (writeGuardReleased) {
+      return inner->tryWriteSync(pieces);
+    }
+    return false;
   }
 
   Promise<void> whenWriteDisconnected() override {
@@ -5591,6 +5751,10 @@ public:
     return constPromise<size_t, 0>();
   }
 
+  kj::Maybe<size_t> tryReadSync(ArrayPtr<byte> buffer, size_t minBytes) override {
+    return size_t(0);
+  }
+
   kj::Maybe<uint64_t> tryGetLength() override {
     return expectedLength;
   }
@@ -6129,6 +6293,17 @@ kj::Promise<size_t> PausableReadAsyncIoStream::tryReadImpl(
   });
 }
 
+kj::Maybe<size_t> PausableReadAsyncIoStream::tryReadSync(
+    kj::ArrayPtr<byte> buffer, size_t minBytes) {
+  if (maybePausableRead != kj::none || currentlyReading) {
+    // A read is already pending (possibly paused); can't read synchronously.
+    return kj::none;
+  }
+  // Note: A synchronous read completes immediately, so there is no window during which it could
+  // need to be paused; no PausableRead or trackRead() bookkeeping is needed.
+  return inner->tryReadSync(buffer, minBytes);
+}
+
 kj::Maybe<uint64_t> PausableReadAsyncIoStream::tryGetLength() {
   return inner->tryGetLength();
 }
@@ -6145,6 +6320,24 @@ kj::Promise<void> PausableReadAsyncIoStream::write(ArrayPtr<const byte> buffer) 
 kj::Promise<void> PausableReadAsyncIoStream::write(
     kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) {
   return inner->write(pieces).attach(trackWrite());
+}
+
+bool PausableReadAsyncIoStream::tryWriteSync(kj::ArrayPtr<const byte> buffer) {
+  if (currentlyWriting) {
+    // A write is already in progress; can't write synchronously.
+    return false;
+  }
+  // Note: A synchronous write completes immediately, so no trackWrite() bookkeeping is needed.
+  return inner->tryWriteSync(buffer);
+}
+
+bool PausableReadAsyncIoStream::tryWriteSync(
+    kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) {
+  if (currentlyWriting) {
+    // A write is already in progress; can't write synchronously.
+    return false;
+  }
+  return inner->tryWriteSync(pieces);
 }
 
 kj::Maybe<kj::Promise<uint64_t>> PausableReadAsyncIoStream::tryPumpFrom(
@@ -6380,6 +6573,10 @@ public:
     return inner->tryRead(buffer, minBytes, maxBytes);
   }
 
+  kj::Maybe<size_t> tryReadSync(kj::ArrayPtr<byte> buffer, size_t minBytes) override {
+    return inner->tryReadSync(buffer, minBytes);
+  }
+
   kj::Maybe<uint64_t> tryGetLength() override {
     return inner->tryGetLength();
   }
@@ -6394,6 +6591,14 @@ public:
 
   kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
     return inner->write(pieces);
+  }
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override {
+    return inner->tryWriteSync(buffer);
+  }
+
+  bool tryWriteSync(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
+    return inner->tryWriteSync(pieces);
   }
 
   kj::Maybe<kj::Promise<uint64_t>> tryPumpFrom(

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -775,6 +775,8 @@ public:
 
   kj::Promise<size_t> tryReadImpl(void* buffer, size_t minBytes, size_t maxBytes);
 
+  kj::Maybe<size_t> tryReadSync(kj::ArrayPtr<byte> buffer, size_t minBytes) override;
+
   kj::Maybe<uint64_t> tryGetLength() override;
 
   kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override;
@@ -782,6 +784,10 @@ public:
   kj::Promise<void> write(ArrayPtr<const byte> buffer) override;
 
   kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override;
+
+  bool tryWriteSync(ArrayPtr<const byte> buffer) override;
+
+  bool tryWriteSync(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override;
 
   kj::Maybe<kj::Promise<uint64_t>> tryPumpFrom(
       kj::AsyncInputStream& input, uint64_t amount = kj::maxValue) override;


### PR DESCRIPTION
Adds the implementation of tryReadSync and tryWriteSync 

Some benchmarks in workerd, focusing solely on the kj path (no js involvement)

```
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
PipeRendezvousWrite_64B_Async          302 us          302 us         2225 bytes_per_second=827.941Mi/s
PipeRendezvousWrite_64B_TrySync        215 us          215 us         3225 bytes_per_second=1.13805Gi/s
PipeRendezvousWrite_4KB_Async         22.2 us         22.2 us        30479 bytes_per_second=44.0779Gi/s
PipeRendezvousWrite_4KB_TrySync       17.5 us         17.5 us        40466 bytes_per_second=55.8927Gi/s
PipeRendezvousRead_64B_Async           316 us          316 us         2373 bytes_per_second=792.345Mi/s
PipeRendezvousRead_64B_TrySync         185 us          185 us         3749 bytes_per_second=1.32261Gi/s
PipeRendezvousRead_4KB_Async          22.2 us         22.2 us        31865 bytes_per_second=43.9467Gi/s
PipeRendezvousRead_4KB_TrySync        15.7 us         15.7 us        44479 bytes_per_second=62.319Gi/s
Pump_1MB_FullAsync                    30.2 us         30.1 us        23217 bytes_per_second=32.3936Gi/s
Pump_1MB_SyncRead                     19.3 us         19.3 us        36582 bytes_per_second=50.6375Gi/s
Pump_1MB_FullSync                     9.61 us         9.60 us        76620 bytes_per_second=101.676Gi/s
GzipDecode_1MB_Async                   200 us          200 us         3485 asyncReads=65 bytes_per_second=4.89249Gi/s syncReads=0
GzipDecode_1MB_TrySync                 204 us          204 us         3554 asyncReads=2 bytes_per_second=4.79358Gi/s syncReads=63
```

So we end up saving roughly 21-80ns per chunk of data on stream workloads that are dominated by the i/o. The Gzip bench highlights that there really is no difference when the stream overhead is mostly the processing. These results are exactly what should be expected.