### PR TITLE
Fix epoll detection on Android NDK API < 23

### DIFF
--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -33,7 +33,10 @@
 KJ_BEGIN_HEADER
 
 #if !defined(KJ_USE_EPOLL) && !defined(KJ_USE_KQUEUE)
-#if __linux__
+
+// Android NDK less than API version 23 doesn't have sigtimedwait
+// sigtimedwait is used in async-unix.c++ if KJ_USE_EPOLL is defined
+#if __linux__ && !(__ANDROID__ && __ANDROID_API__ < 23)
 // Default to epoll on Linux.
 #define KJ_USE_EPOLL 1
 #elif __APPLE__ || __FreeBSD__ || __NetBSD__ || __DragonFly__


### PR DESCRIPTION
For 2.x

The `KJ_USE_EPOLL` macro was being defined on Android because `__linux__` is true there, but the epoll implementation in `async-unix.c++` uses `sigtimedwait` which requires Android API level >= 23. This caused build failures on older Android targets.

Guard the epoll default with `!defined(__ANDROID__) || __ANDROID_API__ >= 23` to fall back on older Android NDK versions.