### PR TITLE
Add MKCALENDAR to recognized HTTP methods

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -187,6 +187,7 @@ enum HttpMethod {
 
   query @26;
   ban @27;
+  mkcalendar @28;
 }
 
 annotation commonText @0x857745131db6fc83(enumerant) :Text;

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -85,7 +85,8 @@ namespace kj {
   MACRO(QUERY) \
   /* https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-05.html */ \
   MACRO(BAN) \
-  /* Non-standard method name requested by a Cloudflare customer. */
+  /* Non-standard method name requested by a Cloudflare customer. */ \
+  MACRO(MKCALENDAR)
 
 enum class HttpMethod {
   // Enum of known HTTP methods.


### PR DESCRIPTION
`MKCALENDAR` is CalDAV’s standard calendar-creation method (RFC 4791 §5.3.1).

Add it to KJ’s recognized HTTP-method set alongside existing WebDAV methods such as `MKCOL`, `PROPFIND`, and `REPORT`.

This unblocks cloudflare/workerd#6877, where workerd currently rejects `MKCALENDAR` before Worker code runs.
