### PR TITLE
Maybe::assertSome,assertNone utility function

### DIFF
--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2110,6 +2110,17 @@ public:
     }
   }
 
+  T& assertSome() & {
+    // Returns the contained value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    return *ptr;
+  }
+  const T& assertSome() const & {
+    // Returns the contained value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    return *ptr;
+  }
+
   T& orDefault(T& defaultValue) & {
     if (ptr == nullptr) {
       return defaultValue;
@@ -2309,6 +2320,17 @@ public:
   inline bool operator==(decltype(nullptr)) const { return ptr == nullptr; }
 
   inline bool operator==(kj::None) const { return ptr == nullptr; }
+
+  T& assertSome() & {
+    // Returns the referenced value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    return *ptr;
+  }
+  const T& assertSome() const & {
+    // Returns the referenced value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    return *ptr;
+  }
 
   T& orDefault(T& defaultValue) {
     if (ptr == nullptr) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2120,6 +2120,23 @@ public:
     KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
     return *ptr;
   }
+  T assertSome() && {
+    // Returns and removes the contained value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    T result(kj::mv(*ptr));
+    ptr = nullptr;
+    return result;
+  }
+  const T&& assertSome() const && {
+    // Returns the contained value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    return kj::mv(*ptr);
+  }
+
+  void assertNone() const {
+    // Verifies that the Maybe does not contain a value.
+    KJ_IREQUIRE(ptr == nullptr, "expected Maybe<> to be none");
+  }
 
   T& orDefault(T& defaultValue) & {
     if (ptr == nullptr) {
@@ -2330,6 +2347,21 @@ public:
     // Returns the referenced value. The Maybe must not be none.
     KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
     return *ptr;
+  }
+  T& assertSome() && {
+    // Returns the referenced value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    return *ptr;
+  }
+  const T& assertSome() const && {
+    // Returns the referenced value. The Maybe must not be none.
+    KJ_IREQUIRE(ptr != nullptr, "null Maybe<> dereference");
+    return *ptr;
+  }
+
+  void assertNone() const {
+    // Verifies that the Maybe does not contain a reference.
+    KJ_IREQUIRE(ptr == nullptr, "expected Maybe<> to be none");
   }
 
   T& orDefault(T& defaultValue) {

--- a/c++/src/kj/maybe-test.c++
+++ b/c++/src/kj/maybe-test.c++
@@ -854,12 +854,32 @@ KJ_TEST("Maybe assertSome") {
   const Maybe<int&> constMaybeReference = value;
   KJ_EXPECT(constMaybeReference.assertSome() == value);
 
-#if defined(KJ_DEBUG) || (defined(KJ_ENABLE_IREQUIRE) && KJ_ENABLE_IREQUIRE)
-  Maybe<int> emptyValue = kj::none;
-  KJ_EXPECT_THROW_MESSAGE("null Maybe<> dereference", (void)emptyValue.assertSome());
+  const Maybe<int> constMaybeValue = value;
+  static_assert(isSameType<decltype(kj::mv(maybeValue).assertSome()), int>());
+  static_assert(isSameType<decltype(kj::mv(constMaybeValue).assertSome()), const int&&>());
+  static_assert(isSameType<decltype(kj::mv(maybeReference).assertSome()), int&>());
+  static_assert(isSameType<decltype(kj::mv(constMaybeReference).assertSome()), const int&>());
 
+  Maybe<int> movedByAssertNonNull = 123;
+  KJ_EXPECT(KJ_ASSERT_NONNULL(kj::mv(movedByAssertNonNull)) == 123);
+  movedByAssertNonNull.assertNone();
+
+  Maybe<int> movedByAssertSome = 456;
+  KJ_EXPECT(kj::mv(movedByAssertSome).assertSome() == 456);
+  movedByAssertSome.assertNone();
+
+  KJ_EXPECT(kj::mv(maybeReference).assertSome() == value);
+
+  Maybe<int> emptyValue = kj::none;
+  emptyValue.assertNone();
   Maybe<int&> emptyReference = kj::none;
+  emptyReference.assertNone();
+
+#if defined(KJ_DEBUG) || (defined(KJ_ENABLE_IREQUIRE) && KJ_ENABLE_IREQUIRE)
+  KJ_EXPECT_THROW_MESSAGE("null Maybe<> dereference", (void)emptyValue.assertSome());
   KJ_EXPECT_THROW_MESSAGE("null Maybe<> dereference", (void)emptyReference.assertSome());
+  KJ_EXPECT_THROW_MESSAGE("expected Maybe<> to be none", maybeValue.assertNone());
+  KJ_EXPECT_THROW_MESSAGE("expected Maybe<> to be none", maybeReference.assertNone());
 #endif
 }
 

--- a/c++/src/kj/maybe-test.c++
+++ b/c++/src/kj/maybe-test.c++
@@ -837,6 +837,32 @@ KJ_TEST("Maybe") {
   }
 }
 
+KJ_TEST("Maybe assertSome") {
+  int value = 123;
+
+  Maybe<int> maybeValue = value;
+  KJ_EXPECT(&maybeValue.assertSome() != &value);
+  KJ_EXPECT(maybeValue.assertSome() == value);
+  maybeValue.assertSome() = 456;
+  KJ_EXPECT(KJ_ASSERT_NONNULL(maybeValue) == 456);
+
+  Maybe<int&> maybeReference = value;
+  KJ_EXPECT(&maybeReference.assertSome() == &value);
+  maybeReference.assertSome() = 789;
+  KJ_EXPECT(value == 789);
+
+  const Maybe<int&> constMaybeReference = value;
+  KJ_EXPECT(constMaybeReference.assertSome() == value);
+
+#if defined(KJ_DEBUG) || (defined(KJ_ENABLE_IREQUIRE) && KJ_ENABLE_IREQUIRE)
+  Maybe<int> emptyValue = kj::none;
+  KJ_EXPECT_THROW_MESSAGE("null Maybe<> dereference", (void)emptyValue.assertSome());
+
+  Maybe<int&> emptyReference = kj::none;
+  KJ_EXPECT_THROW_MESSAGE("null Maybe<> dereference", (void)emptyReference.assertSome());
+#endif
+}
+
 KJ_TEST("Maybe emplaceInit") {
   {
     Maybe<int> m;


### PR DESCRIPTION
We tend to use KJ_ASSERT_NONNULL(x), but arguably x.assertSome() reads better.

I am not suggestion any wide replacements, just a way to write code in a more fluent way.