### PR TITLE
Implement interim (1xx) response support

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -497,13 +497,23 @@ KJ_TEST("HTTP-over-Cap'n-Proto forwards informational responses") {
     kj::Promise<void> request(
         kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
         kj::AsyncInputStream& requestBody, Response& response) override {
+      KJ_EXPECT_THROW_MESSAGE("unsupported informational response status",
+          response.sendInformational(
+              static_cast<kj::HttpInformationalStatus>(199),
+              "Extension Response", kj::HttpHeaders(table)));
+
       kj::HttpHeaders first(table);
       first.setPtr(infoHeader, "first");
-      response.sendInformational(103, "Early Hints", first);
+      response.sendInformational(kj::HttpInformationalStatus::CONTINUE, "Continue", first);
 
       kj::HttpHeaders second(table);
       second.setPtr(infoHeader, "second");
-      response.sendInformational(102, "Processing", second);
+      response.sendInformational(kj::HttpInformationalStatus::PROCESSING, "Processing", second);
+
+      kj::HttpHeaders third(table);
+      third.setPtr(infoHeader, "third");
+      response.sendInformational(
+          kj::HttpInformationalStatus::EARLY_HINTS, "Early Hints", third);
 
       if (url == "/body") {
         auto body = response.send(200, "OK", kj::HttpHeaders(table), uint64_t(3));
@@ -528,7 +538,7 @@ KJ_TEST("HTTP-over-Cap'n-Proto forwards informational responses") {
   kj::HttpClient::RequestOptions options;
   options.informationResponseHandler =
       [&](kj::HttpClient::InformationalResponse&& response) {
-    events.add(response.statusCode);
+    events.add(static_cast<uint>(response.statusCode));
     values.add(kj::str(KJ_ASSERT_NONNULL(response.headers.get(infoHeader))));
   };
 
@@ -539,13 +549,15 @@ KJ_TEST("HTTP-over-Cap'n-Proto forwards informational responses") {
   events.add(response.statusCode);
   response.body = nullptr;
 
-  KJ_ASSERT(events.size() == 3);
-  KJ_EXPECT(events[0] == 103);
+  KJ_ASSERT(events.size() == 4);
+  KJ_EXPECT(events[0] == 100);
   KJ_EXPECT(events[1] == 102);
-  KJ_EXPECT(events[2] == 204);
-  KJ_ASSERT(values.size() == 2);
+  KJ_EXPECT(events[2] == 103);
+  KJ_EXPECT(events[3] == 204);
+  KJ_ASSERT(values.size() == 3);
   KJ_EXPECT(values[0] == "first");
   KJ_EXPECT(values[1] == "second");
+  KJ_EXPECT(values[2] == "third");
 
   auto withoutHandler = client->request(
       kj::HttpMethod::GET, "/", kj::HttpHeaders(*headerTable));
@@ -573,6 +585,55 @@ KJ_TEST("HTTP-over-Cap'n-Proto forwards informational responses") {
   KJ_EXPECT_THROW(DISCONNECTED, disconnected.response.wait(waitScope));
 }
 
+KJ_TEST("HTTP-over-Cap'n-Proto rejects invalid informational response status") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory streamFactory;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  auto headerTable = tableBuilder.build();
+
+  class Service final: public capnp::HttpService::Server {
+  public:
+    Service(bool& rejected): rejected(rejected) {}
+
+    kj::Promise<void> request(RequestContext context) override {
+      auto clientContext = context.getParams().getContext();
+      auto invalidRequest = clientContext.sendInformationalRequest();
+      invalidRequest.initInfo().setStatusCode(capnp::HttpInformationalStatus::INVALID);
+
+      return invalidRequest.send().ignoreResult().then([]() {
+        KJ_FAIL_ASSERT("invalid informational response unexpectedly succeeded");
+      }, [this](kj::Exception&& exception) {
+        rejected = true;
+        KJ_EXPECT(exception.getDescription().contains("unknown informational response status"));
+      }).then([clientContext = kj::mv(clientContext)]() mutable {
+        auto finalRequest = clientContext.startResponseRequest();
+        auto finalResponse = finalRequest.initResponse();
+        finalResponse.setStatusCode(204);
+        finalResponse.setStatusText("No Content");
+        finalResponse.getBodySize().setFixed(0);
+        return finalRequest.send().ignoreResult();
+      });
+    }
+
+  private:
+    bool& rejected;
+  };
+
+  bool rejected = false;
+  auto service = factory.capnpToKj(kj::heap<Service>(rejected));
+  auto client = kj::newHttpClient(*service);
+  auto request = client->request(
+      kj::HttpMethod::GET, "/", kj::HttpHeaders(*headerTable));
+  request.body = nullptr;
+  auto response = request.response.wait(waitScope);
+  KJ_EXPECT(response.statusCode == 204);
+  KJ_EXPECT(rejected);
+  response.body = nullptr;
+}
+
 KJ_TEST("HTTP-over-Cap'n-Proto drops informational responses for an old peer") {
   kj::EventLoop eventLoop;
   kj::WaitScope waitScope(eventLoop);
@@ -589,7 +650,8 @@ KJ_TEST("HTTP-over-Cap'n-Proto drops informational responses for an old peer") {
     kj::Promise<void> request(
         kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
         kj::AsyncInputStream& requestBody, Response& response) override {
-      response.sendInformational(103, "Early Hints", kj::HttpHeaders(table));
+      response.sendInformational(
+          kj::HttpInformationalStatus::EARLY_HINTS, "Early Hints", kj::HttpHeaders(table));
       response.send(204, "No Content", kj::HttpHeaders(table), uint64_t(0));
       return kj::READY_NOW;
     }
@@ -651,7 +713,7 @@ KJ_TEST("HTTP-over-Cap'n-Proto rejects informational responses after the final r
 
       auto lateRequest = clientContext.sendInformationalRequest();
       auto info = lateRequest.initInfo();
-      info.setStatusCode(103);
+      info.setStatusCode(capnp::HttpInformationalStatus::EARLY_HINTS);
       info.setStatusText("Early Hints");
       auto latePromise = lateRequest.send().ignoreResult();
 

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -70,7 +70,7 @@ KJ_TEST("HttpOverCapnpFactory::capnpToKj rejects out of range common values") {
 
     KJ_EXPECT_THROW_MESSAGE("unknown common header value", factory.capnpToKj(invalidValue.get()));
   }
-  
+
   {
     auto invalidValue = orphanage.newOrphan<List<HttpHeader>>(1);
     auto invalidValueHeader = invalidValue.get()[0];
@@ -477,6 +477,208 @@ KJ_TEST("HTTP-over-Cap'n-Proto E2E, with path shortening") {
   auto headerTable = tableBuilder.build();
 
   runEndToEndTests(timer, *headerTable, factory, factory, waitScope);
+}
+
+KJ_TEST("HTTP-over-Cap'n-Proto forwards informational responses") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory streamFactory;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  auto infoHeader = tableBuilder.add("X-Info");
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  auto headerTable = tableBuilder.build();
+
+  class Service final: public kj::HttpService {
+  public:
+    Service(kj::HttpHeaderTable& table, kj::HttpHeaderId infoHeader)
+        : table(table), infoHeader(infoHeader) {}
+
+    kj::Promise<void> request(
+        kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      kj::HttpHeaders first(table);
+      first.setPtr(infoHeader, "first");
+      response.sendInformational(103, "Early Hints", first);
+
+      kj::HttpHeaders second(table);
+      second.setPtr(infoHeader, "second");
+      response.sendInformational(102, "Processing", second);
+
+      if (url == "/body") {
+        auto body = response.send(200, "OK", kj::HttpHeaders(table), uint64_t(3));
+        return body->write("foo"_kjb).attach(kj::mv(body));
+      } else {
+        response.send(204, "No Content", kj::HttpHeaders(table), uint64_t(0));
+        return kj::READY_NOW;
+      }
+    }
+
+  private:
+    kj::HttpHeaderTable& table;
+    kj::HttpHeaderId infoHeader;
+  };
+
+  auto rpcService = factory.kjToCapnp(kj::heap<Service>(*headerTable, infoHeader));
+  auto service = factory.capnpToKj(rpcService);
+  auto client = kj::newHttpClient(*service);
+
+  kj::Vector<uint> events;
+  kj::Vector<kj::String> values;
+  kj::HttpClient::RequestOptions options;
+  options.informationResponseHandler =
+      [&](kj::HttpClient::InformationalResponse&& response) {
+    events.add(response.statusCode);
+    values.add(kj::str(KJ_ASSERT_NONNULL(response.headers.get(infoHeader))));
+  };
+
+  auto request = client->request(
+      kj::HttpMethod::GET, "/", kj::HttpHeaders(*headerTable), kj::mv(options));
+  request.body = nullptr;
+  auto response = request.response.wait(waitScope);
+  events.add(response.statusCode);
+  response.body = nullptr;
+
+  KJ_ASSERT(events.size() == 3);
+  KJ_EXPECT(events[0] == 103);
+  KJ_EXPECT(events[1] == 102);
+  KJ_EXPECT(events[2] == 204);
+  KJ_ASSERT(values.size() == 2);
+  KJ_EXPECT(values[0] == "first");
+  KJ_EXPECT(values[1] == "second");
+
+  auto withoutHandler = client->request(
+      kj::HttpMethod::GET, "/", kj::HttpHeaders(*headerTable));
+  withoutHandler.body = nullptr;
+  auto finalResponse = withoutHandler.response.wait(waitScope);
+  KJ_EXPECT(finalResponse.statusCode == 204);
+  finalResponse.body = nullptr;
+
+  kj::HttpClient::RequestOptions failingOptions;
+  failingOptions.informationResponseHandler = [](kj::HttpClient::InformationalResponse&&) {
+    KJ_FAIL_REQUIRE("RPC information handler failed");
+  };
+  auto failing = client->request(
+      kj::HttpMethod::GET, "/body", kj::HttpHeaders(*headerTable), kj::mv(failingOptions));
+  failing.body = nullptr;
+  KJ_EXPECT_THROW_MESSAGE("RPC information handler failed", failing.response.wait(waitScope));
+
+  kj::HttpClient::RequestOptions disconnectedOptions;
+  disconnectedOptions.informationResponseHandler = [](kj::HttpClient::InformationalResponse&&) {
+    kj::throwRecoverableException(KJ_EXCEPTION(DISCONNECTED, "callback disconnected"));
+  };
+  auto disconnected = client->request(
+      kj::HttpMethod::GET, "/", kj::HttpHeaders(*headerTable), kj::mv(disconnectedOptions));
+  disconnected.body = nullptr;
+  KJ_EXPECT_THROW(DISCONNECTED, disconnected.response.wait(waitScope));
+}
+
+KJ_TEST("HTTP-over-Cap'n-Proto drops informational responses for an old peer") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory streamFactory;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  auto headerTable = tableBuilder.build();
+
+  class Service final: public kj::HttpService {
+  public:
+    Service(kj::HttpHeaderTable& table): table(table) {}
+
+    kj::Promise<void> request(
+        kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      response.sendInformational(103, "Early Hints", kj::HttpHeaders(table));
+      response.send(204, "No Content", kj::HttpHeaders(table), uint64_t(0));
+      return kj::READY_NOW;
+    }
+
+  private:
+    kj::HttpHeaderTable& table;
+  };
+
+  class OldContext final: public capnp::HttpService::ClientRequestContext::Server {
+  public:
+    OldContext(kj::Own<kj::PromiseFulfiller<uint>> fulfiller)
+        : fulfiller(kj::mv(fulfiller)) {}
+
+    kj::Promise<void> startResponse(StartResponseContext context) override {
+      fulfiller->fulfill(context.getParams().getResponse().getStatusCode());
+      return kj::READY_NOW;
+    }
+
+  private:
+    kj::Own<kj::PromiseFulfiller<uint>> fulfiller;
+  };
+
+  auto rpcService = factory.kjToCapnp(kj::heap<Service>(*headerTable));
+  auto responsePaf = kj::newPromiseAndFulfiller<uint>();
+  auto request = rpcService.requestRequest();
+  auto metadata = request.initRequest();
+  metadata.setMethod(capnp::HttpMethod::GET);
+  metadata.setUrl("/");
+  metadata.getBodySize().setFixed(0);
+  request.setContext(kj::heap<OldContext>(kj::mv(responsePaf.fulfiller)));
+  auto requestPromise = request.send();
+
+  KJ_EXPECT(responsePaf.promise.wait(waitScope) == 204);
+  requestPromise.wait(waitScope);
+}
+
+KJ_TEST("HTTP-over-Cap'n-Proto rejects informational responses after the final response") {
+  kj::EventLoop eventLoop;
+  kj::WaitScope waitScope(eventLoop);
+
+  ByteStreamFactory streamFactory;
+  kj::HttpHeaderTable::Builder tableBuilder;
+  HttpOverCapnpFactory factory(streamFactory, tableBuilder, TEST_PEER_OPTIMIZATION_LEVEL);
+  auto headerTable = tableBuilder.build();
+
+  class OutOfOrderService final: public capnp::HttpService::Server {
+  public:
+    OutOfOrderService(bool& rejected): rejected(rejected) {}
+
+    kj::Promise<void> request(RequestContext context) override {
+      auto clientContext = context.getParams().getContext();
+
+      auto finalRequest = clientContext.startResponseRequest();
+      auto finalResponse = finalRequest.initResponse();
+      finalResponse.setStatusCode(204);
+      finalResponse.setStatusText("No Content");
+      finalResponse.getBodySize().setFixed(0);
+      auto finalPromise = finalRequest.send().ignoreResult();
+
+      auto lateRequest = clientContext.sendInformationalRequest();
+      auto info = lateRequest.initInfo();
+      info.setStatusCode(103);
+      info.setStatusText("Early Hints");
+      auto latePromise = lateRequest.send().ignoreResult();
+
+      return finalPromise.then([this, latePromise = kj::mv(latePromise)]() mutable {
+        return latePromise.then([]() {
+          KJ_FAIL_ASSERT("late informational response unexpectedly succeeded");
+        }, [this](kj::Exception&& exception) {
+          rejected = true;
+          KJ_EXPECT(exception.getDescription().contains("after startResponse()"));
+        });
+      });
+    }
+
+  private:
+    bool& rejected;
+  };
+
+  bool rejected = false;
+  auto service = factory.capnpToKj(kj::heap<OutOfOrderService>(rejected));
+  auto client = kj::newHttpClient(*service);
+  auto request = client->request(
+      kj::HttpMethod::GET, "/", kj::HttpHeaders(*headerTable));
+  request.body = nullptr;
+  auto response = request.response.wait(waitScope);
+  KJ_EXPECT(response.statusCode == 204);
+  KJ_EXPECT(rejected);
+  response.body = nullptr;
 }
 
 KJ_TEST("HTTP-over-Cap'n-Proto 205 bug with HttpClientAdapter") {

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -321,6 +321,42 @@ private:
 
 // =======================================================================================
 
+namespace {
+
+kj::HttpInformationalStatus capnpToKjInformationalStatus(
+    capnp::HttpInformationalStatus status) {
+  switch (status) {
+    case capnp::HttpInformationalStatus::CONTINUE:
+      return kj::HttpInformationalStatus::CONTINUE;
+    case capnp::HttpInformationalStatus::PROCESSING:
+      return kj::HttpInformationalStatus::PROCESSING;
+    case capnp::HttpInformationalStatus::EARLY_HINTS:
+      return kj::HttpInformationalStatus::EARLY_HINTS;
+    default:
+      KJ_FAIL_REQUIRE(
+          "unknown informational response status", static_cast<uint>(status));
+  }
+}
+
+capnp::HttpInformationalStatus kjToCapnpInformationalStatus(
+    kj::HttpInformationalStatus status) {
+  switch (status) {
+    case kj::HttpInformationalStatus::CONTINUE:
+      return capnp::HttpInformationalStatus::CONTINUE;
+    case kj::HttpInformationalStatus::PROCESSING:
+      return capnp::HttpInformationalStatus::PROCESSING;
+    case kj::HttpInformationalStatus::EARLY_HINTS:
+      return capnp::HttpInformationalStatus::EARLY_HINTS;
+    default:
+      KJ_FAIL_REQUIRE(
+          "unsupported informational response status", static_cast<uint>(status));
+  }
+}
+
+}  // namespace
+
+// =======================================================================================
+
 class HttpOverCapnpFactory::ClientRequestContextImpl final
     : public capnp::HttpService::ClientRequestContext::Server {
 public:
@@ -338,9 +374,7 @@ public:
     KJ_REQUIRE(!sentResponse,
         "sendInformational() after startResponse() or startWebSocket()");
     auto info = context.getParams().getInfo();
-    auto statusCode = info.getStatusCode();
-    KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
-        "informational status must be between 100 and 199, excluding 101");
+    auto statusCode = capnpToKjInformationalStatus(info.getStatusCode());
     KJ_TRY {
       kjResponse.sendInformational(
           statusCode, info.getStatusText(), factory.capnpToKj(info.getHeaders()));
@@ -813,14 +847,13 @@ public:
         clientContext(kj::mv(clientContext)) {}
 
   void sendInformational(
-      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+      kj::HttpInformationalStatus statusCode, kj::StringPtr statusText,
+      const kj::HttpHeaders& headers) override {
     KJ_REQUIRE(!responseSent, "already called send() or acceptWebSocket()");
-    KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
-        "informational status must be between 100 and 199, excluding 101");
 
     auto req = clientContext.sendInformationalRequest();
     auto info = req.initInfo();
-    info.setStatusCode(statusCode);
+    info.setStatusCode(kjToCapnpInformationalStatus(statusCode));
     info.setStatusText(statusText);
     info.adoptHeaders(factory.headersToCapnp(
         headers, Orphanage::getForMessageContaining(info)));

--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -334,12 +334,31 @@ public:
     }
   }
 
+  kj::Promise<void> sendInformational(SendInformationalContext context) override {
+    KJ_REQUIRE(!sentResponse,
+        "sendInformational() after startResponse() or startWebSocket()");
+    auto info = context.getParams().getInfo();
+    auto statusCode = info.getStatusCode();
+    KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
+        "informational status must be between 100 and 199, excluding 101");
+    KJ_TRY {
+      kjResponse.sendInformational(
+          statusCode, info.getStatusText(), factory.capnpToKj(info.getHeaders()));
+    } KJ_CATCH(exception) {
+      informationalErrorOccurred = true;
+      if (informationalError == kj::none) informationalError = kj::mv(exception);
+    }
+    return kj::READY_NOW;
+  }
+
   kj::Promise<void> startResponse(StartResponseContext context) override {
     KJ_REQUIRE(!sentResponse, "already called startResponse() or startWebSocket()");
     sentResponse = true;
 
     auto params = context.getParams();
     auto rpcResponse = params.getResponse();
+    KJ_REQUIRE(rpcResponse.getStatusCode() >= 200,
+        "final response status must be at least 200; use sendInformational() for 1xx");
 
     auto bodySize = rpcResponse.getBodySize();
     kj::Maybe<uint64_t> expectedSize;
@@ -350,10 +369,20 @@ public:
       hasBody = size > 0;
     }
 
+    auto results = context.getResults(MessageSize { 16, 1 });
+    if (informationalError != kj::none) {
+      if (hasBody) {
+        auto pipe = kj::newOneWayPipe();
+        auto sink = kj::heap<kj::NullStream>();
+        results.setBody(factory.streamFactory.kjToCapnp(kj::mv(pipe.out)));
+        responsePumpTask = pipe.in->pumpTo(*sink).ignoreResult()
+            .attach(kj::mv(pipe.in), kj::mv(sink));
+      }
+      return kj::READY_NOW;
+    }
+
     auto bodyStream = kjResponse.send(rpcResponse.getStatusCode(), rpcResponse.getStatusText(),
         factory.capnpToKj(rpcResponse.getHeaders()), expectedSize);
-
-    auto results = context.getResults(MessageSize { 16, 1 });
     if (hasBody) {
       auto pipe = kj::newOneWayPipe();
       results.setBody(factory.streamFactory.kjToCapnp(kj::mv(pipe.out)));
@@ -443,6 +472,10 @@ public:
     return ownWebSocket != kj::none;
   }
 
+  bool hasInformationalError() {
+    return informationalErrorOccurred;
+  }
+
   kj::Promise<void> closeWebSocketForOverload() {
     if (closingForOverload) {
       return finishPump().catch_([](kj::Exception&&) {});
@@ -477,12 +510,19 @@ private:
   kj::Maybe<kj::Own<kj::WebSocket>> ownWebSocket;
   kj::Maybe<kj::Promise<void>> responsePumpTask;
   kj::Maybe<CapnpToKjWebSocketAdapter&> maybeWebSocket;
+  kj::Maybe<kj::Exception> informationalError;
 
   kj::HttpService::Response& kjResponse;
   bool sentResponse = false;
   bool closingForOverload = false;
+  bool informationalErrorOccurred = false;
 
   kj::Promise<void> finishPumpInner() {
+    KJ_IF_SOME(exception, informationalError) {
+      auto result = kj::mv(exception);
+      informationalError = kj::none;
+      return kj::mv(result);
+    }
     KJ_IF_SOME(r, responsePumpTask) {
       auto promise = kj::mv(r);
       // Null out the task so a second call can't await the moved-from (null) promise.
@@ -684,7 +724,8 @@ public:
       // do the same. Actually, technically, even non-DISCONNECTED exceptions arguably shouldn't
       // propagate here for the same reason. But, non-DISCONNECTED exceptions are more likely to
       // flag some real bug, so I'm leaving them alone for now. This could be revisited later.
-      if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
+      if (context.hasInformationalError() ||
+          exception.getType() != kj::Exception::Type::DISCONNECTED) {
         kj::throwFatalException(kj::mv(exception));
       }
     }
@@ -771,10 +812,27 @@ public:
         headers(factory.capnpToKj(request.getHeaders())),
         clientContext(kj::mv(clientContext)) {}
 
+  void sendInformational(
+      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+    KJ_REQUIRE(!responseSent, "already called send() or acceptWebSocket()");
+    KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
+        "informational status must be between 100 and 199, excluding 101");
+
+    auto req = clientContext.sendInformationalRequest();
+    auto info = req.initInfo();
+    info.setStatusCode(statusCode);
+    info.setStatusText(statusText);
+    info.adoptHeaders(factory.headersToCapnp(
+        headers, Orphanage::getForMessageContaining(info)));
+    dontWaitForRpc(req.send());
+  }
+
   kj::Own<kj::AsyncOutputStream> send(
       uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
     KJ_REQUIRE(!responseSent, "already called send() or acceptWebSocket()");
+    KJ_REQUIRE(statusCode >= 200,
+        "final response status must be at least 200; use sendInformational() for 1xx");
     responseSent = true;
 
     auto req = clientContext.startResponseRequest();

--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -84,6 +84,9 @@ interface HttpService {
     #
     # Client -> Server WebSocket frames will be sent via method calls on `upSocket`, while
     # Server -> Client will be sent as calls to `downSocket`.
+
+    sendInformational @2 (info :HttpInformationalResponse);
+    # Sends an informational response before the final response or WebSocket handshake.
   }
 
   interface ConnectClientRequestContext {
@@ -147,6 +150,12 @@ struct HttpResponse {
     unknown @3 :Void;   # e.g. due to transfer-encoding: chunked
     fixed @4 :UInt64;   # e.g. due to content-length
   }
+}
+
+struct HttpInformationalResponse {
+  statusCode @0 :UInt16;
+  statusText @1 :Text;
+  headers @2 :List(HttpHeader);
 }
 
 enum HttpMethod {

--- a/c++/src/capnp/compat/http-over-capnp.capnp
+++ b/c++/src/capnp/compat/http-over-capnp.capnp
@@ -152,8 +152,17 @@ struct HttpResponse {
   }
 }
 
+enum HttpInformationalStatus {
+  invalid @0;
+  # Dummy to serve as default value. Should never actually appear on wire.
+
+  continue @1;
+  processing @2;
+  earlyHints @3;
+}
+
 struct HttpInformationalResponse {
-  statusCode @0 :UInt16;
+  statusCode @0 :HttpInformationalStatus;
   statusText @1 :Text;
   headers @2 :List(HttpHeader);
 }

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -1244,6 +1244,9 @@ KJ_TEST("HttpClient handles informational responses") {
         "HTTP/1.1 100 Continue\r\n"
         "X-Interim: first\r\n"
         "\r\n"
+        "HTTP/1.1 199 Extension Response\r\n"
+        "X-Interim: ignored\r\n"
+        "\r\n"
         "HTTP/1.1 103 Early Hints\r\n"
         "Connection: close\r\n"
         "X-Interim: second\r\n"
@@ -1261,7 +1264,7 @@ KJ_TEST("HttpClient handles informational responses") {
   auto table = builder.build();
   auto client = newHttpClient(*table, *pipe.ends[0]);
 
-  kj::Vector<uint> statuses;
+  kj::Vector<HttpInformationalStatus> statuses;
   kj::Vector<kj::String> values;
   kj::Maybe<HttpHeaders> retainedHeaders;
   HttpClient::RequestOptions options;
@@ -1283,8 +1286,8 @@ KJ_TEST("HttpClient handles informational responses") {
   firstResponse.body = nullptr;
 
   KJ_ASSERT(statuses.size() == 2);
-  KJ_EXPECT(statuses[0] == 100);
-  KJ_EXPECT(statuses[1] == 103);
+  KJ_EXPECT(statuses[0] == HttpInformationalStatus::CONTINUE);
+  KJ_EXPECT(statuses[1] == HttpInformationalStatus::EARLY_HINTS);
   KJ_EXPECT(values[0] == "first");
   KJ_EXPECT(values[1] == "second");
   KJ_EXPECT(KJ_ASSERT_NONNULL(KJ_ASSERT_NONNULL(retainedHeaders).get(interimHeader)) == "first");
@@ -1338,7 +1341,7 @@ KJ_TEST("HttpClient limits informational responses") {
   request.body = nullptr;
   expectRead(*pipe.ends[1], "GET /sixteen HTTP/1.1\r\n\r\n").wait(waitScope);
   auto sixteen = kj::str(
-      kj::strArray(kj::repeat("HTTP/1.1 103 Early Hints\r\n\r\n", 16), ""),
+      kj::strArray(kj::repeat("HTTP/1.1 199 Extension Response\r\n\r\n", 16), ""),
       "HTTP/1.1 204 No Content\r\n\r\n");
   pipe.ends[1]->write(sixteen.asBytes()).wait(waitScope);
   auto response = request.response.wait(waitScope);
@@ -1353,7 +1356,7 @@ KJ_TEST("HttpClient limits informational responses") {
       "GET /seventeen HTTP/1.1\r\n\r\n"
       "GET /queued HTTP/1.1\r\n\r\n").wait(waitScope);
   auto seventeen = kj::str(
-      kj::strArray(kj::repeat("HTTP/1.1 103 Early Hints\r\n\r\n", 17), ""),
+      kj::strArray(kj::repeat("HTTP/1.1 199 Extension Response\r\n\r\n", 17), ""),
       "HTTP/1.1 204 No Content\r\n\r\n");
   pipe.ends[1]->write(seventeen.asBytes()).wait(waitScope);
   KJ_EXPECT_THROW_MESSAGE("Too many informational responses", excessive.response.wait(waitScope));
@@ -1627,17 +1630,21 @@ KJ_TEST("HttpServer sends informational responses") {
       informational.setPtr(HttpHeaderId::TRANSFER_ENCODING, "chunked");
       informational.setPtr(infoHeader, "value");
 
-      response.sendInformational(103, "Early Hints", informational);
-      KJ_EXPECT_THROW_MESSAGE("between 100 and 199",
-          response.sendInformational(99, "Invalid", informational));
-      KJ_EXPECT_THROW_MESSAGE("excluding 101",
-          response.sendInformational(101, "Switching Protocols", informational));
+      response.sendInformational(
+          HttpInformationalStatus::EARLY_HINTS, "Early Hints", informational);
+      KJ_EXPECT_THROW_MESSAGE("unsupported informational response status",
+          response.sendInformational(
+              static_cast<HttpInformationalStatus>(99), "Invalid", informational));
+      KJ_EXPECT_THROW_MESSAGE("unsupported informational response status",
+          response.sendInformational(
+              static_cast<HttpInformationalStatus>(101), "Switching Protocols", informational));
       KJ_EXPECT_THROW_MESSAGE("final response status must be at least 200",
           response.send(103, "Early Hints", informational, uint64_t(0)));
 
       auto body = response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
       KJ_EXPECT_THROW_MESSAGE("already called send",
-          response.sendInformational(103, "Late", informational));
+          response.sendInformational(
+              HttpInformationalStatus::EARLY_HINTS, "Late", informational));
       return kj::READY_NOW;
     }
 
@@ -1682,7 +1689,8 @@ KJ_TEST("HttpServer handles Expect: 100-continue") {
         HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
         kj::AsyncInputStream& requestBody, Response& response) override {
       if (mode == MANUAL_CONTINUE) {
-        response.sendInformational(100, "Continue", HttpHeaders(table));
+        response.sendInformational(
+            HttpInformationalStatus::CONTINUE, "Continue", HttpHeaders(table));
       } else if (mode == REJECT) {
         response.send(417, "Expectation Failed", HttpHeaders(table), uint64_t(0));
         co_return;
@@ -1810,7 +1818,7 @@ KJ_TEST("HttpClient and HttpServer coordinate 100-continue") {
   options.expectedBodySize = uint64_t(3);
   options.informationResponseHandler = [&](HttpClient::InformationalResponse&& response) {
     ++interimCount;
-    KJ_EXPECT(response.statusCode == 100);
+    KJ_EXPECT(response.statusCode == HttpInformationalStatus::CONTINUE);
     upload = requestBody->write("foo"_kjb);
   };
 
@@ -5554,7 +5562,8 @@ KJ_TEST("HttpServer preserves HTTP/1.0 across request suspension") {
     kj::Promise<void> request(
         HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
         kj::AsyncInputStream& requestBody, Response& response) override {
-      response.sendInformational(103, "Early Hints", HttpHeaders(table));
+      response.sendInformational(
+          HttpInformationalStatus::EARLY_HINTS, "Early Hints", HttpHeaders(table));
       response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
       return kj::READY_NOW;
     }
@@ -6127,7 +6136,8 @@ KJ_TEST("newHttpClient from HttpService forwards informational responses") {
         kj::AsyncInputStream& requestBody, Response& response) override {
       HttpHeaders informational(table);
       informational.setPtr(infoHeader, "value");
-      response.sendInformational(103, "Early Hints", informational);
+      response.sendInformational(
+          HttpInformationalStatus::EARLY_HINTS, "Early Hints", informational);
       KJ_EXPECT_THROW_MESSAGE("final response status must be at least 200",
           response.send(103, "Early Hints", informational, uint64_t(0)));
       response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
@@ -6144,7 +6154,7 @@ KJ_TEST("newHttpClient from HttpService forwards informational responses") {
   HttpClient::RequestOptions options;
   options.informationResponseHandler = [&](HttpClient::InformationalResponse&& response) {
     ++callbackCount;
-    KJ_EXPECT(response.statusCode == 103);
+    KJ_EXPECT(response.statusCode == HttpInformationalStatus::EARLY_HINTS);
     KJ_EXPECT(response.statusText == "Early Hints");
     KJ_EXPECT(KJ_ASSERT_NONNULL(response.headers.get(infoHeader)) == "value");
   };
@@ -6512,7 +6522,8 @@ public:
       }
 
       if (url == "/interim") {
-        response.sendInformational(103, "Early Hints", HttpHeaders(headerTable));
+        response.sendInformational(
+            HttpInformationalStatus::EARLY_HINTS, "Early Hints", HttpHeaders(headerTable));
       }
 
       auto body = kj::str(headers.get(HttpHeaderId::HOST).orDefault("null"), ":", url);
@@ -6567,7 +6578,7 @@ KJ_TEST("HttpClient connection management") {
     HttpClient::RequestOptions options;
     options.informationResponseHandler = [&](HttpClient::InformationalResponse&& response) {
       sawInterim = true;
-      KJ_EXPECT(response.statusCode == 103);
+      KJ_EXPECT(response.statusCode == HttpInformationalStatus::EARLY_HINTS);
     };
     auto request = client->request(
         HttpMethod::GET, "/interim", HttpHeaders(headerTable), kj::mv(options));

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -238,6 +238,32 @@ KJ_TEST("HttpHeaders::parseResponse") {
       "\r\n");
 }
 
+KJ_TEST("HttpHeaders parses HTTP/1.0 requests") {
+  HttpHeaderTable table;
+
+  {
+    HttpHeaders headers(table);
+    auto text = kj::heapString("GET / HTTP/1.0  \t\r\n\r\n");
+    auto request = headers.tryParseRequest(text.asArray()).get<HttpHeaders::Request>();
+    KJ_EXPECT(request.isHttp10);
+  }
+
+  {
+    HttpHeaders headers(table);
+    auto text = kj::heapString("CONNECT example.com:443 HTTP/1.0\r\n\r\n");
+    auto request = headers.tryParseRequestOrConnect(text.asArray())
+        .get<HttpHeaders::ConnectRequest>();
+    KJ_EXPECT(request.isHttp10);
+  }
+
+  {
+    HttpHeaders headers(table);
+    auto text = kj::heapString("GET / HTTP/1.1\r\n\r\n");
+    auto request = headers.tryParseRequest(text.asArray()).get<HttpHeaders::Request>();
+    KJ_EXPECT(!request.isHttp10);
+  }
+}
+
 KJ_TEST("HttpHeaders parse invalid") {
   auto table = HttpHeaderTable::Builder().build();
   HttpHeaders headers(*table);
@@ -1206,6 +1232,135 @@ KJ_TEST("HttpClient responses") {
   }
 }
 
+KJ_TEST("HttpClient handles informational responses") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  auto serverTask = expectRead(*pipe.ends[1],
+      "GET /first HTTP/1.1\r\n\r\n"
+      "GET /second HTTP/1.1\r\n\r\n")
+      .then([&]() {
+    return pipe.ends[1]->write(
+        "HTTP/1.1 100 Continue\r\n"
+        "X-Interim: first\r\n"
+        "\r\n"
+        "HTTP/1.1 103 Early Hints\r\n"
+        "Connection: close\r\n"
+        "X-Interim: second\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 2\r\n"
+        "\r\n"
+        "ok"
+        "HTTP/1.1 102 Processing\r\n\r\n"
+        "HTTP/1.1 204 No Content\r\n\r\n"_kjb);
+  }).eagerlyEvaluate([](kj::Exception&& e) { KJ_LOG(ERROR, e); });
+
+  HttpHeaderTable::Builder builder;
+  auto interimHeader = builder.add("X-Interim");
+  auto table = builder.build();
+  auto client = newHttpClient(*table, *pipe.ends[0]);
+
+  kj::Vector<uint> statuses;
+  kj::Vector<kj::String> values;
+  kj::Maybe<HttpHeaders> retainedHeaders;
+  HttpClient::RequestOptions options;
+  options.informationResponseHandler = [&](HttpClient::InformationalResponse&& response) {
+    statuses.add(response.statusCode);
+    values.add(kj::str(KJ_ASSERT_NONNULL(response.headers.get(interimHeader))));
+    if (retainedHeaders == kj::none) retainedHeaders = response.headers.clone();
+  };
+
+  auto first = client->request(
+      HttpMethod::GET, "/first", HttpHeaders(*table), kj::mv(options));
+  first.body = nullptr;
+  auto second = client->request(HttpMethod::GET, "/second", HttpHeaders(*table));
+  second.body = nullptr;
+  auto firstResponse = first.response.wait(waitScope);
+  KJ_EXPECT(firstResponse.statusCode == 200);
+  KJ_EXPECT(firstResponse.headers->get(interimHeader) == kj::none);
+  KJ_EXPECT(firstResponse.body->readAllText().wait(waitScope) == "ok");
+  firstResponse.body = nullptr;
+
+  KJ_ASSERT(statuses.size() == 2);
+  KJ_EXPECT(statuses[0] == 100);
+  KJ_EXPECT(statuses[1] == 103);
+  KJ_EXPECT(values[0] == "first");
+  KJ_EXPECT(values[1] == "second");
+  KJ_EXPECT(KJ_ASSERT_NONNULL(KJ_ASSERT_NONNULL(retainedHeaders).get(interimHeader)) == "first");
+
+  auto secondResponse = second.response.wait(waitScope);
+  KJ_EXPECT(secondResponse.statusCode == 204);
+  secondResponse.body = nullptr;
+
+  serverTask.wait(waitScope);
+}
+
+KJ_TEST("HttpClient closes when informational response handler throws") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  auto serverTask = expectRead(*pipe.ends[1],
+      "GET / HTTP/1.1\r\n\r\n"
+      "GET /queued HTTP/1.1\r\n\r\n")
+      .then([&]() {
+    return pipe.ends[1]->write(
+        "HTTP/1.1 103 Early Hints\r\n\r\n"
+        "HTTP/1.1 204 No Content\r\n\r\n"_kjb);
+  }).eagerlyEvaluate([](kj::Exception&& e) { KJ_LOG(ERROR, e); });
+
+  HttpHeaderTable table;
+  auto client = newHttpClient(table, *pipe.ends[0]);
+  HttpClient::RequestOptions options;
+  options.informationResponseHandler = [](HttpClient::InformationalResponse&&) {
+    KJ_FAIL_REQUIRE("informational handler failed");
+  };
+
+  auto request = client->request(HttpMethod::GET, "/", HttpHeaders(table), kj::mv(options));
+  request.body = nullptr;
+  auto queued = client->request(HttpMethod::GET, "/queued", HttpHeaders(table));
+  queued.body = nullptr;
+  KJ_EXPECT_THROW_MESSAGE("informational handler failed", request.response.wait(waitScope));
+  KJ_EXPECT_THROW_MESSAGE("did not finish reading previous HTTP response",
+      queued.response.wait(waitScope));
+  KJ_EXPECT_THROW_MESSAGE("connection has been closed",
+      client->request(HttpMethod::GET, "/again", HttpHeaders(table)));
+  serverTask.wait(waitScope);
+}
+
+KJ_TEST("HttpClient limits informational responses") {
+  KJ_HTTP_TEST_SETUP_IO;
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+  HttpHeaderTable table;
+  auto client = newHttpClient(table, *pipe.ends[0]);
+
+  auto request = client->request(HttpMethod::GET, "/sixteen", HttpHeaders(table));
+  request.body = nullptr;
+  expectRead(*pipe.ends[1], "GET /sixteen HTTP/1.1\r\n\r\n").wait(waitScope);
+  auto sixteen = kj::str(
+      kj::strArray(kj::repeat("HTTP/1.1 103 Early Hints\r\n\r\n", 16), ""),
+      "HTTP/1.1 204 No Content\r\n\r\n");
+  pipe.ends[1]->write(sixteen.asBytes()).wait(waitScope);
+  auto response = request.response.wait(waitScope);
+  KJ_EXPECT(response.statusCode == 204);
+  response.body = nullptr;
+
+  auto excessive = client->request(HttpMethod::GET, "/seventeen", HttpHeaders(table));
+  excessive.body = nullptr;
+  auto queued = client->request(HttpMethod::GET, "/queued", HttpHeaders(table));
+  queued.body = nullptr;
+  expectRead(*pipe.ends[1],
+      "GET /seventeen HTTP/1.1\r\n\r\n"
+      "GET /queued HTTP/1.1\r\n\r\n").wait(waitScope);
+  auto seventeen = kj::str(
+      kj::strArray(kj::repeat("HTTP/1.1 103 Early Hints\r\n\r\n", 17), ""),
+      "HTTP/1.1 204 No Content\r\n\r\n");
+  pipe.ends[1]->write(seventeen.asBytes()).wait(waitScope);
+  KJ_EXPECT_THROW_MESSAGE("Too many informational responses", excessive.response.wait(waitScope));
+  KJ_EXPECT_THROW_MESSAGE("did not finish reading previous HTTP response",
+      queued.response.wait(waitScope));
+}
+
 KJ_TEST("HttpClient canceled write") {
   KJ_HTTP_TEST_SETUP_IO;
 
@@ -1448,6 +1603,229 @@ KJ_TEST("HttpServer responses") {
         testCase.method == HttpMethod::HEAD ? HEAD_REQUEST : REQUEST, testCase,
         KJ_HTTP_TEST_CREATE_2PIPE);
   }
+}
+
+KJ_TEST("HttpServer sends informational responses") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  HttpHeaderTable::Builder builder;
+  auto infoHeader = builder.add("X-Info");
+  auto table = builder.build();
+
+  class Service final: public HttpService {
+  public:
+    Service(HttpHeaderTable& table, HttpHeaderId infoHeader)
+        : table(table), infoHeader(infoHeader) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      HttpHeaders informational(table);
+      informational.setPtr(HttpHeaderId::CONNECTION, "close");
+      informational.setPtr(HttpHeaderId::CONTENT_LENGTH, "123");
+      informational.setPtr(HttpHeaderId::TRANSFER_ENCODING, "chunked");
+      informational.setPtr(infoHeader, "value");
+
+      response.sendInformational(103, "Early Hints", informational);
+      KJ_EXPECT_THROW_MESSAGE("between 100 and 199",
+          response.sendInformational(99, "Invalid", informational));
+      KJ_EXPECT_THROW_MESSAGE("excluding 101",
+          response.sendInformational(101, "Switching Protocols", informational));
+      KJ_EXPECT_THROW_MESSAGE("final response status must be at least 200",
+          response.send(103, "Early Hints", informational, uint64_t(0)));
+
+      auto body = response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
+      KJ_EXPECT_THROW_MESSAGE("already called send",
+          response.sendInformational(103, "Late", informational));
+      return kj::READY_NOW;
+    }
+
+  private:
+    HttpHeaderTable& table;
+    HttpHeaderId infoHeader;
+  } service(*table, infoHeader);
+
+  auto run = [&](kj::StringPtr request, kj::StringPtr expected) {
+    auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+    HttpServer server(timer, *table, service);
+    auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+    pipe.ends[1]->write(request.asBytes()).wait(waitScope);
+    pipe.ends[1]->shutdownWrite();
+    KJ_EXPECT(pipe.ends[1]->readAllText().wait(waitScope) == expected);
+    listenTask.wait(waitScope);
+  };
+
+  run("GET / HTTP/1.1\r\n\r\n",
+      "HTTP/1.1 103 Early Hints\r\n"
+      "X-Info: value\r\n"
+      "\r\n"
+      "HTTP/1.1 204 No Content\r\n"
+      "\r\n");
+  run("GET / HTTP/1.0\r\n\r\n",
+      "HTTP/1.1 204 No Content\r\n"
+      "\r\n");
+}
+
+KJ_TEST("HttpServer handles Expect: 100-continue") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  HttpHeaderTable table;
+
+  class Service final: public HttpService {
+  public:
+    enum Mode { READ_BODY, MANUAL_CONTINUE, REJECT };
+
+    Service(HttpHeaderTable& table, Mode mode): table(table), mode(mode) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      if (mode == MANUAL_CONTINUE) {
+        response.sendInformational(100, "Continue", HttpHeaders(table));
+      } else if (mode == REJECT) {
+        response.send(417, "Expectation Failed", HttpHeaders(table), uint64_t(0));
+        co_return;
+      }
+
+      auto body = co_await requestBody.readAllText();
+      KJ_EXPECT(body == "foo");
+      response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
+    }
+
+  private:
+    HttpHeaderTable& table;
+    Mode mode;
+  };
+
+  auto runCompleteUpload = [&](bool enabled, kj::StringPtr version) {
+    auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+    Service service(table, Service::READ_BODY);
+    HttpServer server(timer, table, service, { .autoHandle100Continue = enabled });
+    auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+    auto request = kj::str(
+        "POST / ", version, "\r\n"
+        "Content-Length: 3\r\n"
+        "Expect: 100-continue\r\n"
+        "\r\n"
+        "foo");
+    pipe.ends[1]->write(request.asBytes()).wait(waitScope);
+    pipe.ends[1]->shutdownWrite();
+    KJ_EXPECT(pipe.ends[1]->readAllText().wait(waitScope) ==
+        "HTTP/1.1 204 No Content\r\n\r\n");
+    listenTask.wait(waitScope);
+  };
+
+  runCompleteUpload(false, "HTTP/1.1");
+  runCompleteUpload(true, "HTTP/1.0");
+
+  for (auto mode: { Service::READ_BODY, Service::MANUAL_CONTINUE }) {
+    auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+    Service service(table, mode);
+    HttpServer server(timer, table, service, { .autoHandle100Continue = true });
+    auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+    pipe.ends[1]->write(
+        "POST / HTTP/1.1\r\n"
+        "Content-Length: 3\r\n"
+        "Expect: 100-Continue\r\n"
+        "\r\n"_kjb).wait(waitScope);
+    expectRead(*pipe.ends[1], "HTTP/1.1 100 Continue\r\n\r\n").wait(waitScope);
+    pipe.ends[1]->write("foo"_kjb).wait(waitScope);
+    pipe.ends[1]->shutdownWrite();
+    KJ_EXPECT(pipe.ends[1]->readAllText().wait(waitScope) ==
+        "HTTP/1.1 204 No Content\r\n\r\n");
+    listenTask.wait(waitScope);
+  }
+
+  {
+    auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+    Service service(table, Service::READ_BODY);
+    HttpServer server(timer, table, service, { .autoHandle100Continue = true });
+    auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+
+    pipe.ends[1]->write(
+        "POST / HTTP/1.1\r\n"
+        "Content-Length: 3\r\n"
+        "Expect: other, \t100-Continue  \r\n"
+        "\r\n"_kjb).wait(waitScope);
+    expectRead(*pipe.ends[1], "HTTP/1.1 100 Continue\r\n\r\n").wait(waitScope);
+    pipe.ends[1]->write("foo"_kjb).wait(waitScope);
+    pipe.ends[1]->shutdownWrite();
+    KJ_EXPECT(pipe.ends[1]->readAllText().wait(waitScope) ==
+        "HTTP/1.1 204 No Content\r\n\r\n");
+    listenTask.wait(waitScope);
+  }
+
+  {
+    auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+    Service service(table, Service::REJECT);
+    HttpServer server(timer, table, service, { .autoHandle100Continue = true });
+    auto listenTask = server.listenHttp(kj::mv(pipe.ends[0]));
+    pipe.ends[1]->write(
+        "POST / HTTP/1.1\r\n"
+        "Content-Length: 3\r\n"
+        "Expect: 100-continue\r\n"
+        "\r\n"_kjb).wait(waitScope);
+    pipe.ends[1]->shutdownWrite();
+    KJ_EXPECT(pipe.ends[1]->readAllText().wait(waitScope) ==
+        "HTTP/1.1 417 Expectation Failed\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n");
+    listenTask.wait(waitScope);
+  }
+}
+
+KJ_TEST("HttpClient and HttpServer coordinate 100-continue") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+  HttpHeaderTable table;
+
+  class Service final: public HttpService {
+  public:
+    Service(HttpHeaderTable& table): table(table) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      KJ_EXPECT(co_await requestBody.readAllText() == "foo");
+      response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
+    }
+
+  private:
+    HttpHeaderTable& table;
+  } service(table);
+
+  HttpServer server(timer, table, service, { .autoHandle100Continue = true });
+  auto listenTask = server.listenHttp(kj::mv(pipe.ends[1]));
+  auto client = newHttpClient(table, *pipe.ends[0]);
+
+  HttpHeaders headers(table);
+  headers.setPtr(HttpHeaderId::EXPECT, "100-continue");
+  kj::Own<kj::AsyncOutputStream> requestBody;
+  kj::Maybe<kj::Promise<void>> upload;
+  uint interimCount = 0;
+  HttpClient::RequestOptions options;
+  options.expectedBodySize = uint64_t(3);
+  options.informationResponseHandler = [&](HttpClient::InformationalResponse&& response) {
+    ++interimCount;
+    KJ_EXPECT(response.statusCode == 100);
+    upload = requestBody->write("foo"_kjb);
+  };
+
+  auto request = client->request(HttpMethod::POST, "/", headers, kj::mv(options));
+  requestBody = kj::mv(request.body);
+  auto response = request.response.wait(waitScope);
+  KJ_ASSERT(upload != kj::none);
+  KJ_ASSERT_NONNULL(upload).wait(waitScope);
+  KJ_EXPECT(interimCount == 1);
+  KJ_EXPECT(response.statusCode == 204);
+  requestBody = nullptr;
+  response.body = nullptr;
+
+  pipe.ends[0]->shutdownWrite();
+  listenTask.wait(waitScope);
 }
 
 // -----------------------------------------------------------------------------
@@ -3186,7 +3564,9 @@ KJ_TEST("HttpClient WebSocket handshake") {
   auto request = kj::str("GET /websocket", WEBSOCKET_REQUEST_HANDSHAKE);
 
   auto serverTask = expectRead(*pipe.ends[1], request)
-      .then([&]() { return writeA(*pipe.ends[1], WEBSOCKET_RESPONSE_HANDSHAKE); })
+      .then([&]() {
+    return pipe.ends[1]->write("HTTP/1.1 103 Early Hints\r\n\r\n"_kjb);
+  }).then([&]() { return writeA(*pipe.ends[1], WEBSOCKET_RESPONSE_HANDSHAKE); })
       .then([&]() { return writeA(*pipe.ends[1], WEBSOCKET_FIRST_MESSAGE_INLINE); })
       .then([&]() { return expectRead(*pipe.ends[1], WEBSOCKET_SEND_MESSAGE); })
       .then([&]() { return writeA(*pipe.ends[1], WEBSOCKET_REPLY_MESSAGE); })
@@ -5161,6 +5541,57 @@ KJ_TEST("HttpServer can suspend a request") {
   }
 }
 
+KJ_TEST("HttpServer preserves HTTP/1.0 across request suspension") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto pipe = KJ_HTTP_TEST_CREATE_2PIPE;
+  HttpHeaderTable table;
+
+  class Service final: public HttpService {
+  public:
+    Service(HttpHeaderTable& table): table(table) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      response.sendInformational(103, "Early Hints", HttpHeaders(table));
+      response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
+      return kj::READY_NOW;
+    }
+
+  private:
+    HttpHeaderTable& table;
+  } service(table);
+
+  HttpServer server(timer, table, service);
+  bool shouldSuspend = true;
+  kj::Maybe<HttpServer::SuspendedRequest> suspended;
+  auto factory = [&](HttpServer::SuspendableRequest& request)
+      -> kj::Maybe<kj::Own<HttpService>> {
+    if (shouldSuspend) {
+      suspended = request.suspend();
+      return kj::none;
+    }
+    return kj::Own<HttpService>(&service, kj::NullDisposer::instance);
+  };
+
+  auto firstListen = server.listenHttpCleanDrain(*pipe.ends[0], factory);
+  pipe.ends[1]->write("GET / HTTP/1.0\r\n\r\n"_kjb).wait(waitScope);
+  KJ_EXPECT(firstListen.poll(waitScope));
+  KJ_EXPECT(!firstListen.wait(waitScope));
+  KJ_ASSERT(suspended != kj::none);
+
+  shouldSuspend = false;
+  auto secondListen = server.listenHttpCleanDrain(
+      *pipe.ends[0], factory, kj::mv(suspended));
+  auto drainTask = server.drain();
+  auto readTask = pipe.ends[1]->readAllText();
+  KJ_EXPECT(secondListen.wait(waitScope));
+  drainTask.wait(waitScope);
+  pipe.ends[0] = nullptr;
+  KJ_EXPECT(readTask.wait(waitScope) == "HTTP/1.1 204 No Content\r\n\r\n");
+}
+
 KJ_TEST("HttpServer can suspend and resume pipelined requests") {
   // This test sends multiple requests with both Content-Length and Transfer-Encoding: chunked
   // bodies, and verifies that suspending both kinds does not corrupt the stream.
@@ -5475,6 +5906,43 @@ KJ_TEST("newHttpService from HttpClient") {
   writeResponsesPromise.wait(waitScope);
 }
 
+KJ_TEST("newHttpService from HttpClient forwards informational responses") {
+  KJ_HTTP_TEST_SETUP_IO;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  auto frontPipe = KJ_HTTP_TEST_CREATE_2PIPE;
+  auto backPipe = KJ_HTTP_TEST_CREATE_2PIPE;
+
+  auto backendTask = expectRead(*backPipe.ends[1], "GET / HTTP/1.1\r\n\r\n")
+      .then([&]() {
+    return backPipe.ends[1]->write(
+        "HTTP/1.1 103 Early Hints\r\n"
+        "X-Info: value\r\n"
+        "\r\n"
+        "HTTP/1.1 204 No Content\r\n"
+        "\r\n"_kjb);
+  }).eagerlyEvaluate([](kj::Exception&& e) { KJ_LOG(ERROR, e); });
+
+  HttpHeaderTable::Builder builder;
+  builder.add("X-Info");
+  auto table = builder.build();
+  auto backClient = newHttpClient(*table, *backPipe.ends[0]);
+  auto frontService = newHttpService(*backClient);
+  HttpServer frontServer(timer, *table, *frontService);
+  auto listenTask = frontServer.listenHttp(kj::mv(frontPipe.ends[1]));
+
+  frontPipe.ends[0]->write("GET / HTTP/1.1\r\n\r\n"_kjb).wait(waitScope);
+  expectRead(*frontPipe.ends[0],
+      "HTTP/1.1 103 Early Hints\r\n"
+      "X-Info: value\r\n"
+      "\r\n"
+      "HTTP/1.1 204 No Content\r\n"
+      "\r\n").wait(waitScope);
+
+  frontPipe.ends[0]->shutdownWrite();
+  listenTask.wait(waitScope);
+  backendTask.wait(waitScope);
+}
+
 KJ_TEST("newHttpService from HttpClient WebSockets") {
   KJ_HTTP_TEST_SETUP_IO;
   kj::TimerImpl timer(kj::origin<kj::TimePoint>());
@@ -5640,6 +6108,53 @@ KJ_TEST("newHttpClient from HttpService") {
   for (auto& testCase: PIPELINE_TESTS) {
     testHttpClient(waitScope, table, *client, testCase);
   }
+}
+
+KJ_TEST("newHttpClient from HttpService forwards informational responses") {
+  KJ_HTTP_TEST_SETUP_IO;
+
+  HttpHeaderTable::Builder builder;
+  auto infoHeader = builder.add("X-Info");
+  auto table = builder.build();
+
+  class Service final: public HttpService {
+  public:
+    Service(HttpHeaderTable& table, HttpHeaderId infoHeader)
+        : table(table), infoHeader(infoHeader) {}
+
+    kj::Promise<void> request(
+        HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+        kj::AsyncInputStream& requestBody, Response& response) override {
+      HttpHeaders informational(table);
+      informational.setPtr(infoHeader, "value");
+      response.sendInformational(103, "Early Hints", informational);
+      KJ_EXPECT_THROW_MESSAGE("final response status must be at least 200",
+          response.send(103, "Early Hints", informational, uint64_t(0)));
+      response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
+      return kj::READY_NOW;
+    }
+
+  private:
+    HttpHeaderTable& table;
+    HttpHeaderId infoHeader;
+  } service(*table, infoHeader);
+
+  auto client = newHttpClient(service);
+  uint callbackCount = 0;
+  HttpClient::RequestOptions options;
+  options.informationResponseHandler = [&](HttpClient::InformationalResponse&& response) {
+    ++callbackCount;
+    KJ_EXPECT(response.statusCode == 103);
+    KJ_EXPECT(response.statusText == "Early Hints");
+    KJ_EXPECT(KJ_ASSERT_NONNULL(response.headers.get(infoHeader)) == "value");
+  };
+
+  auto request = client->request(HttpMethod::GET, "/", HttpHeaders(*table), kj::mv(options));
+  request.body = nullptr;
+  auto response = request.response.wait(waitScope);
+  KJ_EXPECT(response.statusCode == 204);
+  KJ_EXPECT(callbackCount == 1);
+  response.body = nullptr;
 }
 
 KJ_TEST("newHttpClient from HttpService WebSockets") {
@@ -5996,6 +6511,10 @@ public:
         return KJ_EXCEPTION(FAILED, "client requested failure");
       }
 
+      if (url == "/interim") {
+        response.sendInformational(103, "Early Hints", HttpHeaders(headerTable));
+      }
+
       auto body = kj::str(headers.get(HttpHeaderId::HOST).orDefault("null"), ":", url);
       auto stream = response.send(200, "OK", HttpHeaders(headerTable), body.size());
       auto promises = kj::heapArrayBuilder<kj::Promise<void>>(2);
@@ -6042,6 +6561,22 @@ KJ_TEST("HttpClient connection management") {
 
   KJ_EXPECT(count == 0);
   KJ_EXPECT(cumulative == 0);
+
+  {
+    bool sawInterim = false;
+    HttpClient::RequestOptions options;
+    options.informationResponseHandler = [&](HttpClient::InformationalResponse&& response) {
+      sawInterim = true;
+      KJ_EXPECT(response.statusCode == 103);
+    };
+    auto request = client->request(
+        HttpMethod::GET, "/interim", HttpHeaders(headerTable), kj::mv(options));
+    request.body = nullptr;
+    auto response = request.response.wait(waitScope);
+    KJ_EXPECT(response.body->readAllText().wait(waitScope) == "null:/interim");
+    response.body = nullptr;
+    KJ_EXPECT(sawInterim);
+  }
 
   uint i = 0;
   auto doRequest = [&]() {
@@ -6721,7 +7256,9 @@ KJ_TEST("HttpClientImpl connect()") {
 
   expectRead(*pipe.ends[1], "CONNECT foo:123 HTTP/1.1\r\n\r\n").wait(waitScope);
 
-  pipe.ends[1]->write("HTTP/1.1 200 OK\r\n\r\nthis is the"_kjb).wait(waitScope);
+  pipe.ends[1]->write(
+      "HTTP/1.1 103 Early Hints\r\n\r\n"
+      "HTTP/1.1 200 OK\r\n\r\nthis is the"_kjb).wait(waitScope);
 
   KJ_EXPECT(!readPromise.poll(waitScope));
 

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1070,8 +1070,19 @@ HttpHeaders::RequestConnectOrProtocolError HttpHeaders::tryParseRequestOrConnect
         "Unrecognized request method.", content };
   }
 
-  // Ignore rest of line. Don't care about "HTTP/1.1" or whatever.
-  consumeLine(ptr);
+  auto versionLine = consumeLine(ptr);
+  auto versionEnd = versionLine.end();
+  while (versionEnd > versionLine.begin() &&
+         (versionEnd[-1] == ' ' || versionEnd[-1] == '\t')) {
+    --versionEnd;
+  }
+  bool isHttp10 = versionLine.slice(0, versionEnd - versionLine.begin()) ==
+      kj::StringPtr("HTTP/1.0").asArray();
+  if (result.is<HttpHeaders::Request>()) {
+    result.get<HttpHeaders::Request>().isHttp10 = isHttp10;
+  } else {
+    result.get<HttpHeaders::ConnectRequest>().isHttp10 = isHttp10;
+  }
 
   if (!parseHeaders(ptr, end)) {
     return ProtocolError { 400, "Bad Request",
@@ -1437,19 +1448,27 @@ private:
 static constexpr size_t MIN_BUFFER = 4096;
 static constexpr size_t MAX_BUFFER = 128 * 1024;
 static constexpr size_t MAX_CHUNK_HEADER_SIZE = 32;
+static constexpr uint MAX_INFORMATION_RESPONSES = 16;
+// The maximum number of interim responses (1xx) that we will accept before giving up.
+// RFC 9110 section 15.2.6 says that a client MUST be prepared to receive one or more
+// 1xx responses before a final response, but it doesn't specify a limit. We set a
+// limit to avoid DoS attacks. The limit is high enough that it should never be a
+// problem in practice. Eventually we might want to make this configurable, but that
+// feels like overkill for now.
 
 class HttpInputStreamImpl final: public HttpInputStream,
                                  public WrappableStreamMixin<HttpInputStreamImpl> {
 private:
   static kj::OneOf<HttpHeaders::Request, HttpHeaders::ConnectRequest> getResumingRequest(
       kj::OneOf<HttpMethod, HttpConnectMethod> method,
-      kj::StringPtr url) {
+      kj::StringPtr url,
+      bool isHttp10) {
     KJ_SWITCH_ONEOF(method) {
       KJ_CASE_ONEOF(m, HttpMethod) {
-        return HttpHeaders::Request { m, url };
+        return HttpHeaders::Request { m, url, isHttp10 };
       }
       KJ_CASE_ONEOF(m, HttpConnectMethod) {
-        return HttpHeaders::ConnectRequest { url };
+        return HttpHeaders::ConnectRequest { url, isHttp10 };
       }
     }
     KJ_UNREACHABLE;
@@ -1461,17 +1480,18 @@ public:
 
   explicit HttpInputStreamImpl(AsyncInputStream& inner,
       kj::Array<char> headerBufferParam,
-      kj::ArrayPtr<char> leftoverParam,
-      kj::OneOf<HttpMethod, HttpConnectMethod> method,
-      kj::StringPtr url,
-      HttpHeaders headers)
+       kj::ArrayPtr<char> leftoverParam,
+       kj::OneOf<HttpMethod, HttpConnectMethod> method,
+       kj::StringPtr url,
+       bool isHttp10,
+       HttpHeaders headers)
       : inner(inner),
         headerBuffer(kj::mv(headerBufferParam)),
         // Initialize `messageHeaderEnd` to a safe value, we'll adjust it below.
         messageHeaderEnd(leftoverParam.begin() - headerBuffer.begin()),
         leftover(leftoverParam),
         headers(kj::mv(headers)),
-        resumingRequest(getResumingRequest(method, url)) {
+        resumingRequest(getResumingRequest(method, url, isHttp10)) {
     // Constructor used for resuming a SuspendedRequest.
 
     // We expect headerBuffer to look like this:
@@ -1701,21 +1721,50 @@ public:
     KJ_UNREACHABLE;
   }
 
-  inline kj::Promise<HttpHeaders::ResponseOrProtocolError> readResponseHeaders() {
+  inline kj::Promise<HttpHeaders::ResponseOrProtocolError> readResponseHeaders(
+      kj::Maybe<kj::Function<void(HttpClient::InformationalResponse&&)>> handler = kj::none) {
     // Note: readResponseHeaders() could be called multiple times concurrently when pipelining
     //   requests. readMessageHeaders() will serialize these, but it's important not to mess with
     //   state (like calling headers.clear()) before said serialization has taken place.
-    auto headersOrError = co_await readMessageHeaders();
-    KJ_SWITCH_ONEOF(headersOrError) {
-      KJ_CASE_ONEOF(protocolError, HttpHeaders::ProtocolError) {
-        co_return protocolError;
+    KJ_TRY {
+      auto headersOrError = co_await readMessageHeaders();
+      uint interimCount = 0;
+      for (;;) {
+        KJ_SWITCH_ONEOF(headersOrError) {
+          KJ_CASE_ONEOF(protocolError, HttpHeaders::ProtocolError) {
+            abortRead();
+            co_return protocolError;
+          }
+          KJ_CASE_ONEOF(text, kj::ArrayPtr<char>) {
+            headers.clear();
+            auto responseOrError = headers.tryParseResponse(text);
+            KJ_IF_SOME(response, responseOrError.tryGet<HttpHeaders::Response>()) {
+              if (response.statusCode >= 100 && response.statusCode < 200 &&
+                  response.statusCode != 101) {
+                if (++interimCount > MAX_INFORMATION_RESPONSES) {
+                  abortRead();
+                  co_return HttpHeaders::ProtocolError {
+                    502, "Bad Gateway", "Too many informational responses.", text
+                  };
+                }
+                KJ_IF_SOME(h, handler) {
+                  h(HttpClient::InformationalResponse {
+                    response.statusCode, response.statusText, headers
+                  });
+                }
+                headersOrError = co_await readHeader(HeaderType::MESSAGE, 0, 0);
+                continue;
+              }
+            }
+            if (responseOrError.is<HttpHeaders::ProtocolError>()) abortRead();
+            co_return responseOrError;
+          }
+        }
       }
-      KJ_CASE_ONEOF(text, kj::ArrayPtr<char>) {
-        headers.clear();
-        co_return headers.tryParseResponse(text);
-      }
+    } KJ_CATCH(exception) {
+      if (onMessageDone != kj::none) abortRead();
+      kj::throwRecoverableException(kj::mv(exception));
     }
-
     KJ_UNREACHABLE;
   }
 
@@ -2477,6 +2526,12 @@ public:
     KJ_REQUIRE(!inBody, "previous HTTP message body incomplete; can't write more messages");
     inBody = true;
 
+    queueWrite(kj::mv(content));
+  }
+
+  void writeInformationalHeaders(String content) {
+    KJ_REQUIRE(!writeInProgress, "concurrent write()s not allowed") { return; }
+    KJ_REQUIRE(!inBody, "previous HTTP message body incomplete; can't write more messages");
     queueWrite(kj::mv(content));
   }
 
@@ -5621,7 +5676,14 @@ public:
   }
 
   Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
-                  kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+                   kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+    RequestOptions options;
+    options.expectedBodySize = expectedBodySize;
+    return request(method, url, headers, kj::mv(options));
+  }
+
+  Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+                  RequestOptions options) override {
     KJ_REQUIRE(!upgraded,
         "can't make further requests on this HttpClient because it has been or is in the process "
         "of being upgraded");
@@ -5637,7 +5699,7 @@ public:
     bool isGet = method == HttpMethod::GET || method == HttpMethod::HEAD;
     bool hasBody;
 
-    KJ_IF_SOME(s, expectedBodySize) {
+    KJ_IF_SOME(s, options.expectedBodySize) {
       if (isGet && s == 0) {
         // GET with empty body; don't send any Content-Length.
         hasBody = false;
@@ -5668,7 +5730,7 @@ public:
       // No entity-body.
       httpOutput.finishBody();
       bodyStream = heap<HttpNullEntityWriter>();
-    } else KJ_IF_SOME(s, expectedBodySize) {
+    } else KJ_IF_SOME(s, options.expectedBodySize) {
       bodyStream = heap<HttpFixedLengthEntityWriter>(httpOutput, s);
     } else {
       bodyStream = heap<HttpChunkedEntityWriter>(httpOutput);
@@ -5676,7 +5738,8 @@ public:
 
     auto id = ++counter;
 
-    auto responsePromise = httpInput.readResponseHeaders().then(
+    auto responsePromise = httpInput.readResponseHeaders(
+        kj::mv(options.informationResponseHandler)).then(
         [this,method,id](HttpHeaders::ResponseOrProtocolError&& responseOrProtocolError)
             -> HttpClient::Response {
       KJ_SWITCH_ONEOF(responseOrProtocolError) {
@@ -5708,6 +5771,10 @@ public:
         }
       }
 
+      KJ_UNREACHABLE;
+    }, [this](kj::Exception&& exception) -> HttpClient::Response {
+      closed = true;
+      kj::throwRecoverableException(kj::mv(exception));
       KJ_UNREACHABLE;
     });
 
@@ -6002,6 +6069,11 @@ private:
 
 }  // namespace
 
+HttpClient::Request HttpClient::request(
+    HttpMethod method, kj::StringPtr url, const HttpHeaders& headers, RequestOptions options) {
+  return request(method, url, headers, options.expectedBodySize);
+}
+
 kj::Promise<HttpClient::WebSocketResponse> HttpClient::openWebSocket(
     kj::StringPtr url, const HttpHeaders& headers) {
   return request(HttpMethod::GET, url, headers, kj::none)
@@ -6233,9 +6305,16 @@ public:
   }
 
   Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
-                  kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+                   kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+    RequestOptions options;
+    options.expectedBodySize = expectedBodySize;
+    return request(method, url, headers, kj::mv(options));
+  }
+
+  Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+                  RequestOptions options) override {
     auto refcounted = getClient();
-    auto result = refcounted->client->request(method, url, headers, expectedBodySize);
+    auto result = refcounted->client->request(method, url, headers, kj::mv(options));
     result.body = result.body.attach(refcounted.addRef());
     result.response = result.response.then(
         [refcounted=kj::mv(refcounted)](Response&& response) mutable {
@@ -6472,17 +6551,25 @@ public:
   }
 
   Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
-                  kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+                   kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+    RequestOptions options;
+    options.expectedBodySize = expectedBodySize;
+    return request(method, url, headers, kj::mv(options));
+  }
+
+  Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+                  RequestOptions options) override {
     KJ_IF_SOME(c, client) {
-      return c->request(method, url, headers, expectedBodySize);
+      return c->request(method, url, headers, kj::mv(options));
     } else {
       // This gets complicated since request() returns a pair of a stream and a promise.
       auto urlCopy = kj::str(url);
       auto headersCopy = headers.clone();
       auto combined = promise.addBranch().then(
-          [this,method,expectedBodySize,url=kj::mv(urlCopy), headers=kj::mv(headersCopy)]()
+          [this,method,options=kj::mv(options),url=kj::mv(urlCopy),
+           headers=kj::mv(headersCopy)]() mutable
           -> kj::Tuple<kj::Own<kj::AsyncOutputStream>, kj::Promise<Response>> {
-        auto req = KJ_ASSERT_NONNULL(client)->request(method, url, headers, expectedBodySize);
+        auto req = KJ_ASSERT_NONNULL(client)->request(method, url, headers, kj::mv(options));
         return kj::tuple(kj::mv(req.body), kj::mv(req.response));
       });
 
@@ -6547,7 +6634,14 @@ public:
         tasks(*this) {}
 
   Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
-                  kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+                   kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+    RequestOptions options;
+    options.expectedBodySize = expectedBodySize;
+    return request(method, url, headers, kj::mv(options));
+  }
+
+  Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+                  RequestOptions options) override {
     // We need to parse the proxy-style URL to convert it to host-style.
     // Use URL parsing options that avoid unnecessary rewrites.
     Url::Options urlOptions;
@@ -6558,7 +6652,7 @@ public:
     auto path = parsed.toString(Url::HTTP_REQUEST);
     auto headersCopy = headers.clone();
     headersCopy.setPtr(HttpHeaderId::HOST, parsed.host);
-    return getClient(parsed).request(method, path, headersCopy, expectedBodySize);
+    return getClient(parsed).request(method, path, headersCopy, kj::mv(options));
   }
 
   kj::Promise<WebSocketResponse> openWebSocket(
@@ -6756,10 +6850,17 @@ public:
   }
 
   Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
-                  kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+                   kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+    RequestOptions options;
+    options.expectedBodySize = expectedBodySize;
+    return request(method, url, headers, kj::mv(options));
+  }
+
+  Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+                  RequestOptions options) override {
     if (concurrentRequests < maxConcurrentRequests) {
       auto counter = ConnectionCounter(*this);
-      auto request = inner.request(method, url, headers, expectedBodySize);
+      auto request = inner.request(method, url, headers, kj::mv(options));
       fireCountChanged();
       auto promise = releaseSlotOnHeadersReceived
           ? releaseCounterOnHeaders(kj::mv(request.response), kj::mv(counter))
@@ -6776,8 +6877,8 @@ public:
                method,
                urlCopy = kj::mv(urlCopy),
                headersCopy = kj::mv(headersCopy),
-               expectedBodySize](ConnectionCounter&& counter) mutable {
-      auto req = inner.request(method, urlCopy, headersCopy, expectedBodySize);
+               options = kj::mv(options)](ConnectionCounter&& counter) mutable {
+      auto req = inner.request(method, urlCopy, headersCopy, kj::mv(options));
       auto promise = releaseSlotOnHeadersReceived
           ? releaseCounterOnHeaders(kj::mv(req.response), kj::mv(counter))
           : attachCounter(kj::mv(req.response), kj::mv(counter));
@@ -7017,19 +7118,27 @@ public:
   HttpClientAdapter(HttpService& service): service(service) {}
 
   Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
-                  kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+                   kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+    RequestOptions options;
+    options.expectedBodySize = expectedBodySize;
+    return request(method, url, headers, kj::mv(options));
+  }
+
+  Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+                  RequestOptions options) override {
     // We have to clone the URL and headers because HttpService implementation are allowed to
     // assume that they remain valid until the service handler completes whereas HttpClient callers
     // are allowed to destroy them immediately after the call.
     auto urlCopy = kj::str(url);
     auto headersCopy = kj::heap(headers.clone());
 
-    auto pipe = newOneWayPipe(expectedBodySize);
+    auto pipe = newOneWayPipe(options.expectedBodySize);
 
     // TODO(cleanup): The ownership relationships here are a mess. Can we do something better
     //   involving a PromiseAdapter, maybe?
     auto paf = kj::newPromiseAndFulfiller<Response>();
-    auto responder = kj::refcounted<ResponseImpl>(method, kj::mv(paf.fulfiller));
+    auto responder = kj::refcounted<ResponseImpl>(
+        method, kj::mv(paf.fulfiller), kj::mv(options.informationResponseHandler));
 
     auto requestPaf = kj::newPromiseAndFulfiller<kj::Promise<void>>();
     responder->setPromise(kj::mv(requestPaf.promise));
@@ -7193,8 +7302,11 @@ private:
   class ResponseImpl final: public HttpService::Response, public kj::Refcounted {
   public:
     ResponseImpl(kj::HttpMethod method,
-                 kj::Own<kj::PromiseFulfiller<HttpClient::Response>> fulfiller)
-        : method(method), fulfiller(kj::mv(fulfiller)) {}
+                 kj::Own<kj::PromiseFulfiller<HttpClient::Response>> fulfiller,
+                 kj::Maybe<kj::Function<void(HttpClient::InformationalResponse&&)>>
+                     informationResponseHandler)
+        : method(method), fulfiller(kj::mv(fulfiller)),
+          informationResponseHandler(kj::mv(informationResponseHandler)) {}
 
     void setPromise(kj::Promise<void> promise) {
       task = promise.eagerlyEvaluate([this](kj::Exception&& exception) {
@@ -7210,6 +7322,10 @@ private:
     kj::Own<kj::AsyncOutputStream> send(
         uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+      KJ_REQUIRE(!responseStarted, "already called send() or acceptWebSocket()");
+      KJ_REQUIRE(statusCode >= 200,
+          "final response status must be at least 200; use sendInformational() for 1xx");
+      responseStarted = true;
       // The caller of HttpClient is allowed to assume that the statusText and headers remain
       // valid until the body stream is dropped, but the HttpService implementation is allowed to
       // send values that are only valid until send() returns, so we have to copy.
@@ -7250,10 +7366,23 @@ private:
       KJ_FAIL_REQUIRE("a WebSocket was not requested");
     }
 
+    void sendInformational(
+        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+      KJ_REQUIRE(!responseStarted, "already called send() or acceptWebSocket()");
+      KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
+          "informational status must be between 100 and 199, excluding 101");
+      KJ_IF_SOME(handler, informationResponseHandler) {
+        handler(HttpClient::InformationalResponse { statusCode, statusText, headers });
+      }
+    }
+
   private:
     kj::HttpMethod method;
     kj::Own<kj::PromiseFulfiller<HttpClient::Response>> fulfiller;
+    kj::Maybe<kj::Function<void(HttpClient::InformationalResponse&&)>>
+        informationResponseHandler;
     kj::Promise<void> task = nullptr;
+    bool responseStarted = false;
   };
 
   class DelayedCloseWebSocket final: public WebSocket {
@@ -7358,6 +7487,8 @@ private:
     kj::Own<kj::AsyncOutputStream> send(
         uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers,
         kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+      KJ_REQUIRE(statusCode >= 200,
+          "final response status must be at least 200; use sendInformational() for 1xx");
       // The caller of HttpClient is allowed to assume that the statusText and headers remain
       // valid until the body stream is dropped, but the HttpService implementation is allowed to
       // send values that are only valid until send() returns, so we have to copy.
@@ -7548,7 +7679,13 @@ public:
       HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
       kj::AsyncInputStream& requestBody, Response& response) override {
     if (!headers.isWebSocket()) {
-      auto innerReq = client.request(method, url, headers, requestBody.tryGetLength());
+      HttpClient::RequestOptions options;
+      options.expectedBodySize = requestBody.tryGetLength();
+      options.informationResponseHandler =
+          [&response](HttpClient::InformationalResponse&& info) {
+        response.sendInformational(info.statusCode, info.statusText, info.headers);
+      };
+      auto innerReq = client.request(method, url, headers, kj::mv(options));
 
       auto promises = kj::heapArrayBuilder<kj::Promise<void>>(2);
       promises.add(requestBody.pumpTo(*innerReq.body).ignoreResult()
@@ -7677,6 +7814,9 @@ kj::Promise<void> HttpService::Response::sendError(
   return sendError(statusCode, statusText, HttpHeaders(headerTable));
 }
 
+void HttpService::Response::sendInformational(
+    uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) {}
+
 kj::Promise<void> HttpService::connect(
     kj::StringPtr host,
     const HttpHeaders& headers,
@@ -7685,6 +7825,87 @@ kj::Promise<void> HttpService::connect(
     kj::HttpConnectSettings settings) {
   KJ_UNIMPLEMENTED("CONNECT is not implemented by this HttpService");
 }
+
+namespace {
+
+class OnFirstReadInputStream final: public kj::AsyncInputStream {
+public:
+  OnFirstReadInputStream(
+      kj::Own<kj::AsyncInputStream> inner, kj::Function<void()> callback)
+      : inner(kj::mv(inner)), callback(kj::mv(callback)) {}
+
+  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+    start();
+    return inner->tryRead(buffer, minBytes, maxBytes);
+  }
+
+  kj::Maybe<uint64_t> tryGetLength() override {
+    return inner->tryGetLength();
+  }
+
+  kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
+    start();
+    return inner->pumpTo(output, amount);
+  }
+
+private:
+  kj::Own<kj::AsyncInputStream> inner;
+  kj::Function<void()> callback;
+  bool started = false;
+
+  void start() {
+    if (!started) {
+      started = true;
+      callback();
+    }
+  }
+};
+
+bool is100Continue(kj::StringPtr value) {
+  constexpr char expected[] = "100-continue";
+  auto begin = value.begin();
+  while (begin < value.end()) {
+    while (begin < value.end() && (*begin == ' ' || *begin == '\t')) ++begin;
+    auto end = begin;
+    bool quoted = false;
+    bool escaped = false;
+    while (end < value.end()) {
+      if (escaped) {
+        escaped = false;
+      } else if (quoted && *end == '\\') {
+        escaped = true;
+      } else if (*end == '"') {
+        quoted = !quoted;
+      } else if (!quoted && *end == ',') {
+        break;
+      }
+      ++end;
+    }
+    auto trimmedEnd = end;
+    while (trimmedEnd > begin &&
+           (trimmedEnd[-1] == ' ' || trimmedEnd[-1] == '\t')) {
+      --trimmedEnd;
+    }
+
+    if (trimmedEnd - begin == sizeof(expected) - 1) {
+      bool matches = true;
+      for (size_t i = 0; i < sizeof(expected) - 1; ++i) {
+        char c = begin[i];
+        if ('A' <= c && c <= 'Z') c += 'a' - 'A';
+        if (c != expected[i]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) return true;
+    }
+
+    begin = end + (end < value.end());
+  }
+  return false;
+}
+
+}  // namespace
 
 class HttpServer::Connection final: private HttpService::Response,
                                     private HttpService::ConnectResponse,
@@ -7758,6 +7979,7 @@ public:
       released.leftover,
       suspendable.method,
       suspendable.url,
+      currentRequestIsHttp10,
       kj::mv(headers),
     };
   }
@@ -7772,6 +7994,8 @@ private:
   HttpInputStreamImpl httpInput;
   HttpOutputStream httpOutput;
   kj::Maybe<kj::OneOf<HttpMethod, HttpConnectMethod>> currentMethod;
+  bool currentRequestIsHttp10 = false;
+  bool auto100ContinuePending = false;
   bool timedOut = false;
   bool closed = false;
   bool upgraded = false;
@@ -7795,6 +8019,7 @@ private:
           sr.leftover.asChars(),
           sr.method,
           sr.url,
+          sr.isHttp10,
           kj::mv(sr.headers));
     }
     return HttpInputStreamImpl(stream, table);
@@ -7968,6 +8193,8 @@ private:
         // sendError() uses Response::send(), which requires that we have a currentMethod, but we
         // never read one. GET seems like the correct choice here.
         currentMethod = HttpMethod::GET;
+        currentRequestIsHttp10 = true;
+        auto100ContinuePending = false;
         co_return co_await sendError(kj::mv(protocolError));
       }
     }
@@ -7979,6 +8206,8 @@ private:
     auto& headers = httpInput.getHeaders();
 
     currentMethod = HttpConnectMethod();
+    currentRequestIsHttp10 = request.isHttp10;
+    auto100ContinuePending = false;
 
     // The HTTP specification says that CONNECT requests have no meaningful payload
     // but stops short of saying that CONNECT *cannot* have a payload. Implementations
@@ -8042,6 +8271,8 @@ private:
     auto& headers = httpInput.getHeaders();
 
     currentMethod = request.method;
+    currentRequestIsHttp10 = request.isHttp10;
+    auto100ContinuePending = false;
 
     SuspendableRequest suspendable(*this, request.method, request.url, headers);
     auto maybeService = factory(suspendable);
@@ -8060,6 +8291,23 @@ private:
 
     auto body = httpInput.getEntityBody(
         HttpInputStreamImpl::REQUEST, request.method, 0, headers);
+
+    if (server.settings.autoHandle100Continue && !request.isHttp10 &&
+        body->tryGetLength().orDefault(1) > 0) {
+      KJ_IF_SOME(expect, headers.get(HttpHeaderId::EXPECT)) {
+        if (is100Continue(expect)) {
+          auto100ContinuePending = true;
+          body = kj::heap<OnFirstReadInputStream>(kj::mv(body), [this]() {
+            if (!auto100ContinuePending) return;
+            auto100ContinuePending = false;
+            if (currentMethod != kj::none) {
+              httpOutput.writeInformationalHeaders(
+                  kj::str("HTTP/1.1 100 Continue\r\n\r\n"));
+            }
+          });
+        }
+      }
+    }
 
     co_await service->request(
         request.method, request.url, headers, *body, *this).attach(kj::mv(service));
@@ -8167,11 +8415,27 @@ private:
     }
   }
 
+  void sendInformational(
+      uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+    KJ_REQUIRE(currentMethod != kj::none, "already called send() or acceptWebSocket()");
+    KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
+        "informational status must be between 100 and 199, excluding 101");
+    if (currentRequestIsHttp10) return;
+
+    kj::StringPtr connectionHeaders[HttpHeaders::CONNECTION_HEADERS_COUNT] = {};
+    httpOutput.writeInformationalHeaders(
+        headers.serializeResponse(statusCode, statusText, connectionHeaders));
+    if (statusCode == 100) auto100ContinuePending = false;
+  }
+
   kj::Own<kj::AsyncOutputStream> send(
       uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize) override {
     auto method = KJ_REQUIRE_NONNULL(currentMethod, "already called send()");
+    KJ_REQUIRE(statusCode >= 200,
+        "final response status must be at least 200; use sendInformational() for 1xx");
     currentMethod = kj::none;
+    auto100ContinuePending = false;
 
     kj::StringPtr connectionHeaders[HttpHeaders::CONNECTION_HEADERS_COUNT];
     kj::String lengthStr;
@@ -8319,6 +8583,7 @@ private:
     // callback. This prevents the error handler from inadvertently trying to send another error on
     // the connection.
     currentMethod = kj::none;
+    auto100ContinuePending = false;
 
     httpOutput.writeHeaders(headers.serializeResponse(
         101, "Switching Protocols", connectionHeaders));
@@ -8408,6 +8673,7 @@ private:
   void accept(uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
     auto method = KJ_REQUIRE_NONNULL(currentMethod, "already called send()");
     currentMethod = kj::none;
+    auto100ContinuePending = false;
     KJ_ASSERT(method.is<HttpConnectMethod>(), "only use accept() with CONNECT requests");
     KJ_REQUIRE(statusCode >= 200 && statusCode < 300, "the statusCode must be 2xx for accept");
     tunnelRejected = kj::none;
@@ -8563,11 +8829,12 @@ void HttpServer::taskFailed(kj::Exception&& exception) {
 HttpServer::SuspendedRequest::SuspendedRequest(
     kj::Array<byte> bufferParam, kj::ArrayPtr<byte> leftoverParam,
     kj::OneOf<HttpMethod, HttpConnectMethod> method,
-    kj::StringPtr url, HttpHeaders headers)
+    kj::StringPtr url, bool isHttp10, HttpHeaders headers)
     : buffer(kj::mv(bufferParam)),
       leftover(leftoverParam),
       method(method),
       url(url),
+      isHttp10(isHttp10),
       headers(kj::mv(headers)) {
   if (leftover.size() > 0) {
     // We have a `leftover`; make sure it is a slice of `buffer`.

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1449,12 +1449,28 @@ static constexpr size_t MIN_BUFFER = 4096;
 static constexpr size_t MAX_BUFFER = 128 * 1024;
 static constexpr size_t MAX_CHUNK_HEADER_SIZE = 32;
 static constexpr uint MAX_INFORMATION_RESPONSES = 16;
-// The maximum number of interim responses (1xx) that we will accept before giving up.
+// The maximum number of informational responses (1xx) that we will accept before giving up.
 // RFC 9110 section 15.2.6 says that a client MUST be prepared to receive one or more
 // 1xx responses before a final response, but it doesn't specify a limit. We set a
 // limit to avoid DoS attacks. The limit is high enough that it should never be a
 // problem in practice. Eventually we might want to make this configurable, but that
 // feels like overkill for now.
+
+kj::Maybe<HttpInformationalStatus> tryGetInformationalStatus(uint statusCode) {
+  switch (statusCode) {
+    case 100: return HttpInformationalStatus::CONTINUE;
+    case 102: return HttpInformationalStatus::PROCESSING;
+    case 103: return HttpInformationalStatus::EARLY_HINTS;
+    default: return kj::none;
+  }
+}
+
+uint getInformationalStatusCode(HttpInformationalStatus status) {
+  auto statusCode = static_cast<uint>(status);
+  KJ_REQUIRE(tryGetInformationalStatus(statusCode) != kj::none,
+      "unsupported informational response status", statusCode);
+  return statusCode;
+}
 
 class HttpInputStreamImpl final: public HttpInputStream,
                                  public WrappableStreamMixin<HttpInputStreamImpl> {
@@ -1747,10 +1763,12 @@ public:
                     502, "Bad Gateway", "Too many informational responses.", text
                   };
                 }
-                KJ_IF_SOME(h, handler) {
-                  h(HttpClient::InformationalResponse {
-                    response.statusCode, response.statusText, headers
-                  });
+                KJ_IF_SOME(status, tryGetInformationalStatus(response.statusCode)) {
+                  KJ_IF_SOME(h, handler) {
+                    h(HttpClient::InformationalResponse {
+                      status, response.statusText, headers
+                    });
+                  }
                 }
                 headersOrError = co_await readHeader(HeaderType::MESSAGE, 0, 0);
                 continue;
@@ -7367,12 +7385,12 @@ private:
     }
 
     void sendInformational(
-        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+        HttpInformationalStatus status, kj::StringPtr statusText,
+        const HttpHeaders& headers) override {
       KJ_REQUIRE(!responseStarted, "already called send() or acceptWebSocket()");
-      KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
-          "informational status must be between 100 and 199, excluding 101");
+      getInformationalStatusCode(status);
       KJ_IF_SOME(handler, informationResponseHandler) {
-        handler(HttpClient::InformationalResponse { statusCode, statusText, headers });
+        handler(HttpClient::InformationalResponse { status, statusText, headers });
       }
     }
 
@@ -7815,7 +7833,9 @@ kj::Promise<void> HttpService::Response::sendError(
 }
 
 void HttpService::Response::sendInformational(
-    uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) {}
+    HttpInformationalStatus status, kj::StringPtr statusText, const HttpHeaders& headers) {
+  getInformationalStatusCode(status);
+}
 
 kj::Promise<void> HttpService::connect(
     kj::StringPtr host,
@@ -8416,16 +8436,16 @@ private:
   }
 
   void sendInformational(
-      uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers) override {
+      HttpInformationalStatus status, kj::StringPtr statusText,
+      const HttpHeaders& headers) override {
     KJ_REQUIRE(currentMethod != kj::none, "already called send() or acceptWebSocket()");
-    KJ_REQUIRE(statusCode >= 100 && statusCode < 200 && statusCode != 101,
-        "informational status must be between 100 and 199, excluding 101");
+    auto statusCode = getInformationalStatusCode(status);
     if (currentRequestIsHttp10) return;
 
     kj::StringPtr connectionHeaders[HttpHeaders::CONNECTION_HEADERS_COUNT] = {};
     httpOutput.writeInformationalHeaders(
         headers.serializeResponse(statusCode, statusText, connectionHeaders));
-    if (statusCode == 100) auto100ContinuePending = false;
+    if (status == HttpInformationalStatus::CONTINUE) auto100ContinuePending = false;
   }
 
   kj::Own<kj::AsyncOutputStream> send(

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -98,6 +98,17 @@ KJ_HTTP_FOR_EACH_METHOD(DECLARE_METHOD)
 #undef DECLARE_METHOD
 };
 
+enum class HttpInformationalStatus {
+  // We intentionally only support a subset of the 1xx informational status code.
+  // Because we don't know what future semantics will be added to future 1xx
+  // codes, we don't support them. They will be ignored when received and we
+  // won't allow sending them. The ones we do support here are known to be
+  // safe to handle at either the kj or application level.
+  CONTINUE = 100,
+  PROCESSING = 102,
+  EARLY_HINTS = 103,
+};
+
 struct HttpConnectMethod {};
 // CONNECT is handled specially and separately from the other HttpMethods.
 
@@ -829,7 +840,7 @@ class HttpClient {
 
 public:
   struct InformationalResponse {
-    uint statusCode;
+    HttpInformationalStatus statusCode;
     kj::StringPtr statusText;
     const HttpHeaders& headers;
   };
@@ -960,7 +971,7 @@ public:
     //
     // `send()` may only be called a single time. Calling it a second time will cause an exception
     // to be thrown.
-    // `statusCode` must be 200 or greater; use sendInformational() for non-101 1xx responses.
+    // `statusCode` must be 200 or greater; use sendInformational() for informational responses.
 
     virtual kj::Own<WebSocket> acceptWebSocket(const HttpHeaders& headers) = 0;
     // If headers.isWebSocket() is true then you can call acceptWebSocket() instead of send().
@@ -976,8 +987,8 @@ public:
     // exception to be thrown.
 
     virtual void sendInformational(
-        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers);
-    // Sends a non-101 informational response before send() or acceptWebSocket().
+        HttpInformationalStatus statusCode, kj::StringPtr statusText, const HttpHeaders& headers);
+    // Sends a supported informational response before send() or acceptWebSocket().
 
     kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText,
                                 const HttpHeaders& headers);

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -167,7 +167,8 @@ public:
   MACRO(LOCATION, "Location") \
   MACRO(CONTENT_TYPE, "Content-Type") \
   MACRO(RANGE, "Range") \
-  MACRO(CONTENT_RANGE, "Content-Range")
+  MACRO(CONTENT_RANGE, "Content-Range") \
+  MACRO(EXPECT, "Expect")
   // For convenience, these headers are valid for all HttpHeaderTables. You can refer to them like:
   //
   //     HttpHeaderId::HOST
@@ -386,9 +387,11 @@ public:
   struct Request {
     HttpMethod method;
     kj::StringPtr url;
+    bool isHttp10 = false;
   };
   struct ConnectRequest {
     kj::StringPtr authority;
+    bool isHttp10 = false;
   };
   struct Response {
     uint statusCode;
@@ -825,6 +828,17 @@ class HttpClient {
   //   The `url` specified in a request is a full URL including protocol and hostname.
 
 public:
+  struct InformationalResponse {
+    uint statusCode;
+    kj::StringPtr statusText;
+    const HttpHeaders& headers;
+  };
+
+  struct RequestOptions {
+    kj::Maybe<uint64_t> expectedBodySize = kj::none;
+    kj::Maybe<kj::Function<void(InformationalResponse&&)>> informationResponseHandler = kj::none;
+  };
+
   struct Response {
     uint statusCode;
     kj::StringPtr statusText;
@@ -857,6 +871,11 @@ public:
   // `expectedBodySize`, if provided, must be exactly the number of bytes that will be written to
   // the body. This will trigger use of the `Content-Length` connection header. Otherwise,
   // `Transfer-Encoding: chunked` will be used.
+
+  virtual Request request(HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
+                          RequestOptions options);
+  // Performs a request and synchronously reports informational responses before the final response.
+  // The handler must not retain `statusText` or `headers` without copying them.
 
   struct WebSocketResponse {
     uint statusCode;
@@ -941,6 +960,7 @@ public:
     //
     // `send()` may only be called a single time. Calling it a second time will cause an exception
     // to be thrown.
+    // `statusCode` must be 200 or greater; use sendInformational() for non-101 1xx responses.
 
     virtual kj::Own<WebSocket> acceptWebSocket(const HttpHeaders& headers) = 0;
     // If headers.isWebSocket() is true then you can call acceptWebSocket() instead of send().
@@ -954,6 +974,10 @@ public:
     //
     // `acceptWebSocket()` may only be called a single time. Calling it a second time will cause an
     // exception to be thrown.
+
+    virtual void sendInformational(
+        uint statusCode, kj::StringPtr statusText, const HttpHeaders& headers);
+    // Sends a non-101 informational response before send() or acceptWebSocket().
 
     kj::Promise<void> sendError(uint statusCode, kj::StringPtr statusText,
                                 const HttpHeaders& headers);
@@ -1241,6 +1265,9 @@ struct HttpServerSettings {
     AUTOMATIC_COMPRESSION, // Will perform compression parameter negotiation if client requests it.
   };
   WebSocketCompressionMode webSocketCompressionMode = NO_COMPRESSION;
+
+  bool autoHandle100Continue = false;
+  // Sends 100 Continue when a request body carrying Expect: 100-continue is first read.
 };
 
 class HttpServerErrorHandler {
@@ -1353,7 +1380,8 @@ public:
     // Nothing, this is an opaque type.
 
   private:
-    SuspendedRequest(kj::Array<byte>, kj::ArrayPtr<byte>, kj::OneOf<HttpMethod, HttpConnectMethod>, kj::StringPtr, HttpHeaders);
+    SuspendedRequest(kj::Array<byte>, kj::ArrayPtr<byte>,
+        kj::OneOf<HttpMethod, HttpConnectMethod>, kj::StringPtr, bool, HttpHeaders);
 
     kj::Array<byte> buffer;
     // A buffer containing at least the request's method, URL, and headers, and possibly content
@@ -1365,6 +1393,7 @@ public:
 
     kj::OneOf<HttpMethod, HttpConnectMethod> method;
     kj::StringPtr url;
+    bool isHttp10;
     HttpHeaders headers;
     // Parsed request front matter. `url` and `headers` both store pointers into `buffer`.
 


### PR DESCRIPTION
Adds the ability to send and receive informational (1xx) http responses.

Receiving:

```c++
  HttpClient::RequestOptions options;
  // The handler is invoked for every information response
  // received (up to a strict limit)
  options.informationResponseHandler =
      [&](HttpClient::InformationalResponse&& response) {
    switch (response.statusCode) {
      case kj::HttpInformationalStatus::CONTINUE: { /* ... */ }
      case kj::HttpInformationalStatus::PROCESSING: { /* ... */ }
      case kj::HttpInformationalStatus::EARLY_HINTS: { /* ... */ }
      default: { /* ... */ }
    }
    values.add(kj::str(KJ_ASSERT_NONNULL(response.headers.get(interimHeader))));
    if (retainedHeaders == kj::none) retainedHeaders = response.headers.clone();
  };

  auto req = client->request(
      HttpMethod::GET, "/", HttpHeaders(*table), kj::mv(options));
  // ...
```

Sending:

```c++
// In the HttpService (server side)
// ...
kj::Promise<void> request(
    HttpMethod method, kj::StringPtr url, const HttpHeaders& headers,
    kj::AsyncInputStream& requestBody, Response& response) override {
  HttpHeaders informational(table);
  informational.setPtr(infoHeader, "value");
  response.sendInformational(kj::HttpInformationalStatus::EARLY_HINTS,
      "Early Hints", informational);
  // Can call sendInformational multiple times...
  response.send(204, "No Content", HttpHeaders(table), uint64_t(0));
  return kj::READY_NOW;
}
```

http-over-capnp support is included.

The existing handling of 101 responses for protocol upgrade is preserved.

Optional automatic server-side handling of 100-continue responses is included, but off by default.