### PR TITLE
make WeakRc more thread-safe

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -22,6 +22,8 @@
 #include "refcount.h"
 #include "array.h"
 #include "string.h"
+#include "thread.h"
+#include "mutex.h"
 #include <kj/compat/gtest.h>
 
 namespace kj {
@@ -816,6 +818,41 @@ KJ_TEST("WeakRc with non-refcounted type") {
   ref2 = nullptr;
   EXPECT_TRUE(b);
   EXPECT_TRUE(weak == nullptr);
+}
+
+KJ_TEST("WeakRc destroyed on another thread") {
+  // A WeakRc<T> must be safe to move to and destroy on a thread other than the one owning the
+  // referent, even while the owner thread is concurrently dropping the last strong Rc<T>. Both
+  // sides decrement the shared cell's (atomic) refcount. Run this under TSAN to catch races.
+  bool b = false;
+  auto ref = kj::rc<SetTrueInDestructor>(&b);
+
+  constexpr size_t kCount = 1000;
+  auto builder = kj::heapArrayBuilder<WeakRc<SetTrueInDestructor>>(kCount);
+  for (size_t i = 0; i < kCount; i++) {
+    builder.add(ref.downgrade());
+  }
+  auto weaks = builder.finish();
+
+  // Used to release both threads roughly simultaneously to maximize contention on the cell.
+  kj::MutexGuarded<bool> go(false);
+
+  {
+    kj::Thread thread([&]() {
+      go.when([](bool ready) { return ready; }, [](bool&) {});
+      // Destroy all the weak references from this thread.
+      for (auto& w: weaks) {
+        w = nullptr;
+      }
+    });
+
+    *go.lockExclusive() = true;
+    // Meanwhile, drop the last strong reference on the owner thread.
+    ref = nullptr;
+  }
+
+  // The referent was destroyed and nothing crashed / no cell was double-freed.
+  EXPECT_TRUE(b);
 }
 
 KJ_TEST("WeakRc from null Rc") {

--- a/c++/src/kj/refcount.c++
+++ b/c++/src/kj/refcount.c++
@@ -32,6 +32,44 @@
 namespace kj {
 
 // =======================================================================================
+// WeakRc<T> validity cell
+//
+// The cell's refcount is atomic so that a WeakRc<T> can be moved, cloned, or destroyed from any
+// thread, even though the referent itself (and its strong Rc<T>s) remain single-threaded. In
+// particular the owner thread's disposeImpl() below decrements this same refcount, and that must
+// not race with a WeakRc<T> being destroyed on another thread.
+
+namespace _ {  // private
+
+void RcWeakCell::addRef() {
+#if _MSC_VER && !defined(__clang__)
+  KJ_MSVC_INTERLOCKED(Increment, nf)(&refcount);
+#else
+  __atomic_add_fetch(&refcount, 1, __ATOMIC_RELAXED);
+#endif
+}
+
+void RcWeakCell::decRef() {
+#if _MSC_VER && !defined(__clang__)
+  if (KJ_MSVC_INTERLOCKED(Decrement, rel)(&refcount) == 0) {
+    std::atomic_thread_fence(std::memory_order_acquire);
+    delete this;
+  }
+#else
+  // Use acquire-release on the decrement itself rather than a release decrement plus a separate
+  // acquire fence. Both are correct, but the RMW form guarantees the thread that observes the
+  // count reach zero has also acquired every prior release (including the owner thread nulling
+  // `refcounted` in disposeImpl()) before it frees the cell. It is also understood by
+  // ThreadSanitizer, which does not model standalone atomic_thread_fence.
+  if (__atomic_sub_fetch(&refcount, 1, __ATOMIC_ACQ_REL) == 0) {
+    delete this;
+  }
+#endif
+}
+
+}  // namespace _ (private)
+
+// =======================================================================================
 // Non-atomic (thread-unsafe) refcounting
 
 Refcounted::~Refcounted() noexcept(false) {

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -58,18 +58,36 @@ class RcWeakCell {
   // before the strong-side reference is released, allowing outstanding WeakRc pointers to observe
   // expiration safely. The cell outlives the referent so that expiration can be detected, and is
   // freed once both the strong side and all WeakRc references are gone.
+  //
+  // The cell's own refcount is manipulated atomically. This is what makes it safe to move, clone,
+  // and (importantly) destroy a WeakRc<T> from a thread other than the one that owns the referent:
+  // dropping the last strong Rc<T> decrements this same refcount from the owner thread, and that
+  // decrement must not race with a WeakRc<T> being destroyed elsewhere. (Actually *upgrading* a
+  // WeakRc<T> back to a strong Rc<T> still has to happen on the owner thread, because that touches
+  // the referent's non-atomic refcount -- see WeakRc<T>::upgrade().)
 
 public:
   explicit RcWeakCell(Refcounted* refcounted): refcounted(refcounted) {}
 
-  inline void addRef() { ++refcount; }
-  inline void decRef() { if (--refcount == 0) { delete this; } }
+  void addRef();
+  void decRef();
+  // Adjust the (atomic) weak-side refcount. Defined out-of-line in refcount.c++ so the atomic
+  // machinery (and, on MSVC, the acquire fence used before deletion) lives in one place.
 
   Refcounted* refcounted;
   // The live Refcounted object, or nullptr once the last strong reference has been dropped.
+  //
+  // This back-pointer is *not* synchronized: it is written once (nulled) by the owner thread when
+  // the last strong reference drops, and is only meant to be read on the owner thread (during
+  // upgrade()/get()). Cross-thread WeakRc<T> use is limited to lifecycle operations (move/clone/
+  // destroy), which only ever touch the atomic refcount above.
 
 private:
-  size_t refcount = 1;
+#if _MSC_VER && !defined(__clang__)
+  volatile long refcount = 1;
+#else
+  volatile uint refcount = 1;
+#endif
   // Starts at 1 to account for the strong-side reference held while `refcounted` is non-null.
 };
 
@@ -408,7 +426,15 @@ class WeakRc {
   // - upgrade() (or its synonym addStrongRef()) upgrades to Maybe<Rc<T>>
   //
   // WeakRc<T> is movable but, like kj::Rc<T>, not implicitly copyable; use clone() to make an
-  // additional weak reference explicitly. Like kj::Rc<T> it is NOT threadsafe.
+  // additional weak reference explicitly.
+  //
+  // Threading: the referent and its strong Rc<T>s still belong to a single "owner" thread, and
+  // upgrading a WeakRc<T> back to Rc<T> (upgrade(), tryGet(), assertLive(), operator==, KJ_IF_SOME,
+  // etc.) must be done on that owner thread. However, a WeakRc<T>'s own lifecycle -- moving,
+  // cloning, and (most usefully) destroying it -- is safe to perform from any thread, because the
+  // weak-side refcount in the shared cell is manipulated atomically. This means you can hand a
+  // WeakRc<T> to another thread and let it be dropped there without having to bounce the
+  // destruction back to the owner thread.
   //
   // Upgrading never resurrects a dead object: once the last strong Rc<T> is dropped the referent's
   // refcount reaches zero and is never incremented again. upgrade() only ever produces a strong


### PR DESCRIPTION
Move/Clone/Delete are allowed to be performed on different threads. This makes WeakRc much more versatile and safer to use.