### PR TITLE
Rc::downcast should not consume this

### DIFF
--- a/c++/src/kj/refcount-test.c++
+++ b/c++/src/kj/refcount-test.c++
@@ -529,13 +529,16 @@ KJ_TEST("Rc inheritance") {
   kj::Rc<SetTrueInDestructor> parent = child.addRef();
 
   auto down = parent.downcast<Child>();
-  EXPECT_TRUE(parent == nullptr);
+  EXPECT_TRUE(parent != nullptr);
   EXPECT_TRUE(down != nullptr);
+  EXPECT_TRUE(parent.get() == down.get());
 
   EXPECT_FALSE(b);
   child = nullptr;
   EXPECT_FALSE(b);
   down = nullptr;
+  EXPECT_FALSE(b);
+  parent = nullptr;
   EXPECT_TRUE(b);
 }
 
@@ -1128,13 +1131,16 @@ KJ_TEST("Arc inheritance") {
   kj::Arc<AtomicSetTrueInDestructor> parent = child.addRef();
 
   auto down = parent.downcast<AtomicChild>();
-  EXPECT_TRUE(parent == nullptr);
+  EXPECT_TRUE(parent != nullptr);
   EXPECT_TRUE(down != nullptr);
+  EXPECT_TRUE(parent.get() == down.get());
 
   EXPECT_FALSE(b);
   child = nullptr;
   EXPECT_FALSE(b);
   down = nullptr;
+  EXPECT_FALSE(b);
+  parent = nullptr;
   EXPECT_TRUE(b);
 }
 
@@ -1338,13 +1344,15 @@ KJ_TEST("Arc polymorphic upcast") {
   EXPECT_FALSE(b);
 
   Arc<ConcreteForArc> concrete = abstract.downcast<ConcreteForArc>();
-  EXPECT_TRUE(abstract == nullptr);
+  EXPECT_TRUE(abstract != nullptr);
   EXPECT_TRUE(concrete.get() == ref2.get());
 
   concrete = nullptr;
   EXPECT_FALSE(b);
 
   ref2 = nullptr;
+  EXPECT_FALSE(b);
+  abstract = nullptr;
   EXPECT_TRUE(b);
 }
 

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -335,11 +335,14 @@ public:
   }
 
   template <typename U>
-  Rc<U> downcast() {
-    Rc<U> result(refcounted, &kj::downcast<U>(*ptr));
-    refcounted = nullptr;
-    ptr = nullptr;
-    return result;
+  Rc<U> downcast() const {
+    // Create an additional reference to this object, downcast to U.
+    if (ptr != nullptr) {
+      auto downcasted = &kj::downcast<U>(*ptr);
+      ++refcounted->refcount;
+      return Rc<U>(refcounted, downcasted);
+    }
+    return Rc<U>();
   }
 
   inline bool operator==(const Rc<T>& other) const { return ptr == other.ptr; }
@@ -888,14 +891,14 @@ public:
   }
 
   template <typename U>
-  Arc<U> downcast() {
-    Arc<U> result;
+  Arc<U> downcast() const {
+    // Create an additional reference to this object, downcast to U.
     if (ptr != nullptr) {
-      result = Arc<U>(refcounted, &kj::downcast<const U>(*ptr));
-      refcounted = nullptr;
-      ptr = nullptr;
+      auto downcasted = &kj::downcast<const U>(*ptr);
+      refcounted->incRefcount();
+      return Arc<U>(refcounted, downcasted);
     }
-    return result;
+    return Arc<U>();
   }
 
   inline bool operator==(const Arc<T>& other) const { return ptr == other.ptr; }


### PR DESCRIPTION
I think current implementation was a mistake: while it is "eficcient" it is very error prone.