### PR TITLE
keep capabilities alive until their attached FDs have been written

### DIFF
--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -522,6 +522,11 @@ public:
   // If this capability is backed by a file descriptor that is safe to directly expose to clients,
   // returns that FD. When FD passing has been enabled in the RPC layer, this FD may be sent to
   // other processes along with the capability.
+  //
+  // The descriptor must stay open for at least as long as the capability itself. The RPC layer may
+  // hold a reference to the capability in order to keep the descriptor valid until it has finished
+  // sending it, so a server which closes its descriptor early can cause the peer to receive a
+  // descriptor that has been closed, or that now refers to some unrelated file.
 
   virtual kj::Maybe<kj::Promise<Capability::Client>> shortenPath();
   // If this returns non-null, then it is a promise which, when resolved, points to a new

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -44,6 +44,7 @@
 #include <kj/windows-sanity.h>
 #else
 #include <sys/socket.h>
+#include <sys/stat.h>
 #endif
 
 // TODO(cleanup): Auto-generate stringification functions for union discriminants.
@@ -591,6 +592,154 @@ KJ_TEST("FD per message limit") {
             == "");
   KJ_EXPECT(io.lowLevelProvider->wrapInputFd(kj::mv(in2))->readAllText().wait(io.waitScope)
             == "foo");
+}
+
+class FdWriteGate final: public MessageStream {
+  // A MessageStream which holds back the first message that has FDs attached until the test
+  // releases it, then reports what that FD referred to at the moment it was finally written. This
+  // lets a test control what happens in between the RPC system choosing which FD to attach to a
+  // message and the message actually being written.
+
+public:
+  FdWriteGate(MessageStream& inner, kj::Own<kj::PromiseFulfiller<void>> sawFdWrite,
+              kj::Promise<void> release, kj::Own<kj::PromiseFulfiller<void>> wroteFd)
+      : inner(inner), sawFdWrite(kj::mv(sawFdWrite)), release(kj::mv(release)),
+        wroteFd(kj::mv(wroteFd)) {}
+
+  bool statSucceeded = false;
+  mode_t mode = 0;
+  // Result of fstat()ing the attached FD at the moment the gated message was written. Valid once
+  // the `wroteFd` promise has resolved.
+
+  kj::Promise<kj::Maybe<MessageReaderAndFds>> tryReadMessage(
+      kj::ArrayPtr<kj::OwnFd> fdSpace, ReaderOptions options, kj::ArrayPtr<word> scratch) override {
+    return inner.tryReadMessage(fdSpace, options, scratch);
+  }
+
+  kj::Promise<void> writeMessage(kj::ArrayPtr<const int> fds,
+      kj::ArrayPtr<const kj::ArrayPtr<const word>> segments) override {
+    if (fds.size() == 0) return inner.writeMessage(fds, segments);
+
+    auto releasePromise = kj::mv(KJ_ASSERT_NONNULL(release, "expected only one message with FDs"));
+    release = kj::none;
+    sawFdWrite->fulfill();
+
+    // Capturing `fds` and `segments` is safe because MessageStream requires the caller to keep them
+    // valid until the promise returned here resolves.
+    return releasePromise.then([this, fds, segments]() {
+      struct stat stats;
+      if (fstat(fds[0], &stats) >= 0) {
+        statSucceeded = true;
+        mode = stats.st_mode;
+      }
+      wroteFd->fulfill();
+      return inner.writeMessage(fds, segments);
+    });
+  }
+
+  kj::Promise<void> writeMessages(
+      kj::ArrayPtr<kj::ArrayPtr<const kj::ArrayPtr<const word>>> messages) override {
+    return inner.writeMessages(messages);
+  }
+
+  kj::Maybe<int> getSendBufferSize() override { return inner.getSendBufferSize(); }
+  kj::Promise<void> end() override { return inner.end(); }
+
+  // Make sure the overridden virtual methods don't hide the non-virtual overloads.
+  using MessageStream::tryReadMessage;
+  using MessageStream::writeMessage;
+  using MessageStream::writeMessages;
+
+private:
+  MessageStream& inner;
+  kj::Own<kj::PromiseFulfiller<void>> sawFdWrite;
+  kj::Maybe<kj::Promise<void>> release;
+  kj::Own<kj::PromiseFulfiller<void>> wroteFd;
+};
+
+class FdCapHolder final: public test::TestMoreStuff::Server {
+  // Bootstrap which hands out a single capability owning a file descriptor. The descriptor is
+  // closed, and `destroyed` fulfilled, when that capability is dropped. getHeld() may only be
+  // called once.
+
+public:
+  FdCapHolder(kj::OwnFd fd, kj::Own<kj::PromiseFulfiller<void>> destroyed)
+      : fd(kj::mv(fd)), destroyed(kj::mv(destroyed)) {}
+
+  kj::Promise<void> getHeld(GetHeldContext context) override {
+    context.getResults().setCap(kj::heap<Held>(kj::mv(fd), kj::mv(destroyed)));
+    return kj::READY_NOW;
+  }
+
+private:
+  class Held final: public test::TestInterface::Server {
+    // Like `TestFdCap`, but also signals when it is destroyed, which is the moment its
+    // descriptor is closed.
+
+  public:
+    Held(kj::OwnFd fd, kj::Own<kj::PromiseFulfiller<void>> destroyed)
+        : fd(kj::mv(fd)), destroyed(kj::mv(destroyed)) {}
+    ~Held() noexcept(false) { destroyed->fulfill(); }
+
+    kj::Maybe<int> getFd() override { return fd.get(); }
+
+  private:
+    kj::OwnFd fd;
+    kj::Own<kj::PromiseFulfiller<void>> destroyed;
+  };
+
+  kj::OwnFd fd;
+  kj::Own<kj::PromiseFulfiller<void>> destroyed;
+};
+
+KJ_TEST("attached FD outlives a capability dropped before the message is written") {
+  // send() is only required to *queue* a message, so the FD chosen for a CapDescriptor may not be
+  // written for some time. A capability's FD is only guaranteed to stay open as long as the
+  // capability itself, so if the capability is dropped in the meantime, the queued message is left
+  // holding a number that has been closed -- or that the OS has since recycled for an unrelated
+  // file. The RPC system must keep the capability alive until the message has been written.
+
+  auto io = kj::setupAsyncIo();
+  auto pipe = io.provider->newCapabilityPipe();
+
+  // The capability holds one end of a socketpair, so that we can distinguish the FD still being
+  // open from its number having been reused by something else.
+  int socketFds[2]{};
+  KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, socketFds));
+  kj::OwnFd peerEnd(socketFds[0]);
+  kj::OwnFd heldEnd(socketFds[1]);
+
+  auto sawFdWrite = kj::newPromiseAndFulfiller<void>();
+  auto release = kj::newPromiseAndFulfiller<void>();
+  auto wroteFd = kj::newPromiseAndFulfiller<void>();
+  auto destroyed = kj::newPromiseAndFulfiller<void>();
+
+  AsyncCapabilityMessageStream serverStream(*pipe.ends[0]);
+  FdWriteGate gate(serverStream, kj::mv(sawFdWrite.fulfiller), kj::mv(release.promise),
+      kj::mv(wroteFd.fulfiller));
+  TwoPartyVatNetwork network(gate, 1, rpc::twoparty::Side::SERVER);
+  auto rpcServer = makeRpcServer(network, test::TestMoreStuff::Client(
+      kj::heap<FdCapHolder>(kj::mv(heldEnd), kj::mv(destroyed.fulfiller))));
+
+  TwoPartyClient client(*pipe.ends[1], 1);
+  auto promise = client.bootstrap().castAs<test::TestMoreStuff>().getHeldRequest().send();
+
+  // Wait until the server has built its Return message and chosen the FD to attach to it.
+  sawFdWrite.promise.wait(io.waitScope);
+
+  // Abandon the question. Because the Return hasn't arrived yet, the Finish sets
+  // releaseResultCaps, so the server drops the export -- the only other reference to the
+  // capability -- while its Return is still sitting in the write queue.
+  { auto abandoned = kj::mv(promise); }
+
+  // The capability must survive regardless, since the queued message still refers to its FD.
+  KJ_EXPECT(!destroyed.promise.poll(io.waitScope));
+
+  // Let the write proceed, and confirm the peer is being handed the socket we meant to send.
+  release.fulfiller->fulfill();
+  wroteFd.promise.wait(io.waitScope);
+  KJ_EXPECT(gate.statSucceeded);
+  KJ_EXPECT((gate.mode & S_IFMT) == S_IFSOCK, gate.mode);
 }
 #endif  // !_WIN32 && !__CYGWIN__
 

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -402,6 +402,41 @@ private:
   kj::HashMap<Id, T> high;
 };
 
+class OutgoingFds {
+  // Accumulates the file descriptors to attach to one outgoing message, along with a reference to
+  // the capability each one came from.
+  //
+  // A capability's descriptor is only guaranteed to stay open as long as the capability itself
+  // lives, but `OutgoingRpcMessage::send()` is permitted to merely queue the message. A capability
+  // dropped in between would take its descriptor with it, leaving a number that is closed, or that
+  // has since been reused for some unrelated file, to be written. `release()` therefore hands these
+  // references to the message so that the capabilities outlive the write.
+
+public:
+  size_t size() {
+    return fds.size();
+  }
+
+  void add(int fd, ClientHook& owner) {
+    fds.add(fd);
+    owners.add(owner.addRef());
+  }
+
+  kj::Array<int> release() {
+    // The descriptors, with the capabilities they came from attached. Pass this to
+    // `OutgoingRpcMessage::setFds()`, which holds it until the message has been written.
+    if (fds.size() == 0) {
+      // Nothing to keep alive, and there'd be no array to attach it to in any case.
+      return nullptr;
+    }
+    return fds.releaseAsArray().attach(owners.releaseAsArray());
+  }
+
+private:
+  kj::Vector<int> fds;
+  kj::Vector<kj::Own<ClientHook>> owners;
+};
+
 }  // namespace
 
 // =======================================================================================
@@ -989,7 +1024,7 @@ private:
     };
 
     virtual WriteDescriptorResult writeDescriptor(rpc::CapDescriptor::Builder descriptor,
-                                                  kj::Vector<int>& fds) = 0;
+                                                  OutgoingFds& fds) = 0;
     // Writes a CapDescriptor referencing this client.  The CapDescriptor must be sent as part of
     // the very next message sent on the connection, as it may become invalid if other things
     // happen.
@@ -1192,7 +1227,7 @@ private:
     }
 
     WriteDescriptorResult writeDescriptor(rpc::CapDescriptor::Builder descriptor,
-                                          kj::Vector<int>& fds) override {
+                                          OutgoingFds& fds) override {
       descriptor.setReceiverHosted(importId);
       return {
         .exportId = kj::none,
@@ -1240,7 +1275,7 @@ private:
         : RpcClient(connectionState), questionRef(kj::mv(questionRef)), ops(kj::mv(ops)) {}
 
     WriteDescriptorResult writeDescriptor(rpc::CapDescriptor::Builder descriptor,
-                                          kj::Vector<int>& fds) override {
+                                          OutgoingFds& fds) override {
       auto promisedAnswer = descriptor.initReceiverAnswer();
       promisedAnswer.setQuestionId(questionRef->getId());
       promisedAnswer.adoptTransform(fromPipelineOps(
@@ -1331,7 +1366,7 @@ private:
     }
 
     WriteDescriptorResult writeDescriptor(rpc::CapDescriptor::Builder descriptor,
-                                          kj::Vector<int>& fds) override {
+                                          OutgoingFds& fds) override {
       // TODO(now): Setting receivedCall = true seems wrong here, writing a descriptor does not
       //   imply that the capability is being called, and so does not imply that an embargo is
       //   needed when the capability is resolved.
@@ -1587,7 +1622,7 @@ private:
     }
 
     WriteDescriptorResult writeDescriptor(rpc::CapDescriptor::Builder descriptor,
-                                          kj::Vector<int>& fds) override {
+                                          OutgoingFds& fds) override {
       KJ_SWITCH_ONEOF(state) {
         KJ_CASE_ONEOF(deferred, Deferred) {
           // A ThirdPartyCapDescriptor was sent to us, and we are sending it *back* over the same
@@ -1741,7 +1776,7 @@ private:
   };
 
   RpcClient::WriteDescriptorResult writeDescriptor(
-      ClientHook& cap, rpc::CapDescriptor::Builder descriptor, kj::Vector<int>& fds) {
+      ClientHook& cap, rpc::CapDescriptor::Builder descriptor, OutgoingFds& fds) {
     // Write a descriptor for the given capability.
 
     // Follow all promise resolutions before writing the descriptor. This is important to comply
@@ -1758,7 +1793,7 @@ private:
 
     KJ_IF_SOME(fd, inner->getFd()) {
       descriptor.setAttachedFd(fds.size());
-      fds.add(kj::mv(fd));
+      fds.add(fd, *inner);
     }
 
     KJ_IF_SOME(rpcInner, unwrapIfSameNetwork(*inner)) {
@@ -1861,7 +1896,7 @@ private:
 
   kj::Array<ExportId> writeDescriptors(
       kj::ArrayPtr<kj::Maybe<kj::Own<ClientHook>>> capTable,
-      rpc::Payload::Builder payload, kj::Vector<int>& fds,
+      rpc::Payload::Builder payload, OutgoingFds& fds,
       kj::Maybe<kj::HashMap<ClientHook*, kj::Own<ClientHook>>&> describedMap = kj::none) {
     // Write all descriptors for a cap table.
     //
@@ -1991,9 +2026,9 @@ private:
           messageSizeHint<rpc::Resolve>() + sizeInWords<rpc::CapDescriptor>() + 16);
       auto resolve = message->getBody().initAs<rpc::Message>().initResolve();
       resolve.setPromiseId(exportId);
-      kj::Vector<int> fds;
+      OutgoingFds fds;
       auto writeDescResult = writeDescriptor(*exp.clientHook, resolve.initCap(), fds);
-      message->setFds(fds.releaseAsArray());
+      message->setFds(fds.release());
       message->send();
 
       // `writeDescriptor()` can create new exports, invalidating the `exp` reference. Look it up
@@ -2155,7 +2190,7 @@ private:
       return true;
     }
     WriteDescriptorResult writeDescriptor(rpc::CapDescriptor::Builder descriptor,
-                                                  kj::Vector<int>& fds) override {
+                                                  OutgoingFds& fds) override {
       return inner->writeDescriptor(descriptor, fds);
     }
     kj::Maybe<kj::Own<ClientHook>> writeTarget(
@@ -2632,10 +2667,10 @@ private:
 
     SetupSendResult setupSend(bool isTailCall) {
       // Build the cap table.
-      kj::Vector<int> fds;
+      OutgoingFds fds;
       auto exports = connectionState->writeDescriptors(
           capTable.getTable(), callBuilder.getParams(), fds);
-      message->setFds(fds.releaseAsArray());
+      message->setFds(fds.release());
 
       // Init the question table.  Do this after writing descriptors to avoid interference.
       QuestionId questionId;
@@ -2719,10 +2754,10 @@ private:
       // Since must of setupSend() is subtly different for this case, we don't reuse it.
 
       // Build the cap table.
-      kj::Vector<int> fds;
+      OutgoingFds fds;
       auto exports = connectionState->writeDescriptors(
           capTable.getTable(), callBuilder.getParams(), fds);
-      message->setFds(fds.releaseAsArray());
+      message->setFds(fds.release());
 
       if (exports.size() > 0) {
         connectionState->sentCapabilitiesInPipelineOnlyCall = true;
@@ -2979,10 +3014,10 @@ private:
 
       // Build the cap table.
       auto capTable = this->capTable.getTable();
-      kj::Vector<int> fds;
+      OutgoingFds fds;
       auto exports = connectionState.writeDescriptors(
           capTable, payload, fds, resolutionsAtReturnTime);
-      message->setFds(fds.releaseAsArray());
+      message->setFds(fds.release());
 
       message->send();
       if (capTable.size() == 0) {
@@ -3808,10 +3843,10 @@ private:
 
       auto capTableArray = capTable.getTable();
       KJ_DASSERT(capTableArray.size() == 1);
-      kj::Vector<int> fds;
+      OutgoingFds fds;
       kj::HashMap<ClientHook*, kj::Own<ClientHook>> resolutionsAtReturnTime;
       resultExports = writeDescriptors(capTableArray, payload, fds, resolutionsAtReturnTime);
-      response->setFds(fds.releaseAsArray());
+      response->setFds(fds.release());
       capHook = kj::mv(KJ_ASSERT_NONNULL(capTableArray[0]));
 
       // If we're returning a capability that turns out to be an PromiseClient pointing back on

--- a/c++/src/capnp/rpc.h
+++ b/c++/src/capnp/rpc.h
@@ -198,6 +198,12 @@ public:
   virtual void setFds(kj::Array<int> fds) {}
   // Set the list of file descriptors to send along with this message, if FD passing is supported.
   // An implementation may ignore this.
+  //
+  // An implementation which defers the actual write, as `send()` permits, must keep the array
+  // itself alive until the write completes, rather than copying the numbers out of it. The array
+  // may carry attachments which are the only thing holding the descriptors open; dropping it early
+  // can leave the numbers referring to nothing, or to whatever file has since been given the same
+  // number.
 
   virtual void send() = 0;
   // Send the message, or at least put it in a queue to be sent later.  Note that the builder


### PR DESCRIPTION
writeDescriptor() reads a capability's descriptor with ClientHook::getFd() and puts the bare number into the kj::Array<int> handed to OutgoingRpcMessage::setFds(). But send() is only required to queue the message: TwoPartyVatNetwork defers the write to kj::evalLast(), and under backpressure the queue can sit for an unbounded time. A descriptor is only guaranteed to stay open as long as the capability that produced it, so a capability dropped in the meantime takes its descriptor with it, and we write a number that has since been closed -- or that the OS has already recycled for an unrelated file, silently handing the peer the wrong one.

This is reachable in practice. A caller that abandons a question before the Return arrives sends a Finish with releaseResultCaps set, which drops the answer's result exports immediately. If such an export held the last reference to an FD-bearing server, that server is destroyed and closes its descriptor while the Return is still sitting in the write queue.

Collect the descriptors alongside a reference to the capability each one came from, and attach those references to the array passed to setFds(), so the capabilities outlive the write.