### PR TITLE
Fix `KJ_NO_RTTI` and `KJ_NO_EXCEPTIONS` detection on NetBSD

### DIFF
--- a/c++/src/kj/arena-test.c++
+++ b/c++/src/kj/arena-test.c++
@@ -148,7 +148,7 @@ TEST(Arena, OwnArray) {
   EXPECT_EQ(0, TestObject::count);
 }
 
-#ifndef KJ_NO_EXCEPTIONS
+#if !KJ_NO_EXCEPTIONS
 
 TEST(Arena, ObjectThrow) {
   TestObject::count = 0;
@@ -178,7 +178,7 @@ TEST(Arena, ArrayThrow) {
   EXPECT_EQ(0, TestObject::count);
 }
 
-#endif
+#endif  // !KJ_NO_EXCEPTIONS
 
 TEST(Arena, Alignment) {
   Arena arena;

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -151,6 +151,18 @@ typedef unsigned char byte;
 //   that is the standard compliant way. However, it's unclear how to use those macros (or any
 //   others) to distinguish between the compiler supporting feature detection and the feature being
 //   disabled vs the compiler not supporting feature detection at all.
+
+// NetBSD's <sys/cdefs.h> defines a fallback `__has_feature(x) 0` stub for
+// compilers that lack the `__has_feature` extension. This defeats the
+// detection logic below: `defined(__has_feature)` is true, but every query
+// answers 0. Undefine the stub on the affected configuration so the logic
+// below takes its intended fallback path. GCC implements `__has_feature`
+// natively since version 14. Clang always provides it as a builtin and must
+// be excluded explicitly because it also defines `__GNUC__`.
+#if defined(__NetBSD__) && !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 14
+#undef __has_feature
+#endif
+
 #if defined(__has_feature)
   #if !defined(KJ_NO_RTTI) && !__has_feature(cxx_rtti)
     #define KJ_NO_RTTI 1


### PR DESCRIPTION
NetBSD provides a compatibility [stub](https://github.com/NetBSD/src/blob/01bb5fdac48f5ae014ae903602be631c468c5141/sys/sys/cdefs.h#L58-L70) in <sys/cdefs.h> for compilers that lack the `__has_feature` extension:
```c++
#ifndef __has_feature
#define __has_feature(x) 0
#endif
```

Therefore, using `!__has_feature(...)` produces wrong results when using GCC <14.x, where the `__has_feature` extension has not been implemented yet.

This PR fixes the issue.