### PR TITLE
[nfc] Clean up promise continuations

### DIFF
--- a/c++/src/capnp/compat/http-over-capnp.c++
+++ b/c++/src/capnp/compat/http-over-capnp.c++
@@ -651,7 +651,7 @@ public:
     // Wait for the server to indicate completion. Meanwhile, if the
     // promise is canceled from the client side, we propagate cancellation naturally.
     KJ_TRY {
-      co_await pipeline.ignoreResult();
+      co_await pipeline;
     } KJ_CATCH(exception) {
       if (exception.getType() == kj::Exception::Type::OVERLOADED &&
           context.hasStartedWebSocket()) {
@@ -744,7 +744,7 @@ public:
       return kj::NEVER_DONE;
     });
 
-    co_await pipeline.ignoreResult();
+    co_await pipeline;
   }
 
 

--- a/c++/src/capnp/compat/json-rpc.c++
+++ b/c++/src/capnp/compat/json-rpc.c++
@@ -250,7 +250,7 @@ kj::Promise<void> JsonRpc::readLoop() {
             tasks.add(promise.attach(kj::mv(idCopy)));
           } else {
             // No 'id', so this is a notification.
-            tasks.add(req.send().ignoreResult().catch_([](kj::Exception&& exception) {
+            tasks.add(req.sendIgnoringResult().catch_([](kj::Exception&& exception) {
               if (exception.getType() != kj::Exception::Type::UNIMPLEMENTED) {
                 KJ_LOG(ERROR, "JSON-RPC notification threw exception into the abyss", exception);
               }

--- a/c++/src/capnp/dynamic-capability.c++
+++ b/c++/src/capnp/dynamic-capability.c++
@@ -99,6 +99,12 @@ RemotePromise<DynamicStruct> Request<DynamicStruct, DynamicStruct>::send() {
   return RemotePromise<DynamicStruct>(kj::mv(typedPromise), kj::mv(typedPipeline));
 }
 
+kj::Promise<void> Request<DynamicStruct, DynamicStruct>::sendIgnoringResult() {
+  auto typelessPromise = hook->send();
+  hook = nullptr;  // prevent reuse
+  return kj::mv(typelessPromise).ignoreResult();
+}
+
 kj::Promise<void> Request<DynamicStruct, DynamicStruct>::sendStreaming() {
   KJ_REQUIRE(resultSchema.isStreamResult());
 

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -560,6 +560,9 @@ public:
   RemotePromise<DynamicStruct> send();
   // Send the call and return a promise for the results.
 
+  kj::Promise<void> sendIgnoringResult();
+  // Equivalent to send().ignoreResult(), but is a bit more efficient.
+
   kj::Promise<void> sendStreaming();
   // Use when the caller is aware that the response type is StreamResult and wants to invoke
   // streaming behavior. It is an error to call this if the response type is not StreamResult.

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -2491,7 +2491,7 @@ private:
 
     auto req = next.holdRequest();
     req.setCap(kj::mv(cap));
-    co_await req.send();
+    co_await req.sendIgnoringResult();
 
     // (hold() has no results)
   }


### PR DESCRIPTION
Eliminates a few memory allocations. Based on downstream workerd-promise-ignore-result check.