### PR TITLE
replace non-atomic read in AtomicRefcounted with atomic

### DIFF
--- a/c++/src/kj/refcount.c++
+++ b/c++/src/kj/refcount.c++
@@ -72,7 +72,13 @@ void Refcounted::disposeImpl(void* pointer) const {
 // Atomic (thread-safe) refcounting
 
 AtomicRefcounted::~AtomicRefcounted() noexcept(false) {
-  KJ_ASSERT(refcount == 0, "Refcounted object deleted with non-zero refcount.");
+#if _MSC_VER && !defined(__clang__)
+  KJ_ASSERT(KJ_MSVC_INTERLOCKED(Or, acq)(&refcount, 0) == 0,
+      "Refcounted object deleted with non-zero refcount.");
+#else
+  KJ_ASSERT(__atomic_load_n(&refcount, __ATOMIC_ACQUIRE) == 0,
+      "Refcounted object deleted with non-zero refcount.");
+#endif
 }
 
 void AtomicRefcounted::disposeImpl(void* pointer) const {


### PR DESCRIPTION
If delete happens not through destructor, then non-atomic read is not fenced. Probably doesn't matter in practice but tsan complains.