### PR TITLE
fix XThreadFulfiller isWaiting

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -1945,18 +1945,9 @@ namespace _ {  // (private)
 template <typename T>
 class XThreadFulfiller;
 
-class XThreadPaf: public PromiseNode {
+class XThreadPafControl final: public AtomicRefcounted {
 public:
-  XThreadPaf(Own<const Executor> executor);
-  virtual ~XThreadPaf() noexcept(false);
-  void destroy() override;
-
-  // implements PromiseNode ----------------------------------------------------
-  void onReady(Event* event) noexcept override;
-  void tracePromise(TraceBuilder& builder, bool stopAtNextEvent) override;
-
-private:
-  enum {
+  enum State {
     WAITING,
     // Not yet fulfilled, and the waiter is still waiting.
     //
@@ -1988,8 +1979,22 @@ private:
     // The waiting thread atomically transitions the state from WAITING to CANCELED if it is no
     // longer listening. In this state, it is the fulfiller thread's responsibility to destroy the
     // object.
-  } state;
+  };
 
+  mutable State state = WAITING;
+};
+
+class XThreadPaf: public PromiseNode {
+public:
+  XThreadPaf(Own<const Executor> executor, Arc<XThreadPafControl> control);
+  virtual ~XThreadPaf() noexcept(false);
+  void destroy() override;
+
+  // implements PromiseNode ----------------------------------------------------
+  void onReady(Event* event) noexcept override;
+  void tracePromise(TraceBuilder& builder, bool stopAtNextEvent) override;
+
+private:
   Own<const Executor> executor;
   // Executor of the waiting thread. We hold a strong reference to it so that we have no risk of UB
   // if the waiting thread exits before the promise is fulfilled.
@@ -1999,6 +2004,10 @@ private:
   // thread's executor. In those states, these pointers are guarded by said executor's mutex.
 
   OnReadyEvent onReadyEvent;
+
+  Arc<XThreadPafControl> control;
+  // The control block is shared with the fulfiller so that isWaiting() can inspect the state
+  // without dereferencing this object after cancellation has allowed it to be destroyed.
 
   class FulfillScope;
 
@@ -2052,7 +2061,8 @@ private:
 template <typename T>
 class XThreadFulfiller final: public CrossThreadPromiseFulfiller<T> {
 public:
-  XThreadFulfiller(XThreadPafImpl<T>* target): target(target) {}
+  XThreadFulfiller(XThreadPafImpl<T>* target, Arc<XThreadPafControl> control)
+      : target(target), control(kj::mv(control)) {}
 
   ~XThreadFulfiller() noexcept(false) {
     if (target != nullptr) {
@@ -2076,20 +2086,17 @@ public:
     }
   }
   bool isWaiting() const override {
-    KJ_IF_SOME(t, target) {
 #if _MSC_VER && !__clang__
-      // Just assume 1-byte loads are atomic... on what kind of absurd platform would they not be?
-      return t.state == XThreadPaf::WAITING;
+    // Just assume enum-sized loads are atomic... on what kind of absurd platform would they not be?
+    return control->state == XThreadPafControl::WAITING;
 #else
-      return __atomic_load_n(&t.state, __ATOMIC_RELAXED) == XThreadPaf::WAITING;
+    return __atomic_load_n(&control->state, __ATOMIC_RELAXED) == XThreadPafControl::WAITING;
 #endif
-    } else {
-      return false;
-    }
   }
 
 private:
   mutable XThreadPaf* target;  // accessed using atomic ops
+  Arc<XThreadPafControl> control;
 };
 
 template <typename T>
@@ -2111,8 +2118,10 @@ PromiseCrossThreadFulfillerPair<T> newPromiseAndCrossThreadFulfiller() {
 
 template <typename T>
 PromiseCrossThreadFulfillerPair<T> Executor::newPromiseAndCrossThreadFulfiller() const {
-  kj::Own<_::XThreadPafImpl<T>, _::PromiseDisposer> node(new _::XThreadPafImpl<T>(addRef()));
-  auto fulfiller = kj::heap<_::XThreadFulfiller<T>>(node);
+  auto control = kj::arc<_::XThreadPafControl>();
+  kj::Own<_::XThreadPafImpl<T>, _::PromiseDisposer> node(
+      new _::XThreadPafImpl<T>(addRef(), control.addRef()));
+  auto fulfiller = kj::heap<_::XThreadFulfiller<T>>(node, kj::mv(control));
   return { _::PromiseNode::to<_::ReducePromises<T>>(kj::mv(node)), kj::mv(fulfiller) };
 }
 

--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -30,6 +30,7 @@
 #include <kj/test.h>
 
 #include <atomic>
+#include <thread>
 
 #if _WIN32
 #include <windows.h>
@@ -1015,6 +1016,60 @@ KJ_TEST("cross-thread fulfiller canceled") {
 
     *done.lockExclusive() = true;
   })();
+}
+
+KJ_TEST("cross-thread fulfiller isWaiting concurrent with cancellation") {
+  // `isWaiting()` is documented as a cross-thread operation. Race it against the ownership
+  // transfer which follows cancellation: the fulfiller observes CANCELED and deletes its target.
+  // The observer threads make it likely that one has loaded `target` immediately before that
+  // deletion. ASan then detects its subsequent access to `target->state`.
+  KJ_XTHREAD_TEST_SETUP_LOOP;
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
+  auto* fulfiller = paf.fulfiller.get();
+
+  constexpr uint OBSERVER_COUNT = 64;
+  std::atomic<uint> entered(0);
+  std::atomic<bool> start(false);
+  std::atomic<bool> cancel(false);
+  std::atomic<bool> stop(false);
+
+  Vector<Own<Thread>> observers;
+  for (uint i = 0; i < OBSERVER_COUNT; ++i) {
+    observers.add(kj::heap<Thread>([&]() noexcept {
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+
+      // Ensure that every observer is actively polling before cancellation starts.
+      fulfiller->isWaiting();
+      entered.fetch_add(1, std::memory_order_release);
+      while (!stop.load(std::memory_order_acquire)) {
+        fulfiller->isWaiting();
+      }
+    }));
+  }
+
+  {
+    Thread fulfillThread([&]() noexcept {
+      while (!cancel.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      fulfiller->fulfill();
+    });
+
+    start.store(true, std::memory_order_release);
+    while (entered.load(std::memory_order_acquire) != OBSERVER_COUNT) {
+      std::this_thread::yield();
+    }
+
+    paf.promise = nullptr;
+    cancel.store(true, std::memory_order_release);
+
+    // `fulfill()` must atomically claim the target, see the canceled state, and delete it before
+    // it returns. Leaving this scope joins the thread, establishing that deletion is complete.
+  }
+  stop.store(true, std::memory_order_release);
 }
 
 KJ_TEST("cross-thread fulfiller multiple fulfills") {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -795,7 +795,7 @@ struct Executor::Impl {
 
       for (auto& event: fulfilled) {
         fulfilled.remove(event);
-        event.state = _::XThreadPaf::DISPATCHED;
+        event.control->state = _::XThreadPafControl::DISPATCHED;
         event.onReadyEvent.armBreadthFirst();
       }
     }
@@ -890,7 +890,7 @@ struct Executor::Impl {
       KJ_LOG(ERROR, "EventLoop destroyed with cross-thread fulfiller replies outstanding");
       for (auto& event: s.fulfilled) {
         s.fulfilled.remove(event);
-        event.state = _::XThreadPaf::DISPATCHED;
+        event.control->state = _::XThreadPafControl::DISPATCHED;
       }
     }
   }};
@@ -1148,27 +1148,29 @@ void XThreadEvent::onReady(Event* event) noexcept {
   onReadyEvent.init(event);
 }
 
-XThreadPaf::XThreadPaf(Own<const Executor> executor)
-    : state(WAITING), executor(kj::mv(executor)) {}
+XThreadPaf::XThreadPaf(Own<const Executor> executor, Arc<XThreadPafControl> control)
+    : executor(kj::mv(executor)), control(kj::mv(control)) {}
 XThreadPaf::~XThreadPaf() noexcept(false) {}
 
 void XThreadPaf::destroy() {
-  auto oldState = WAITING;
+  auto oldState = XThreadPafControl::WAITING;
 
-  if (__atomic_load_n(&state, __ATOMIC_ACQUIRE) == DISPATCHED) {
+  if (__atomic_load_n(&control->state, __ATOMIC_ACQUIRE) == XThreadPafControl::DISPATCHED) {
     // Common case: Promise was fully fulfilled and dispatched, no need for locking.
     delete this;
-  } else if (__atomic_compare_exchange_n(&state, &oldState, CANCELED, false,
-                                         __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
+  } else if (__atomic_compare_exchange_n(
+                 &control->state, &oldState, XThreadPafControl::CANCELED, false,
+                 __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
     // State transitioned from WAITING to CANCELED, so now it's the fulfiller's job to destroy the
     // object.
   } else {
     // Whoops, another thread is already in the process of fulfilling this promise. We'll have to
     // wait for it to finish and transition the state to FULFILLED.
     executor->impl->state.when([&](auto&) {
-      return state == FULFILLED || state == DISPATCHED;
+      return control->state == XThreadPafControl::FULFILLED ||
+          control->state == XThreadPafControl::DISPATCHED;
     }, [&](Executor::Impl::State& exState) {
-      if (state == FULFILLED) {
+      if (control->state == XThreadPafControl::FULFILLED) {
         // The object is on the queue but was not yet dispatched. Remove it.
         exState.fulfilled.remove(*this);
       }
@@ -1192,15 +1194,16 @@ void XThreadPaf::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
 
 XThreadPaf::FulfillScope::FulfillScope(XThreadPaf** pointer) {
   obj = __atomic_exchange_n(pointer, static_cast<XThreadPaf*>(nullptr), __ATOMIC_ACQUIRE);
-  auto oldState = WAITING;
+  auto oldState = XThreadPafControl::WAITING;
   if (obj == nullptr) {
     // Already fulfilled (possibly by another thread).
-  } else if (__atomic_compare_exchange_n(&obj->state, &oldState, FULFILLING, false,
-                                         __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
+  } else if (__atomic_compare_exchange_n(
+                 &obj->control->state, &oldState, XThreadPafControl::FULFILLING, false,
+                 __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
     // Transitioned to FULFILLING, good.
   } else {
     // The waiting thread must have canceled.
-    KJ_ASSERT(oldState == CANCELED);
+    KJ_ASSERT(oldState == XThreadPafControl::CANCELED);
 
     // It's our responsibility to clean up, then.
     delete obj;
@@ -1213,7 +1216,7 @@ XThreadPaf::FulfillScope::~FulfillScope() noexcept(false) {
   if (obj != nullptr) {
     auto lock = obj->executor->impl->state.lockExclusive();
     lock->fulfilled.add(*obj);
-    __atomic_store_n(&obj->state, FULFILLED, __ATOMIC_RELEASE);
+    __atomic_store_n(&obj->control->state, XThreadPafControl::FULFILLED, __ATOMIC_RELEASE);
     KJ_IF_SOME(l, lock->loop) {
       // TODO(perf): It's annoying we have to call wake() with the lock held, but we have to
       //   prevent the destination EventLoop from being destroyed first.


### PR DESCRIPTION
Fixes uaf: https://gist.github.com/mikea/862a4b6ae19834d717620115d8176974 by introducing a refcounted object.

The other alternative would be to introduce some kind of locking, but that would be too slow I guess. This also fixes all fastpath tsan complaints.