### PR TITLE
Don't fail the listener when a connection is reset before accept() on Windows

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -3705,8 +3705,43 @@ KJ_TEST("Calling abortRead() after tryRead() raised exception") {
 // On Unix platforms, accept() typically returns the aborted connection, which fails on first
 // read (throws "Connection reset by peer" or returns 0 bytes). The test then calls accept()
 // again to get the valid connection. Some platforms may filter out aborted connections.
+//
+// On Windows the abort surfaces differently: it completes the pending AcceptEx() operation with
+// an error rather than yielding a socket, so the listener discards it and the first accept()
+// returns the valid connection.
 
-#if !_WIN32
+// Open an IPv4 connection to a loopback port and immediately reset it, leaving a dead entry in
+// that listener's accept queue. SO_LINGER with a zero timeout makes close() send RST rather than
+// FIN. This works below kj::Network on purpose: the connection has to die before anything accepts
+// it, which means owning the socket's close behaviour directly.
+void connectAndReset(uint16_t port) {
+#if _WIN32
+  SOCKET s = ::socket(AF_INET, SOCK_STREAM, 0);
+  KJ_ASSERT(s != INVALID_SOCKET);
+  KJ_DEFER(::closesocket(s));
+#else
+  int s = ::socket(AF_INET, SOCK_STREAM, 0);
+  KJ_ASSERT(s >= 0);
+  KJ_DEFER(::close(s));
+#endif
+
+  struct linger lg = {1, 0};
+  sockaddr_in a {};
+  a.sin_family = AF_INET;
+  a.sin_port = htons(port);
+  a.sin_addr.s_addr = htonl(0x7f000001);
+
+#if _WIN32
+  KJ_WINSOCK(::setsockopt(s, SOL_SOCKET, SO_LINGER,
+                          reinterpret_cast<const char*>(&lg), static_cast<int>(sizeof(lg))));
+  KJ_WINSOCK(::connect(s, reinterpret_cast<sockaddr*>(&a), static_cast<int>(sizeof(a))));
+#else
+  KJ_SYSCALL(::setsockopt(s, SOL_SOCKET, SO_LINGER,
+                          reinterpret_cast<const char*>(&lg), sizeof(lg)));
+  KJ_SYSCALL(::connect(s, reinterpret_cast<sockaddr*>(&a), sizeof(a)));
+#endif
+}
+
 KJ_TEST("accept() with aborted connection - IPv4") {
   // -- async-io boilerplate ---------------------------------------------------
   auto io = kj::setupAsyncIo();
@@ -3716,22 +3751,7 @@ KJ_TEST("accept() with aborted connection - IPv4") {
   auto listener = listenerAddr->listen();
   uint16_t port = listener->getPort();
 
-  // Create a connection that will be aborted (sends RST packet)
-  int s = ::socket(AF_INET, SOCK_STREAM, 0);
-  KJ_ASSERT(s >= 0);
-
-  // Configure socket to send RST on close instead of FIN
-  struct linger lg = {1, 0};
-  KJ_SYSCALL(setsockopt(s, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)));
-
-  sockaddr_in a {};
-  a.sin_family = AF_INET;
-  a.sin_port = htons(port);
-  a.sin_addr.s_addr = htonl(0x7f000001);
-  KJ_SYSCALL(::connect(s, reinterpret_cast<sockaddr*>(&a), sizeof(a)));
-
-  // Close immediately to send RST packet
-  KJ_SYSCALL(::close(s));
+  connectAndReset(port);
 
   // Allow aborted connection to reach accept queue first
   io.provider->getTimer().afterDelay(20 * kj::MILLISECONDS).wait(io.waitScope);
@@ -3785,7 +3805,6 @@ KJ_TEST("accept() with aborted connection - IPv4") {
   KJ_ASSERT(amount == 5);
   KJ_ASSERT(memcmp(buffer, "hello", 5) == 0);
 }
-#endif  // !_WIN32
 
 // ---------------------------------------------------------------------------------------------
 // accept() with aborted connection - dual-stack IPv4/IPv6 listener
@@ -3819,27 +3838,12 @@ KJ_TEST("accept() with aborted connection - dual-stack IPv4/IPv6") {
   auto listener = listenerAddr->listen();
   uint16_t port = listener->getPort();
 
-  // Create IPv4 connection that will be aborted (sends RST packet)
-  int s = ::socket(AF_INET, SOCK_STREAM, 0);
-  KJ_ASSERT(s >= 0);
-
-  // Configure socket to send RST on close instead of FIN
-  struct linger lg = {1, 0};
-  KJ_SYSCALL(setsockopt(s, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)));
-
-  sockaddr_in a {};
-  a.sin_family = AF_INET;
-  a.sin_port = htons(port);
-  a.sin_addr.s_addr = htonl(0x7f000001);
-  KJ_SYSCALL(::connect(s, reinterpret_cast<sockaddr*>(&a), sizeof(a)));
-
-  // Close immediately to send RST packet
-  KJ_SYSCALL(::close(s));
+  // The connection that gets aborted is IPv4, reaching the listener through its IPv4 mapping.
+  connectAndReset(port);
 
   // Allow aborted connection to reach accept queue first
   io.provider->getTimer().afterDelay(20 * kj::MILLISECONDS).wait(io.waitScope);
-  
-  
+
   // Create valid IPv6 connection
   auto clientP = net.parseAddress("::1", port)
       .then([](Own<NetworkAddress> addr) { return addr->connect(); });

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -3702,13 +3702,11 @@ KJ_TEST("Calling abortRead() after tryRead() raised exception") {
 // Test accept() behavior when connections are aborted (send RST) before being accepted.
 // Creates an aborted IPv4 connection followed by a valid one, then verifies proper handling.
 //
-// On Unix platforms, accept() typically returns the aborted connection, which fails on first
-// read (throws "Connection reset by peer" or returns 0 bytes). The test then calls accept()
-// again to get the valid connection. Some platforms may filter out aborted connections.
-//
-// On Windows the abort surfaces differently: it completes the pending AcceptEx() operation with
-// an error rather than yielding a socket, so the listener discards it and the first accept()
-// returns the valid connection.
+// Platforms differ in what becomes of a connection that dies while queued: it may never reach
+// accept() at all, it may be reported as an error from accept() -- which the accept loop is
+// expected to retry past -- or it may be handed over as a socket that fails on first read. What
+// matters either way is that the listener survives and goes on to produce the valid connection,
+// so the test tolerates receiving the dead connection or not.
 
 // Open an IPv4 connection to a loopback port and immediately reset it, leaving a dead entry in
 // that listener's accept queue. SO_LINGER with a zero timeout makes close() send RST rather than
@@ -3812,15 +3810,10 @@ KJ_TEST("accept() with aborted connection - IPv4") {
 // Test accept() behavior with aborted cross-protocol connections on dual-stack listeners.
 // Creates an aborted IPv4 connection to an IPv6 listener, followed by a valid IPv6 connection.
 //
-// Expected behavior:
-// - Darwin/macOS: When IPv4 connects to IPv6 listener and gets aborted, accept() returns
-//   a socket with addrlen=0. KJ's accept loop detects this Darwin quirk and discards the
-//   socket automatically, so first accept() returns the valid connection.
-// - Linux/other Unix: accept() returns the aborted connection, which fails on first
-//   read (throws exception or returns 0 bytes). Test then calls accept() again for the
-//   valid connection.
-//
-// This test specifically exercises the Darwin addrlen==0 bug workaround in KJ's accept loop.
+// As above, the dead connection may or may not reach accept(), and the test tolerates either.
+// The case worth having here is Darwin: an aborted IPv4 connection to an IPv6 listener makes
+// accept() return a socket with addrlen == 0, so this exercises the workaround for that quirk in
+// KJ's accept loop.
 
 #if !_WIN32
 KJ_TEST("accept() with aborted connection - dual-stack IPv4/IPv6") {

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -819,19 +819,18 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
 // =======================================================================================
 
 bool isTransientAcceptError(DWORD error) {
-  // AcceptEx() reports the state of the connection it accepted, not the state of the listener. A
-  // client that completes the handshake and then resets before the server gets around to accepting
-  // leaves a dead connection in the queue, and that is what surfaces here. Such an error says
+  // AcceptEx() may fail because the listener is broken, or because the connection it was accepting
+  // is: a client that completes the handshake and then resets before the server gets around to
+  // accepting leaves a dead entry in the queue, and that is what surfaces here. The latter says
   // nothing about the listener's health, so accept() must take the next connection rather than
-  // fail: ConnectionReceiver::accept() reports only permanent errors.
+  // fail -- ConnectionReceiver::accept() reports only permanent errors. Telling the two apart is
+  // the job of this function, and as in the Unix implementation it's hard to say exactly which
+  // codes mean which, so we've made a guess.
   //
-  // The two platforms surface a reset connection at different points, so this list is not the same
-  // as the one Unix retries on. On Unix accept() succeeds and the reset is only discovered on the
-  // first read, whereas AcceptEx() fails at accept time instead -- so the codes meaning "reset"
-  // have to be treated as transient here, and Unix has no need for them. Both Win32 and Winsock
-  // spellings appear because an overlapped completion may report either. ERROR_OPERATION_ABORTED is
-  // deliberately absent -- that means the operation was cancelled, which must propagate -- as are
-  // WSAENOTSOCK and WSAEINVAL, which indicate a genuinely broken listener.
+  // Both Win32 and Winsock spellings appear because an overlapped completion may report either.
+  // ERROR_OPERATION_ABORTED is deliberately absent -- that means the operation was cancelled,
+  // which must propagate -- as are WSAENOTSOCK and WSAEINVAL, which indicate a genuinely broken
+  // listener.
   switch (error) {
     case ERROR_NETNAME_DELETED:
     case ERROR_CONNECTION_ABORTED:

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -818,6 +818,39 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
 
 // =======================================================================================
 
+bool isTransientAcceptError(DWORD error) {
+  // AcceptEx() reports the state of the connection it accepted, not the state of the listener. A
+  // client that completes the handshake and then resets before the server gets around to accepting
+  // leaves a dead connection in the queue, and that is what surfaces here. Such an error says
+  // nothing about the listener's health, so accept() must take the next connection rather than
+  // fail: ConnectionReceiver::accept() reports only permanent errors.
+  //
+  // The two platforms surface a reset connection at different points, so this list is not the same
+  // as the one Unix retries on. On Unix accept() succeeds and the reset is only discovered on the
+  // first read, whereas AcceptEx() fails at accept time instead -- so the codes meaning "reset"
+  // have to be treated as transient here, and Unix has no need for them. Both Win32 and Winsock
+  // spellings appear because an overlapped completion may report either. ERROR_OPERATION_ABORTED is
+  // deliberately absent -- that means the operation was cancelled, which must propagate -- as are
+  // WSAENOTSOCK and WSAEINVAL, which indicate a genuinely broken listener.
+  switch (error) {
+    case ERROR_NETNAME_DELETED:
+    case ERROR_CONNECTION_ABORTED:
+    case ERROR_SEM_TIMEOUT:
+    case WSAECONNRESET:
+    case WSAECONNABORTED:
+    case WSAETIMEDOUT:
+    case WSAENETDOWN:
+    case WSAENETRESET:
+    case WSAEHOSTDOWN:
+    case WSAEHOSTUNREACH:
+    case WSAENETUNREACH:
+      return true;
+
+    default:
+      return false;
+  }
+}
+
 class FdConnectionReceiver final: public ConnectionReceiver, public OwnedFd {
 public:
   FdConnectionReceiver(Win32EventPort& eventPort, SOCKET fd,
@@ -858,6 +891,10 @@ public:
         (Win32EventPort::IoResult ioResult) mutable
         -> Promise<Own<AsyncIoStream>> {
       if (ioResult.errorCode != ERROR_SUCCESS) {
+        if (isTransientAcceptError(ioResult.errorCode)) {
+          // The queued connection died before we could take it. Move on to the next one.
+          return accept();
+        }
         KJ_FAIL_WIN32("AcceptEx()", ioResult.errorCode) { break; }
       } else {
         SOCKET me = fd;

--- a/c++/src/kj/debug.c++
+++ b/c++/src/kj/debug.c++
@@ -138,10 +138,14 @@ Exception::Type typeOfErrno(int error) {
 #if _WIN32 || __CYGWIN__
 
 Exception::Type typeOfWin32Error(DWORD error) {
+  // Winsock and Win32 have separate spellings for most of these conditions, and which one a given
+  // failure reports depends on how it was discovered: a direct Winsock call yields WSAE*, while an
+  // overlapped operation's completion status yields ERROR_*. Both spellings must be classified.
   switch (error) {
     // TODO(someday): This needs more work.
 
     case WSAETIMEDOUT:
+    case ERROR_SEM_TIMEOUT:
       return Exception::Type::OVERLOADED;
 
     case WSAENOTCONN:
@@ -154,6 +158,16 @@ Exception::Type typeOfWin32Error(DWORD error) {
     case WSAENETRESET:
     case WSAENETUNREACH:
     case WSAESHUTDOWN:
+    case ERROR_NETNAME_DELETED:  // What a reset connection looks like to overlapped I/O.
+    case ERROR_CONNECTION_ABORTED:
+    case ERROR_CONNECTION_REFUSED:
+    case ERROR_CONNECTION_INVALID:
+    case ERROR_HOST_UNREACHABLE:
+    case ERROR_NETWORK_UNREACHABLE:
+    case ERROR_PORT_UNREACHABLE:
+    case ERROR_BROKEN_PIPE:
+    case ERROR_NO_DATA:
+    case ERROR_PIPE_NOT_CONNECTED:
       return Exception::Type::DISCONNECTED;
 
     case WSAEOPNOTSUPP:

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -634,9 +634,22 @@ namespace {
                                      stringifyStackTrace(trace), '\n');
     }
   } else {
-    message = kj::str("*** std::terminate() called with no exception"
-                      "\nstack: ", stringifyStackTraceAddresses(trace),
-                                   stringifyStackTrace(trace), '\n');
+    // std::current_exception() only reports an exception that is "currently being handled". When
+    // terminate() is reached because an exception escaped a noexcept function, some ABIs -- the
+    // MSVC one in particular -- have not begun handling it yet, so nothing is reported here even
+    // though an exception is very much in flight. KJ tracks its own exceptions independently of
+    // the C++ runtime, so fall back to that rather than reporting nothing at all. Unlike a stack
+    // trace taken here, a kj::Exception names the throw site and carries its own trace, so this
+    // stays useful even when the binary has no symbols.
+    InFlightExceptionIterator iter;
+    KJ_IF_SOME(exception, iter.next()) {
+      message = kj::str("*** std::terminate() called with in-flight kj::Exception: ",
+                        exception, '\n');
+    } else {
+      message = kj::str("*** std::terminate() called with no exception"
+                        "\nstack: ", stringifyStackTraceAddresses(trace),
+                                     stringifyStackTrace(trace), '\n');
+    }
   }
 
   kj::FdOutputStream(STDERR_FILENO).write(message.asBytes());

--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -643,8 +643,7 @@ namespace {
     // stays useful even when the binary has no symbols.
     InFlightExceptionIterator iter;
     KJ_IF_SOME(exception, iter.next()) {
-      message = kj::str("*** std::terminate() called with in-flight kj::Exception: ",
-                        exception, '\n');
+      message = kj::str("*** Fatal uncaught kj::Exception: ", exception, '\n');
     } else {
       message = kj::str("*** std::terminate() called with no exception"
                         "\nstack: ", stringifyStackTraceAddresses(trace),


### PR DESCRIPTION
A client that completes the TCP handshake and then resets before the server gets around to
accepting leaves a dead connection in the accept queue. `AcceptEx()` reports this as
`ERROR_NETNAME_DELETED` on the overlapped completion, and `FdConnectionReceiver::accept()` failed
the whole listener. The exception propagates out of `accept()`, and callers generally treat an
`accept()` failure as fatal to the accept loop.

Unix does not have this problem because `async-io-unix` has always retried these errors. Linux
`accept()` likewise reports pending network errors from the connection it accepted — the man page
says so explicitly — and `acceptImpl()` treats a guessed-at set of those codes as transient. The
platforms behave the same way here; only the Win32 implementation was missing the logic.

## Commits

### report in-flight `kj::Exception` from the terminate handler

`std::current_exception()` only reports an exception that is *currently being handled*. When an
exception escapes a `noexcept` function the MSVC ABI reaches `std::terminate()` before it begins
handling it, so the handler saw nothing and printed:

```
*** std::terminate() called with no exception
```

followed by a stack of exception-dispatch frames that says nothing about who threw. Against a
stripped release binary that leaves no way to identify the failure.

KJ tracks its own exceptions independently of the C++ runtime — `getDestructionReason()` already
relies on this — and `InFlightExceptionIterator` is documented safe to use from a signal handler.
Consult it when the runtime reports nothing. A `kj::Exception` names the throw site and carries its
description and trace as data, so the report stays useful with no symbols present.

This recovers `kj::Exception`s thrown through KJ's own throw functions, which is what
`InFlightExceptionIterator` can see; anything thrown by a bare `throw` or by the standard library
still reports nothing, as before.

### retry transient errors from `AcceptEx()`

Classify the statuses that describe a dead queued connection as transient and take the next
connection instead. Which codes those are is a guess, as it is on Unix. Both Win32 and Winsock
spellings appear since an overlapped completion may report either. `ERROR_OPERATION_ABORTED` is
excluded: that means the operation was cancelled, which must propagate.

The reset-before-accept tests added in 7df5bd0 were Unix-only because they build the doomed
connection from raw POSIX socket calls. That setup moves into a helper with a Winsock
implementation so the IPv4 case runs on both platforms. The dual-stack case stays Unix-only; it
exists to exercise a Darwin `accept()` quirk with no Win32 analogue.

### classify Win32 spellings of network errors

`typeOfWin32Error()` recognised only the Winsock spellings, so a failure surfacing as an overlapped
completion status fell through to `Exception::Type::FAILED`. A connection reset reported as
`ERROR_NETNAME_DELETED` therefore did not read as `DISCONNECTED`, and callers which branch on the
exception type — including kj's own reset-before-accept tests — treated it as an unexpected error.

### correct the description of Unix `accept()` behaviour

Addresses review. The comment above the reset-before-accept tests, which predates this branch,
claimed Unix hands over the dead connection and only fails on the first read. It doesn't, and that
claim had propagated into the new `isTransientAcceptError()` comment and into this PR description.
Describe what actually happens, and state plainly that `isTransientAcceptError()` is guessing which
errors belong to the listener and which to the connection, as its Unix counterpart already admits
about itself. Also reports an in-flight `kj::Exception` under the same heading as a
currently-handled one.

## Verification

Red/green on the newly enabled test, run on a fork so as not to put a knowingly-broken build here.

**Without the accept fix**, both Windows jobs fail identically:

```
[ TEST ] async-io-test.c++:3745: accept() with aborted connection - IPv4
kj/async-io-win32.c++:861: failed: AcceptEx(): #64 The specified network name is no longer available.
[ FAIL ] async-io-test.c++:3745: accept() with aborted connection - IPv4 (42.032ms)
```

`#64` is `ERROR_NETNAME_DELETED`, and line 861 is the `KJ_FAIL_WIN32` this change guards. Worth
noting that Windows does *not* drop the reset connection from the backlog before `AcceptEx()` sees
it, so the test is not vacuous.

**With it**, all 16 jobs pass, including `MSVC`, `Windows-bazel-clang-cl`, asan, ubsan and
clang-tidy. The review fixes on top are comments plus one message string, so that evidence stands.
