### PR TITLE
HashMap callback style api

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -1447,27 +1447,29 @@ private:
 JsonCodec::AnnotatedHandler& JsonCodec::loadAnnotatedHandler(
       StructSchema schema, kj::Maybe<json::DiscriminatorOptions::Reader> discriminator,
       kj::Maybe<kj::StringPtr> unionDeclName, kj::Vector<Schema>& dependencies) {
-  auto& entry = impl->annotatedHandlers.upsert(schema, kj::none,
-      [&](kj::Maybe<kj::Own<AnnotatedHandler>>& existing, auto dummy) {
-    KJ_ASSERT(existing != kj::none,
+  auto existing = impl->annotatedHandlers.upsert(schema, kj::none,
+      [&](kj::Maybe<kj::Own<AnnotatedHandler>>& value, auto dummy) {
+    KJ_ASSERT(value != kj::none,
         "cyclic JSON flattening detected", schema.getProto().getDisplayName());
+  }, [](auto& value) {
+    return value.map([](auto& handler) -> AnnotatedHandler& { return *handler; });
   });
 
-  KJ_IF_SOME(v, entry.value) {
-    // Already exists.
-    return *v;
-  } else {
-    // Not seen before.
-    auto newHandler = kj::heap<AnnotatedHandler>(
-          *this, schema, discriminator, unionDeclName, dependencies);
-    auto& result = *newHandler;
+  KJ_IF_SOME(handler, existing) {
+    return handler;
+  }
 
-    // Map may have changed, so we have to look up again.
-    KJ_ASSERT_NONNULL(impl->annotatedHandlers.find(schema)) = kj::mv(newHandler);
+  auto newHandler = kj::heap<AnnotatedHandler>(
+        *this, schema, discriminator, unionDeclName, dependencies);
+  auto& result = *newHandler;
 
-    addTypeHandler(schema, result);
-    return result;
-  };
+  // Constructing the handler may have rehashed the map, so look up its placeholder again.
+  impl->annotatedHandlers.find(schema, [&](auto& entry) {
+    entry = kj::mv(newHandler);
+  }).assertSome();
+
+  addTypeHandler(schema, result);
+  return result;
 }
 
 void JsonCodec::handleByAnnotation(Schema schema) {

--- a/c++/src/capnp/membrane.c++
+++ b/c++/src/capnp/membrane.c++
@@ -366,18 +366,20 @@ public:
     }
 
     auto& map = reverse ? policy.reverseWrappers : policy.wrappers;
-    ClientHook*& slot = map.findOrCreate(&cap, [&]() -> kj::Decay<decltype(map)>::Entry {
-      return { &cap, nullptr };
-    });
-    if (slot == nullptr) {
-      auto result = ClientHook::from(
-          reverse ? policy.importExternal(Capability::Client(cap.addRef()))
-                  : policy.exportInternal(Capability::Client(cap.addRef())));
-      slot = result;
-      return result;
-    } else {
-      return slot->addRef();
+    KJ_IF_SOME(existing, map.find(&cap, [](ClientHook* existing) {
+      return existing->addRef();
+    })) {
+      return kj::mv(existing);
     }
+
+    auto result = ClientHook::from(
+        reverse ? policy.importExternal(Capability::Client(cap.addRef()))
+                : policy.exportInternal(Capability::Client(cap.addRef())));
+    map.upsert(&cap, result, [&](ClientHook*& existing, ClientHook*) {
+      // Creating the wrapper could have recursively added it to the map. Prefer that one.
+      result = existing->addRef();
+    });
+    return result;
   }
 
   static kj::Own<ClientHook> wrap(kj::Own<ClientHook> cap, MembranePolicy& policy, bool reverse) {
@@ -396,18 +398,21 @@ public:
     }
 
     auto& map = reverse ? policy.reverseWrappers : policy.wrappers;
-    ClientHook*& slot = map.findOrCreate(cap.get(), [&]() -> kj::Decay<decltype(map)>::Entry {
-      return { cap.get(), nullptr };
-    });
-    if (slot == nullptr) {
-      auto result = ClientHook::from(
-          reverse ? policy.importExternal(Capability::Client(kj::mv(cap)))
-                  : policy.exportInternal(Capability::Client(kj::mv(cap))));
-      slot = result;
-      return result;
-    } else {
-      return slot->addRef();
+    auto key = cap.get();
+    KJ_IF_SOME(existing, map.find(key, [](ClientHook* existing) {
+      return existing->addRef();
+    })) {
+      return kj::mv(existing);
     }
+
+    auto result = ClientHook::from(
+        reverse ? policy.importExternal(Capability::Client(kj::mv(cap)))
+                : policy.exportInternal(Capability::Client(kj::mv(cap))));
+    map.upsert(key, result, [&](ClientHook*& existing, ClientHook*) {
+      // Creating the wrapper could have recursively added it to the map. Prefer that one.
+      result = existing->addRef();
+    });
+    return result;
   }
 
   Request<AnyPointer, AnyPointer> newCall(

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2279,6 +2279,53 @@ private:
   friend const U* _::readMaybe(const Maybe<U>& maybe);
 };
 
+template <>
+class Maybe<void> {
+  // Records whether an operation which has no result value took place.
+
+public:
+  constexpr Maybe(): hasValue(false) {}
+  constexpr Maybe(kj::None): hasValue(false) {}
+  constexpr Maybe(const Maybe&) = default;
+  constexpr Maybe& operator=(const Maybe&) = default;
+  constexpr Maybe(Maybe&& other) noexcept: hasValue(other.hasValue) {
+    other.hasValue = false;
+  }
+  constexpr Maybe& operator=(Maybe&& other) noexcept {
+    hasValue = other.hasValue;
+    other.hasValue = false;
+    return *this;
+  }
+
+  static constexpr Maybe present() {
+    Maybe result;
+    result.hasValue = true;
+    return result;
+  }
+
+  inline Maybe& operator=(kj::None) {
+    hasValue = false;
+    return *this;
+  }
+  inline bool operator==(kj::None) const { return !hasValue; }
+  inline bool operator==(const Maybe& other) const { return hasValue == other.hasValue; }
+
+  void assertSome() const & {
+    KJ_IREQUIRE(hasValue, "null Maybe<> dereference");
+  }
+  void assertSome() && {
+    KJ_IREQUIRE(hasValue, "null Maybe<> dereference");
+    hasValue = false;
+  }
+  void assertNone() const {
+    KJ_IREQUIRE(!hasValue, "expected Maybe<> to be none");
+  }
+
+private:
+  bool hasValue;
+};
+
+
 template <typename T>
 class Maybe<T&> {
 public:

--- a/c++/src/kj/map-test.c++
+++ b/c++/src/kj/map-test.c++
@@ -164,6 +164,97 @@ KJ_TEST("TreeMap range") {
   }
 }
 
+KJ_TEST("HashMap callback API") {
+  HashMap<String, int> map;
+  map.insert(kj::str("foo"), 123);
+
+  auto found = map.find("foo"_kj, [&](int& value) {
+    KJ_EXPECT(value == 123);
+    value = 456;
+    return value * 2;
+  });
+  KJ_EXPECT(found.assertSome() == 912);
+
+  auto copied = map.find("foo"_kj, [](int& value) -> int& { return value; });
+  static_assert(kj::isSameType<decltype(copied), kj::Maybe<int>>());
+  map.find("foo"_kj, [](int& value) { return value = 457; });
+  KJ_EXPECT(copied.assertSome() == 456);
+
+  bool called = false;
+  auto missing = map.find("missing"_kj, [&](int&) {
+    called = true;
+  });
+  static_assert(kj::isSameType<decltype(missing), kj::Maybe<void>>());
+  missing.assertNone();
+  KJ_EXPECT(!called);
+
+  auto modified = map.find("foo"_kj, [](int& value) { value = 458; });
+  static_assert(kj::isSameType<decltype(modified), kj::Maybe<void>>());
+  modified.assertSome();
+
+  const auto& constMap = map;
+  KJ_EXPECT(constMap.find("foo"_kj, [&](const int& value) {
+    return value;
+  }).assertSome() == 458);
+
+  KJ_EXPECT(map.findEntry("foo"_kj, [&](HashMap<String, int>::Entry& entry) {
+    entry.value = 789;
+    return entry.key.asPtr();
+  }).assertSome() == "foo");
+  KJ_EXPECT(constMap.findEntry("foo"_kj,
+      [&](const HashMap<String, int>::Entry& entry) {
+    return entry.value;
+  }).assertSome() == 789);
+
+  bool created = false;
+  auto existing = map.findOrCreate("foo"_kj, [&]() -> HashMap<String, int>::Entry {
+    KJ_FAIL_ASSERT("shouldn't have been called");
+  }, [&](int& value) {
+    KJ_EXPECT(value == 789);
+    return value * 2;
+  });
+  KJ_EXPECT(existing == 1578);
+  map.findOrCreate("bar"_kj, [&]() -> HashMap<String, int>::Entry {
+    created = true;
+    return { kj::str("bar"), 321 };
+  }, [&](int& value) {
+    KJ_EXPECT(value == 321);
+    value = 654;
+  });
+  KJ_EXPECT(created);
+  KJ_EXPECT(map.find("bar"_kj).assertSome() == 654);
+
+  auto insertedEntry = map.findOrCreateEntry(
+      "baz"_kj, [&]() -> HashMap<String, int>::Entry {
+    return { kj::str("baz"), 987 };
+  }, [&](HashMap<String, int>::Entry& entry) {
+    KJ_EXPECT(entry.value == 987);
+    return entry.key.asPtr();
+  });
+  KJ_EXPECT(insertedEntry == "baz");
+
+  HashMap<String, int> upsertMap;
+  auto& oldApiResult = upsertMap.upsert(kj::str("foo"), 123,
+      [](int&, int&&) { KJ_FAIL_ASSERT("shouldn't have been called"); });
+  KJ_EXPECT(oldApiResult.value == 123);
+
+  auto upsertInserted = upsertMap.upsert(kj::str("bar"), 456,
+      [](int&, int&&) { KJ_FAIL_ASSERT("shouldn't have been called"); },
+      [](int& value) -> int& { return value; });
+  static_assert(kj::isSameType<decltype(upsertInserted), int>());
+  KJ_EXPECT(upsertInserted == 456);
+
+  auto upsertUpdated = upsertMap.upsert(kj::str("foo"), 456,
+      [](int& oldValue, int&& newValue) { oldValue += newValue; },
+      [](int& value) { return value; });
+  KJ_EXPECT(upsertUpdated == 579);
+
+  upsertMap.upsert(kj::str("foo"), 1,
+      [](int& oldValue, int&& newValue) { oldValue += newValue; },
+      [](int&) {});
+  KJ_EXPECT(upsertMap.find("foo"_kj).assertSome() == 580);
+}
+
 KJ_TEST("HashMap findOrCreate throws") {
   HashMap<int, String> m;
   try {

--- a/c++/src/kj/map.h
+++ b/c++/src/kj/map.h
@@ -71,7 +71,14 @@ public:
   Entry& upsert(Key key, Value value);
   // Tries to insert a new entry. However, if a duplicate already exists (according to some index),
   // then update(Value& existingValue, Value&& newValue) is called to modify the existing value.
-  // If no function is provided, the default is to simply replace the value (but not the key).
+  // If no update function is provided, the default is to simply replace the value (but not the
+  // key).
+
+  template <typename UpdateFunc, typename Func>
+  auto upsert(Key key, Value value, UpdateFunc&& update, Func&& callback);
+  // Like upsert(key, value, update), then calls callback(value) on the inserted or updated value.
+  // Returns the callback's decayed result. The callback must not modify this map while it is using
+  // the value.
 
   template <typename KeyLike>
   kj::Maybe<Value&> find(KeyLike&& key);
@@ -83,9 +90,24 @@ public:
   // Note that the default hasher for String accepts StringPtr.
 
   template <typename KeyLike, typename Func>
+  auto find(KeyLike&& key, Func&& callback);
+  template <typename KeyLike, typename Func>
+  auto find(KeyLike&& key, Func&& callback) const;
+  // Search for a matching key and, if found, call callback(value). Returns `none` if the key wasn't
+  // found, otherwise returns a `Maybe` containing the callback's decayed result. A void callback
+  // produces a populated `Maybe<void>`. The callback must not modify this map while it is using the
+  // value.
+
+  template <typename KeyLike, typename Func>
   Value& findOrCreate(KeyLike&& key, Func&& createEntry);
   // Like find() but if the key isn't present then call createEntry() to create the corresponding
   // entry and insert it. createEntry() must return type `Entry`.
+
+  template <typename KeyLike, typename CreateFunc, typename Func>
+  auto findOrCreate(KeyLike&& key, CreateFunc&& createEntry, Func&& callback);
+  // Like findOrCreate(key, createEntry), then calls callback(value) on the found or created value.
+  // Returns the callback's decayed result. The callback must not modify this map while it is using
+  // the value.
 
   template <typename KeyLike>
   kj::Maybe<Entry&> findEntry(KeyLike&& key);
@@ -94,6 +116,21 @@ public:
   template <typename KeyLike, typename Func>
   Entry& findOrCreateEntry(KeyLike&& key, Func&& createEntry);
   // Sometimes you need to see the whole matching Entry, not just the Value.
+
+  template <typename KeyLike, typename Func>
+  auto findEntry(KeyLike&& key, Func&& callback);
+  template <typename KeyLike, typename Func>
+  auto findEntry(KeyLike&& key, Func&& callback) const;
+  // Search for a matching key and, if found, call callback(entry). Returns `none` if the key wasn't
+  // found, otherwise returns a `Maybe` containing the callback's decayed result. A void callback
+  // produces a populated `Maybe<void>`. The callback must not modify this map while it is using the
+  // entry.
+
+  template <typename KeyLike, typename CreateFunc, typename Func>
+  auto findOrCreateEntry(KeyLike&& key, CreateFunc&& createEntry, Func&& callback);
+  // Like findOrCreateEntry(key, createEntry), then calls callback(entry) on the found or created
+  // entry. Returns the callback's decayed result. The callback must not modify this map while it is
+  // using the entry.
 
   template <typename KeyLike>
   bool erase(KeyLike&& key);
@@ -114,6 +151,27 @@ public:
   // Erase all values for which predicate(key, value) returns true. This scans over the entire map.
 
 private:
+  template <typename Func, typename Arg>
+  static auto callCallback(Func&& callback, Arg&& arg) {
+    using Result = kj::Decay<decltype(callback(kj::fwd<Arg>(arg)))>;
+    if constexpr (kj::isSameType<Result, void>()) {
+      callback(kj::fwd<Arg>(arg));
+    } else {
+      return Result(callback(kj::fwd<Arg>(arg)));
+    }
+  }
+
+  template <typename Func, typename Arg>
+  static auto callMaybeCallback(Func&& callback, Arg&& arg) {
+    using Result = kj::Decay<decltype(callback(kj::fwd<Arg>(arg)))>;
+    if constexpr (kj::isSameType<Result, void>()) {
+      callback(kj::fwd<Arg>(arg));
+      return kj::Maybe<void>::present();
+    } else {
+      return kj::Maybe<Result>(callback(kj::fwd<Arg>(arg)));
+    }
+  }
+
   class Callbacks {
   public:
     inline const Key& keyForRow(const Entry& entry) const { return entry.key; }
@@ -368,6 +426,16 @@ typename HashMap<Key, Value>::Entry& HashMap<Key, Value>::upsert(
     existingEntry.value = kj::mv(newEntry.value);
   });
 }
+template <typename Key, typename Value>
+template <typename UpdateFunc, typename Func>
+auto HashMap<Key, Value>::upsert(
+    Key key, Value value, UpdateFunc&& update, Func&& callback) {
+  auto& entry = table.upsert(Entry { kj::mv(key), kj::mv(value) },
+      [&](Entry& existingEntry, Entry&& newEntry) {
+    update(existingEntry.value, kj::mv(newEntry.value));
+  });
+  return callCallback(callback, entry.value);
+}
 
 template <typename Key, typename Value>
 template <typename KeyLike>
@@ -379,11 +447,36 @@ template <typename KeyLike>
 kj::Maybe<const Value&> HashMap<Key, Value>::find(KeyLike&& key) const {
   return table.find(key).map([](const Entry& e) -> const Value& { return e.value; });
 }
+template <typename Key, typename Value>
+template <typename KeyLike, typename Func>
+auto HashMap<Key, Value>::find(KeyLike&& key, Func&& callback) {
+  using Result = decltype(callMaybeCallback(callback, instance<Value&>()));
+  KJ_IF_SOME(entry, table.find(kj::fwd<KeyLike>(key))) {
+    return callMaybeCallback(callback, entry.value);
+  }
+  return Result(kj::none);
+}
+template <typename Key, typename Value>
+template <typename KeyLike, typename Func>
+auto HashMap<Key, Value>::find(KeyLike&& key, Func&& callback) const {
+  using Result = decltype(callMaybeCallback(callback, instance<const Value&>()));
+  KJ_IF_SOME(entry, table.find(kj::fwd<KeyLike>(key))) {
+    return callMaybeCallback(callback, entry.value);
+  }
+  return Result(kj::none);
+}
 
 template <typename Key, typename Value>
 template <typename KeyLike, typename Func>
 Value& HashMap<Key, Value>::findOrCreate(KeyLike&& key, Func&& createEntry) {
   return table.findOrCreate(key, kj::fwd<Func>(createEntry)).value;
+}
+template <typename Key, typename Value>
+template <typename KeyLike, typename CreateFunc, typename Func>
+auto HashMap<Key, Value>::findOrCreate(
+    KeyLike&& key, CreateFunc&& createEntry, Func&& callback) {
+  return callCallback(callback, table.findOrCreate(
+      kj::fwd<KeyLike>(key), kj::fwd<CreateFunc>(createEntry)).value);
 }
 
 template <typename Key, typename Value>
@@ -400,9 +493,34 @@ HashMap<Key, Value>::findEntry(KeyLike&& key) const {
 }
 template <typename Key, typename Value>
 template <typename KeyLike, typename Func>
+auto HashMap<Key, Value>::findEntry(KeyLike&& key, Func&& callback) {
+  using Result = decltype(callMaybeCallback(callback, instance<Entry&>()));
+  KJ_IF_SOME(entry, table.find(kj::fwd<KeyLike>(key))) {
+    return callMaybeCallback(callback, entry);
+  }
+  return Result(kj::none);
+}
+template <typename Key, typename Value>
+template <typename KeyLike, typename Func>
+auto HashMap<Key, Value>::findEntry(KeyLike&& key, Func&& callback) const {
+  using Result = decltype(callMaybeCallback(callback, instance<const Entry&>()));
+  KJ_IF_SOME(entry, table.find(kj::fwd<KeyLike>(key))) {
+    return callMaybeCallback(callback, entry);
+  }
+  return Result(kj::none);
+}
+template <typename Key, typename Value>
+template <typename KeyLike, typename Func>
 typename HashMap<Key, Value>::Entry&
 HashMap<Key, Value>::findOrCreateEntry(KeyLike&& key, Func&& createEntry) {
   return table.findOrCreate(kj::fwd<KeyLike>(key), kj::fwd<Func>(createEntry));
+}
+template <typename Key, typename Value>
+template <typename KeyLike, typename CreateFunc, typename Func>
+auto HashMap<Key, Value>::findOrCreateEntry(
+    KeyLike&& key, CreateFunc&& createEntry, Func&& callback) {
+  return callCallback(callback,
+      table.findOrCreate(kj::fwd<KeyLike>(key), kj::fwd<CreateFunc>(createEntry)));
 }
 
 template <typename Key, typename Value>

--- a/c++/src/kj/maybe-test.c++
+++ b/c++/src/kj/maybe-test.c++
@@ -883,6 +883,46 @@ KJ_TEST("Maybe assertSome") {
 #endif
 }
 
+KJ_TEST("Maybe<void>") {
+  static_assert(sizeof(Maybe<void>) == sizeof(bool));
+
+  Maybe<void> empty;
+  empty.assertNone();
+  KJ_EXPECT(empty == kj::none);
+
+  auto present = Maybe<void>::present();
+  present.assertSome();
+  KJ_EXPECT(present != kj::none);
+  KJ_EXPECT(present == Maybe<void>::present());
+  KJ_EXPECT(present != empty);
+
+  const auto copied = present;
+  copied.assertSome();
+  present.assertSome();
+
+  auto moved = kj::mv(present);
+  moved.assertSome();
+  present.assertNone();
+
+  auto moveAssigned = Maybe<void>::present();
+  moveAssigned = kj::mv(moved);
+  moveAssigned.assertSome();
+  moved.assertNone();
+
+  kj::mv(moveAssigned).assertSome();
+  moveAssigned.assertNone();
+
+  auto reset = Maybe<void>::present();
+  reset = kj::none;
+  reset.assertNone();
+
+#if defined(KJ_DEBUG) || (defined(KJ_ENABLE_IREQUIRE) && KJ_ENABLE_IREQUIRE)
+  KJ_EXPECT_THROW_MESSAGE("null Maybe<> dereference", empty.assertSome());
+  KJ_EXPECT_THROW_MESSAGE(
+      "expected Maybe<> to be none", Maybe<void>::present().assertNone());
+#endif
+}
+
 KJ_TEST("Maybe emplaceInit") {
   {
     Maybe<int> m;


### PR DESCRIPTION
Reference returning api is prone to errors, since it is very easy to invalidate those (e.g. insert into map and trigger rehash).

The only non-trivial part here is returning `Maybe` from functions conditionally calling callbacks. This makes end user code slightly more elegant.

Not to force people `return true` every time, this includes `Maybe<void>` support.