### PR TITLE
Refactor kj async build targets

### DIFF
--- a/c++/samples/BUILD.bazel
+++ b/c++/samples/BUILD.bazel
@@ -29,6 +29,7 @@ cc_binary(
     deps = [
         ":calculator_capnp",
         "@capnp-cpp//src/capnp:capnp-rpc",
+        "@capnp-cpp//src/kj:kj-async-os",
     ],
 )
 
@@ -38,5 +39,6 @@ cc_binary(
     deps = [
         ":calculator_capnp",
         "@capnp-cpp//src/capnp:capnp-rpc",
+        "@capnp-cpp//src/kj:kj-async-os",
     ],
 )

--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -8,6 +8,7 @@ capnp_configure()
 
 exports_files([
     "c++.capnp",
+    "rpc.capnp",
 ])
 
 cc_library(
@@ -66,7 +67,8 @@ cc_library(
     include_prefix = "capnp",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/kj:kj-async",
+        "//src/kj:kj-async-core",
+        "//src/kj:kj-async-io",
     ],
 )
 
@@ -129,6 +131,10 @@ cc_library(
         "compiler/type-id.h",
     ],
     include_prefix = "capnp",
+    linkopts = select({
+        "@platforms//os:windows": ["Advapi32.lib"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":capnp",
@@ -229,6 +235,7 @@ cc_library(
         ":capnp-rpc",
         ":capnp_test",
         ":capnpc",
+        "//src/kj:kj-async-os",
         "//src/kj:kj-test",
     ],
 )

--- a/c++/src/capnp/compat/BUILD.bazel
+++ b/c++/src/capnp/compat/BUILD.bazel
@@ -6,6 +6,8 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 exports_files([
     "json.capnp",
     "std-iterator.h",
+    "byte-stream.capnp",
+    "http-over-capnp.capnp",
 ])
 
 # because git contains generated artifacts (which are used to bootstrap the compiler)

--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -88,13 +88,71 @@ cc_library(
 )
 
 cc_library(
-    name = "kj-async",
+    name = "kj-async-core",
     srcs = [
         "async.c++",
+        "timer.c++",
+    ],
+    hdrs = [
+        "async.h",
+        "async-coroutine-alloc.h",
+        "async-inl.h",
+        "async-prelude.h",
+        "async-queue.h",
+        "timer.h",
+    ],
+    # Disable header parsing based on async-inl.h
+    features = ["-parse_headers"],
+    include_prefix = "kj",
+    visibility = ["//visibility:public"],
+    deps = [":kj"],
+)
+
+cc_library(
+    name = "kj-async-io",
+    srcs = [
         "async-io.c++",
         "cidr.c++",
-        "timer.c++",
-    ] + select({
+    ],
+    hdrs = [
+        "async-io.h",
+        "async-io-internal.h",
+        "cidr.h",
+    ],
+    # Disable header parsing based on async-inl.h
+    features = ["-parse_headers"],
+    include_prefix = "kj",
+    # async-io.c++ / cidr.c++ use winsock (socket(), inet_pton) for address parsing on Windows.
+    linkopts = select({
+        "@platforms//os:windows": ["Ws2_32.lib"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":kj",
+        ":kj-async-core",
+    ],
+)
+
+cc_library(
+    name = "kj-async-os-hdrs",
+    hdrs = select({
+        "@platforms//os:windows": ["async-win32.h"],
+        "//conditions:default": ["async-unix.h"],
+    }),
+    features = ["-parse_headers"],
+    include_prefix = "kj",
+    visibility = ["//visibility:public"],
+    deps = [
+        # async-unix.h includes async.h and timer.h; async-win32.h additionally includes io.h.
+        ":kj",
+        ":kj-async-core",
+    ],
+)
+
+cc_library(
+    name = "kj-async-os",
+    srcs = select({
         "@platforms//os:windows": [
             "async-io-win32.c++",
             "async-win32.c++",
@@ -104,23 +162,6 @@ cc_library(
             "async-unix.c++",
         ],
     }),
-    hdrs = [
-        "async.h",
-        "async-coroutine-alloc.h",
-        "async-inl.h",
-        "async-io.h",
-        "async-io-internal.h",
-        "async-prelude.h",
-        "async-queue.h",
-        "cidr.h",
-        "timer.h",
-    ] + select({
-        "@platforms//os:windows": ["async-win32.h"],
-        "//conditions:default": ["async-unix.h"],
-    }),
-    # Disable header parsing based on async-inl.h
-    features = ["-parse_headers"],
-    include_prefix = "kj",
     linkopts = select({
         "@platforms//os:windows": [
             "Ws2_32.lib",
@@ -129,7 +170,22 @@ cc_library(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
-    deps = [":kj"],
+    deps = [
+        ":kj",
+        ":kj-async-core",
+        ":kj-async-io",
+        ":kj-async-os-hdrs",
+    ],
+)
+
+cc_library(
+    name = "kj-async",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":kj-async-core",
+        ":kj-async-io",
+        ":kj-async-os",
+    ],
 )
 
 cc_library(
@@ -194,6 +250,7 @@ cc_test(
     srcs = ["async-coroutine-test.c++"],
     deps = [
         ":kj-test",
+        "//src/kj:kj-async-os",
         "//src/kj/compat:kj-http",
     ],
 )

--- a/c++/src/kj/async-io-internal.h
+++ b/c++/src/kj/async-io-internal.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "vector.h"
+#include <kj/vector.h>
 #include "async-io.h"
 #include <stdint.h>
 #include "cidr.h"

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "async.h"
+#include <kj/async.h>
 #include <kj/function.h>
 #include <kj/thread.h>
 #include <kj/timer.h>

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -25,8 +25,8 @@
 #error "This file is Unix-specific. On Windows, include async-win32.h instead."
 #endif
 
-#include "async.h"
-#include "timer.h"
+#include <kj/async.h>
+#include <kj/timer.h>
 #include <kj/io.h>
 #include <signal.h>
 

--- a/c++/src/kj/async-win32.h
+++ b/c++/src/kj/async-win32.h
@@ -29,9 +29,9 @@
 // #include windows.h yourself before including this header.)
 #include <kj/win32-api-version.h>
 
-#include "async.h"
-#include "timer.h"
-#include "io.h"
+#include <kj/async.h>
+#include <kj/timer.h>
+#include <kj/io.h>
 #include <atomic>
 #include <inttypes.h>
 

--- a/c++/src/kj/compat/BUILD.bazel
+++ b/c++/src/kj/compat/BUILD.bazel
@@ -27,7 +27,8 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "//src/kj:kj-async",
+        "//src/kj:kj-async-core",
+        "//src/kj:kj-async-io",
         "@ssl",
     ],
 )
@@ -45,7 +46,8 @@ cc_library(
     include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/kj:kj-async",
+        "//src/kj:kj-async-core",
+        "//src/kj:kj-async-io",
         "@zlib",
     ],
 )
@@ -57,7 +59,8 @@ cc_library(
     include_prefix = "kj/compat",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/kj:kj-async",
+        "//src/kj:kj-async-core",
+        "//src/kj:kj-async-io",
         "@zlib",
     ],
 )
@@ -73,7 +76,8 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "//src/kj:kj-async",
+        "//src/kj:kj-async-core",
+        "//src/kj:kj-async-io",
         "@brotli//:brotlidec",
         "@brotli//:brotlienc",
     ],
@@ -97,6 +101,7 @@ kj_tests = [
     srcs = [f],
     deps = [
         ":kj-http",
+        "//src/kj:kj-async-os",
         "//src/kj:kj-test",
     ],
 ) for f in kj_tests]
@@ -115,6 +120,7 @@ cc_test(
     deps = [
         ":http-socketpair-test-base",
         ":kj-http",
+        "//src/kj:kj-async-os",
         "//src/kj:kj-test",
     ],
 )
@@ -134,6 +140,7 @@ kj_tls_tests = [
     deps = [
         ":kj-http",
         ":kj-tls",
+        "//src/kj:kj-async-os",
         "//src/kj:kj-test",
     ],
     size = "large",
@@ -148,6 +155,7 @@ cc_test(
     }),
     deps = [
         ":kj-gzip",
+        "//src/kj:kj-async-os",
         "//src/kj:kj-test",
     ],
 )
@@ -161,6 +169,7 @@ cc_test(
     }),
     deps = [
         ":kj-brotli",
+        "//src/kj:kj-async-os",
         "//src/kj:kj-test",
     ],
 )


### PR DESCRIPTION
The kj async framework is layered into three targets.

:kj-async-core  Promise machinery: kj::Promise / EventLoop / EventPort, coroutine support,
                and timers. No I/O.
:kj-async-io    Abstract, OS-independent async I/O: the AsyncInputStream / AsyncOutputStream /
                AsyncIoStream interfaces (and their default-method implementations), in-memory
                pipes, the kj::Network / NetworkAddress interfaces, NetworkFilter, and CIDR
                address parsing. No event loop.
:kj-async-os    The concrete OS event loop and I/O implementation: kj::UnixEventPort /
                kj::Win32IocpEventPort and kj::setupAsyncIo().

The layering is strictly one-directional (os -> io -> core). The :kj-async umbrella preserves the historical all-in-one target Existing consumers need no changes.