### PR TITLE
[tsan] XThreadEvent: use atomic load to access state

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -918,7 +918,9 @@ void XThreadEvent::ensureDoneOrCanceled() {
     } else {
       // Target event loop is already dead, so we know it's already working on transitioning all
       // events to the DONE state. We can just wait.
-      lock.wait([&](auto&) { return state == DONE; });
+      lock.wait([&](auto&) {
+        return __atomic_load_n(&state, __ATOMIC_ACQUIRE) == DONE;
+      });
       return;
     }
 
@@ -973,7 +975,7 @@ void XThreadEvent::ensureDoneOrCanceled() {
             // after this scope.
           });
 
-          while (state != DONE) {
+          while (__atomic_load_n(&state, __ATOMIC_ACQUIRE) != DONE) {
             bool otherThreadIsWaiting = lock->waitingForCancel;
 
             // Make sure our waitingForCancel is on and dispatch any pending cancellations on this
@@ -1012,7 +1014,8 @@ void XThreadEvent::ensureDoneOrCanceled() {
             // OK, now we can wait for the other thread to either process our cancellation or
             // indicate that it is waiting for remote cancellation.
             lock.wait([&](const Executor::Impl::State& executorState) {
-              return state == DONE || executorState.waitingForCancel;
+              return __atomic_load_n(&state, __ATOMIC_ACQUIRE) == DONE ||
+                  executorState.waitingForCancel;
             });
           }
         } else {
@@ -1021,7 +1024,9 @@ void XThreadEvent::ensureDoneOrCanceled() {
           //
           // NOTE: I don't think we can actually get here, because it implies that this is a
           //   synchronous execution, which means there's no way to cancel it.
-          lock.wait([&](auto&) { return state == DONE; });
+          lock.wait([&](auto&) {
+            return __atomic_load_n(&state, __ATOMIC_ACQUIRE) == DONE;
+          });
         }
         KJ_DASSERT(!targetLink.isLinked());
         break;


### PR DESCRIPTION
Looks to be the last tsan issue: https://github.com/capnproto/capnproto/actions/runs/31715250495/job/94498232970?pr=2768