### PR TITLE
kj/atomic.h

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -144,6 +144,7 @@ noinst_HEADERS = \
 includekj_HEADERS =                                            \
   src/kj/common.h                                              \
   src/kj/units.h                                               \
+  src/kj/atomic.h                                              \
   src/kj/memory.h                                              \
   src/kj/refcount.h                                            \
   src/kj/array.h                                               \

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -26,6 +26,7 @@
 #endif
 
 #include <kj/common.h>
+#include <kj/atomic.h>
 #include <kj/mutex.h>
 #include <kj/exception.h>
 #include <kj/vector.h>
@@ -102,19 +103,11 @@ private:
   KJ_DISALLOW_COPY_AND_MOVE(ReadLimiter);
 
   KJ_ALWAYS_INLINE(void setLimit(uint64_t newLimit)) {
-#if defined(__GNUC__) || defined(__clang__)
-    __atomic_store_n(&limit, newLimit, __ATOMIC_RELAXED);
-#else
-    limit = newLimit;
-#endif
+    kj::atomicStore(&limit, newLimit, kj::AtomicMemoryOrder::RELAXED);
   }
 
   KJ_ALWAYS_INLINE(uint64_t readLimit() const) {
-#if defined(__GNUC__) || defined(__clang__)
-    return __atomic_load_n(&limit, __ATOMIC_RELAXED);
-#else
-    return limit;
-#endif
+    return kj::atomicLoad(&limit, kj::AtomicMemoryOrder::RELAXED);
   }
 };
 

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -21,6 +21,7 @@
 
 #define CAPNP_PRIVATE
 #include "layout.h"
+#include <kj/atomic.h>
 #include <kj/debug.h>
 #include "arena.h"
 #include <string.h>
@@ -44,23 +45,13 @@ static BrokenCapFactory* globalBrokenCapFactory = nullptr;
 void setGlobalBrokenCapFactoryForLayoutCpp(BrokenCapFactory& factory) {
   // Called from capability.c++ when the capability API is used, to make sure that layout.c++
   // is ready for it.  May be called multiple times but always with the same value.
-#if __GNUC__ || defined(__clang__)
-  __atomic_store_n(&globalBrokenCapFactory, &factory, __ATOMIC_RELAXED);
-#elif _MSC_VER
-  *static_cast<BrokenCapFactory* volatile*>(&globalBrokenCapFactory) = &factory;
-#else
-#error "Platform not supported"
-#endif
+  kj::atomicStore(&globalBrokenCapFactory, &factory, kj::AtomicMemoryOrder::RELAXED);
 }
 
 static BrokenCapFactory* readGlobalBrokenCapFactoryForLayoutCpp() {
-#if __GNUC__ || defined(__clang__)
   // Thread-sanitizer doesn't have the right information to know this is safe without doing an
   // atomic read. https://groups.google.com/g/capnproto/c/634juhn5ap0/m/pyRiwWl1AAAJ
-  return __atomic_load_n(&globalBrokenCapFactory, __ATOMIC_RELAXED);
-#else
-  return globalBrokenCapFactory;
-#endif
+  return kj::atomicLoad(&globalBrokenCapFactory, kj::AtomicMemoryOrder::RELAXED);
 }
 
 }  // namespace _ (private)

--- a/c++/src/capnp/raw-schema.h
+++ b/c++/src/capnp/raw-schema.h
@@ -22,10 +22,7 @@
 #pragma once
 
 #include "common.h"  // for uint and friends
-
-#if _MSC_VER && !defined(__clang__)
-#include <atomic>
-#endif
+#include <kj/atomic.h>
 
 CAPNP_BEGIN_HEADER
 
@@ -145,14 +142,7 @@ struct RawBrandedSchema {
     // is required in particular when traversing the dependency list.  RawSchemas for compiled-in
     // types are always initialized; only dynamically-loaded schemas may be lazy.
 
-#if __GNUC__ || defined(__clang__)
-    const Initializer* i = __atomic_load_n(&lazyInitializer, __ATOMIC_ACQUIRE);
-#elif _MSC_VER
-    const Initializer* i = *static_cast<Initializer const* const volatile*>(&lazyInitializer);
-    std::atomic_thread_fence(std::memory_order_acquire);
-#else
-#error "Platform not supported"
-#endif
+    const Initializer* i = kj::atomicLoad(&lazyInitializer, kj::AtomicMemoryOrder::ACQUIRE);
     if (i != nullptr) i->init(this);
   }
 
@@ -211,14 +201,7 @@ struct RawSchema {
     // is required in particular when traversing the dependency list.  RawSchemas for compiled-in
     // types are always initialized; only dynamically-loaded schemas may be lazy.
 
-#if __GNUC__ || defined(__clang__)
-    const Initializer* i = __atomic_load_n(&lazyInitializer, __ATOMIC_ACQUIRE);
-#elif _MSC_VER
-    const Initializer* i = *static_cast<Initializer const* const volatile*>(&lazyInitializer);
-    std::atomic_thread_fence(std::memory_order_acquire);
-#else
-#error "Platform not supported"
-#endif
+    const Initializer* i = kj::atomicLoad(&lazyInitializer, kj::AtomicMemoryOrder::ACQUIRE);
     if (i != nullptr) i->init(this);
   }
 

--- a/c++/src/capnp/schema-loader.c++
+++ b/c++/src/capnp/schema-loader.c++
@@ -24,16 +24,13 @@
 #include "message.h"
 #include "arena.h"
 #include <kj/debug.h>
+#include <kj/atomic.h>
 #include <kj/exception.h>
 #include <kj/arena.h>
 #include <kj/vector.h>
 #include <algorithm>
 #include <kj/map.h>
 #include <capnp/stream.capnp.h>
-
-#if _MSC_VER && !defined(__clang__)
-#include <atomic>
-#endif
 
 namespace capnp {
 
@@ -1297,17 +1294,8 @@ _::RawSchema* SchemaLoader::Impl::load(const schema::Node::Reader& reader, bool 
     // If this schema is not newly-allocated, it may already be in the wild, specifically in the
     // dependency list of other schemas.  Once the initializer is null, it is live, so we must do
     // a release-store here.
-#if __GNUC__ || defined(__clang__)
-    __atomic_store_n(&schema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
-    __atomic_store_n(&schema->defaultBrand.lazyInitializer, nullptr, __ATOMIC_RELEASE);
-#elif _MSC_VER
-    std::atomic_thread_fence(std::memory_order_release);
-    *static_cast<_::RawSchema::Initializer const* volatile*>(&schema->lazyInitializer) = nullptr;
-    *static_cast<_::RawBrandedSchema::Initializer const* volatile*>(
-        &schema->defaultBrand.lazyInitializer) = nullptr;
-#else
-#error "Platform not supported"
-#endif
+    kj::atomicStore(&schema->lazyInitializer, nullptr, kj::AtomicMemoryOrder::RELEASE);
+    kj::atomicStore(&schema->defaultBrand.lazyInitializer, nullptr, kj::AtomicMemoryOrder::RELEASE);
   }
 
   return schema;
@@ -1394,17 +1382,8 @@ _::RawSchema* SchemaLoader::Impl::loadNative(const _::RawSchema* nativeSchema) {
     // If this schema is not newly-allocated, it may already be in the wild, specifically in the
     // dependency list of other schemas.  Once the initializer is null, it is live, so we must do
     // a release-store here.
-#if __GNUC__ || defined(__clang__)
-    __atomic_store_n(&schema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
-    __atomic_store_n(&schema->defaultBrand.lazyInitializer, nullptr, __ATOMIC_RELEASE);
-#elif _MSC_VER
-    std::atomic_thread_fence(std::memory_order_release);
-    *static_cast<_::RawSchema::Initializer const* volatile*>(&schema->lazyInitializer) = nullptr;
-    *static_cast<_::RawBrandedSchema::Initializer const* volatile*>(
-        &schema->defaultBrand.lazyInitializer) = nullptr;
-#else
-#error "Platform not supported"
-#endif
+    kj::atomicStore(&schema->lazyInitializer, nullptr, kj::AtomicMemoryOrder::RELEASE);
+    kj::atomicStore(&schema->defaultBrand.lazyInitializer, nullptr, kj::AtomicMemoryOrder::RELEASE);
   }
 
   return schema;
@@ -2080,18 +2059,8 @@ void SchemaLoader::InitializerImpl::init(const _::RawSchema* schema) const {
               "A schema not belonging to this loader used its initializer.");
 
     // Disable the initializer.
-#if __GNUC__ || defined(__clang__)
-    __atomic_store_n(&mutableSchema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
-    __atomic_store_n(&mutableSchema->defaultBrand.lazyInitializer, nullptr, __ATOMIC_RELEASE);
-#elif _MSC_VER
-    std::atomic_thread_fence(std::memory_order_release);
-    *static_cast<_::RawSchema::Initializer const* volatile*>(
-        &mutableSchema->lazyInitializer) = nullptr;
-    *static_cast<_::RawBrandedSchema::Initializer const* volatile*>(
-        &mutableSchema->defaultBrand.lazyInitializer) = nullptr;
-#else
-#error "Platform not supported"
-#endif
+    kj::atomicStore(&mutableSchema->lazyInitializer, nullptr, kj::AtomicMemoryOrder::RELEASE);
+    kj::atomicStore(&mutableSchema->defaultBrand.lazyInitializer, nullptr, kj::AtomicMemoryOrder::RELEASE);
   }
 }
 
@@ -2117,15 +2086,7 @@ void SchemaLoader::BrandedInitializerImpl::init(const _::RawBrandedSchema* schem
   mutableSchema->dependencyCount = deps.size();
 
   // It's initialized now, so disable the initializer.
-#if __GNUC__ || defined(__clang__)
-  __atomic_store_n(&mutableSchema->lazyInitializer, nullptr, __ATOMIC_RELEASE);
-#elif _MSC_VER
-  std::atomic_thread_fence(std::memory_order_release);
-  *static_cast<_::RawBrandedSchema::Initializer const* volatile*>(
-      &mutableSchema->lazyInitializer) = nullptr;
-#else
-#error "Platform not supported"
-#endif
+  kj::atomicStore(&mutableSchema->lazyInitializer, nullptr, kj::AtomicMemoryOrder::RELEASE);
 }
 
 // =======================================================================================

--- a/c++/src/kj/BUILD.bazel
+++ b/c++/src/kj/BUILD.bazel
@@ -37,6 +37,7 @@ cc_library(
     hdrs = [
         "arena.h",
         "array.h",
+        "atomic.h",
         "common.h",
         "debug.h",
         "encoding.h",

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 set(kj_headers
   common.h
   units.h
+  atomic.h
   memory.h
   refcount.h
   array.h

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -36,6 +36,7 @@
 #endif
 
 #include <kj/list.h>
+#include <kj/atomic.h>
 
 KJ_BEGIN_HEADER
 
@@ -2086,12 +2087,8 @@ public:
     }
   }
   bool isWaiting() const override {
-#if _MSC_VER && !__clang__
-    // Just assume enum-sized loads are atomic... on what kind of absurd platform would they not be?
-    return control->state == XThreadPafControl::WAITING;
-#else
-    return __atomic_load_n(&control->state, __ATOMIC_RELAXED) == XThreadPafControl::WAITING;
-#endif
+    return kj::atomicLoad(&control->state, kj::AtomicMemoryOrder::RELAXED) ==
+        XThreadPafControl::WAITING;
   }
 
 private:

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -40,6 +40,7 @@
 #endif
 
 #include "async.h"
+#include "atomic.h"
 #include "debug.h"
 #include "vector.h"
 #include "mutex.h"
@@ -47,8 +48,8 @@
 #include "function.h"
 #include "list.h"
 #include "map.h"
-#include <deque>
 #include <atomic>
+#include <deque>
 
 #if __linux__
 #include <sys/prctl.h>
@@ -93,28 +94,6 @@
 // Nop the hints so that we don't have to put #ifdefs around every use.
 #define __sanitizer_start_switch_fiber(...)
 #define __sanitizer_finish_switch_fiber(...)
-#endif
-
-#if _MSC_VER && !__clang__
-// MSVC's atomic intrinsics are weird and different, whereas the C++ standard atomics match the GCC
-// builtins -- except for requiring the obnoxious std::atomic<T> wrapper. So, on MSVC let's just
-// #define the builtins based on the C++ library, reinterpret-casting native types to
-// std::atomic... this is cheating but ugh, whatever.
-template <typename T>
-static std::atomic<T>* reinterpretAtomic(T* ptr) { return reinterpret_cast<std::atomic<T>*>(ptr); }
-#define __atomic_store_n(ptr, val, order) \
-    std::atomic_store_explicit(reinterpretAtomic(ptr), val, order)
-#define __atomic_load_n(ptr, order) \
-    std::atomic_load_explicit(reinterpretAtomic(ptr), order)
-#define __atomic_compare_exchange_n(ptr, expected, desired, weak, succ, fail) \
-    std::atomic_compare_exchange_strong_explicit( \
-        reinterpretAtomic(ptr), expected, desired, succ, fail)
-#define __atomic_exchange_n(ptr, val, order) \
-    std::atomic_exchange_explicit(reinterpretAtomic(ptr), val, order)
-#define __ATOMIC_RELAXED std::memory_order_relaxed
-#define __ATOMIC_ACQUIRE std::memory_order_acquire
-#define __ATOMIC_RELEASE std::memory_order_release
-#define __ATOMIC_ACQ_REL std::memory_order_acq_rel
 #endif
 
 namespace kj {
@@ -599,7 +578,7 @@ public:
 #if USE_CORE_LOCAL_FREELISTS
     KJ_IF_SOME(core, lookupCoreLocalFreelist()) {
       for (auto& stackPtr: core.stacks) {
-        _::FiberStack* result = __atomic_exchange_n(&stackPtr, nullptr, __ATOMIC_ACQUIRE);
+        _::FiberStack* result = kj::atomicExchange(&stackPtr, nullptr, kj::AtomicMemoryOrder::ACQUIRE);
         if (result != nullptr) {
           // Found a stack in this slot!
           return { result, *this };
@@ -674,7 +653,7 @@ private:
 #if USE_CORE_LOCAL_FREELISTS
       KJ_IF_SOME(core, lookupCoreLocalFreelist()) {
         for (auto& stackPtr: core.stacks) {
-          stack = __atomic_exchange_n(&stackPtr, stack, __ATOMIC_RELEASE);
+          stack = kj::atomicExchange(&stackPtr, stack, kj::AtomicMemoryOrder::RELEASE);
           if (stack == nullptr) {
             // Cool, we inserted the stack into an unused slot. We're done.
             return;
@@ -910,7 +889,7 @@ void XThreadEvent::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
 }
 
 void XThreadEvent::ensureDoneOrCanceled() {
-  if (__atomic_load_n(&state, __ATOMIC_ACQUIRE) != DONE) {
+  if (kj::atomicLoad(&state, kj::AtomicMemoryOrder::ACQUIRE) != DONE) {
     auto lock = targetExecutor->impl->state.lockExclusive();
 
     const EventLoop* loop;
@@ -920,7 +899,7 @@ void XThreadEvent::ensureDoneOrCanceled() {
       // Target event loop is already dead, so we know it's already working on transitioning all
       // events to the DONE state. We can just wait.
       lock.wait([&](auto&) {
-        return __atomic_load_n(&state, __ATOMIC_ACQUIRE) == DONE;
+        return kj::atomicLoad(&state, kj::AtomicMemoryOrder::ACQUIRE) == DONE;
       });
       return;
     }
@@ -976,7 +955,7 @@ void XThreadEvent::ensureDoneOrCanceled() {
             // after this scope.
           });
 
-          while (__atomic_load_n(&state, __ATOMIC_ACQUIRE) != DONE) {
+          while (kj::atomicLoad(&state, kj::AtomicMemoryOrder::ACQUIRE) != DONE) {
             bool otherThreadIsWaiting = lock->waitingForCancel;
 
             // Make sure our waitingForCancel is on and dispatch any pending cancellations on this
@@ -1015,7 +994,7 @@ void XThreadEvent::ensureDoneOrCanceled() {
             // OK, now we can wait for the other thread to either process our cancellation or
             // indicate that it is waiting for remote cancellation.
             lock.wait([&](const Executor::Impl::State& executorState) {
-              return __atomic_load_n(&state, __ATOMIC_ACQUIRE) == DONE ||
+              return kj::atomicLoad(&state, kj::AtomicMemoryOrder::ACQUIRE) == DONE ||
                   executorState.waitingForCancel;
             });
           }
@@ -1026,7 +1005,7 @@ void XThreadEvent::ensureDoneOrCanceled() {
           // NOTE: I don't think we can actually get here, because it implies that this is a
           //   synchronous execution, which means there's no way to cancel it.
           lock.wait([&](auto&) {
-            return __atomic_load_n(&state, __ATOMIC_ACQUIRE) == DONE;
+            return kj::atomicLoad(&state, kj::AtomicMemoryOrder::ACQUIRE) == DONE;
           });
         }
         KJ_DASSERT(!targetLink.isLinked());
@@ -1110,7 +1089,7 @@ void XThreadEvent::done() {
 }
 
 inline void XThreadEvent::setDoneState() {
-  __atomic_store_n(&state, DONE, __ATOMIC_RELEASE);
+  kj::atomicStore(&state, DONE, kj::AtomicMemoryOrder::RELEASE);
 }
 
 void XThreadEvent::setDisconnected() {
@@ -1161,12 +1140,13 @@ XThreadPaf::~XThreadPaf() noexcept(false) {}
 void XThreadPaf::destroy() {
   auto oldState = XThreadPafControl::WAITING;
 
-  if (__atomic_load_n(&control->state, __ATOMIC_ACQUIRE) == XThreadPafControl::DISPATCHED) {
+  if (kj::atomicLoad(&control->state, kj::AtomicMemoryOrder::ACQUIRE) == XThreadPafControl::DISPATCHED) {
     // Common case: Promise was fully fulfilled and dispatched, no need for locking.
     delete this;
-  } else if (__atomic_compare_exchange_n(
+  } else if (kj::atomicCompareExchange(
                  &control->state, &oldState, XThreadPafControl::CANCELED, false,
-                 __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+                 kj::AtomicMemoryOrder::ACQUIRE_RELEASE,
+                 kj::AtomicMemoryOrder::ACQUIRE)) {
     // State transitioned from WAITING to CANCELED, so now it's the fulfiller's job to destroy the
     // object. The successful CAS must have release semantics, not merely acquire semantics: this
     // publishes this thread's preceding accesses to the object (including the virtual destroy()
@@ -1201,13 +1181,13 @@ void XThreadPaf::tracePromise(TraceBuilder& builder, bool stopAtNextEvent) {
 }
 
 XThreadPaf::FulfillScope::FulfillScope(XThreadPaf** pointer) {
-  obj = __atomic_exchange_n(pointer, static_cast<XThreadPaf*>(nullptr), __ATOMIC_ACQUIRE);
+  obj = kj::atomicExchange(pointer, static_cast<XThreadPaf*>(nullptr), kj::AtomicMemoryOrder::ACQUIRE);
   auto oldState = XThreadPafControl::WAITING;
   if (obj == nullptr) {
     // Already fulfilled (possibly by another thread).
-  } else if (__atomic_compare_exchange_n(
+  } else if (kj::atomicCompareExchange(
                  &obj->control->state, &oldState, XThreadPafControl::FULFILLING, false,
-                 __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
+                 kj::AtomicMemoryOrder::ACQUIRE, kj::AtomicMemoryOrder::ACQUIRE)) {
     // Transitioned to FULFILLING, good.
   } else {
     // The waiting thread must have canceled.
@@ -1224,7 +1204,7 @@ XThreadPaf::FulfillScope::~FulfillScope() noexcept(false) {
   if (obj != nullptr) {
     auto lock = obj->executor->impl->state.lockExclusive();
     lock->fulfilled.add(*obj);
-    __atomic_store_n(&obj->control->state, XThreadPafControl::FULFILLED, __ATOMIC_RELEASE);
+    kj::atomicStore(&obj->control->state, XThreadPafControl::FULFILLED, kj::AtomicMemoryOrder::RELEASE);
     KJ_IF_SOME(l, lock->loop) {
       // TODO(perf): It's annoying we have to call wake() with the lock held, but we have to
       //   prevent the destination EventLoop from being destroyed first.

--- a/c++/src/kj/atomic.h
+++ b/c++/src/kj/atomic.h
@@ -1,0 +1,163 @@
+// Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "common.h"
+
+#if _MSC_VER && !defined(__clang__)
+#include <atomic>
+#endif
+
+KJ_BEGIN_HEADER
+
+namespace kj {
+
+// Atomic operations on ordinary, suitably-aligned objects. These are intentionally a small
+// wrapper around the compiler primitives rather than an atomic container: several data structures
+// in KJ need to preserve their layout or initialize their storage statically.
+enum class AtomicMemoryOrder {
+  RELAXED,
+  ACQUIRE,
+  RELEASE,
+  ACQUIRE_RELEASE,
+  SEQUENTIAL
+};
+
+namespace _ {  // private
+#if _MSC_VER && !defined(__clang__)
+inline constexpr std::memory_order toStdMemoryOrder(AtomicMemoryOrder order) {
+  switch (order) {
+    case AtomicMemoryOrder::RELAXED: return std::memory_order_relaxed;
+    case AtomicMemoryOrder::ACQUIRE: return std::memory_order_acquire;
+    case AtomicMemoryOrder::RELEASE: return std::memory_order_release;
+    case AtomicMemoryOrder::ACQUIRE_RELEASE: return std::memory_order_acq_rel;
+    case AtomicMemoryOrder::SEQUENTIAL: return std::memory_order_seq_cst;
+  }
+  return std::memory_order_seq_cst;
+}
+#else
+inline constexpr int toGnuMemoryOrder(AtomicMemoryOrder order) {
+  switch (order) {
+    case AtomicMemoryOrder::RELAXED: return __ATOMIC_RELAXED;
+    case AtomicMemoryOrder::ACQUIRE: return __ATOMIC_ACQUIRE;
+    case AtomicMemoryOrder::RELEASE: return __ATOMIC_RELEASE;
+    case AtomicMemoryOrder::ACQUIRE_RELEASE: return __ATOMIC_ACQ_REL;
+    case AtomicMemoryOrder::SEQUENTIAL: return __ATOMIC_SEQ_CST;
+  }
+  return __ATOMIC_SEQ_CST;
+}
+#endif
+}  // namespace _ (private)
+
+template <typename T>
+inline T atomicLoad(const volatile T* ptr, AtomicMemoryOrder order) {
+#if _MSC_VER && !defined(__clang__)
+  return std::atomic_load_explicit(
+      reinterpret_cast<const volatile std::atomic<T>*>(ptr), _::toStdMemoryOrder(order));
+#else
+  return __atomic_load_n(ptr, _::toGnuMemoryOrder(order));
+#endif
+}
+
+template <typename T, typename U>
+inline void atomicStore(volatile T* ptr, U&& value, AtomicMemoryOrder order) {
+#if _MSC_VER && !defined(__clang__)
+  std::atomic_store_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr),
+      static_cast<T>(kj::fwd<U>(value)), _::toStdMemoryOrder(order));
+#else
+  __atomic_store_n(ptr, static_cast<T>(kj::fwd<U>(value)), _::toGnuMemoryOrder(order));
+#endif
+}
+
+template <typename T, typename U>
+inline T atomicExchange(volatile T* ptr, U&& value, AtomicMemoryOrder order) {
+#if _MSC_VER && !defined(__clang__)
+  return std::atomic_exchange_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr),
+      static_cast<T>(kj::fwd<U>(value)), _::toStdMemoryOrder(order));
+#else
+  return __atomic_exchange_n(
+      ptr, static_cast<T>(kj::fwd<U>(value)), _::toGnuMemoryOrder(order));
+#endif
+}
+
+template <typename T, typename U>
+inline bool atomicCompareExchange(volatile T* ptr, T* expected, U&& desired, bool weak,
+                                  AtomicMemoryOrder successOrder,
+                                  AtomicMemoryOrder failureOrder) {
+#if _MSC_VER && !defined(__clang__)
+  auto atomicPtr = reinterpret_cast<volatile std::atomic<T>*>(ptr);
+  if (weak) {
+    return std::atomic_compare_exchange_weak_explicit(atomicPtr, expected,
+        static_cast<T>(kj::fwd<U>(desired)), _::toStdMemoryOrder(successOrder),
+        _::toStdMemoryOrder(failureOrder));
+  } else {
+    return std::atomic_compare_exchange_strong_explicit(atomicPtr, expected,
+        static_cast<T>(kj::fwd<U>(desired)), _::toStdMemoryOrder(successOrder),
+        _::toStdMemoryOrder(failureOrder));
+  }
+#else
+  return __atomic_compare_exchange_n(ptr, expected, static_cast<T>(kj::fwd<U>(desired)), weak,
+      _::toGnuMemoryOrder(successOrder), _::toGnuMemoryOrder(failureOrder));
+#endif
+}
+
+template <typename T, typename U>
+inline T atomicAddFetch(volatile T* ptr, U value, AtomicMemoryOrder order) {
+#if _MSC_VER && !defined(__clang__)
+  return std::atomic_fetch_add_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr),
+      static_cast<T>(value), _::toStdMemoryOrder(order)) + static_cast<T>(value);
+#else
+  return __atomic_add_fetch(ptr, static_cast<T>(value), _::toGnuMemoryOrder(order));
+#endif
+}
+
+template <typename T, typename U>
+inline T atomicSubFetch(volatile T* ptr, U value, AtomicMemoryOrder order) {
+#if _MSC_VER && !defined(__clang__)
+  return std::atomic_fetch_sub_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr),
+      static_cast<T>(value), _::toStdMemoryOrder(order)) - static_cast<T>(value);
+#else
+  return __atomic_sub_fetch(ptr, static_cast<T>(value), _::toGnuMemoryOrder(order));
+#endif
+}
+
+template <typename T, typename U>
+inline T atomicFetchAnd(volatile T* ptr, U value, AtomicMemoryOrder order) {
+#if _MSC_VER && !defined(__clang__)
+  return std::atomic_fetch_and_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr),
+      static_cast<T>(value), _::toStdMemoryOrder(order));
+#else
+  return __atomic_fetch_and(ptr, static_cast<T>(value), _::toGnuMemoryOrder(order));
+#endif
+}
+
+inline void atomicThreadFence(AtomicMemoryOrder order) {
+#if _MSC_VER && !defined(__clang__)
+  std::atomic_thread_fence(_::toStdMemoryOrder(order));
+#else
+  __atomic_thread_fence(_::toGnuMemoryOrder(order));
+#endif
+}
+
+}  // namespace kj
+
+KJ_END_HEADER

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -178,8 +178,8 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
     case EXCLUSIVE:
       for (;;) {
         uint state = 0;
-        if (KJ_LIKELY(__atomic_compare_exchange_n(&futex, &state, EXCLUSIVE_HELD, false,
-                                                  __ATOMIC_ACQUIRE, __ATOMIC_RELAXED))) {
+        if (KJ_LIKELY(kj::atomicCompareExchange(&futex, &state, EXCLUSIVE_HELD, false,
+                                                  kj::AtomicMemoryOrder::ACQUIRE, kj::AtomicMemoryOrder::RELAXED))) {
 
           // Acquired.
           break;
@@ -187,8 +187,8 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
 
         // The mutex is contended.  Set the exclusive-requested bit and wait.
         if ((state & EXCLUSIVE_REQUESTED) == 0) {
-          if (!__atomic_compare_exchange_n(&futex, &state, state | EXCLUSIVE_REQUESTED, false,
-                                           __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+          if (!kj::atomicCompareExchange(&futex, &state, state | EXCLUSIVE_REQUESTED, false,
+                                           kj::AtomicMemoryOrder::RELAXED, kj::AtomicMemoryOrder::RELAXED)) {
             // Oops, the state changed before we could set the request bit.  Start over.
             continue;
           }
@@ -217,7 +217,7 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
       kj::Maybe<kj::TimePoint> contentionWaitStart;
 #endif
 
-      uint state = __atomic_add_fetch(&futex, 1, __ATOMIC_ACQUIRE);
+      uint state = kj::atomicAddFetch(&futex, 1, kj::AtomicMemoryOrder::ACQUIRE);
 
       for (;;) {
         if (KJ_LIKELY((state & EXCLUSIVE_HELD) == 0)) {
@@ -243,13 +243,13 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
           // If we timeout though, we need to signal that we're not waiting anymore.
           if (errno == ETIMEDOUT) {
             setCurrentThreadIsNoLongerWaiting();
-            state = __atomic_sub_fetch(&futex, 1, __ATOMIC_RELAXED);
+            state = kj::atomicSubFetch(&futex, 1, kj::AtomicMemoryOrder::RELAXED);
 
             // We may have unlocked since we timed out. So act like we just unlocked the mutex
             // and maybe send a wait signal if needed. See Mutex::unlock SHARED case.
             if (KJ_UNLIKELY(state == EXCLUSIVE_REQUESTED)) {
-              if (__atomic_compare_exchange_n(
-                  &futex, &state, 0, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+              if (kj::atomicCompareExchange(
+                  &futex, &state, 0, false, kj::AtomicMemoryOrder::RELAXED, kj::AtomicMemoryOrder::RELAXED)) {
                 // Wake all exclusive waiters.  We have to wake all of them because one of them will
                 // grab the lock while the others will re-establish the exclusive-requested bit.
                 syscall(SYS_futex, &futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
@@ -258,14 +258,14 @@ bool Mutex::lock(Exclusivity exclusivity, Maybe<Duration> timeout, LockSourceLoc
             return false;
           }
         }
-        state = __atomic_load_n(&futex, __ATOMIC_ACQUIRE);
+        state = kj::atomicLoad(&futex, kj::AtomicMemoryOrder::ACQUIRE);
       }
 
 #ifdef KJ_CONTENTION_WARNING_THRESHOLD
       KJ_IF_SOME(start, contentionWaitStart) {
-        if (__atomic_load_n(&printContendedReader, __ATOMIC_RELAXED)) {
+        if (kj::atomicLoad(&printContendedReader, kj::AtomicMemoryOrder::RELAXED)) {
           // Double-checked lock avoids the CPU needing to acquire the lock in most cases.
-          if (__atomic_exchange_n(&printContendedReader, false, __ATOMIC_RELAXED)) {
+          if (kj::atomicExchange(&printContendedReader, false, kj::AtomicMemoryOrder::RELAXED)) {
             auto contentionDuration = kj::systemPreciseMonotonicClock().now() - start;
             KJ_LOG(WARNING, "Acquired contended lock", location, contentionDuration,
                 kj::getStackTrace());
@@ -302,8 +302,8 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
               // In this case we need to be careful to make sure the target thread isn't already
               // processing a timeout, so we need to do an atomic CAS rather than just a store.
               uint expected = 0;
-              if (__atomic_compare_exchange_n(&waiter.futex, &expected, 1, false,
-                                              __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {
+              if (kj::atomicCompareExchange(&waiter.futex, &expected, 1, false,
+                                              kj::AtomicMemoryOrder::RELEASE, kj::AtomicMemoryOrder::RELAXED)) {
                 // Good, we set it to 1, transferring ownership of the mutex. Continue on below.
               } else {
                 // Looks like the thread already timed out and set its own futex to 1. In that
@@ -318,7 +318,7 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
                 continue;
               }
             } else {
-              __atomic_store_n(&waiter.futex, 1, __ATOMIC_RELEASE);
+              kj::atomicStore(&waiter.futex, 1, kj::AtomicMemoryOrder::RELEASE);
             }
             syscall(SYS_futex, &waiter.futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
 
@@ -334,7 +334,7 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
 #ifdef KJ_CONTENTION_WARNING_THRESHOLD
       uint readerCount;
       {
-        uint oldState = __atomic_load_n(&futex, __ATOMIC_RELAXED);
+        uint oldState = kj::atomicLoad(&futex, kj::AtomicMemoryOrder::RELAXED);
         readerCount = oldState & SHARED_COUNT_MASK;
         if (readerCount >= KJ_CONTENTION_WARNING_THRESHOLD) {
           // Atomic not needed because we're still holding the exclusive lock.
@@ -344,8 +344,8 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
 #endif
 
       // Didn't wake any waiters, so wake normally.
-      uint oldState = __atomic_fetch_and(
-          &futex, ~(EXCLUSIVE_HELD | EXCLUSIVE_REQUESTED), __ATOMIC_RELEASE);
+      uint oldState = kj::atomicFetchAnd(
+          &futex, ~(EXCLUSIVE_HELD | EXCLUSIVE_REQUESTED), kj::AtomicMemoryOrder::RELEASE);
 
       if (KJ_UNLIKELY(oldState & ~EXCLUSIVE_HELD)) {
         // Other threads are waiting.  If there are any shared waiters, they now collectively hold
@@ -366,13 +366,13 @@ void Mutex::unlock(Exclusivity exclusivity, Waiter* waiterToSkip) {
 
     case SHARED: {
       KJ_DASSERT(futex & SHARED_COUNT_MASK, "Unshared a mutex that wasn't shared.");
-      uint state = __atomic_sub_fetch(&futex, 1, __ATOMIC_RELEASE);
+      uint state = kj::atomicSubFetch(&futex, 1, kj::AtomicMemoryOrder::RELEASE);
 
       // The only case where anyone is waiting is if EXCLUSIVE_REQUESTED is set, and the only time
       // it makes sense to wake up that waiter is if the shared count has reached zero.
       if (KJ_UNLIKELY(state == EXCLUSIVE_REQUESTED)) {
-        if (__atomic_compare_exchange_n(
-            &futex, &state, 0, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+        if (kj::atomicCompareExchange(
+            &futex, &state, 0, false, kj::AtomicMemoryOrder::RELAXED, kj::AtomicMemoryOrder::RELAXED)) {
           // Wake all exclusive waiters.  We have to wake all of them because one of them will
           // grab the lock while the others will re-establish the exclusive-requested bit.
           syscall(SYS_futex, &futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
@@ -447,8 +447,8 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocati
           // first must atomically take control of our destiny.
           KJ_ASSERT(timeout != kj::none);
           uint expected = 0;
-          if (__atomic_compare_exchange_n(&waiter.futex, &expected, 1, false,
-                                          __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
+          if (kj::atomicCompareExchange(&waiter.futex, &expected, 1, false,
+                                          kj::AtomicMemoryOrder::ACQUIRE, kj::AtomicMemoryOrder::ACQUIRE)) {
             // OK, we set our own futex to 1. That means no other thread will, and so we won't be
             // receiving a mutex ownership transfer. We have to lock the mutex ourselves.
             setCurrentThreadIsNoLongerWaiting();
@@ -467,7 +467,7 @@ void Mutex::wait(Predicate& predicate, Maybe<Duration> timeout, LockSourceLocati
 
       setCurrentThreadIsNoLongerWaiting();
 
-      if (__atomic_load_n(&waiter.futex, __ATOMIC_ACQUIRE)) {
+      if (kj::atomicLoad(&waiter.futex, kj::AtomicMemoryOrder::ACQUIRE)) {
         // We received a lock ownership transfer from another thread.
         currentlyLocked = true;
 
@@ -512,13 +512,13 @@ uint Mutex::numReadersWaitingForTest() const {
 void Once::runOnce(Initializer& init, LockSourceLocationArg location) {
 startOver:
   uint state = UNINITIALIZED;
-  if (__atomic_compare_exchange_n(&futex, &state, INITIALIZING, false,
-                                  __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+  if (kj::atomicCompareExchange(&futex, &state, INITIALIZING, false,
+                                  kj::AtomicMemoryOrder::RELAXED, kj::AtomicMemoryOrder::RELAXED)) {
     // It's our job to initialize!
     {
       KJ_ON_SCOPE_FAILURE({
         // An exception was thrown by the initializer.  We have to revert.
-        if (__atomic_exchange_n(&futex, UNINITIALIZED, __ATOMIC_RELEASE) ==
+        if (kj::atomicExchange(&futex, UNINITIALIZED, kj::AtomicMemoryOrder::RELEASE) ==
             INITIALIZING_WITH_WAITERS) {
           // Someone was waiting for us to finish.
           syscall(SYS_futex, &futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
@@ -527,7 +527,7 @@ startOver:
 
       init.run();
     }
-    if (__atomic_exchange_n(&futex, INITIALIZED, __ATOMIC_RELEASE) ==
+    if (kj::atomicExchange(&futex, INITIALIZED, kj::AtomicMemoryOrder::RELEASE) ==
         INITIALIZING_WITH_WAITERS) {
       // Someone was waiting for us to finish.
       syscall(SYS_futex, &futex, FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0);
@@ -541,8 +541,8 @@ startOver:
         break;
       } else if (state == INITIALIZING) {
         // Initialization is taking place in another thread.  Indicate that we're waiting.
-        if (!__atomic_compare_exchange_n(&futex, &state, INITIALIZING_WITH_WAITERS, true,
-                                         __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
+        if (!kj::atomicCompareExchange(&futex, &state, INITIALIZING_WITH_WAITERS, true,
+                                         kj::AtomicMemoryOrder::ACQUIRE, kj::AtomicMemoryOrder::ACQUIRE)) {
           // State changed, retry.
           continue;
         }
@@ -554,7 +554,7 @@ startOver:
       setCurrentThreadIsWaitingFor(&blockReason);
       syscall(SYS_futex, &futex, FUTEX_WAIT_PRIVATE, INITIALIZING_WITH_WAITERS,
                          nullptr, nullptr, 0);
-      state = __atomic_load_n(&futex, __ATOMIC_ACQUIRE);
+      state = kj::atomicLoad(&futex, kj::AtomicMemoryOrder::ACQUIRE);
 
       if (state == UNINITIALIZED) {
         // Oh hey, apparently whoever was trying to initialize gave up.  Let's take it from the
@@ -567,8 +567,8 @@ startOver:
 
 void Once::reset() {
   uint state = INITIALIZED;
-  if (!__atomic_compare_exchange_n(&futex, &state, UNINITIALIZED,
-                                   false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {
+  if (!kj::atomicCompareExchange(&futex, &state, UNINITIALIZED,
+                                   false, kj::AtomicMemoryOrder::RELEASE, kj::AtomicMemoryOrder::RELAXED)) {
     KJ_FAIL_REQUIRE("reset() called while not initialized.");
   }
 }
@@ -1032,13 +1032,13 @@ void Once::runOnce(Initializer& init, NoopSourceLocation) {
 
   init.run();
 
-  __atomic_store_n(&state, INITIALIZED, __ATOMIC_RELEASE);
+  kj::atomicStore(&state, INITIALIZED, kj::AtomicMemoryOrder::RELEASE);
 }
 
 void Once::reset() {
   State oldState = INITIALIZED;
-  if (!__atomic_compare_exchange_n(&state, &oldState, UNINITIALIZED,
-                                   false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {
+  if (!kj::atomicCompareExchange(&state, &oldState, UNINITIALIZED,
+                                   false, kj::AtomicMemoryOrder::RELEASE, kj::AtomicMemoryOrder::RELAXED)) {
     KJ_FAIL_REQUIRE("reset() called while not initialized.");
   }
 }

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "memory.h"
+#include "atomic.h"
 #include <inttypes.h>
 #include "time.h"
 #include "source-location.h"
@@ -185,9 +186,9 @@ public:
   inline bool isInitialized() noexcept {
     // Fast path check to see if runOnce() would simply return immediately.
 #if KJ_USE_FUTEX
-    return __atomic_load_n(&futex, __ATOMIC_ACQUIRE) == INITIALIZED;
+    return kj::atomicLoad(&futex, kj::AtomicMemoryOrder::ACQUIRE) == INITIALIZED;
 #else
-    return __atomic_load_n(&state, __ATOMIC_ACQUIRE) == INITIALIZED;
+    return kj::atomicLoad(&state, kj::AtomicMemoryOrder::ACQUIRE) == INITIALIZED;
 #endif
   }
 #endif

--- a/c++/src/kj/refcount.c++
+++ b/c++/src/kj/refcount.c++
@@ -22,13 +22,6 @@
 #include "refcount.h"
 #include "debug.h"
 
-#if _MSC_VER && !defined(__clang__)
-// Annoyingly, MSVC only implements the C++ atomic libs, not the C libs, so the only useful
-// thing we can get from <atomic> seems to be atomic_thread_fence... but that one function is
-// indeed not implemented by the intrinsics, so...
-#include <atomic>
-#endif
-
 namespace kj {
 
 // =======================================================================================
@@ -72,32 +65,19 @@ void Refcounted::disposeImpl(void* pointer) const {
 // Atomic (thread-safe) refcounting
 
 AtomicRefcounted::~AtomicRefcounted() noexcept(false) {
-#if _MSC_VER && !defined(__clang__)
-  KJ_ASSERT(KJ_MSVC_INTERLOCKED(Or, acq)(&refcount, 0) == 0,
+  KJ_ASSERT(kj::atomicLoad(&refcount, kj::AtomicMemoryOrder::ACQUIRE) == 0,
       "Refcounted object deleted with non-zero refcount.");
-#else
-  KJ_ASSERT(__atomic_load_n(&refcount, __ATOMIC_ACQUIRE) == 0,
-      "Refcounted object deleted with non-zero refcount.");
-#endif
 }
 
 void AtomicRefcounted::disposeImpl(void* pointer) const {
-#if _MSC_VER && !defined(__clang__)
-  if (KJ_MSVC_INTERLOCKED(Decrement, rel)(&refcount) == 0) {
-    std::atomic_thread_fence(std::memory_order_acquire);
+  if (kj::atomicSubFetch(&refcount, 1, kj::AtomicMemoryOrder::RELEASE) == 0) {
+    kj::atomicThreadFence(kj::AtomicMemoryOrder::ACQUIRE);
     delete this;
   }
-#else
-  if (__atomic_sub_fetch(&refcount, 1, __ATOMIC_RELEASE) == 0) {
-    __atomic_thread_fence(__ATOMIC_ACQUIRE);
-    delete this;
-  }
-#endif
 }
 
 bool AtomicRefcounted::addRefWeakInternal() const {
-#if _MSC_VER && !defined(__clang__)
-  long orig = refcount;
+  uint orig = kj::atomicLoad(&refcount, kj::AtomicMemoryOrder::RELAXED);
 
   for (;;) {
     if (orig == 0) {
@@ -105,28 +85,12 @@ bool AtomicRefcounted::addRefWeakInternal() const {
       return false;
     }
 
-    unsigned long old = KJ_MSVC_INTERLOCKED(CompareExchange, nf)(&refcount, orig + 1, orig);
-    if (old == orig) {
-      return true;
-    }
-    orig = old;
-  }
-#else
-  uint orig = __atomic_load_n(&refcount, __ATOMIC_RELAXED);
-
-  for (;;) {
-    if (orig == 0) {
-      // Refcount already hit zero. Destructor is already running so we can't revive the object.
-      return false;
-    }
-
-    if (__atomic_compare_exchange_n(&refcount, &orig, orig + 1, true,
-        __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+    if (kj::atomicCompareExchange(&refcount, &orig, orig + 1, true,
+        kj::AtomicMemoryOrder::RELAXED, kj::AtomicMemoryOrder::RELAXED)) {
       // Successfully incremented refcount without letting it hit zero.
       return true;
     }
   }
-#endif
 }
 
 }  // namespace kj

--- a/c++/src/kj/refcount.h
+++ b/c++/src/kj/refcount.h
@@ -22,10 +22,7 @@
 #pragma once
 
 #include "memory.h"
-
-#if _MSC_VER && !defined(__clang__)
-#include <intrin0.h> // _InterlockedXX
-#endif
+#include "atomic.h"
 
 KJ_BEGIN_HEADER
 
@@ -634,14 +631,6 @@ Own<RefcountedWrapper<Own<T>>> refcountedWrapper(Own<T>&& wrapped) {
 //
 // Warning: Atomic ops are SLOW.
 
-#if _MSC_VER && !defined(__clang__)
-#if _M_ARM
-#define KJ_MSVC_INTERLOCKED(OP, MEM) _Interlocked##OP##_##MEM
-#else
-#define KJ_MSVC_INTERLOCKED(OP, MEM) _Interlocked##OP
-#endif
-#endif
-
 template<typename T>
 class Arc;
 
@@ -662,11 +651,7 @@ public:
   KJ_DISALLOW_COPY_AND_MOVE(AtomicRefcounted);
 
   inline bool isShared() const {
-#if _MSC_VER && !defined(__clang__)
-    return KJ_MSVC_INTERLOCKED(Or, acq)(&refcount, 0) > 1;
-#else
-    return __atomic_load_n(&refcount, __ATOMIC_ACQUIRE) > 1;
-#endif
+    return kj::atomicLoad(&refcount, kj::AtomicMemoryOrder::ACQUIRE) > 1;
   }
 
 protected:
@@ -675,20 +660,12 @@ protected:
   }
 
 private:
-#if _MSC_VER && !defined(__clang__)
-  mutable volatile long refcount = 0;
-#else
   mutable volatile uint refcount = 0;
-#endif
 
   bool addRefWeakInternal() const;
 
   inline void incRefcount() const {
-#if _MSC_VER && !defined(__clang__)
-    KJ_MSVC_INTERLOCKED(Increment, nf)(&refcount);
-#else
-    __atomic_add_fetch(&refcount, 1, __ATOMIC_RELAXED);
-#endif
+    kj::atomicAddFetch(&refcount, 1, kj::AtomicMemoryOrder::RELAXED);
   }
 
   void disposeImpl(void* pointer) const override;

--- a/c++/src/kj/thread.c++
+++ b/c++/src/kj/thread.c++
@@ -21,6 +21,7 @@
 
 #include "thread.h"
 #include "debug.h"
+#include "atomic.h"
 
 #if _WIN32
 #include <windows.h>
@@ -148,12 +149,8 @@ Thread::ThreadState::ThreadState(Function<void()> func)
       refcount(2) {}
 
 void Thread::ThreadState::unref() {
-#if _MSC_VER && !defined(__clang__)
-  if (_InterlockedDecrement(&refcount) == 0) {
-#else
-  if (__atomic_sub_fetch(&refcount, 1, __ATOMIC_RELEASE) == 0) {
-    __atomic_thread_fence(__ATOMIC_ACQUIRE);
-#endif
+  if (kj::atomicSubFetch(&refcount, 1, kj::AtomicMemoryOrder::RELEASE) == 0) {
+    kj::atomicThreadFence(kj::AtomicMemoryOrder::ACQUIRE);
 
     KJ_IF_SOME(e, exception) {
       // If the exception is still present in ThreadState, this must be a detached thread, so


### PR DESCRIPTION
Consolidating all intrinsics usages in a single file. Using std `<atomic>` for windows consistently