### PR TITLE
more XThreadPaf tsan fixes

### DIFF
--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -1091,6 +1091,36 @@ KJ_TEST("cross-thread fulfiller isWaiting concurrent with cancellation") {
   stop.store(true, std::memory_order_release);
 }
 
+KJ_TEST("cross-thread fulfiller isWaiting after cross-thread dispatch") {
+  KJ_XTHREAD_TEST_SETUP_LOOP;
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
+  auto* fulfiller = paf.fulfiller.get();
+
+  // Coordinate using relaxed atomics so that observing `dispatched` does not itself establish a
+  // happens-before edge. isWaiting() is a cross-thread operation, so it must be safe even after
+  // the event loop has changed the promise's state to DISPATCHED.
+  std::atomic<bool> dispatched(false);
+  std::atomic<bool> checked(false);
+  Thread observer([&]() noexcept {
+    while (!dispatched.load(std::memory_order_relaxed)) {
+      std::this_thread::yield();
+    }
+    KJ_EXPECT(!fulfiller->isWaiting());
+    checked.store(true, std::memory_order_relaxed);
+  });
+
+  Thread fulfillThread([&]() noexcept {
+    fulfiller->fulfill();
+  });
+  paf.promise.wait(waitScope);
+
+  dispatched.store(true, std::memory_order_relaxed);
+  while (!checked.load(std::memory_order_relaxed)) {
+    std::this_thread::yield();
+  }
+}
+
 KJ_TEST("cross-thread fulfiller multiple fulfills") {
   MutexGuarded<Maybe<Own<PromiseFulfiller<int>>>> fulfillerMutex;
 

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -775,7 +775,8 @@ struct Executor::Impl {
 
       for (auto& event: fulfilled) {
         fulfilled.remove(event);
-        event.control->state = _::XThreadPafControl::DISPATCHED;
+        kj::atomicStore(&event.control->state, _::XThreadPafControl::DISPATCHED,
+            kj::AtomicMemoryOrder::RELEASE);
         event.onReadyEvent.armBreadthFirst();
       }
     }
@@ -870,7 +871,8 @@ struct Executor::Impl {
       KJ_LOG(ERROR, "EventLoop destroyed with cross-thread fulfiller replies outstanding");
       for (auto& event: s.fulfilled) {
         s.fulfilled.remove(event);
-        event.control->state = _::XThreadPafControl::DISPATCHED;
+        kj::atomicStore(&event.control->state, _::XThreadPafControl::DISPATCHED,
+            kj::AtomicMemoryOrder::RELEASE);
       }
     }
   }};
@@ -1155,10 +1157,11 @@ void XThreadPaf::destroy() {
     // Whoops, another thread is already in the process of fulfilling this promise. We'll have to
     // wait for it to finish and transition the state to FULFILLED.
     executor->impl->state.when([&](auto&) {
-      return control->state == XThreadPafControl::FULFILLED ||
-          control->state == XThreadPafControl::DISPATCHED;
+      auto state = kj::atomicLoad(&control->state, kj::AtomicMemoryOrder::ACQUIRE);
+      return state == XThreadPafControl::FULFILLED || state == XThreadPafControl::DISPATCHED;
     }, [&](Executor::Impl::State& exState) {
-      if (control->state == XThreadPafControl::FULFILLED) {
+      if (kj::atomicLoad(&control->state, kj::AtomicMemoryOrder::ACQUIRE) ==
+          XThreadPafControl::FULFILLED) {
         // The object is on the queue but was not yet dispatched. Remove it.
         exState.fulfilled.remove(*this);
       }


### PR DESCRIPTION
These reads do look unprotected to me. Downstream tests have triggered these.