### PR TITLE
kj/http: retry bodiless requests that fail on a reused pooled connection

### DIFF
--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -6170,6 +6170,86 @@ KJ_TEST("HttpClient connection management") {
   KJ_EXPECT(cumulative == 9);
 }
 
+KJ_TEST("HttpClient retries a bodiless request that fails on a reused connection") {
+  KJ_HTTP_TEST_SETUP_IO;
+  KJ_HTTP_TEST_SETUP_LOOPBACK_LISTENER_AND_ADDR;
+
+  kj::TimerImpl clientTimer(kj::origin<kj::TimePoint>());
+  HttpHeaderTable headerTable;
+
+  // A raw server which serves one keep-alive response on its first connection, then closes
+  // that connection abruptly upon receiving a second request on it. This deterministically
+  // reproduces the keep-alive race: the server dropping a pooled connection at the same
+  // moment the client reuses it (e.g. because the server's idle timeout fired). The retried
+  // request is then served properly on a second connection, and finally a POST on that
+  // (again pooled) connection is killed the same way to verify non-bodiless requests are
+  // NOT retried.
+  auto readRequest = [](kj::AsyncIoStream& conn, size_t bodySize) -> kj::Promise<void> {
+    auto buffer = kj::heapArray<char>(4096);
+    size_t total = 0;
+    for (;;) {
+      auto n = co_await conn.tryRead(buffer.begin() + total, 1, buffer.size() - total);
+      KJ_ASSERT(n > 0, "connection closed before full request arrived");
+      total += n;
+      for (size_t i = 4; i <= total; i++) {
+        if (kj::ArrayPtr<const char>(buffer.begin() + i - 4, 4) == "\r\n\r\n"_kj.asArray()) {
+          if (total >= i + bodySize) co_return;
+        }
+      }
+    }
+  };
+
+  auto serverTask = kj::coCapture([&]() -> kj::Promise<void> {
+    auto conn = co_await listener->accept();
+    co_await readRequest(*conn, 0);
+    co_await conn->write("HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nfoo"_kjb);
+    co_await readRequest(*conn, 0);
+    conn = nullptr;  // abruptly close the reused connection without responding
+
+    auto conn2 = co_await listener->accept();
+    co_await readRequest(*conn2, 0);
+    co_await conn2->write("HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nbar"_kjb);
+    co_await readRequest(*conn2, 3);
+    conn2 = nullptr;  // abruptly close again, this time on a POST
+  })();
+
+  uint count = 0;
+  uint cumulative = 0;
+  CountingNetworkAddress countingAddr(*addr, count, cumulative);
+
+  FakeEntropySource entropySource;
+  HttpClientSettings clientSettings;
+  clientSettings.entropySource = entropySource;
+  auto client = newHttpClient(clientTimer, headerTable, countingAddr, clientSettings);
+
+  auto doGet = [&](kj::StringPtr path) {
+    return client->request(HttpMethod::GET, path, HttpHeaders(headerTable)).response
+        .then([](HttpClient::Response&& response) {
+      auto promise = response.body->readAllText();
+      return promise.attach(kj::mv(response.body));
+    });
+  };
+
+  KJ_EXPECT(doGet("/first").wait(waitScope) == "foo");
+  KJ_EXPECT(cumulative == 1);
+
+  // This request is written into the pooled connection, which the server closes without
+  // responding. The client should transparently retry on a fresh connection.
+  KJ_EXPECT(doGet("/second").wait(waitScope) == "bar");
+  KJ_EXPECT(cumulative == 2);
+
+  // A request with a body must NOT be retried: it fails, and no new connection is made.
+  {
+    auto req = client->request(
+        HttpMethod::POST, "/third", HttpHeaders(headerTable), size_t(3));
+    req.body->write("xyz"_kjb).wait(waitScope);
+    KJ_EXPECT_THROW_RECOVERABLE(DISCONNECTED, req.response.wait(waitScope));
+  }
+  KJ_EXPECT(cumulative == 2);
+
+  serverTask.wait(waitScope);
+}
+
 KJ_TEST("HttpClient disable connection reuse") {
   KJ_HTTP_TEST_SETUP_IO;
   KJ_HTTP_TEST_SETUP_LOOPBACK_LISTENER_AND_ADDR;

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -6236,6 +6236,37 @@ public:
                   kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
     auto refcounted = getClient();
     auto result = refcounted->client->request(method, url, headers, expectedBodySize);
+
+    // When reusing a pooled connection, the server may have closed it after our canReuse()
+    // check but before our request bytes reached it -- e.g. the server's idle timeout fired
+    // while the request was in flight, a race inherent to HTTP/1.1 keep-alive. In that case
+    // the request is known not to have been processed, so requests which provably have no
+    // body to replay (mirroring the `hasBody` logic in HttpClientImpl::request()) are safe
+    // to retry once, on a fresh connection.
+    bool retriable = refcounted->reusedConnection &&
+        (method == HttpMethod::GET || method == HttpMethod::HEAD) &&
+        expectedBodySize.orDefault(0) == 0 &&
+        headers.get(HttpHeaderId::TRANSFER_ENCODING) == kj::none;
+    if (retriable) {
+      result.response = result.response.catch_(
+          [this, method, url=kj::str(url), headers=headers.clone(), expectedBodySize]
+          (kj::Exception&& exception) mutable -> kj::Promise<Response> {
+        if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
+          return kj::mv(exception);
+        }
+        auto retryRefcounted = getFreshClient();
+        auto retryResult = retryRefcounted->client->request(
+            method, url, headers, expectedBodySize);
+        return retryResult.response.then(
+            [retryBody=kj::mv(retryResult.body), url=kj::mv(url), headers=kj::mv(headers),
+             retryRefcounted=kj::mv(retryRefcounted)](Response&& response) mutable {
+          response.body = response.body.attach(kj::mv(retryBody), kj::mv(url),
+              kj::mv(headers), kj::mv(retryRefcounted));
+          return kj::mv(response);
+        });
+      });
+    }
+
     result.body = result.body.attach(refcounted.addRef());
     result.response = result.response.then(
         [refcounted=kj::mv(refcounted)](Response&& response) mutable {
@@ -6298,8 +6329,9 @@ private:
   std::deque<AvailableClient> availableClients;
 
   struct RefcountedClient final: public kj::Refcounted {
-    RefcountedClient(NetworkAddressHttpClient& parent, kj::Own<HttpClientImpl> client)
-        : parent(parent), client(kj::mv(client)) {
+    RefcountedClient(NetworkAddressHttpClient& parent, kj::Own<HttpClientImpl> client,
+                     bool reusedConnection)
+        : parent(parent), client(kj::mv(client)), reusedConnection(reusedConnection) {
       ++parent.activeConnectionCount;
     }
     ~RefcountedClient() noexcept(false) {
@@ -6313,23 +6345,28 @@ private:
 
     NetworkAddressHttpClient& parent;
     kj::Own<HttpClientImpl> client;
+    bool reusedConnection;
   };
 
   kj::Rc<RefcountedClient> getClient() {
     for (;;) {
       if (availableClients.empty()) {
-        auto stream = newPromisedStream(address->connect());
-        return kj::rc<RefcountedClient>(*this,
-          kj::heap<HttpClientImpl>(responseHeaderTable, kj::mv(stream), settings));
+        return getFreshClient();
       } else {
         auto client = kj::mv(availableClients.back().client);
         availableClients.pop_back();
         if (client->canReuse()) {
-          return kj::rc<RefcountedClient>(*this, kj::mv(client));
+          return kj::rc<RefcountedClient>(*this, kj::mv(client), true);
         }
         // Whoops, this client's connection was closed by the server at some point. Discard.
       }
     }
+  }
+
+  kj::Rc<RefcountedClient> getFreshClient() {
+    auto stream = newPromisedStream(address->connect());
+    return kj::rc<RefcountedClient>(*this,
+      kj::heap<HttpClientImpl>(responseHeaderTable, kj::mv(stream), settings), false);
   }
 
   void returnClientToAvailable(kj::Own<HttpClientImpl> client) {


### PR DESCRIPTION
## Problem

An HTTP/1.1 server may close an idle persistent connection at any moment, including concurrently with the client reusing it. With kj's defaults the race is structural: `HttpClientSettings::idleTimeout` and `HttpServerSettings::pipelineTimeout` are both 5 seconds, so when both ends are kj, both act on the same tick for any connection idling ≈5s.

`NetworkAddressHttpClient` already handles the *observed* half of this: `HttpClientImpl` destroys its socket when it sees the server's EOF while pooled, and `getClient()` lazily discards clients whose `canReuse()` is false. But a close that is still in flight at checkout is invisible — the request is written into a closing connection and fails with `DISCONNECTED`, even though it provably never reached the application.

We hit this in production CI at Mixcloud through Cloudflare's `wrangler dev` (which proxies every request over a kj client pool to a workerd runtime): bursty traffic with ~5s idle gaps between bursts loses about 1 in 24,000 requests this way, and reproduces organically within minutes with idle gaps swept across the 5s boundary — failures interleave with same-millisecond successes, the classic signature of stale pool checkouts dying while fresh connections succeed. Downstream report: cloudflare/workers-sdk#14926.

## Change

Per RFC 9112 §9.6 (a client SHOULD retry idempotent requests when a persistent connection closes before a response arrives), `NetworkAddressHttpClient::request()` now retries **once**, on a **fresh** connection (deliberately bypassing the pool — neighbouring pooled connections tend to expire together), when all of the following hold:

- the failed attempt used a **reused** pooled connection,
- the failure is `DISCONNECTED` (the response promise rejected, so no response bytes were interpreted),
- the request provably has **no body to replay**: GET/HEAD with a zero or absent `expectedBodySize` and no `Transfer-Encoding` header — exactly mirroring the `hasBody` logic in `HttpClientImpl::request()`, including its chunked-GET escape hatch.

Anything else — fresh-connection failures, non-DISCONNECTED errors, requests with bodies — propagates unchanged.

## Test

`HttpClient retries a bodiless request that fails on a reused connection`: a raw server serves one keep-alive response, then closes the connection abruptly **upon receiving** the second request on it (compressing the race into a certainty), then serves the retried request on a second connection; finally a POST on the again-pooled second connection is killed the same way. Asserts: the second GET transparently succeeds with exactly one extra connection, and the POST fails with `DISCONNECTED` with no extra connection.

The test fails without the fix (DISCONNECTED surfaces on the second GET) and passes with it; the full `compat/http-test.c++` suite passes (134 tests, macOS arm64, cmake Debug).

> [!NOTE]
> This is a contribution from an AI agent: Claude Code (Claude Fable 5), working under the direction and review of Gregory Collett.