### PR TITLE
kj/memory.h kj::PtrTarget: allow for descendent classes to invalidate references

### DIFF
--- a/c++/src/kj/memory-test.c++
+++ b/c++/src/kj/memory-test.c++
@@ -1406,6 +1406,7 @@ struct TargetObj: public kj::PtrTarget {
 
   kj::Ptr<TargetObj> getPtr() { return addPtrToThis(); }
   kj::Weak<TargetObj> getWeak() { return addWeakToThis(); }
+  void invalidateWeakForTest() { invalidateWeak(); }
 
   kj::String name;
 
@@ -1466,6 +1467,110 @@ KJ_TEST("kj::PtrTarget addWeakToThis") {
   } else {
     KJ_FAIL_EXPECT("expected Maybe<Weak<T>> to contain an expired pointer");
   }
+}
+
+KJ_TEST("kj::PtrTarget invalidateWeak") {
+  TargetObj obj("a");
+  auto weak = obj.getWeak();
+
+  KJ_EXPECT(weak.upgrade() != kj::none);
+  obj.invalidateWeakForTest();
+  KJ_EXPECT(weak.tryGet() == kj::none);
+  KJ_EXPECT(weak.upgrade() == kj::none);
+
+  // Invalidation is permanent, including for weak pointers created afterwards.
+  auto laterWeak = obj.getWeak();
+  KJ_EXPECT(laterWeak.tryGet() == kj::none);
+  KJ_EXPECT(laterWeak.upgrade() == kj::none);
+
+  // Repeated invalidation leaves all weak pointers expired.
+  obj.invalidateWeakForTest();
+  KJ_EXPECT(weak.upgrade() == kj::none);
+  KJ_EXPECT(laterWeak.upgrade() == kj::none);
+}
+
+KJ_TEST("kj::PtrTarget invalidated before first weak pointer") {
+  TargetObj obj("a");
+  obj.invalidateWeakForTest();
+
+  auto weak = obj.getWeak();
+  KJ_EXPECT(weak.tryGet() == kj::none);
+  KJ_EXPECT(weak.upgrade() == kj::none);
+}
+
+struct AddWeakBeforeInvalidatingInDestructor: public kj::PtrTarget {
+  AddWeakBeforeInvalidatingInDestructor(
+      kj::Weak<AddWeakBeforeInvalidatingInDestructor>& weakFromDestructor,
+      bool& upgradedBeforeInvalidation)
+      : weakFromDestructor(weakFromDestructor),
+        upgradedBeforeInvalidation(upgradedBeforeInvalidation) {}
+
+  ~AddWeakBeforeInvalidatingInDestructor() noexcept(false) {
+    weakFromDestructor = addWeakToThis();
+    upgradedBeforeInvalidation = weakFromDestructor.upgrade() != kj::none;
+  }
+
+  kj::Weak<AddWeakBeforeInvalidatingInDestructor>& weakFromDestructor;
+  bool& upgradedBeforeInvalidation;
+};
+
+KJ_TEST("kj::PtrTarget addWeakToThis works in destructor before invalidation") {
+  kj::Weak<AddWeakBeforeInvalidatingInDestructor> weakFromDestructor;
+  bool upgradedBeforeInvalidation = false;
+
+  {
+    AddWeakBeforeInvalidatingInDestructor obj(weakFromDestructor, upgradedBeforeInvalidation);
+  }
+
+  KJ_EXPECT(upgradedBeforeInvalidation);
+  KJ_EXPECT(weakFromDestructor.upgrade() == kj::none);
+}
+
+struct InvalidateWeakInDestructor: public kj::PtrTarget {
+  InvalidateWeakInDestructor(
+      kj::Weak<InvalidateWeakInDestructor>& weakFromDestructor, bool throwLater = false)
+      : weakFromDestructor(weakFromDestructor), throwLater(throwLater) {}
+
+  ~InvalidateWeakInDestructor() noexcept(false) {
+    invalidateWeak();
+    weakFromDestructor = addWeakToThis();
+    if (throwLater) {
+      throw KJ_EXCEPTION(FAILED, "exception after invalidateWeak");
+    }
+  }
+
+  kj::Weak<InvalidateWeakInDestructor> getWeak() { return addWeakToThis(); }
+
+  kj::Weak<InvalidateWeakInDestructor>& weakFromDestructor;
+  bool throwLater;
+};
+
+KJ_TEST("kj::PtrTarget invalidated in destructor") {
+  kj::Weak<InvalidateWeakInDestructor> weakBeforeDestruction;
+  kj::Weak<InvalidateWeakInDestructor> weakFromDestructor;
+
+  {
+    auto obj = kj::heap<InvalidateWeakInDestructor>(weakFromDestructor);
+    weakBeforeDestruction = obj->getWeak();
+  }
+
+  KJ_EXPECT(weakBeforeDestruction.upgrade() == kj::none);
+  KJ_EXPECT(weakFromDestructor.upgrade() == kj::none);
+}
+
+KJ_TEST("kj::PtrTarget invalidation survives later destructor exception") {
+  kj::Weak<InvalidateWeakInDestructor> weakBeforeDestruction;
+  kj::Weak<InvalidateWeakInDestructor> weakFromDestructor;
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    auto obj = kj::heap<InvalidateWeakInDestructor>(weakFromDestructor, true);
+    weakBeforeDestruction = obj->getWeak();
+    obj = nullptr;
+  });
+
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(weakBeforeDestruction.upgrade() == kj::none);
+  KJ_EXPECT(weakFromDestructor.upgrade() == kj::none);
 }
 
 KJ_TEST("kj::PtrTarget subtyping") {

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -249,6 +249,18 @@ protected:
     return Weak<Self>(&self, asPtrTarget(self));
   }
 
+  inline void invalidateWeak() {
+    // Permanently invalidate weak pointers to this object. Derived class destructors can call this
+    // before tearing down state that may otherwise be accessed while the rest of the object is
+    // destroyed.
+    if (weakCell == nullptr) {
+      weakCell = new _::WeakCell(nullptr, nullptr);
+    } else {
+      weakCell->ptr = nullptr;
+      weakCell->target = nullptr;
+    }
+  }
+
 private:
   template <typename Self>
   static inline PtrTarget* asPtrTarget(Self& self) {


### PR DESCRIPTION
Imagine you have

    class MyClass : public kj::PtrTarget {
     public:
      MyClass() : task(run(addWeakToThis())) {}
      ~MyClass() { cleanup(); }

     private:
      static kj::Promise<void> run(kj::Weak<MyClass> weak) {
        KJ_DEFER(weak.assertLive().doSomething());
        co_await kj::Promise<void>(kj::NEVER_DONE);
      }

      void doSomething();
      void cleanup();

      kj::Promise<void> task;
    };

If you have an instance of MyClass and it destructs, it might be surprising to realize that `doSomething` here *runs successfully* and runs *after* `cleanup`.

With this change, now you can add invalidateWeak() to ~MyClass() so that `weak` in `run` won't be able to be upgraded to a live pointer in a partially destructed state.