### PR TITLE
assert no live ArrayPtr exists on Array destruction

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -547,6 +547,8 @@ heavy_tests =                                                  \
   src/capnp/compat/json-test.c++                               \
   src/capnp/compat/websocket-rpc-test.c++                      \
   src/capnp/compiler/lexer-test.c++                            \
+  src/capnp/compiler/module-loader.c++                         \
+  src/capnp/compiler/module-loader-test.c++                    \
   src/capnp/compiler/type-id-test.c++
 capnp_test_LDADD =                                             \
   libcapnp-test.a                                              \

--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -273,6 +273,18 @@ cc_library(
 ]]
 
 cc_test(
+    name = "compiler/module-loader-test",
+    srcs = [
+        "compiler/module-loader-test.c++",
+        "compiler/module-loader.c++",
+    ],
+    deps = [
+        ":capnpc",
+        "//src/kj:kj-test",
+    ],
+)
+
+cc_test(
     name = "endian-reverse-test",
     srcs = ["endian-reverse-test.c++"],
     target_compatible_with = select({

--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -291,6 +291,8 @@ if(BUILD_TESTING)
       rpc-test.c++
       rpc-twoparty-test.c++
       compiler/lexer-test.c++
+      compiler/module-loader.c++
+      compiler/module-loader-test.c++
       compiler/type-id-test.c++
       test-util.c++
       compat/json-test.c++

--- a/c++/src/capnp/compat/json-rpc-test.c++
+++ b/c++/src/capnp/compat/json-rpc-test.c++
@@ -27,6 +27,16 @@ namespace capnp {
 namespace _ {  // private
 namespace {
 
+KJ_TEST("content-length transport releases canceled send buffers") {
+  auto pipe = kj::newTwoWayPipe();
+  JsonRpc::ContentLengthTransport transport(*pipe.ends[0]);
+
+  auto text = kj::str("message");
+  auto promise = transport.send(text);
+  // Cancel the send while it still retains views of both the generated header and text. Destruction
+  // of the promise must release those views before either owner is destroyed.
+}
+
 KJ_TEST("json-rpc basics") {
   auto io = kj::setupAsyncIo();
   auto pipe = kj::newTwoWayPipe();

--- a/c++/src/capnp/compat/json-rpc.c++
+++ b/c++/src/capnp/compat/json-rpc.c++
@@ -324,17 +324,34 @@ JsonRpc::ContentLengthTransport::ContentLengthTransport(kj::AsyncIoStream& strea
 JsonRpc::ContentLengthTransport::~ContentLengthTransport() noexcept(false) {}
 
 kj::Promise<void> JsonRpc::ContentLengthTransport::send(kj::StringPtr text) {
-  auto headers = kj::str("Content-Length: ", text.size(), "\r\n\r\n");
-  parts[0] = headers.asBytes();
-  parts[1] = text.asBytes();
-  return stream.write(parts).attach(kj::mv(headers));
+  struct SendState {
+    // Declare the owner before its views so that the views are destroyed first.
+    kj::String headers;
+    kj::ArrayPtr<const byte> parts[2];
+
+    SendState(kj::String headers, kj::StringPtr text): headers(kj::mv(headers)) {
+      parts[0] = this->headers.asBytes();
+      parts[1] = text.asBytes();
+    }
+  };
+
+  // The state must have a stable address because write() may retain a view of the parts array.
+  auto state = kj::heap<SendState>(
+      kj::str("Content-Length: ", text.size(), "\r\n\r\n"), text);
+  auto promise = stream.write(state->parts);
+  return promise.attach(kj::mv(state));
 }
 
 kj::Promise<kj::String> JsonRpc::ContentLengthTransport::receive() {
   return input->readMessage()
       .then([](kj::HttpInputStream::Message&& message) {
-    auto promise = message.body->readAllText();
-    return promise.attach(kj::mv(message.body));
+    return message.body->readAllText()
+        .then([body = kj::mv(message.body)](kj::String text) mutable {
+      // Reading the body releases the input stream for the next message. Drop the body now so its
+      // header views don't remain attached while that next read resizes the header buffer.
+      body = nullptr;
+      return text;
+    });
   });
 }
 

--- a/c++/src/capnp/compat/json-rpc.h
+++ b/c++/src/capnp/compat/json-rpc.h
@@ -108,7 +108,6 @@ public:
 private:
   kj::AsyncIoStream& stream;
   kj::Own<kj::HttpInputStream> input;
-  kj::ArrayPtr<const byte> parts[2];
 };
 
 }  // namespace capnp

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -143,11 +143,11 @@ struct JsonCodec::Impl {
     size_t maxChildSize = 0;
     for (auto& e: elements) maxChildSize = kj::max(maxChildSize, e.size());
 
+    kj::String ownPrefix;
+    kj::String ownDelim;
     kj::StringPtr prefix;
     kj::StringPtr delim;
     kj::StringPtr suffix;
-    kj::String ownPrefix;
-    kj::String ownDelim;
     if (!prettyPrint) {
       // No whitespace.
       delim = ",";
@@ -973,14 +973,14 @@ public:
         unionTagName = unionDeclName;
       }
       KJ_IF_SOME(u, unionTagName) {
-        fieldsByName.insert(u, FieldNameInfo {
-          FieldNameInfo::UNION_TAG, 0, 0, nullptr
+        fieldsByName.insert(kj::heapString(u), FieldNameInfo {
+          FieldNameInfo::UNION_TAG, 0, 0
         });
       }
 
       if (d.hasValueName()) {
-        fieldsByName.insert(d.getValueName(), FieldNameInfo {
-          FieldNameInfo::UNION_VALUE, 0, 0, nullptr
+        fieldsByName.insert(kj::heapString(d.getValueName()), FieldNameInfo {
+          FieldNameInfo::UNION_VALUE, 0, 0
         });
       }
     }
@@ -1058,8 +1058,8 @@ public:
       KJ_IF_SOME(fh, info.flattenHandler) {
         // Set up fieldsByName for each of the child's fields.
         for (auto& entry: fh.fieldsByName) {
-          kj::StringPtr flattenedName;
           kj::String ownName;
+          kj::StringPtr flattenedName;
           if (info.prefix.size() > 0) {
             ownName = kj::str(info.prefix, entry.key);
             flattenedName = ownName;
@@ -1067,9 +1067,9 @@ public:
             flattenedName = entry.key;
           }
 
-          fieldsByName.upsert(flattenedName, FieldNameInfo {
+          fieldsByName.upsert(kj::heapString(flattenedName), FieldNameInfo {
             isUnionMember ? FieldNameInfo::FLATTENED_FROM_UNION : FieldNameInfo::FLATTENED,
-            field.getIndex(), (uint)info.prefix.size(), kj::mv(ownName)
+            field.getIndex(), (uint)info.prefix.size()
           }, [&](FieldNameInfo& existing, FieldNameInfo&& replacement) {
             KJ_REQUIRE(existing.type == FieldNameInfo::FLATTENED_FROM_UNION &&
                        replacement.type == FieldNameInfo::FLATTENED_FROM_UNION,
@@ -1092,7 +1092,7 @@ public:
         }
 
         if (!isUnionWithValueName) {
-          fieldsByName.insert(info.name, kj::mv(nameInfo));
+          fieldsByName.insert(kj::heapString(info.name), kj::mv(nameInfo));
         }
       }
 
@@ -1209,10 +1209,9 @@ private:
     // For `NORMAL` and `FLATTENED`, the index of the field in schema.getFields().
 
     uint prefixLength;
-    kj::String ownName;
   };
 
-  kj::HashMap<kj::StringPtr, FieldNameInfo> fieldsByName;
+  kj::HashMap<kj::String, FieldNameInfo> fieldsByName;
   // Maps JSON names to info needed to parse them.
 
   kj::HashMap<kj::StringPtr, StructSchema::Field> unionTagValues;
@@ -1285,6 +1284,10 @@ private:
         }
       }
     }
+
+    // prefix may point into ownPrefix, but function parameters are destroyed after local variables.
+    // Release the view explicitly before ownPrefix is destroyed.
+    prefix = nullptr;
   }
 
   bool decodeField(const JsonCodec& codec, kj::StringPtr name, JsonValue::Reader value,

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -391,8 +391,9 @@ private:
 
       // Figure out what name to use.
       Schema parent = schemaLoader.get(node.getScopeId());
-      kj::StringPtr unqualifiedName;
+      // Declare the owner first so unqualifiedName is destroyed before it when naming a group.
       kj::String ownUnqualifiedName;
+      kj::StringPtr unqualifiedName;
       KJ_IF_SOME(annotatedName, annotationValue(node, NAME_ANNOTATION_ID)) {
         // The node's name has been overridden for C++ by an annotation.
         unqualifiedName = annotatedName.getText();

--- a/c++/src/capnp/compiler/module-loader-test.c++
+++ b/c++/src/capnp/compiler/module-loader-test.c++
@@ -1,0 +1,49 @@
+// Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+
+#include "module-loader.h"
+#include "error-reporter.h"
+#include <kj/compat/gtest.h>
+#include <kj/filesystem.h>
+#include <kj/test.h>
+#include <cstdlib>
+
+namespace capnp {
+namespace compiler {
+namespace {
+
+class NullErrorReporter final: public GlobalErrorReporter {
+public:
+  void addError(const kj::ReadableDirectory&, kj::PathPtr,
+                SourcePos, SourcePos, kj::StringPtr) override {
+    KJ_FAIL_ASSERT("unexpected parse error");
+  }
+
+  bool hadErrors() override { return false; }
+};
+
+TEST(ModuleLoader, DuplicateFileAtDifferentPaths) {
+  auto filesystem = kj::newDiskFilesystem();
+  auto testDir = getenv("TEST_TMPDIR");
+  KJ_ASSERT(testDir != nullptr);
+  auto testPath = kj::Path(nullptr).evalNative(testDir);
+  auto root = filesystem->getRoot().openSubdir(testPath, kj::WriteMode::MODIFY);
+  root->openFile(kj::Path::parse("nested/schema.capnp"),
+                 kj::WriteMode::CREATE | kj::WriteMode::CREATE_PARENT)
+      ->writeAll("@0xabcdefabcdefabcd;\n");
+  auto nested = root->openSubdir(kj::Path("nested"));
+
+  NullErrorReporter errorReporter;
+  ModuleLoader loader(errorReporter);
+  auto& first = KJ_ASSERT_NONNULL(loader.loadModule(
+      *root, kj::Path::parse("nested/schema.capnp")));
+
+  KJ_EXPECT_LOG(WARNING, "same source file mapped at two different paths");
+  auto& second = KJ_ASSERT_NONNULL(loader.loadModule(*nested, kj::Path("schema.capnp")));
+
+  EXPECT_EQ(&first, &second);
+}
+
+}  // namespace
+}  // namespace compiler
+}  // namespace capnp

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -45,21 +45,23 @@ struct FileKey {
   // This is probably over-engineered.
 
   const kj::ReadableDirectory& baseDir;
-  kj::PathPtr path;
+  // This must own its path independently of ModuleImpl. In particular, when an insertion collides,
+  // std::pair destroys the new ModuleImpl while the corresponding FileKey is still alive.
+  kj::Path path;
   kj::Maybe<const kj::ReadableFile&> file;
   uint64_t hashCode;
   uint64_t size;
   kj::Date lastModified;
 
   FileKey(const kj::ReadableDirectory& baseDir, kj::PathPtr path)
-      : baseDir(baseDir), path(path), file(kj::none),
+      : baseDir(baseDir), path(path.clone()), file(kj::none),
         hashCode(0), size(0), lastModified(kj::UNIX_EPOCH) {}
   FileKey(const kj::ReadableDirectory& baseDir, kj::PathPtr path, const kj::ReadableFile& file)
       : FileKey(baseDir, path, file, file.stat()) {}
 
   FileKey(const kj::ReadableDirectory& baseDir, kj::PathPtr path, const kj::ReadableFile& file,
           kj::FsNode::Metadata meta)
-      : baseDir(baseDir), path(path), file(&file),
+      : baseDir(baseDir), path(path.clone()), file(&file),
         hashCode(meta.hashCode), size(meta.size), lastModified(meta.lastModified) {}
 
   bool operator==(const FileKey& other) const {
@@ -244,7 +246,7 @@ kj::Maybe<Module&> ModuleLoader::Impl::loadModule(
     auto key = FileKey(dir, pathCopy, *file);
     auto module = kj::heap<ModuleImpl>(*this, kj::mv(file), dir, kj::mv(pathCopy));
     auto& result = *module;
-    auto insertResult = modules.insert(std::make_pair(key, kj::mv(module)));
+    auto insertResult = modules.insert(std::make_pair(kj::mv(key), kj::mv(module)));
     if (insertResult.second) {
       return result;
     } else {

--- a/c++/src/capnp/dynamic-test.c++
+++ b/c++/src/capnp/dynamic-test.c++
@@ -66,6 +66,137 @@ TEST(DynamicApi, Read) {
   checkDynamicTestMessage(toDynamic(root));
 }
 
+template <typename Check>
+void exerciseDynamicReader(DynamicValue::Reader value, DynamicValue::Type type, Check&& check) {
+  EXPECT_EQ(type, value.getType());
+  check(value);
+
+  DynamicValue::Reader copied(value);
+  EXPECT_EQ(type, copied.getType());
+  check(copied);
+
+  DynamicValue::Reader moved(kj::mv(copied));
+  EXPECT_EQ(type, moved.getType());
+  check(moved);
+
+  DynamicValue::Reader copyAssigned;
+  copyAssigned = value;
+  EXPECT_EQ(type, copyAssigned.getType());
+  check(copyAssigned);
+
+  DynamicValue::Reader moveAssigned;
+  moveAssigned = kj::mv(moved);
+  EXPECT_EQ(type, moveAssigned.getType());
+  check(moveAssigned);
+
+  auto& copySelf = copyAssigned;
+  copyAssigned = copySelf;
+  check(copyAssigned);
+  auto& moveSelf = moveAssigned;
+  moveAssigned = kj::mv(moveSelf);
+  check(moveAssigned);
+}
+
+template <typename Check>
+void exerciseDynamicBuilder(DynamicValue::Builder value, DynamicValue::Type type, Check&& check) {
+  EXPECT_EQ(type, value.getType());
+  check(value);
+
+  DynamicValue::Builder copied(value);
+  EXPECT_EQ(type, copied.getType());
+  check(copied);
+
+  DynamicValue::Builder moved(kj::mv(copied));
+  EXPECT_EQ(type, moved.getType());
+  check(moved);
+
+  DynamicValue::Builder copyAssigned;
+  copyAssigned = value;
+  EXPECT_EQ(type, copyAssigned.getType());
+  check(copyAssigned);
+
+  DynamicValue::Builder moveAssigned;
+  moveAssigned = kj::mv(moved);
+  EXPECT_EQ(type, moveAssigned.getType());
+  check(moveAssigned);
+
+  auto& copySelf = copyAssigned;
+  copyAssigned = copySelf;
+  check(copyAssigned);
+  auto& moveSelf = moveAssigned;
+  moveAssigned = kj::mv(moveSelf);
+  check(moveAssigned);
+}
+
+TEST(DynamicApi, ValueCopyMoveAndDestruction) {
+  MallocMessageBuilder message;
+  auto root = message.initRoot<TestAllTypes>();
+  initTestMessage(root);
+
+  MallocMessageBuilder anyMessage;
+  auto anyRoot = anyMessage.initRoot<test::TestAnyPointer>();
+  anyRoot.getAnyPointerField().setAs<Text>("any pointer");
+
+  exerciseDynamicReader(nullptr, DynamicValue::UNKNOWN,
+      [](auto& value) { EXPECT_EQ(DynamicValue::UNKNOWN, value.getType()); });
+  exerciseDynamicReader(VOID, DynamicValue::VOID,
+      [](auto& value) { value.template as<Void>(); });
+  exerciseDynamicReader(true, DynamicValue::BOOL,
+      [](auto& value) { EXPECT_TRUE(value.template as<bool>()); });
+  exerciseDynamicReader(int64_t(-123), DynamicValue::INT,
+      [](auto& value) { EXPECT_EQ(-123, value.template as<int64_t>()); });
+  exerciseDynamicReader(uint64_t(456), DynamicValue::UINT,
+      [](auto& value) { EXPECT_EQ(456u, value.template as<uint64_t>()); });
+  exerciseDynamicReader(1.25, DynamicValue::FLOAT,
+      [](auto& value) { EXPECT_EQ(1.25, value.template as<double>()); });
+  exerciseDynamicReader(Text::Reader("text"), DynamicValue::TEXT,
+      [](auto& value) { EXPECT_EQ("text", value.template as<Text>()); });
+  exerciseDynamicReader(data("data"), DynamicValue::DATA,
+      [](auto& value) { EXPECT_EQ(data("data"), value.template as<Data>()); });
+  exerciseDynamicReader(toDynamic(root.asReader().getTextList()), DynamicValue::LIST,
+      [](auto& value) { EXPECT_EQ(3u, value.template as<DynamicList>().size()); });
+  exerciseDynamicReader(toDynamic(TestEnum::BAZ), DynamicValue::ENUM,
+      [](auto& value) { EXPECT_EQ(TestEnum::BAZ, value.template as<TestEnum>()); });
+  exerciseDynamicReader(toDynamic(root.asReader().getStructField()), DynamicValue::STRUCT,
+      [](auto& value) { EXPECT_EQ("baz", value.template as<TestAllTypes>().getTextField()); });
+  exerciseDynamicReader(
+      anyRoot.asReader().getAnyPointerField(), DynamicValue::ANY_POINTER,
+      [](auto& value) { EXPECT_FALSE(value.template as<AnyPointer>().isNull()); });
+
+  DynamicCapability::Client capability = test::TestInterface::Client(nullptr);
+  exerciseDynamicReader(DynamicValue::Reader(capability), DynamicValue::CAPABILITY,
+      [](auto& value) { EXPECT_EQ(DynamicValue::CAPABILITY, value.getType()); });
+
+  exerciseDynamicBuilder(DynamicValue::Builder(), DynamicValue::UNKNOWN,
+      [](auto& value) { EXPECT_EQ(DynamicValue::UNKNOWN, value.getType()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(VOID), DynamicValue::VOID,
+      [](auto& value) { value.template as<Void>(); });
+  exerciseDynamicBuilder(DynamicValue::Builder(true), DynamicValue::BOOL,
+      [](auto& value) { EXPECT_TRUE(value.template as<bool>()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(int64_t(-123)), DynamicValue::INT,
+      [](auto& value) { EXPECT_EQ(-123, value.template as<int64_t>()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(uint64_t(456)), DynamicValue::UINT,
+      [](auto& value) { EXPECT_EQ(456u, value.template as<uint64_t>()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(1.25), DynamicValue::FLOAT,
+      [](auto& value) { EXPECT_EQ(1.25, value.template as<double>()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(root.getTextField()), DynamicValue::TEXT,
+      [](auto& value) { EXPECT_EQ("foo", value.template as<Text>()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(root.getDataField()), DynamicValue::DATA,
+      [](auto& value) { EXPECT_EQ(data("bar"), value.template as<Data>()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(toDynamic(root.getTextList())), DynamicValue::LIST,
+      [](auto& value) { EXPECT_EQ(3u, value.template as<DynamicList>().size()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(toDynamic(TestEnum::BAZ)), DynamicValue::ENUM,
+      [](auto& value) { EXPECT_EQ(TestEnum::BAZ, value.template as<TestEnum>()); });
+  exerciseDynamicBuilder(
+      DynamicValue::Builder(toDynamic(root.getStructField())), DynamicValue::STRUCT,
+      [](auto& value) { EXPECT_EQ("baz", value.template as<TestAllTypes>().getTextField()); });
+  exerciseDynamicBuilder(
+      DynamicValue::Builder(anyRoot.getAnyPointerField()), DynamicValue::ANY_POINTER,
+      [](auto& value) { EXPECT_FALSE(value.template as<AnyPointer>().isNull()); });
+  exerciseDynamicBuilder(DynamicValue::Builder(capability), DynamicValue::CAPABILITY,
+      [](auto& value) { EXPECT_EQ(DynamicValue::CAPABILITY, value.getType()); });
+}
+
 TEST(DynamicApi, Defaults) {
   AlignedData<1> nullRoot = {{0, 0, 0, 0, 0, 0, 0, 0}};
   kj::ArrayPtr<const word> segments[1] = {kj::arrayPtr(nullRoot.words, 1)};

--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -1465,180 +1465,134 @@ DynamicValue::Reader::Reader(ConstSchema constant): type(VOID) {
   }
 }
 
-#if __GNUC__ && !__clang__ && __GNUC__ >= 9
-// In the copy constructors below, we use memcpy() to copy only after verifying that it is safe.
-// But GCC 9 doesn't know we've checked, and whines. I suppose GCC is probably right: our checks
-// probably don't technically make memcpy safe according to the standard. But it works in practice,
-// and if it ever stops working, the tests will catch it.
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-
-DynamicValue::Reader::Reader(const Reader& other) {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      KJ_ASSERT_CAN_MEMCPY(Text::Reader);
-      KJ_ASSERT_CAN_MEMCPY(Data::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicList::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicEnum);
-      KJ_ASSERT_CAN_MEMCPY(DynamicStruct::Reader);
-      KJ_ASSERT_CAN_MEMCPY(AnyPointer::Reader);
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, other.capabilityValue);
-      return;
+DynamicValue::Reader::Reader(const Reader& other): type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: voidValue = other.voidValue; break;
+    case BOOL: boolValue = other.boolValue; break;
+    case INT: intValue = other.intValue; break;
+    case UINT: uintValue = other.uintValue; break;
+    case FLOAT: floatValue = other.floatValue; break;
+    case TEXT: kj::ctor(textValue, other.textValue); break;
+    case DATA: kj::ctor(dataValue, other.dataValue); break;
+    case LIST: kj::ctor(listValue, other.listValue); break;
+    case ENUM: kj::ctor(enumValue, other.enumValue); break;
+    case STRUCT: kj::ctor(structValue, other.structValue); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, other.anyPointerValue); break;
+    case CAPABILITY: kj::ctor(capabilityValue, other.capabilityValue); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
-DynamicValue::Reader::Reader(Reader&& other) noexcept {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      KJ_ASSERT_CAN_MEMCPY(Text::Reader);
-      KJ_ASSERT_CAN_MEMCPY(Data::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicList::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicEnum);
-      KJ_ASSERT_CAN_MEMCPY(DynamicStruct::Reader);
-      KJ_ASSERT_CAN_MEMCPY(AnyPointer::Reader);
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, kj::mv(other.capabilityValue));
-      return;
+DynamicValue::Reader::Reader(Reader&& other) noexcept: type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: voidValue = other.voidValue; break;
+    case BOOL: boolValue = other.boolValue; break;
+    case INT: intValue = other.intValue; break;
+    case UINT: uintValue = other.uintValue; break;
+    case FLOAT: floatValue = other.floatValue; break;
+    case TEXT: kj::ctor(textValue, kj::mv(other.textValue)); break;
+    case DATA: kj::ctor(dataValue, kj::mv(other.dataValue)); break;
+    case LIST: kj::ctor(listValue, kj::mv(other.listValue)); break;
+    case ENUM: kj::ctor(enumValue, kj::mv(other.enumValue)); break;
+    case STRUCT: kj::ctor(structValue, kj::mv(other.structValue)); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, kj::mv(other.anyPointerValue)); break;
+    case CAPABILITY: kj::ctor(capabilityValue, kj::mv(other.capabilityValue)); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
 DynamicValue::Reader::~Reader() noexcept(false) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  switch (type) {
+    case UNKNOWN:
+    case VOID:
+    case BOOL:
+    case INT:
+    case UINT:
+    case FLOAT:
+      break;
+    case TEXT: kj::dtor(textValue); break;
+    case DATA: kj::dtor(dataValue); break;
+    case LIST: kj::dtor(listValue); break;
+    case ENUM: kj::dtor(enumValue); break;
+    case STRUCT: kj::dtor(structValue); break;
+    case CAPABILITY: kj::dtor(capabilityValue); break;
+    case ANY_POINTER: kj::dtor(anyPointerValue); break;
   }
 }
 
 DynamicValue::Reader& DynamicValue::Reader::operator=(const Reader& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
-  }
+  if (this == &other) return *this;
+  kj::dtor(*this);
   kj::ctor(*this, other);
   return *this;
 }
 DynamicValue::Reader& DynamicValue::Reader::operator=(Reader&& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
-  }
+  if (this == &other) return *this;
+  kj::dtor(*this);
   kj::ctor(*this, kj::mv(other));
   return *this;
 }
 
-DynamicValue::Builder::Builder(Builder& other) {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      // Unfortunately canMemcpy() doesn't work on these types due to the use of
-      // DisallowConstCopy, but __has_trivial_destructor should detect if any of these types
-      // become non-trivial.
-      static_assert(KJ_HAS_TRIVIAL_DESTRUCTOR(Text::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(Data::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicList::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicEnum) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicStruct::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(AnyPointer::Builder),
-                    "Assumptions here don't hold.");
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, other.capabilityValue);
-      return;
+DynamicValue::Builder::Builder(Builder& other): type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: voidValue = other.voidValue; break;
+    case BOOL: boolValue = other.boolValue; break;
+    case INT: intValue = other.intValue; break;
+    case UINT: uintValue = other.uintValue; break;
+    case FLOAT: floatValue = other.floatValue; break;
+    case TEXT: kj::ctor(textValue, other.textValue); break;
+    case DATA: kj::ctor(dataValue, other.dataValue); break;
+    case LIST: kj::ctor(listValue, other.listValue); break;
+    case ENUM: kj::ctor(enumValue, other.enumValue); break;
+    case STRUCT: kj::ctor(structValue, other.structValue); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, other.anyPointerValue); break;
+    case CAPABILITY: kj::ctor(capabilityValue, other.capabilityValue); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
-DynamicValue::Builder::Builder(Builder&& other) noexcept {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      // Unfortunately __has_trivial_copy doesn't work on these types due to the use of
-      // DisallowConstCopy, but __has_trivial_destructor should detect if any of these types
-      // become non-trivial.
-      static_assert(KJ_HAS_TRIVIAL_DESTRUCTOR(Text::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(Data::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicList::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicEnum) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicStruct::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(AnyPointer::Builder),
-                    "Assumptions here don't hold.");
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, kj::mv(other.capabilityValue));
-      return;
+DynamicValue::Builder::Builder(Builder&& other) noexcept: type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: voidValue = other.voidValue; break;
+    case BOOL: boolValue = other.boolValue; break;
+    case INT: intValue = other.intValue; break;
+    case UINT: uintValue = other.uintValue; break;
+    case FLOAT: floatValue = other.floatValue; break;
+    case TEXT: kj::ctor(textValue, kj::mv(other.textValue)); break;
+    case DATA: kj::ctor(dataValue, kj::mv(other.dataValue)); break;
+    case LIST: kj::ctor(listValue, kj::mv(other.listValue)); break;
+    case ENUM: kj::ctor(enumValue, kj::mv(other.enumValue)); break;
+    case STRUCT: kj::ctor(structValue, kj::mv(other.structValue)); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, kj::mv(other.anyPointerValue)); break;
+    case CAPABILITY: kj::ctor(capabilityValue, kj::mv(other.capabilityValue)); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
 DynamicValue::Builder::~Builder() noexcept(false) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  switch (type) {
+    case UNKNOWN:
+    case VOID:
+    case BOOL:
+    case INT:
+    case UINT:
+    case FLOAT:
+      break;
+    case TEXT: kj::dtor(textValue); break;
+    case DATA: kj::dtor(dataValue); break;
+    case LIST: kj::dtor(listValue); break;
+    case ENUM: kj::dtor(enumValue); break;
+    case STRUCT: kj::dtor(structValue); break;
+    case CAPABILITY: kj::dtor(capabilityValue); break;
+    case ANY_POINTER: kj::dtor(anyPointerValue); break;
   }
 }
 
 DynamicValue::Builder& DynamicValue::Builder::operator=(Builder& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
-  }
+  if (this == &other) return *this;
+  kj::dtor(*this);
   kj::ctor(*this, other);
   return *this;
 }
 DynamicValue::Builder& DynamicValue::Builder::operator=(Builder&& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
-  }
+  if (this == &other) return *this;
+  kj::dtor(*this);
   kj::ctor(*this, kj::mv(other));
   return *this;
 }

--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -129,16 +129,18 @@ private:
   ReaderOptions options;
 
 #if defined(__EMSCRIPTEN__) || (defined(__APPLE__) && (defined(__ppc__) || defined(__i386__)))
-  static constexpr size_t arenaSpacePadding = 19;
+  static constexpr size_t arenaSpacePadding = 15;
 #else
-  static constexpr size_t arenaSpacePadding = 18;
+  static constexpr size_t arenaSpacePadding = 14;
 #endif
 
   // Space in which we can construct a ReaderArena.  We don't use ReaderArena directly here
   // because we don't want clients to have to #include arena.h, which itself includes a bunch of
   // other headers.  We don't use a pointer to a ReaderArena because that would require an
   // extra malloc on every message which could be expensive when processing small messages.
-  alignas(8) void* arenaSpace[arenaSpacePadding + sizeof(kj::MutexGuarded<void*>) / sizeof(void*)];
+  alignas(8) void* arenaSpace[
+      arenaSpacePadding + 2 * sizeof(kj::ArrayPtr<const word>) / sizeof(void*) +
+      sizeof(kj::MutexGuarded<void*>) / sizeof(void*)];
   bool allocatedArena;
 
   _::ReaderArena* arena() { return reinterpret_cast<_::ReaderArena*>(arenaSpace); }
@@ -242,7 +244,8 @@ public:
   // Add up the allocated space from all segments.
 
 private:
-  alignas(8) void* arenaSpace[22];
+  alignas(8) void* arenaSpace[
+      20 + sizeof(kj::ArrayPtr<const word>) / sizeof(void*)];
   // Space in which we can construct a BuilderArena.  We don't use BuilderArena directly here
   // because we don't want clients to have to #include arena.h, which itself includes a bunch of
   // big STL headers.  We don't use a pointer to a BuilderArena because that would require an

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -148,6 +148,7 @@ kj::Exception toException(const rpc::Exception::Reader& exception) {
 
 void fromException(const kj::Exception& exception, rpc::Exception::Builder builder,
                    kj::Maybe<kj::Function<kj::String(const kj::Exception&)>&> traceEncoder) {
+  kj::String scratch;
   kj::StringPtr description = exception.getDescription();
 
   // Include context, if any.
@@ -160,7 +161,6 @@ void fromException(const kj::Exception& exception, rpc::Exception::Builder build
       break;
     }
   }
-  kj::String scratch;
   if (contextLines.size() > 0) {
     scratch = kj::str(description, '\n', kj::strArray(contextLines, "\n"));
     description = scratch;

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -185,10 +185,12 @@ struct SchemaParser::DiskFileCompat {
 struct SchemaParser::Impl {
   typedef std::unordered_map<
       const SchemaFile*, kj::Own<ModuleImpl>, SchemaFileHash, SchemaFileEq> FileMap;
+
+  // Modules can retain views into translated import paths, so the compatibility cache must be
+  // declared first and therefore destroyed after both the compiler and the modules.
+  kj::MutexGuarded<kj::Maybe<DiskFileCompat>> compat;
   kj::MutexGuarded<FileMap> fileMap;
   compiler::Compiler compiler;
-
-  kj::MutexGuarded<kj::Maybe<DiskFileCompat>> compat;
 };
 
 SchemaParser::SchemaParser(): impl(kj::heap<Impl>()) {}
@@ -271,7 +273,8 @@ ParsedSchema SchemaParser::parseDiskFile(
 
     KJ_IF_SOME(match, matchedImportDir) {
       baseDir = match.dir;
-      path = path.slice(match.path.size(), path.size()).clone();
+      auto relativePath = path.slice(match.path.size(), path.size()).clone();
+      path = kj::mv(relativePath);
     }
   }
 

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -587,6 +587,7 @@ public:
       : FlatArrayMessageReader(scratchBuffer, options) {}
 
   ~MessageReaderImpl() noexcept(false) {
+    releaseSegments();
     KJ_IF_SOME(parent, state.tryGet<BufferedMessageStream*>()) {
       parent->hasOutstandingShortLivedMessage = false;
     }

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -136,6 +136,11 @@ size_t expectedSizeInWordsFromPrefix(kj::ArrayPtr<const word> array) {
   return totalSize;
 }
 
+void FlatArrayMessageReader::releaseSegments() {
+  moreSegments = nullptr;
+  segment0 = nullptr;
+}
+
 kj::ArrayPtr<const word> FlatArrayMessageReader::getSegment(uint id) {
   if (id == 0) {
     return segment0;
@@ -278,6 +283,11 @@ InputStreamMessageReader::~InputStreamMessageReader() noexcept(false) {
       inputStream.skip(allEnd - readPos);
     });
   }
+
+  // These point into ownedSpace when the caller's scratch space was too small. Release them before
+  // ownedSpace is destroyed. (Member destruction order alone would destroy ownedSpace first.)
+  segment0 = nullptr;
+  moreSegments = nullptr;
 }
 
 kj::ArrayPtr<const word> InputStreamMessageReader::getSegment(uint id) {

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -70,12 +70,20 @@ public:
   // get at it.
 
 private:
+  // Declared before the views so it is destroyed after them. This owns their backing storage when
+  // the byte-array constructor has to copy misaligned input.
+  kj::Array<word> alignedCopy;
+
+protected:
+  void releaseSegments();
+  // Releases all views into the input storage. Derived classes that own the input in a member must
+  // call this from their destructor body, before their members are destroyed.
+
+private:
   // Optimize for single-segment case.
   kj::ArrayPtr<const word> segment0;
   kj::Array<kj::ArrayPtr<const word>> moreSegments;
   const word* end;
-
-  kj::Array<word> alignedCopy;
 
   void init(kj::ArrayPtr<const word> array);
 };

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -42,6 +42,36 @@ KJ_TEST("Array rejects destruction with an active ArrayPtr") {
 }
 #endif
 
+KJ_TEST("Array can be replaced with a heap copy of its own slice") {
+  auto array = heapArray<int>({ 1, 2, 3, 4 });
+  array = heapArray(array.slice(1, 4));
+  KJ_EXPECT(array == kj::ArrayPtr<const int>({ 2, 3, 4 }));
+
+  const auto& constArray = array;
+  array = heapArray(constArray.slice(1, 3));
+  KJ_EXPECT(array == kj::ArrayPtr<const int>({ 3, 4 }));
+}
+
+KJ_TEST("ArrayBuilder preserves ArrayPtr tracking when finished") {
+  auto builder = heapArrayBuilder<int>(1);
+  builder.add(123);
+  auto ptr = builder.asPtr();
+  auto array = builder.finish();
+  KJ_EXPECT(ptr[0] == 123);
+  ptr = nullptr;
+}
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+KJ_TEST("ArrayBuilder rejects destruction with an active ArrayPtr") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    auto builder = heapArrayBuilder<int>(1);
+    builder.add(123);
+    auto ptr = new ArrayPtr<int>(builder.asPtr());
+    (void)ptr;
+  });
+}
+#endif
+
 struct CloneableElement {
   int clone() const { return 123; }
 };

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -21,6 +21,9 @@
 
 #include "array.h"
 #include "debug.h"
+#include "test.h"
+#include "function.h"
+#include <signal.h>
 #include <string>
 #include <list>
 #include <kj/compat/gtest.h>
@@ -28,6 +31,16 @@
 
 namespace kj {
 namespace {
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+KJ_TEST("Array rejects destruction with an active ArrayPtr") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    auto array = heapArray<int>(4);
+    auto ptr = new ArrayPtr<int>(array.asPtr().slice(1));
+    (void)ptr;
+  });
+}
+#endif
 
 struct CloneableElement {
   int clone() const { return 123; }

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -430,9 +430,17 @@ public:
   explicit ArrayBuilder(RemoveConst<T>* firstElement, size_t capacity,
                         const ArrayDisposer& disposer)
       : ptr(firstElement), pos(firstElement), endPtr(firstElement + capacity),
-        disposer(&disposer) {}
+        disposer(&disposer)
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+      , counter(new _::AtomicPtrCounter)
+#endif
+      {}
   ArrayBuilder(ArrayBuilder&& other) noexcept
       : ptr(other.ptr), pos(other.pos), endPtr(other.endPtr), disposer(other.disposer) {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    counter = other.counter;
+    other.counter = nullptr;
+#endif
     other.ptr = nullptr;
     other.pos = nullptr;
     other.endPtr = nullptr;
@@ -441,23 +449,28 @@ public:
       : ptr(other.ptr), pos(other.ptr + other.size_), endPtr(pos), disposer(other.disposer) {
     // Create an already-full ArrayBuilder from an Array of the same type. This constructor
     // primarily exists to enable Vector<T> to be constructed from Array<T>.
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    counter = other.counter;
+    other.counter = nullptr;
+#endif
     other.ptr = nullptr;
     other.size_ = 0;
   }
   KJ_DISALLOW_COPY(ArrayBuilder);
-  inline ~ArrayBuilder() noexcept(false) { dispose(); }
+  inline ~ArrayBuilder() noexcept(false) {
+    dispose();
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    delete counter;
+#endif
+  }
 
-  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
-    return arrayPtr(ptr, pos);
-  }
+  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND { return makePtr<T>(ptr, pos - ptr); }
   inline operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND {
-    return arrayPtr(ptr, pos);
+    return makePtr<const T>(ptr, pos - ptr);
   }
-  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND {
-    return arrayPtr(ptr, pos);
-  }
+  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND { return makePtr<T>(ptr, pos - ptr); }
   inline ArrayPtr<const T> asPtr() const KJ_LIFETIMEBOUND {
-    return arrayPtr(ptr, pos);
+    return makePtr<const T>(ptr, pos - ptr);
   }
 
   inline size_t size() const { return pos - ptr; }
@@ -484,6 +497,11 @@ public:
 
   ArrayBuilder& operator=(ArrayBuilder&& other) {
     dispose();
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    delete counter;
+    counter = other.counter;
+    other.counter = nullptr;
+#endif
     ptr = other.ptr;
     pos = other.pos;
     endPtr = other.endPtr;
@@ -584,6 +602,11 @@ public:
     // without knowing the final size in advance.
     KJ_IREQUIRE(pos == endPtr, "ArrayBuilder::finish() called prematurely.");
     Array<T> result(reinterpret_cast<T*>(ptr), pos - ptr, *disposer);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    delete result.counter;
+    result.counter = counter;
+    counter = nullptr;
+#endif
     ptr = nullptr;
     pos = nullptr;
     endPtr = nullptr;
@@ -599,8 +622,28 @@ private:
   RemoveConst<T>* pos;
   T* endPtr;
   const ArrayDisposer* disposer = &NullArrayDisposer::instance;
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  _::AtomicPtrCounter* counter = nullptr;
+#endif
+
+  template <typename U>
+  inline ArrayPtr<U> makePtr(U* ptr, size_t size) const {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return counter == nullptr ? ArrayPtr<U>(ptr, size)
+                              : ArrayPtr<U>(ptr, size, *counter);
+#else
+    return ArrayPtr<U>(ptr, size);
+#endif
+  }
+
+  inline void assertNoRefs() const {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    if (counter != nullptr) counter->assertEmpty();
+#endif
+  }
 
   inline void dispose() {
+    assertNoRefs();
     // Make sure that if an exception is thrown, we are left with a null ptr, so we won't possibly
     // dispose again.
     T* ptrCopy = ptr;
@@ -988,14 +1031,21 @@ template <typename T>
 Array<T> heapArray(ArrayPtr<T> content) {
   ArrayBuilder<T> builder = heapArrayBuilder<T>(content.size());
   builder.addAll(content);
-  return builder.finish();
+  auto result = builder.finish();
+  // A temporary used to initialize a by-value parameter may live until the end of the caller's
+  // full-expression. Drop our view explicitly so replacing an Array with a copy of its own slice
+  // does not leave that Array appearing to have a live pointer when move-assignment disposes it.
+  content = nullptr;
+  return result;
 }
 
 template <typename T>
 Array<T> heapArray(ArrayPtr<const T> content) {
   ArrayBuilder<T> builder = heapArrayBuilder<T>(content.size());
   builder.addAll(content);
-  return builder.finish();
+  auto result = builder.finish();
+  content = nullptr;
+  return result;
 }
 
 template <typename T, typename Iterator> Array<T>

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -130,33 +130,51 @@ class Array {
 public:
   inline Array(): ptr(nullptr), size_(0), disposer(nullptr) {}
   inline Array(decltype(nullptr)): ptr(nullptr), size_(0), disposer(nullptr) {}
-  inline Array(Array&& other) noexcept
-      : ptr(other.ptr), size_(other.size_), disposer(other.disposer) {
+  inline Array(Array&& other) noexcept: ptr(nullptr), size_(0), disposer(nullptr) {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    counter = other.counter;
+    other.counter = nullptr;
+#endif
+    ptr = other.ptr;
+    size_ = other.size_;
+    disposer = other.disposer;
     other.ptr = nullptr;
     other.size_ = 0;
   }
   inline Array(Array<RemoveConstOrDisable<T>>&& other) noexcept
-      : ptr(other.ptr), size_(other.size_), disposer(other.disposer) {
+      : ptr(nullptr), size_(0), disposer(nullptr) {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    counter = other.counter;
+    other.counter = nullptr;
+#endif
+    ptr = other.ptr;
+    size_ = other.size_;
+    disposer = other.disposer;
     other.ptr = nullptr;
     other.size_ = 0;
   }
   inline Array(T* firstElement KJ_LIFETIMEBOUND, size_t size, const ArrayDisposer& disposer)
-      : ptr(firstElement), size_(size), disposer(&disposer) {}
+      : ptr(firstElement), size_(size), disposer(&disposer)
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+      , counter(new _::AtomicPtrCounter)
+#endif
+      {}
 
   KJ_DISALLOW_COPY(Array);
-  inline ~Array() noexcept(false) { dispose(); }
+  inline ~Array() noexcept(false) {
+    dispose();
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    delete counter;
+#endif
+  }
 
-  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
-  }
+  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND { return makePtr<T>(ptr, size_); }
   inline operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
+    return makePtr<const T>(ptr, size_);
   }
-  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
-  }
+  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND { return makePtr<T>(ptr, size_); }
   inline ArrayPtr<const T> asPtr() const KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
+    return makePtr<const T>(ptr, size_);
   }
 
   inline constexpr size_t size() const { return size_; }
@@ -183,19 +201,19 @@ public:
 
   inline ArrayPtr<T> slice(size_t start, size_t end) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().", start, end, size_);
-    return ArrayPtr<T>(ptr + start, end - start);
+    return makePtr<T>(ptr + start, end - start);
   }
   inline ArrayPtr<const T> slice(size_t start, size_t end) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().", start, end, size_);
-    return ArrayPtr<const T>(ptr + start, end - start);
+    return makePtr<const T>(ptr + start, end - start);
   }
   inline ArrayPtr<T> slice(size_t start) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
-    return ArrayPtr<T>(ptr + start, size_ - start);
+    return makePtr<T>(ptr + start, size_ - start);
   }
   inline ArrayPtr<const T> slice(size_t start) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
-    return ArrayPtr<const T>(ptr + start, size_ - start);
+    return makePtr<const T>(ptr + start, size_ - start);
   }
 
   inline ArrayPtr<T> first(size_t count) KJ_LIFETIMEBOUND { return slice(0, count); }
@@ -225,6 +243,11 @@ public:
     if (disposer == nullptr) return nullptr;
     Array<PropagateConst<T, byte>> result(
         reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_, *disposer);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    delete result.counter;
+    result.counter = counter;
+    counter = nullptr;
+#endif
     ptr = nullptr;
     size_ = 0;
     return result;
@@ -236,6 +259,11 @@ public:
     if (disposer == nullptr) return nullptr;
     Array<PropagateConst<T, char>> result(
         reinterpret_cast<PropagateConst<T, char>*>(ptr), size_, *disposer);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    delete result.counter;
+    result.counter = counter;
+    counter = nullptr;
+#endif
     ptr = nullptr;
     size_ = 0;
     return result;
@@ -250,6 +278,11 @@ public:
 
   inline Array& operator=(Array&& other) {
     dispose();
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    delete counter;
+    counter = other.counter;
+    other.counter = nullptr;
+#endif
     ptr = other.ptr;
     size_ = other.size_;
     disposer = other.disposer;
@@ -284,8 +317,28 @@ private:
   T* ptr;
   size_t size_;
   const ArrayDisposer* disposer;
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  _::AtomicPtrCounter* counter = nullptr;
+#endif
+
+  template <typename U>
+  inline ArrayPtr<U> makePtr(U* ptr, size_t size) const {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return counter == nullptr ? ArrayPtr<U>(ptr, size)
+                              : ArrayPtr<U>(ptr, size, *counter);
+#else
+    return ArrayPtr<U>(ptr, size);
+#endif
+  }
+
+  inline void assertNoRefs() const {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    if (counter != nullptr) counter->assertEmpty();
+#endif
+  }
 
   inline void dispose() {
+    assertNoRefs();
     // Make sure that if an exception is thrown, we are left with a null ptr, so we won't possibly
     // dispose again.
     T* ptrCopy = ptr;
@@ -301,6 +354,9 @@ private:
   friend class Array;
   template <typename U>
   friend class ArrayBuilder;
+  friend class String;
+  friend class StringPtr;
+  friend class ConstString;
 };
 
 static_assert(!canMemcpy<Array<char>>(), "canMemcpy<>() is broken");

--- a/c++/src/kj/atomic.h
+++ b/c++/src/kj/atomic.h
@@ -184,6 +184,71 @@ inline void atomicThreadFence(
 #endif
 }
 
+namespace _ {  // private
+
+void atomicPtrCounterAssertionFailed(const char* reason);
+
+class AtomicPtrCounter {
+  // Only the counter itself is observed, so relaxed ordering is sufficient.
+public:
+  inline void inc() { atomicAddFetch(&count, size_t(1), AtomicMemoryOrder::RELAXED); }
+
+  inline void dec() {
+    size_t remaining = atomicSubFetch(&count, size_t(1), AtomicMemoryOrder::RELAXED);
+    if (KJ_UNLIKELY(remaining == size_t(-1))) {
+      atomicPtrCounterAssertionFailed("unbalanced inc/dec");
+    }
+  }
+
+  inline bool isEmpty() const {
+    return atomicLoad(&count, AtomicMemoryOrder::RELAXED) == 0;
+  }
+
+  inline void assertEmpty() const {
+    if (KJ_UNLIKELY(!isEmpty())) {
+      atomicPtrCounterAssertionFailed("active pointers exist");
+    }
+  }
+
+private:
+  size_t count = 0;
+};
+
+class PtrCounter {
+  // Tracks one pointer against an optional AtomicPtrCounter. Moving a pointer leaves the source
+  // valid, so move operations increment the counter just like copies.
+protected:
+  PtrCounter() = default;
+  inline constexpr PtrCounter(const Maybe<AtomicPtrCounter&>& source)
+      : counter(const_cast<Maybe<AtomicPtrCounter&>&>(source)) { inc(); }
+  inline constexpr PtrCounter(const PtrCounter& other)
+      : counter(const_cast<Maybe<AtomicPtrCounter&>&>(other.counter)) { inc(); }
+  inline constexpr PtrCounter(PtrCounter&& other): counter(other.counter) { inc(); }
+  inline constexpr ~PtrCounter() { dec(); }
+
+  inline constexpr PtrCounter& operator=(const PtrCounter& other) {
+    setCounter(other.counter);
+    return *this;
+  }
+  inline constexpr PtrCounter& operator=(PtrCounter&& other) {
+    setCounter(other.counter);
+    return *this;
+  }
+
+  Maybe<AtomicPtrCounter&> counter;
+
+  inline constexpr void setCounter(const Maybe<AtomicPtrCounter&>& newCounter) {
+    dec();
+    counter = const_cast<Maybe<AtomicPtrCounter&>&>(newCounter);
+    inc();
+  }
+
+private:
+  inline constexpr void inc() { KJ_IF_SOME(c, counter) { c.inc(); } }
+  inline constexpr void dec() { KJ_IF_SOME(c, counter) { c.dec(); } }
+};
+
+}  // namespace _ (private)
 }  // namespace kj
 
 KJ_END_HEADER

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -175,6 +175,15 @@ typedef unsigned char byte;
 #endif
 #endif
 
+// KJ_DEBUG_MEMORY == 1 enables checks designed to catch memory usage errors.
+#ifndef KJ_DEBUG_MEMORY
+#define KJ_DEBUG_MEMORY 0
+#endif
+
+#ifndef KJ_ASSERT_ARRAYPTR_COUNTERS
+#define KJ_ASSERT_ARRAYPTR_COUNTERS KJ_DEBUG_MEMORY
+#endif
+
 #define KJ_DISALLOW_COPY(classname) \
   classname(const classname&) = delete; \
   classname& operator=(const classname&) = delete
@@ -274,7 +283,7 @@ typedef unsigned char byte;
 // by allowing a syntax like `[[clang::lifetimebound(*this)]]`.
 // https://clang.llvm.org/docs/AttributeReference.html#lifetimebound
 
-#if KJ_HAS_CPP_ATTRIBUTE(clang::musttail)
+#if KJ_HAS_CPP_ATTRIBUTE(clang::musttail) && !KJ_ASSERT_ARRAYPTR_COUNTERS
 #define KJ_MUSTTAIL [[clang::musttail]]
 #else
 #define KJ_MUSTTAIL
@@ -1714,9 +1723,9 @@ inline T* readMaybe(Maybe<T>& maybe) { return maybe.ptr; }
 template <typename T>
 inline const T* readMaybe(const Maybe<T>& maybe) { return maybe.ptr; }
 template <typename T>
-inline T* readMaybe(Maybe<T&>&& maybe) { return maybe.ptr; }
+inline constexpr T* readMaybe(Maybe<T&>&& maybe) { return maybe.ptr; }
 template <typename T>
-inline T* readMaybe(const Maybe<T&>& maybe) { return maybe.ptr; }
+inline constexpr T* readMaybe(const Maybe<T&>& maybe) { return maybe.ptr; }
 
 template <typename T>
 inline T* readMaybe(T* ptr) { return ptr; }
@@ -2426,9 +2435,9 @@ private:
   template <typename U>
   friend class Maybe;
   template <typename U>
-  friend U* _::readMaybe(Maybe<U&>&& maybe);
+  friend constexpr U* _::readMaybe(Maybe<U&>&& maybe);
   template <typename U>
-  friend U* _::readMaybe(const Maybe<U&>& maybe);
+  friend constexpr U* _::readMaybe(const Maybe<U&>& maybe);
 };
 
 // =======================================================================================
@@ -2514,8 +2523,19 @@ struct Mapper<Maybe<T>> {
 //
 // So common that we put it in common.h rather than array.h.
 
+}  // namespace kj
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+#include "atomic.h"
+#endif
+
+namespace kj {
+
 template <typename T>
 class Array;
+class String;
+class StringPtr;
+class ConstString;
 
 namespace _ {  // private
 class SplitIteratorEnd;
@@ -2527,8 +2547,20 @@ template <typename T>
 class SplitIterable;
 }  // namespace _ (private)
 
+namespace _ {  // private
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
 template <typename T>
-class ArrayPtr: public DisallowConstCopyIfNotConst<T> {
+using ArrayPtrCounter = PtrCounter;
+#else
+template <typename T>
+class ArrayPtrCounter {};
+#endif
+
+}  // namespace _ (private)
+
+template <typename T>
+class ArrayPtr: public DisallowConstCopyIfNotConst<T>, private _::ArrayPtrCounter<T> {
   // A pointer to an array.  Includes a size.  Like any pointer, it doesn't own the target data,
   // and passing by value only copies the pointer, not the target.
 
@@ -2540,6 +2572,9 @@ public:
       : ptr(begin), size_(end - begin) {}
   ArrayPtr<T>& operator=(Array<T>&&) = delete;
   ArrayPtr<T>& operator=(decltype(nullptr)) {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    this->setCounter(kj::none);
+#endif
     ptr = nullptr;
     size_ = 0;
     return *this;
@@ -2602,10 +2637,14 @@ public:
   }
 
   inline operator ArrayPtr<const T>() const {
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return ArrayPtr<const T>(ptr, size_, this->counter);
+#else
     return ArrayPtr<const T>(ptr, size_);
+#endif
   }
   inline ArrayPtr<const T> asConst() const {
-    return ArrayPtr<const T>(ptr, size_);
+    return operator ArrayPtr<const T>();
   }
 
   inline constexpr size_t size() const { return size_; }
@@ -2630,20 +2669,36 @@ public:
   inline constexpr ArrayPtr<const T> slice(size_t start, size_t end) const {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds ArrayPtr::slice().",
         start, end, size_);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return ArrayPtr<const T>(ptr + start, end - start, this->counter);
+#else
     return ArrayPtr<const T>(ptr + start, end - start);
+#endif
   }
   inline constexpr ArrayPtr slice(size_t start, size_t end) {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds ArrayPtr::slice().",
         start, end, size_);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return ArrayPtr(ptr + start, end - start, this->counter);
+#else
     return ArrayPtr(ptr + start, end - start);
+#endif
   }
   inline constexpr ArrayPtr<const T> slice(size_t start) const {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return ArrayPtr<const T>(ptr + start, size_ - start, this->counter);
+#else
     return ArrayPtr<const T>(ptr + start, size_ - start);
+#endif
   }
   inline constexpr ArrayPtr slice(size_t start) {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return ArrayPtr(ptr + start, size_ - start, this->counter);
+#else
     return ArrayPtr(ptr + start, size_ - start);
+#endif
   }
   inline constexpr bool startsWith(const ArrayPtr<const T>& other) const {
     return other.size() <= size_ && first(other.size()) == other;
@@ -2682,13 +2737,23 @@ public:
     // Reinterpret the array as a byte array. This is explicitly legal under C++ aliasing
     // rules.
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return ArrayPtr<PropagateConst<T, byte>>(
+        reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_ * sizeof(T), this->counter);
+#else
     return { reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_ * sizeof(T) };
+#endif
   }
   inline ArrayPtr<PropagateConst<T, char>> asChars() const {
     // Reinterpret the array as a char array. This is explicitly legal under C++ aliasing
     // rules.
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    return ArrayPtr<PropagateConst<T, char>>(
+        reinterpret_cast<PropagateConst<T, char>*>(ptr), size_ * sizeof(T), this->counter);
+#else
     return { reinterpret_cast<PropagateConst<T, char>*>(ptr), size_ * sizeof(T) };
+#endif
   }
 
   inline constexpr bool operator==(decltype(nullptr)) const { return size_ == 0; }
@@ -2820,6 +2885,11 @@ public:
 private:
   T* ptr;
   size_t size_;
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  inline constexpr ArrayPtr(
+      T* ptr, size_t size, const Maybe<_::AtomicPtrCounter&>& sourceCounter)
+      : _::ArrayPtrCounter<T>(sourceCounter), ptr(ptr), size_(size) {}
+#endif
 
   inline bool intersects(kj::ArrayPtr<const T> other) const {
     // Checks if memory area intersects with another pointer.
@@ -2829,6 +2899,14 @@ private:
     // Negating the expression gets the result:
     return begin() < other.end() && other.begin() < end();
   }
+
+  template <typename>
+  friend class ArrayPtr;
+  template <typename>
+  friend class Array;
+  friend class String;
+  friend class StringPtr;
+  friend class ConstString;
 };
 
 namespace _ {  // private

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -2533,6 +2533,8 @@ namespace kj {
 
 template <typename T>
 class Array;
+template <typename T>
+class ArrayBuilder;
 class String;
 class StringPtr;
 class ConstString;
@@ -2904,6 +2906,8 @@ private:
   friend class ArrayPtr;
   template <typename>
   friend class Array;
+  template <typename>
+  friend class ArrayBuilder;
   friend class String;
   friend class StringPtr;
   friend class ConstString;

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -1553,10 +1553,12 @@ public:
   }
 
   kj::Promise<Message> readMessage() override {
+    // The previous message body must complete before readMessageHeaders() proceeds, so its header
+    // views are no longer observable. Release them before readHeader() may resize the buffer.
+    headers.clear();
     auto textOrError = co_await readMessageHeaders();
     KJ_REQUIRE(textOrError.is<kj::ArrayPtr<char>>(), "bad message");
     auto text = textOrError.get<kj::ArrayPtr<char>>();
-    headers.clear();
     KJ_REQUIRE(headers.tryParse(text), "bad message");
     auto body = getEntityBody(HttpInputStreamImpl::RESPONSE, HttpMethod::GET, 0, headers);
 
@@ -1792,7 +1794,11 @@ public:
   // Used when suspending a request, or when switching protocols (e.g. WebSocket, CONNENCT).
   // HttpinputStream can no longer be used after this.
   ReleasedBuffer releaseBuffer() {
-    return { headerBuffer.releaseAsBytes(), leftover.asBytes() };
+    auto result = ReleasedBuffer { headerBuffer.releaseAsBytes(), leftover.asBytes() };
+    // Ownership of headerBuffer's pointer counter moved to result.buffer. Do not leave this
+    // HttpInputStreamImpl retaining another view into the released storage.
+    leftover = nullptr;
+    return result;
   }
 
   // Used when suspending a request. HttpinputStream can no longer be used after this.
@@ -1864,6 +1870,7 @@ private:
 
     for (;;) {
       kj::Promise<size_t> readPromise = nullptr;
+      kj::ArrayPtr<byte> readBuffer;
 
       // Figure out where we're reading from.
       if (leftover != nullptr) {
@@ -1924,10 +1931,15 @@ private:
           maxBytes = kj::min(maxBytes, MAX_CHUNK_HEADER_SIZE);
         }
 
-        readPromise = inner.read(headerBuffer.slice(bufferEnd).first(maxBytes).asBytes(), 1);
+        readBuffer = headerBuffer.slice(bufferEnd).first(maxBytes).asBytes();
+        readPromise = inner.read(readBuffer, 1);
       }
 
       auto amount = co_await readPromise;
+      // A completed read promise may still retain the destination view. Drop it before this loop
+      // can resize headerBuffer.
+      readPromise = nullptr;
+      readBuffer = nullptr;
 
       if (lineBreakBeforeNextHeader) {
         // Hackily deal with expected leading line break.
@@ -1990,8 +2002,16 @@ private:
             lineBreakBeforeNextHeader = true;
           }
 
-          auto result = headerBuffer.slice(bufferStart, endIndex);
-          leftover = headerBuffer.slice(leftoverStart, newEnd);
+          // Header views are valid until the caller advances to the next message, at which point
+          // this buffer may be resized. This API-level lifetime is coordinated by the body-stream
+          // lock rather than ownership, so don't tie the returned view to the buffer's counter.
+          auto result = kj::ArrayPtr<char>(
+              headerBuffer.begin() + bufferStart, endIndex - bufferStart);
+          // Preserve the position even when this is an empty view; canSuspend() uses it to verify
+          // that no bytes beyond the headers have been consumed. Like result above, its lifetime
+          // is coordinated by the body-stream lock.
+          leftover = kj::ArrayPtr<char>(
+              headerBuffer.begin() + leftoverStart, newEnd - leftoverStart);
           co_return result;
         } else {
           pos = nl - headerBuffer.begin() + 1;
@@ -2966,6 +2986,14 @@ public:
 #endif // KJ_HAS_ZLIB
   }
 
+  ~WebSocketImpl() noexcept(false) {
+    // Pending internal sends can retain views into queued payloads, and recvData usually points
+    // into recvBuffer. Release all such views before member destruction.
+    sendingControlMessage = kj::none;
+    queuedControlMessage = kj::none;
+    recvData = nullptr;
+  }
+
   kj::Promise<void> send(kj::ArrayPtr<const byte> message) override {
     return sendImpl(OPCODE_BINARY, message);
   }
@@ -3868,7 +3896,7 @@ private:
   uint64_t sentBytes = 0;
   uint64_t receivedBytes = 0;
 
-  kj::Promise<void> sendImpl(byte opcode, kj::ArrayPtr<const byte> message) {
+  kj::Promise<void> sendImpl(byte opcode, kj::ArrayPtr<const byte> inputMessage) {
     KJ_REQUIRE(!disconnected, "WebSocket can't send after disconnect()");
     KJ_REQUIRE(!currentlySending, "another message send is already in progress");
 
@@ -3895,8 +3923,11 @@ private:
 
     Mask mask(maskKeyGenerator);
 
-    bool useCompression = false;
+    // These owners must precede the local view so it is released first during coroutine unwind.
     kj::Maybe<kj::Array<byte>> compressedMessage;
+    kj::Array<byte> ownMessage;
+    kj::ArrayPtr<const byte> message = inputMessage;
+    bool useCompression = false;
     if (opcode == OPCODE_BINARY || opcode == OPCODE_TEXT) {
       // We can only compress data frames.
 #if KJ_HAS_ZLIB
@@ -3931,7 +3962,6 @@ private:
 #endif // KJ_HAS_ZLIB
     }
 
-    kj::Array<byte> ownMessage;
     if (!mask.isZero()) {
       // Sadness, we have to make a copy to apply the mask.
       ownMessage = kj::heapArray(message);
@@ -4935,8 +4965,9 @@ public:
       memcpy(destination, leftover.begin(), bytesToCopy);
       leftover = leftover.slice(bytesToCopy, leftover.size());
 
-      // If we've consumed all of the data in the leftover buffer, go ahead and free it.
+      // If we've consumed all of the data, release the view before freeing its backing storage.
       if (leftover.size() == 0) {
+        leftover = nullptr;
         leftoverBackingBuffer = nullptr;
       }
 
@@ -4972,8 +5003,9 @@ public:
       buffer.write(leftover.first(bytesToCopy));
       leftover = leftover.slice(bytesToCopy, leftover.size());
 
-      // If we've consumed all of the data in the leftover buffer, go ahead and free it.
+      // If we've consumed all of the data, release the view before freeing its backing storage.
       if (leftover.size() == 0) {
+        leftover = nullptr;
         leftoverBackingBuffer = nullptr;
       }
 
@@ -5037,8 +5069,9 @@ private:
       return output.write(leftover.first(bytesToWrite)).then(
           [this, &output, remaining, total, bytesToWrite]() mutable -> kj::Promise<uint64_t> {
         leftover = leftover.slice(bytesToWrite, leftover.size());
-        // If the leftover buffer has been fully consumed, go ahead and free it now.
+        // If the leftover buffer has been fully consumed, release the view before freeing it.
         if (leftover.size() == 0) {
+          leftover = nullptr;
           leftoverBackingBuffer = nullptr;
         }
         remaining -= bytesToWrite;
@@ -5795,8 +5828,9 @@ public:
         "can't start new request until previous request body has been fully written");
     closeWatcherTask = kj::none;
 
-    kj::StringPtr connectionHeaders[HttpHeaders::CONNECTION_HEADERS_COUNT];
+    // lengthStr must outlive the entry in connectionHeaders that may point into it.
     kj::String lengthStr;
+    kj::StringPtr connectionHeaders[HttpHeaders::CONNECTION_HEADERS_COUNT];
 
     bool isGet = method == HttpMethod::GET || method == HttpMethod::HEAD;
     bool hasBody;
@@ -5896,6 +5930,7 @@ public:
         "can't use openWebSocket() because no EntropySource was provided when creating the "
         "HttpClient").generate(keyBytes);
     auto keyBase64 = kj::encodeBase64(keyBytes);
+    kj::Maybe<kj::String> offeredExtensions;
 
     kj::StringPtr connectionHeaders[HttpHeaders::WEBSOCKET_CONNECTION_HEADERS_COUNT];
     connectionHeaders[HttpHeaders::BuiltinIndices::CONNECTION] = "Upgrade";
@@ -5903,7 +5938,6 @@ public:
     connectionHeaders[HttpHeaders::BuiltinIndices::SEC_WEBSOCKET_VERSION] = "13";
     connectionHeaders[HttpHeaders::BuiltinIndices::SEC_WEBSOCKET_KEY] = keyBase64;
 
-    kj::Maybe<kj::String> offeredExtensions;
     kj::Maybe<CompressionParameters> clientOffer;
     kj::Vector<CompressionParameters> extensions;
     auto compressionMode = settings.webSocketCompressionMode;
@@ -6842,12 +6876,26 @@ private:
   HttpClientSettings settings;
 
   struct Host {
-    kj::String name;  // including port, if non-default
     kj::Own<PromiseNetworkAddressHttpClient> client;
   };
 
-  std::map<kj::StringPtr, Host> httpHosts;
-  std::map<kj::StringPtr, Host> httpsHosts;
+  struct StringLess {
+    using is_transparent = void;
+
+    bool operator()(const kj::String& left, const kj::String& right) const {
+      return left.asPtr() < right.asPtr();
+    }
+    bool operator()(const kj::String& left, kj::StringPtr right) const {
+      return left.asPtr() < right;
+    }
+    bool operator()(kj::StringPtr left, const kj::String& right) const {
+      return left < right.asPtr();
+    }
+  };
+
+  using HostMap = std::map<kj::String, Host, StringLess>;
+  HostMap httpHosts;
+  HostMap httpsHosts;
 
   struct RequestInfo {
     HttpMethod method;
@@ -6889,13 +6937,10 @@ private:
             timer, responseHeaderTable, kj::mv(addr), settings);
       });
 
-      Host host {
-        kj::mv(parsed.host),
-        kj::heap<PromiseNetworkAddressHttpClient>(kj::mv(promise))
-      };
-      kj::StringPtr nameRef = host.name;
+      auto hostName = kj::mv(parsed.host);
+      Host host { kj::heap<PromiseNetworkAddressHttpClient>(kj::mv(promise)) };
 
-      auto insertResult = hosts.insert(std::make_pair(nameRef, kj::mv(host)));
+      auto insertResult = hosts.insert(std::make_pair(kj::mv(hostName), kj::mv(host)));
       KJ_ASSERT(insertResult.second);
       iter = insertResult.first;
 
@@ -6905,8 +6950,7 @@ private:
     return *iter->second.client;
   }
 
-  kj::Promise<void> handleCleanup(std::map<kj::StringPtr, Host>& hosts,
-                                  std::map<kj::StringPtr, Host>::iterator iter) {
+  kj::Promise<void> handleCleanup(HostMap& hosts, HostMap::iterator iter) {
     return iter->second.client->onDrained()
         .then([this,&hosts,iter]() -> kj::Promise<void> {
       // Double-check that it's really drained to avoid race conditions.
@@ -8378,8 +8422,9 @@ private:
     auto method = KJ_REQUIRE_NONNULL(currentMethod, "already called send()");
     currentMethod = kj::none;
 
-    kj::StringPtr connectionHeaders[HttpHeaders::CONNECTION_HEADERS_COUNT];
+    // lengthStr must outlive the entry in connectionHeaders that may point into it.
     kj::String lengthStr;
+    kj::StringPtr connectionHeaders[HttpHeaders::CONNECTION_HEADERS_COUNT];
 
     if (!closeAfterSend) {
       // Check if application wants us to close connections.

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -485,6 +485,9 @@ public:
 private:
   const HttpHeaderTable* table;
 
+  // Backing storage must be destroyed after all header views.
+  kj::Vector<kj::Array<char>> ownedStrings;
+
   kj::Array<kj::StringPtr> indexedHeaders;
   // Size is always table->idCount().
 
@@ -493,8 +496,6 @@ private:
     kj::StringPtr value;
   };
   kj::Vector<Header> unindexedHeaders;
-
-  kj::Vector<kj::Array<char>> ownedStrings;
 
   void addNoCheck(kj::StringPtr name, kj::StringPtr value);
 
@@ -837,6 +838,19 @@ public:
     const HttpHeaders* headers;
     kj::Own<kj::AsyncInputStream> body;
     // `statusText` and `headers` remain valid until `body` is dropped or read from.
+
+    Response() = default;
+    Response(uint statusCode, kj::StringPtr statusText, const HttpHeaders* headers,
+             kj::Own<kj::AsyncInputStream> body)
+        : statusCode(statusCode), statusText(statusText), headers(headers), body(kj::mv(body)) {}
+    Response(Response&&) = default;
+    Response& operator=(Response&&) = default;
+
+    ~Response() noexcept(false) {
+      // Adapted clients may attach the backing storage for these views to body.
+      statusText = nullptr;
+      headers = nullptr;
+    }
   };
 
   struct Request {

--- a/c++/src/kj/debug.h
+++ b/c++/src/kj/debug.h
@@ -776,12 +776,50 @@ inline auto tryToCharSequence(T* value) { return kj::toCharSequence(*value); }
 inline StringPtr tryToCharSequence(...) { return "(can't stringify)"_kj; }
 // SFINAE to stringify a value if and only if it can be stringified.
 
+struct DebugNull {};
+inline StringPtr KJ_STRINGIFY(DebugNull) { return "nullptr"_kj; }
+
+template <typename T>
+struct DebugOperandType { using Type = Decay<T>; };
+template <typename T>
+struct DebugOperandType<T&> { using Type = T&; };
+template <>
+struct DebugOperandType<decltype(nullptr)> { using Type = DebugNull; };
+
+template <typename T>
+Maybe<typename DebugOperandType<T>::Type> captureDebugOperand(T&& value) {
+  using Captured = typename DebugOperandType<T>::Type;
+  Maybe<Captured> result;
+  if constexpr (isSameType<T, decltype(nullptr)>()) {
+    result.emplace();
+  } else if constexpr (isReference<T>()) {
+    result = &value;
+  } else {
+    result.emplace(kj::fwd<T>(value));
+  }
+  return result;
+}
+
 template <typename Left, typename Right>
 struct DebugComparison {
-  Left left;
-  Right right;
+  Maybe<typename DebugOperandType<Left>::Type> left;
+  Maybe<typename DebugOperandType<Right>::Type> right;
   StringPtr op;
   bool result;
+
+  DebugComparison(Left&& left, Right&& right, StringPtr op, bool result)
+      : left(captureDebugOperand<Left>(kj::fwd<Left>(left))),
+        right(captureDebugOperand<Right>(kj::fwd<Right>(right))),
+        op(op), result(result) {
+    if (KJ_LIKELY(result)) {
+      // Successful assertions do not need to retain their operands for stringification. Release
+      // them before returning from the comparison operator: an operand may be an ArrayPtr into
+      // another temporary in the same expression, which is destroyed before the if-condition
+      // variable is tested.
+      this->left = kj::none;
+      this->right = kj::none;
+    }
+  }
 
   inline operator bool() const { return KJ_LIKELY(result); }
 
@@ -792,7 +830,12 @@ struct DebugComparison {
 
 template <typename Left, typename Right>
 String KJ_STRINGIFY(DebugComparison<Left, Right>& cmp) {
-  return _::concat(tryToCharSequence(&cmp.left), cmp.op, tryToCharSequence(&cmp.right));
+  KJ_IF_SOME(left, cmp.left) {
+    KJ_IF_SOME(right, cmp.right) {
+      return _::concat(tryToCharSequence(&left), cmp.op, tryToCharSequence(&right));
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 template <typename T>

--- a/c++/src/kj/filesystem.c++
+++ b/c++/src/kj/filesystem.c++
@@ -349,9 +349,10 @@ Path Path::evalImpl(Vector<String>&& parts, StringPtr path) {
   return Path(parts.releaseAsArray(), Path::ALREADY_CHECKED);
 }
 
-Path Path::evalWin32Impl(Vector<String>&& parts, StringPtr path, bool fromApi) {
-  // Convert all forward slashes to backslashes.
+Path Path::evalWin32Impl(Vector<String>&& parts, StringPtr inputPath, bool fromApi) {
+  // Declare the owner before the view so the view is released first, including during unwinding.
   String ownPath;
+  StringPtr path = inputPath;
   if (!fromApi && path.findFirst('/') != kj::none) {
     ownPath = heapString(path);
     for (char& c: ownPath) {
@@ -1450,10 +1451,7 @@ private:
   };
 
   struct EntryImpl {
-    String name;
     OneOf<FileNode, DirectoryNode, SymlinkNode> node;
-
-    EntryImpl(String&& name): name(kj::mv(name)) {}
 
     Own<const File> init(FileNode&& value) {
       return node.init<FileNode>(kj::mv(value)).file->clone();
@@ -1527,7 +1525,21 @@ private:
     const Clock& clock;
     const InMemoryFileFactory& fileFactory;
 
-    std::map<StringPtr, EntryImpl> entries;
+    struct StringLess {
+      using is_transparent = void;
+
+      bool operator()(const String& left, const String& right) const {
+        return left.asPtr() < right.asPtr();
+      }
+      bool operator()(const String& left, StringPtr right) const {
+        return left.asPtr() < right;
+      }
+      bool operator()(StringPtr left, const String& right) const {
+        return left < right.asPtr();
+      }
+    };
+
+    std::map<String, EntryImpl, StringLess> entries;
     // Note: If this changes to a non-sorted map, listNames() and listEntries() must be updated to
     //   sort their results.
 
@@ -1590,10 +1602,10 @@ private:
 
         KJ_ASSERT(newNode != nullptr);
 
-        EntryImpl entry(kj::mv(filename)[0]);
-        StringPtr nameRef = entry.name;
+        String name = kj::mv(filename)[0];
+        EntryImpl entry;
         entry.init(kj::mv(newNode));
-        KJ_ASSERT(entries.insert(std::make_pair(nameRef, kj::mv(entry))).second);
+        KJ_ASSERT(entries.insert(std::make_pair(kj::mv(name), kj::mv(entry))).second);
       }
     }
 
@@ -1621,9 +1633,8 @@ private:
 
     Maybe<EntryImpl&> openEntry(String&& name, WriteMode mode) {
       if (has(mode, WriteMode::CREATE)) {
-        EntryImpl entry(kj::mv(name));
-        StringPtr nameRef = entry.name;
-        auto insertResult = entries.insert(std::make_pair(nameRef, kj::mv(entry)));
+        EntryImpl entry;
+        auto insertResult = entries.insert(std::make_pair(kj::mv(name), kj::mv(entry)));
 
         if (!insertResult.second && !has(mode, WriteMode::MODIFY)) {
           // Entry already existed and MODIFY not specified.

--- a/c++/src/kj/memory.c++
+++ b/c++/src/kj/memory.c++
@@ -29,7 +29,7 @@ const NullDisposer NullDisposer::instance = NullDisposer();
 
 namespace _ {
 
-#if KJ_ASSERT_PTR_COUNTERS
+#if KJ_ASSERT_PTR_COUNTERS || KJ_ASSERT_ARRAYPTR_COUNTERS
 
 void atomicPtrCounterAssertionFailed(char const* reason) {
   KJ_FAIL_ASSERT("ptr counter contract violated", reason);
@@ -38,7 +38,7 @@ void atomicPtrCounterAssertionFailed(char const* reason) {
   KJ_KNOWN_UNREACHABLE(abort());
 }
 
-#endif // KJ_ASSERT_PTR_COUNTERS
+#endif  // Any pointer counters.
 
 void throwWrongDisposerError() {
   KJ_FAIL_REQUIRE("When disowning an object, disposer must be equal to Own's disposer");

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -23,10 +23,11 @@
 
 #include "common.h"
 
-// KJ_DEBUG_MEMORY == 1 enables variety of checks designed to catch memory usage errors.
-// KJ_DEBUG_MEMORY undefined or KJ_DEBUG_MEMORY == 0 disables all such checks.
-#if !defined(KJ_DEBUG_MEMORY)
-#define KJ_DEBUG_MEMORY 0
+#ifndef KJ_ASSERT_PTR_COUNTERS
+#define KJ_ASSERT_PTR_COUNTERS KJ_DEBUG_MEMORY
+#endif
+#if KJ_ASSERT_PTR_COUNTERS
+#include "atomic.h"
 #endif
 
 // KJ_WARN_REFCOUNTED_ATTACH == 1 enables deprecation warnings when using kj::Own<T>::attach() on
@@ -34,18 +35,6 @@
 #if !defined(KJ_WARN_REFCOUNTED_ATTACH)
 #define KJ_WARN_REFCOUNTED_ATTACH 0
 #endif
-
-// KJ_ASSERT_PTR_COUNTERS == 1 keeps track of active Ptr<T> instances and asserts validity
-// of their ownership.
-// Matches KJ_DEBUG_MEMORY by default.
-#if !defined(KJ_ASSERT_PTR_COUNTERS)
-#define KJ_ASSERT_PTR_COUNTERS KJ_DEBUG_MEMORY
-#endif // KJ_ASSERT_PTR_COUNTERS
-
-#if KJ_ASSERT_PTR_COUNTERS
-#include <atomic>
-#endif // KJ_ASSERT_PTR_COUNTERS
-
 
 KJ_BEGIN_HEADER
 
@@ -223,8 +212,6 @@ private:
   size_t refcount = 1;
 };
 
-void atomicPtrCounterAssertionFailed(const char* const);
-
 }  // namespace _ (private)
 
 class PtrTarget {
@@ -270,35 +257,6 @@ private:
     return const_cast<PtrTarget*>(static_cast<const PtrTarget*>(&self));
   }
 
-#if KJ_ASSERT_PTR_COUNTERS
-  class AtomicPtrCounter {
-    // AtomicPtrCounter uses atomic operations to keep track of active pointers.
-    // Since no other memory location is observed, memory_order_relaxed is used.
-
-  public:
-    inline void dec() {
-      size_t prevCount = count.fetch_sub(1, std::memory_order_relaxed);
-      if (KJ_UNLIKELY(prevCount == 0)) {
-        _::atomicPtrCounterAssertionFailed("unbalanced inc/dec");
-      }
-    }
-
-    inline void inc() {
-      count.fetch_add(1, std::memory_order_relaxed);
-    }
-
-    inline void assertEmpty() {
-      size_t c = count.load(std::memory_order_relaxed);
-      if (KJ_UNLIKELY(c != 0)) {
-        _::atomicPtrCounterAssertionFailed("active pointers exist");
-      }
-    }
-
-  private:
-    std::atomic<size_t> count = 0;
-  };
-#endif // KJ_ASSERT_PTR_COUNTERS
-
   inline _::WeakCell* getWeakCell(const void* ptr) {
     if (weakCell == nullptr) {
       weakCell = new _::WeakCell(ptr, this);
@@ -337,7 +295,7 @@ private:
 
   _::WeakCell* weakCell = nullptr;
 #if KJ_ASSERT_PTR_COUNTERS
-  AtomicPtrCounter ptrCounter;
+  _::AtomicPtrCounter ptrCounter;
 #endif // KJ_ASSERT_PTR_COUNTERS
 
   template <typename>

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -20,6 +20,9 @@
 // THE SOFTWARE.
 
 #include "string.h"
+#include "test.h"
+#include "function.h"
+#include <signal.h>
 #include <kj/compat/gtest.h>
 #include <string>
 #include <string_view>
@@ -34,6 +37,16 @@ namespace {
 static_assert(Cloneable<String>);
 static_assert(Cloneable<ConstString>);
 static_assert(Cloneable<StringPtr>);
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+KJ_TEST("String rejects destruction with an active StringPtr") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    auto string = heapString("tracked");
+    auto ptr = new StringPtr(string);
+    (void)ptr;
+  });
+}
+#endif
 
 TEST(String, Str) {
   EXPECT_EQ("foobar", str("foo", "bar"));

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "common.h"
+
 #include <initializer_list>
 #include "array.h"
 #include <string.h>
@@ -322,6 +324,8 @@ public:
 
 private:
   Array<char> content;
+
+  friend class StringPtr;
 };
 
 // =======================================================================================
@@ -433,6 +437,8 @@ public:
 
 private:
   Array<const char> content;
+
+  friend class StringPtr;
 };
 
 String heapString(size_t size);
@@ -704,15 +710,35 @@ inline _::Delimited<ArrayPtr<const T>> operator*(const _::Stringifier&, const Ar
 // =======================================================================================
 // Inline implementation details.
 
-inline constexpr StringPtr::StringPtr(const String& value): content(value.cStr(), value.size() + 1) {}
-inline constexpr StringPtr::StringPtr(const ConstString& value): content(value.cStr(), value.size() + 1) {}
+inline constexpr StringPtr::StringPtr(const String& value)
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    : content(value.content.counter == nullptr
+          ? ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_)
+          : ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_,
+                                 *value.content.counter)) {}
+#else
+    : content(value.cStr(), value.size() + 1) {}
+#endif
+inline constexpr StringPtr::StringPtr(const ConstString& value)
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    : content(value.content.counter == nullptr
+          ? ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_)
+          : ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_,
+                                 *value.content.counter)) {}
+#else
+    : content(value.cStr(), value.size() + 1) {}
+#endif
 
 inline constexpr StringPtr::operator ArrayPtr<const char>() const {
-  return ArrayPtr<const char>(content.begin(), content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline constexpr ArrayPtr<const char> StringPtr::asArray() const {
-  return ArrayPtr<const char>(content.begin(), content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline constexpr bool StringPtr::operator==(const StringPtr& other) const {
@@ -735,24 +761,41 @@ inline LiteralStringConst::operator ConstString() const {
   return ConstString(begin(), size(), NullArrayDisposer::instance);
 }
 
-inline constexpr String::operator ArrayPtr<char>() {
-  return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
-}
-inline constexpr String::operator ArrayPtr<const char>() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
-}
-inline constexpr ConstString::operator ArrayPtr<const char>() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
-}
+inline constexpr String::operator ArrayPtr<char>() { return asArray(); }
+inline constexpr String::operator ArrayPtr<const char>() const { return asArray(); }
+inline constexpr ConstString::operator ArrayPtr<const char>() const { return asArray(); }
 
 inline constexpr ArrayPtr<char> String::asArray() {
-  return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  return content.counter == nullptr
+      ? ArrayPtr<char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1)
+      : ArrayPtr<char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1, *content.counter);
+#else
+  return content == nullptr ? ArrayPtr<char>(nullptr)
+                            : ArrayPtr<char>(content.begin(), content.size() - 1);
+#endif
 }
 inline constexpr ArrayPtr<const char> String::asArray() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  return content.counter == nullptr
+      ? ArrayPtr<const char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1)
+      : ArrayPtr<const char>(
+          content.ptr, content.size_ == 0 ? 0 : content.size_ - 1, *content.counter);
+#else
+  return content == nullptr ? ArrayPtr<const char>(nullptr)
+                            : ArrayPtr<const char>(content.begin(), content.size() - 1);
+#endif
 }
 inline constexpr ArrayPtr<const char> ConstString::asArray() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  return content.counter == nullptr
+      ? ArrayPtr<const char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1)
+      : ArrayPtr<const char>(
+          content.ptr, content.size_ == 0 ? 0 : content.size_ - 1, *content.counter);
+#else
+  return content == nullptr ? ArrayPtr<const char>(nullptr)
+                            : ArrayPtr<const char>(content.begin(), content.size() - 1);
+#endif
 }
 
 inline constexpr const char* String::cStr() const { return content == nullptr ? "" : content.begin(); }

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -619,6 +619,16 @@ CappedArray<char, sizeof(unsigned int) * 2 + 1> hex(unsigned int i);
 CappedArray<char, sizeof(unsigned long) * 2 + 1> hex(unsigned long i);
 CappedArray<char, sizeof(unsigned long long) * 2 + 1> hex(unsigned long long i);
 
+namespace _ {  // private
+
+template <typename T>
+inline void releaseStringifyArgument(T&&) {}
+template <typename T>
+inline void releaseStringifyArgument(ArrayPtr<T>&& value) { value = nullptr; }
+inline void releaseStringifyArgument(StringPtr&& value) { value = nullptr; }
+
+}  // namespace _ (private)
+
 template <typename... Params>
 String str(Params&&... params) {
   // Magic function which builds a string from a bunch of arbitrary values.  Example:
@@ -627,7 +637,11 @@ String str(Params&&... params) {
   //     "1 / 2 = 0.5"
   // To teach `str` how to stringify a type, see `Stringifier`.
 
-  return _::concat(toCharSequence(kj::fwd<Params>(params))...);
+  auto result = _::concat(toCharSequence(kj::fwd<Params>(params))...);
+  // Rvalue views have been consumed. Release their debug pointer counters before returning so an
+  // owner can safely be replaced by this result in the caller's full-expression.
+  (_::releaseStringifyArgument(kj::fwd<Params>(params)), ...);
+  return result;
 }
 
 inline String str(String&& s) { return mv(s); }

--- a/c++/src/kj/table-test.c++
+++ b/c++/src/kj/table-test.c++
@@ -184,6 +184,9 @@ KJ_TEST("simple table") {
     KJ_EXPECT(*iter++ == "waldo");
     KJ_EXPECT(iter == table.end());
   }
+
+  // Release StringPtrs before their backing Strings below are destroyed.
+  table.clear();
 }
 
 class BadHasher {
@@ -844,6 +847,9 @@ KJ_TEST("simple tree table") {
     KJ_EXPECT(iter == table.end());
   }
   KJ_EXPECT(other.begin() == other.end());
+
+  // Release StringPtrs before their backing Strings below are destroyed.
+  table.clear();
 }
 
 class UintCompare {

--- a/c++/src/kj/table.c++
+++ b/c++/src/kj/table.c++
@@ -105,6 +105,8 @@ kj::Array<HashBucket> rehash(kj::ArrayPtr<const HashBucket> oldBuckets, size_t t
     }
   }
 
+  // oldBuckets may be a temporary view created from the Array that the caller is about to replace.
+  oldBuckets = nullptr;
   return newBuckets;
 }
 


### PR DESCRIPTION
in KJ_DEBUG_MEMORY mode (we have it enabled in debug)

Also works for Strings, since they are based on arrays.