### PR TITLE
kj/async: Define KJ_CO_MAGIC kj::CURRENT_INVOCATION and helpers

### DIFF
--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -101,7 +101,7 @@ template <typename Allocator>
 kj::Promise<size_t> immediateUnwindAwareCoroutine(
     Allocator&, bool& completed, CoUnwindAware = {}) {
   auto invocation = KJ_CO_MAGIC CURRENT_INVOCATION;
-  KJ_DEFER(if (!invocation.isUnwinding()) completed = true);
+  KJ_DEFER(if (invocation.scopeOutcome() == CoScopeOutcome::SUCCESS) completed = true);
   co_return 42;
 }
 

--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -71,6 +71,11 @@ static_assert(isSameType<_::CoroutineAllocator::AllocatorType<
 static_assert(isSameType<_::CoroutineAllocator::AllocatorType<
                              DefaultCoroutineAllocator &, DebugCoroutineAllocator &>,
                          DefaultCoroutineAllocator>());
+static_assert(isSameType<_::CoroutineAllocator::AllocatorType<
+                              CoUnwindAware, DebugCoroutineAllocator &>,
+                          DebugCoroutineAllocator>());
+static_assert(!_::isUnwindAwareCoroutine<DebugCoroutineAllocator &>);
+static_assert(_::isUnwindAwareCoroutine<CoUnwindAware, DebugCoroutineAllocator &>);
 
 KJ_TEST("CoroutineAllocator::getAllocator") {
   DefaultCoroutineAllocator def;
@@ -89,6 +94,14 @@ KJ_TEST("CoroutineAllocator::getAllocator") {
 
 template <typename Allocator>
 kj::Promise<size_t> immediateCoroutine(Allocator &) {
+  co_return 42;
+}
+
+template <typename Allocator>
+kj::Promise<size_t> immediateUnwindAwareCoroutine(
+    Allocator&, bool& completed, CoUnwindAware = {}) {
+  auto invocation = KJ_CO_MAGIC CURRENT_INVOCATION;
+  KJ_DEFER(if (!invocation.isUnwinding()) completed = true);
   co_return 42;
 }
 
@@ -114,6 +127,19 @@ KJ_TEST("DebugAllocator") {
   KJ_EXPECT(allocator.totalFreeCount == 1);
   KJ_EXPECT(allocator.totalFreeSize == allocator.totalFreeSize);
 
+}
+
+KJ_TEST("CoUnwindAware composes with a custom coroutine allocator") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  DebugCoroutineAllocator allocator;
+  bool completed = false;
+  auto promise = immediateUnwindAwareCoroutine(allocator, completed);
+  KJ_EXPECT(promise.wait(waitScope) == 42);
+  KJ_EXPECT(completed);
+  KJ_EXPECT(allocator.totalAllocCount == 1);
+  KJ_EXPECT(allocator.totalFreeCount == 1);
 }
 
 template <typename Allocator>

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -890,6 +890,144 @@ KJ_TEST("KJ_TRY/KJ_CATCH inside try/catch with promise rejection in coroutines")
   auto result = testCoro().wait(waitScope);
   KJ_EXPECT(result == "kj:caught std:not-caught");
 }
+
+// =======================================================================================
+// KJ_CO_MAGIC CURRENT_INVOCATION
+
+KJ_TEST("KJ_CO_MAGIC CURRENT_INVOCATION returns CoInvocation without suspending") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  bool reachedEnd = false;
+  auto coro = [&]() -> Promise<void> {
+    auto invocation = KJ_CO_MAGIC CURRENT_INVOCATION;
+    static_assert(isSameType<decltype(invocation), CoInvocation>());
+    reachedEnd = true;
+    co_return;
+  };
+
+  auto promise = coro();
+
+  // Coroutines start eagerly, so had obtaining the reference suspended, the body would not have run
+  // to the end yet.
+  KJ_EXPECT(reachedEnd);
+
+  promise.wait(waitScope);
+}
+
+// =======================================================================================
+// CoInvocation::isCanceling()
+
+template <typename T, typename Coroutine>
+class StateRecorder {
+  // Reports what `query` said about the enclosing coroutine at the moment this object was
+  // destroyed. Meant to live in a coroutine frame, so that its destructor runs on every path out of
+  // the coroutine.
+  //
+  // The coroutine to watch is supplied after construction rather than to the constructor, so that
+  // this can be used as a coroutine parameter: the body cannot obtain the reference until it starts
+  // running, which is after its parameters have been copied into the frame. It also means the
+  // copy left behind at the call site reports nothing when it is destroyed.
+
+public:
+  using Query = T(const Coroutine&);
+
+  StateRecorder(Maybe<T>& result, Query& query)
+      : result(result), query(query) {}
+  ~StateRecorder() {
+    KJ_IF_SOME(c, coroutine) {
+      result = query(c);
+    }
+  }
+
+  void watch(Coroutine c) {
+    coroutine = kj::mv(c);
+  }
+
+private:
+  Maybe<Coroutine> coroutine;
+  Maybe<T>& result;
+  Query& query;
+};
+
+bool canceling(const CoInvocation& invocation) { return invocation.isCanceling(); }
+
+KJ_TEST("isCanceling() is false when a coroutine runs to completion") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<bool> canceled;
+  auto coro = [&]() -> Promise<void> {
+    StateRecorder recorder(canceled, canceling);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::yield();
+  };
+
+  coro().wait(waitScope);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(canceled) == false);
+}
+
+KJ_TEST("isCanceling() is false while an exception propagates out of a coroutine") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<bool> canceled;
+  auto coro = [&]() -> Promise<void> {
+    StateRecorder recorder(canceled, canceling);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::yield();
+    KJ_FAIL_ASSERT("coroutine failed");
+  };
+
+  auto exception = kj::runCatchingExceptions([&]() { coro().wait(waitScope); });
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(canceled) == false);
+}
+
+KJ_TEST("isCanceling() is true while destroying a suspended coroutine") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<bool> canceled;
+  auto coro = [&]() -> Promise<void> {
+    StateRecorder recorder(canceled, canceling);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::Promise<void>(kj::NEVER_DONE);
+  };
+
+  {
+    auto promise = coro();
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(canceled == kj::none);
+  }
+
+  KJ_EXPECT(KJ_ASSERT_NONNULL(canceled) == true);
+}
+
+Promise<void> watchFromParameter(
+    StateRecorder<bool, CoInvocation> recorder, Promise<void> awaitMe) {
+  recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+  co_await awaitMe;
+}
+
+KJ_TEST("isCanceling() is false while destroying a completed coroutine") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  // A coroutine's parameters outlive its body: they are destroyed with the frame, which for a
+  // coroutine that completed happens when its promise is dropped. So this asks isCanceling()
+  // during destruction of a coroutine that was never canceled -- the case that distinguishes being
+  // destroyed from being canceled.
+  Maybe<bool> canceled;
+  {
+    auto promise = watchFromParameter(StateRecorder(canceled, canceling), kj::READY_NOW);
+    KJ_EXPECT(promise.poll(waitScope));
+    KJ_EXPECT(canceled == kj::none);
+  }
+
+  KJ_EXPECT(KJ_ASSERT_NONNULL(canceled) == false);
+}
+
 #endif  // !(__GNUC__ && !__clang__)
 
 }  // namespace

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -44,10 +44,16 @@ static_assert(sizeof(void*) != 8 || alignof(_::CoroutineBase) == 8,
     "CoroutineBase must retain its 64-bit ABI alignment");
 
 template <typename T>
+concept HasScopeOutcome = requires(const T& c) { c.scopeOutcome(); };
+
+template <typename T>
 concept HasIsUnwinding = requires(const T& c) { c.isUnwinding(); };
 
+static_assert(!HasScopeOutcome<CoInvocation>,
+    "scopeOutcome() must be unavailable without kj::CoUnwindAware");
 static_assert(!HasIsUnwinding<CoInvocation>,
     "isUnwinding() must be unavailable without kj::CoUnwindAware");
+static_assert(HasScopeOutcome<CoUnwindAwareInvocation>);
 static_assert(HasIsUnwinding<CoUnwindAwareInvocation>);
 
 template <typename T>
@@ -935,6 +941,7 @@ KJ_TEST("KJ_CO_MAGIC CURRENT_INVOCATION returns CoUnwindAwareInvocation when opt
     static_assert(isSameType<decltype(invocation), CoUnwindAwareInvocation>());
     KJ_EXPECT(!invocation.isCanceling());
     KJ_EXPECT(!invocation.isUnwinding());
+    KJ_EXPECT(invocation.scopeOutcome() == CoScopeOutcome::SUCCESS);
   };
 
   coro().wait(waitScope);
@@ -1189,6 +1196,182 @@ KJ_TEST("isUnwinding() is false when a coroutine runs entirely during an unwind"
   KJ_EXPECT(KJ_ASSERT_NONNULL(result) == false);
 }
 
+// =======================================================================================
+// CoUnwindAwareInvocation::scopeOutcome()
+
+CoScopeOutcome scopeOutcome(const CoUnwindAwareInvocation& invocation) {
+  return invocation.scopeOutcome();
+}
+
+StringPtr describe(CoScopeOutcome outcome) {
+  switch (outcome) {
+    case CoScopeOutcome::SUCCESS: return "SUCCESS"_kj;
+    case CoScopeOutcome::FAILURE: return "FAILURE"_kj;
+    case CoScopeOutcome::CANCELED: return "CANCELED"_kj;
+  }
+  KJ_UNREACHABLE;
+}
+
+KJ_TEST("scopeOutcome() is SUCCESS when a coroutine runs to completion") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<CoScopeOutcome> outcome;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(outcome, scopeOutcome);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::yield();
+  };
+
+  coro().wait(waitScope);
+  KJ_EXPECT(describe(KJ_ASSERT_NONNULL(outcome)) == "SUCCESS");
+}
+
+KJ_TEST("scopeOutcome() is FAILURE while an exception propagates out of a coroutine") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<CoScopeOutcome> outcome;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(outcome, scopeOutcome);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::yield();
+    KJ_FAIL_ASSERT("coroutine failed");
+  };
+
+  auto exception = kj::runCatchingExceptions([&]() { coro().wait(waitScope); });
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(describe(KJ_ASSERT_NONNULL(outcome)) == "FAILURE");
+}
+
+KJ_TEST("scopeOutcome() is CANCELED while destroying a suspended coroutine") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<CoScopeOutcome> outcome;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(outcome, scopeOutcome);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::Promise<void>(kj::NEVER_DONE);
+  };
+
+  {
+    auto promise = coro();
+    KJ_EXPECT(!promise.poll(waitScope));
+    KJ_EXPECT(outcome == kj::none);
+  }
+
+  KJ_EXPECT(describe(KJ_ASSERT_NONNULL(outcome)) == "CANCELED");
+}
+
+KJ_TEST("scopeOutcome() is CANCELED when a coroutine is canceled during an unrelated unwind") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<CoScopeOutcome> outcome;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(outcome, scopeOutcome);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::Promise<void>(kj::NEVER_DONE);
+  };
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    auto promise = coro();
+    KJ_EXPECT(!promise.poll(waitScope));
+
+    // Throwing here destroys `promise` mid-unwind, so the coroutine is canceled while the thread's
+    // uncaught exception count is elevated. Cancellation is the more specific answer of the two.
+    KJ_FAIL_ASSERT("unrelated failure");
+  });
+
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(describe(KJ_ASSERT_NONNULL(outcome)) == "CANCELED");
+}
+
+KJ_TEST("scopeOutcome() is SUCCESS when a coroutine is resumed during an unrelated unwind") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<CoScopeOutcome> outcome;
+  auto paf = newPromiseAndFulfiller<void>();
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(outcome, scopeOutcome);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::mv(paf.promise);
+  };
+
+  auto promise = coro();
+  KJ_EXPECT(!promise.poll(waitScope));
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    ResumeWhileUnwinding resumer{*paf.fulfiller, promise, waitScope};
+    KJ_FAIL_ASSERT("unrelated failure");
+  });
+
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(describe(KJ_ASSERT_NONNULL(outcome)) == "SUCCESS");
+}
+
+// =======================================================================================
+// Using CURRENT_INVOCATION with KJ_DEFER
+
+KJ_TEST("KJ_DEFER can inspect the coroutine scope outcome") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  StringPtr log;
+  auto coro = [&](Promise<void> tail, CoUnwindAware = {}) -> Promise<void> {
+    auto invocation = KJ_CO_MAGIC CURRENT_INVOCATION;
+    KJ_DEFER(log = describe(invocation.scopeOutcome()));
+    co_await tail;
+  };
+
+  coro(kj::READY_NOW).wait(waitScope);
+  KJ_EXPECT(log == "SUCCESS", log);
+
+  KJ_EXPECT_THROW_MESSAGE("boom",
+      coro(kj::Promise<void>(KJ_EXCEPTION(FAILED, "boom"))).wait(waitScope));
+  KJ_EXPECT(log == "FAILURE", log);
+
+  { auto promise = coro(kj::NEVER_DONE); KJ_EXPECT(!promise.poll(waitScope)); }
+  KJ_EXPECT(log == "CANCELED", log);
+}
+
+KJ_TEST("KJ_DEFER sees success when control leaves a coroutine scope via break") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  StringPtr log;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    for (;;) {
+      auto invocation = KJ_CO_MAGIC CURRENT_INVOCATION;
+      KJ_DEFER(log = describe(invocation.scopeOutcome()));
+      co_await kj::yield();
+      break;
+    }
+  };
+
+  coro().wait(waitScope);
+  KJ_EXPECT(log == "SUCCESS", log);
+}
+
+KJ_TEST("KJ_DEFER sees failure before an outer coroutine scope catches the exception") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  StringPtr log;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    co_await kj::yield();
+    try {
+      auto invocation = KJ_CO_MAGIC CURRENT_INVOCATION;
+      KJ_DEFER(log = describe(invocation.scopeOutcome()));
+      KJ_FAIL_ASSERT("inner failure");
+    } catch (kj::Exception&) {}
+  };
+
+  coro().wait(waitScope);
+  KJ_EXPECT(log == "FAILURE", log);
+}
 #endif  // !(__GNUC__ && !__clang__)
 
 }  // namespace

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -29,6 +29,16 @@
 namespace kj {
 namespace {
 
+#if _WIN32
+static_assert(sizeof(void*) != 8 || sizeof(_::CoroutineBase) == 112,
+    "CoroutineBase must retain its 64-bit Windows ABI layout");
+#else
+static_assert(sizeof(void*) != 8 || sizeof(_::CoroutineBase) == 104,
+    "CoroutineBase must retain its 64-bit ABI layout");
+#endif
+static_assert(sizeof(void*) != 8 || alignof(_::CoroutineBase) == 8,
+    "CoroutineBase must retain its 64-bit ABI alignment");
+
 template <typename T>
 Promise<kj::Decay<T>> identity(T&& value) {
   co_return kj::fwd<T>(value);

--- a/c++/src/kj/async-coroutine-test.c++
+++ b/c++/src/kj/async-coroutine-test.c++
@@ -32,12 +32,23 @@ namespace {
 #if _WIN32
 static_assert(sizeof(void*) != 8 || sizeof(_::CoroutineBase) == 112,
     "CoroutineBase must retain its 64-bit Windows ABI layout");
+static_assert(sizeof(void*) != 8 || sizeof(_::UnwindAwareCoroutineBase) == 120,
+    "UnwindAwareCoroutineBase must retain its 64-bit Windows ABI layout");
 #else
 static_assert(sizeof(void*) != 8 || sizeof(_::CoroutineBase) == 104,
     "CoroutineBase must retain its 64-bit ABI layout");
+static_assert(sizeof(void*) != 8 || sizeof(_::UnwindAwareCoroutineBase) == 112,
+    "UnwindAwareCoroutineBase must retain its 64-bit ABI layout");
 #endif
 static_assert(sizeof(void*) != 8 || alignof(_::CoroutineBase) == 8,
     "CoroutineBase must retain its 64-bit ABI alignment");
+
+template <typename T>
+concept HasIsUnwinding = requires(const T& c) { c.isUnwinding(); };
+
+static_assert(!HasIsUnwinding<CoInvocation>,
+    "isUnwinding() must be unavailable without kj::CoUnwindAware");
+static_assert(HasIsUnwinding<CoUnwindAwareInvocation>);
 
 template <typename T>
 Promise<kj::Decay<T>> identity(T&& value) {
@@ -915,6 +926,20 @@ KJ_TEST("KJ_CO_MAGIC CURRENT_INVOCATION returns CoInvocation without suspending"
   promise.wait(waitScope);
 }
 
+KJ_TEST("KJ_CO_MAGIC CURRENT_INVOCATION returns CoUnwindAwareInvocation when opted in") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    auto invocation = KJ_CO_MAGIC CURRENT_INVOCATION;
+    static_assert(isSameType<decltype(invocation), CoUnwindAwareInvocation>());
+    KJ_EXPECT(!invocation.isCanceling());
+    KJ_EXPECT(!invocation.isUnwinding());
+  };
+
+  coro().wait(waitScope);
+}
+
 // =======================================================================================
 // CoInvocation::isCanceling()
 
@@ -1026,6 +1051,142 @@ KJ_TEST("isCanceling() is false while destroying a completed coroutine") {
   }
 
   KJ_EXPECT(KJ_ASSERT_NONNULL(canceled) == false);
+}
+
+// =======================================================================================
+// CoUnwindAwareInvocation::isUnwinding()
+
+bool unwinding(const CoUnwindAwareInvocation& invocation) {
+  return invocation.isUnwinding();
+}
+
+struct ResumeWhileUnwinding {
+  // Fulfills `fulfiller` and runs `promise` to completion from a destructor, so that whatever
+  // coroutine `promise` is waiting on gets resumed onto a stack which is already unwinding, and
+  // stays on it until it finishes.
+
+  PromiseFulfiller<void>& fulfiller;
+  Promise<void>& promise;
+  WaitScope& waitScope;
+
+  ~ResumeWhileUnwinding() noexcept(false) {
+    fulfiller.fulfill();
+    promise.wait(waitScope);
+  }
+};
+
+KJ_TEST("isUnwinding() is false when a coroutine runs to completion") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<bool> result;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(result, unwinding);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::yield();
+  };
+
+  coro().wait(waitScope);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result) == false);
+}
+
+KJ_TEST("isUnwinding() is true while an exception propagates out of a coroutine") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<bool> result;
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(result, unwinding);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::yield();
+    KJ_FAIL_ASSERT("coroutine failed");
+  };
+
+  auto exception = kj::runCatchingExceptions([&]() { coro().wait(waitScope); });
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result) == true);
+}
+
+KJ_TEST("isUnwinding() is true when the operation a coroutine is parked on throws") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  // The exception is raised elsewhere, while this coroutine is suspended, and only reaches it when
+  // co_await rethrows on resumption. It is still this coroutine's failure: the coroutine has
+  // nowhere to go but out.
+  Maybe<bool> result;
+  auto paf = newPromiseAndFulfiller<void>();
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(result, unwinding);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::mv(paf.promise);
+  };
+
+  auto promise = coro();
+  KJ_EXPECT(!promise.poll(waitScope));
+  KJ_EXPECT(result == kj::none);
+
+  paf.fulfiller->reject(KJ_EXCEPTION(FAILED, "awaited operation failed"));
+
+  KJ_EXPECT_THROW_MESSAGE("awaited operation failed", promise.wait(waitScope));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result) == true);
+}
+
+KJ_TEST("isUnwinding() is false when a coroutine is resumed onto an unwinding stack") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  // The case that a thread-wide unwind check cannot get right. The coroutine is entered with the
+  // uncaught exception count already elevated, and runs to completion without ever raising it
+  // further, so nothing about this coroutine is failing.
+  Maybe<bool> result;
+  auto paf = newPromiseAndFulfiller<void>();
+  auto coro = [&](CoUnwindAware = {}) -> Promise<void> {
+    StateRecorder recorder(result, unwinding);
+    recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+    co_await kj::mv(paf.promise);
+  };
+
+  auto promise = coro();
+  KJ_EXPECT(!promise.poll(waitScope));
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    ResumeWhileUnwinding resumer{*paf.fulfiller, promise, waitScope};
+    KJ_FAIL_ASSERT("unrelated failure");
+  });
+
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result) == false);
+}
+
+KJ_TEST("isUnwinding() is false when a coroutine runs entirely during an unwind") {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Maybe<bool> result;
+
+  struct RunWhileUnwinding {
+    // Runs a coroutine start to finish from a destructor. The coroutine never suspends, so its one
+    // and only entry happens with the uncaught exception count already elevated.
+
+    Maybe<bool>& result;
+
+    ~RunWhileUnwinding() noexcept(false) {
+      auto promise = [this](CoUnwindAware = {}) -> Promise<void> {
+        StateRecorder recorder(result, unwinding);
+        recorder.watch(KJ_CO_MAGIC CURRENT_INVOCATION);
+        co_return;
+      }();
+    }
+  };
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    RunWhileUnwinding runner{result};
+    KJ_FAIL_ASSERT("unrelated failure");
+  });
+
+  KJ_EXPECT(exception != kj::none);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result) == false);
 }
 
 #endif  // !(__GNUC__ && !__clang__)

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2147,7 +2147,7 @@ PromiseCrossThreadFulfillerPair<T> Executor::newPromiseAndCrossThreadFulfiller()
 
 namespace kj::_ {
 
-template <typename T, typename Allocator> class Coroutine;
+template <typename T, typename Allocator, bool unwindAware> class Coroutine;
 
 template <typename T>
 concept NoWaitScope = !isSameType<Decay<T>, WaitScope>();
@@ -2224,6 +2224,10 @@ public:
 
 };
 
+template <typename... Args>
+inline constexpr bool isUnwindAwareCoroutine =
+    (isSameType<Decay<Args>, CoUnwindAware>() || ...);
+
 struct DefaultCoroutineAllocator: public CoroutineAllocator {
   // Default coroutine allocator.
   // Used when now allocator parameter is specified in coroutine declaration.
@@ -2271,7 +2275,8 @@ struct coroutine_traits<kj::Promise<T>, Args...> {
   // A second note: This has the reasonable side effect of making it impossible for us to write
   // WaitScope member coroutines.
 
-  using promise_type = kj::_::Coroutine<T, kj::_::CoroutineAllocator::AllocatorType<Args...>>;
+  using promise_type = kj::_::Coroutine<T, kj::_::CoroutineAllocator::AllocatorType<Args...>,
+      kj::_::isUnwindAwareCoroutine<Args...>>;
   // The C++ standard calls this the "promise type". This makes sense when thinking of coroutines
   // returning `std::future<T>`, since the coroutine implementation would be a wrapper around
   // a `std::promise<T>`. It's extremely confusing from a KJ perspective, however, so I call it
@@ -2340,6 +2345,8 @@ protected:
 
   void unhandledExceptionImpl(ExceptionOrValue& resultRef);
 
+  void fire() override;
+
 private:
   // -------------------------------------------------------
   // PromiseNode implementation
@@ -2350,7 +2357,6 @@ private:
   // -------------------------------------------------------
   // Event implementation
 
-  void fire() override;
   void traceEvent(TraceBuilder& builder) override;
 
   stdcoro::coroutine_handle<> coroutine;
@@ -2390,14 +2396,46 @@ private:
   // coroutine.destroy() has returned. Our disposer then rethrows as needed.
 };
 
+class UnwindAwareCoroutineBase: public CoroutineBase {
+public:
+  using CoroutineBase::CoroutineBase;
+
+  bool isUnwinding() const;
+  // See CoUnwindAwareInvocation::isUnwinding for details.
+
+protected:
+  void fire() override;
+
+private:
+  uint uncaughtCountAtEntry = UnwindDetector::uncaughtExceptionCount();
+};
+
+template <bool unwindAware>
+struct CoroutineBaseFor_ { using Type = CoroutineBase; };
+template <>
+struct CoroutineBaseFor_<true> { using Type = UnwindAwareCoroutineBase; };
+
+template <bool unwindAware>
+using CoroutineBaseFor = typename CoroutineBaseFor_<unwindAware>::Type;
+
+template <bool unwindAware>
+struct InvocationFor_ { using Type = CoInvocation; };
+template <>
+struct InvocationFor_<true> { using Type = CoUnwindAwareInvocation; };
+
+template <bool unwindAware>
+using InvocationFor = typename InvocationFor_<unwindAware>::Type;
+
+template <bool unwindAware>
 class CurrentInvocationAccessor {
 public:
-  explicit CurrentInvocationAccessor(CoroutineBase& coroutine): coroutine(coroutine) {}
+  explicit CurrentInvocationAccessor(CoroutineBaseFor<unwindAware>& coroutine)
+      : coroutine(coroutine) {}
   bool await_ready() const { return true; }
   void await_suspend(stdcoro::coroutine_handle<>) const {}
-  CoInvocation await_resume() const { return CoInvocation(coroutine); }
+  InvocationFor<unwindAware> await_resume() const { return InvocationFor<unwindAware>(coroutine); }
 private:
-  CoroutineBase& coroutine;
+  CoroutineBaseFor<unwindAware>& coroutine;
 };
 
 template <typename Self, typename T>
@@ -2409,9 +2447,9 @@ class PromiseAwaiter;
 template <typename T>
 class ForkedPromiseAwaiter;
 
-template <typename T, typename Allocator>
-class Coroutine final: public CoroutineBase,
-                       public CoroutineMixin<Coroutine<T, Allocator>, T> {
+template <typename T, typename Allocator, bool unwindAware>
+class Coroutine final: public CoroutineBaseFor<unwindAware>,
+                       public CoroutineMixin<Coroutine<T, Allocator, unwindAware>, T> {
   // The standard calls this the `promise_type` object. We can call this the "coroutine
   // implementation object" since the word promise means different things in KJ and std styles. This
   // is where we implement how a `kj::Promise<T>` is returned from a coroutine, and how that promise
@@ -2421,12 +2459,12 @@ class Coroutine final: public CoroutineBase,
   // without any overhead. See `CoroutineAllocator` for more details.
 
 public:
-  using Handle = stdcoro::coroutine_handle<Coroutine<T, Allocator>>;
+  using Handle = stdcoro::coroutine_handle<Coroutine<T, Allocator, unwindAware>>;
 
   Coroutine(SourceLocation location = {}): Coroutine(Handle::from_promise(*this), location) {}
 
   Coroutine(stdcoro::coroutine_handle<> handle, SourceLocation location = {})
-      : CoroutineBase(handle, location) {}
+      : CoroutineBaseFor<unwindAware>(handle, location) {}
 
   Promise<T> get_return_object() {
     // Called after coroutine frame construction and before initial_suspend() to create the
@@ -2451,18 +2489,18 @@ public:
     return ForkedPromiseAwaiter<U>(*this, promise);
   }
 
-  CurrentInvocationAccessor yield_value(CurrentInvocationConstant) {
-    return CurrentInvocationAccessor(*this);
+  CurrentInvocationAccessor<unwindAware> yield_value(CurrentInvocationConstant) {
+    return CurrentInvocationAccessor<unwindAware>(*this);
   }
 
   void fulfill(FixVoid<T>&& value) {
     // Called by the return_value()/return_void() functions in our mixin class.
 
     result = kj::mv(value);
-    scheduleResumption();
+    this->scheduleResumption();
   }
 
-  void unhandled_exception() { unhandledExceptionImpl(result); }
+  void unhandled_exception() { this->unhandledExceptionImpl(result); }
 
 
   template <typename... Args>
@@ -2602,6 +2640,14 @@ namespace kj {
 
 inline bool CoInvocation::isCanceling() const { return coroutine.isCanceling(); }
 
+inline CoUnwindAwareInvocation::CoUnwindAwareInvocation(_::UnwindAwareCoroutineBase& coroutine)
+    : coroutine(coroutine) {}
+
+inline bool CoUnwindAwareInvocation::isCanceling() const { return coroutine.isCanceling(); }
+
+inline bool CoUnwindAwareInvocation::isUnwinding() const {
+  return coroutine.isUnwinding();
+}
 // ---------------------------------------------------------
 // Coroutine Magic
 //

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2403,6 +2403,14 @@ public:
   bool isUnwinding() const;
   // See CoUnwindAwareInvocation::isUnwinding for details.
 
+  CoScopeOutcome scopeOutcome() const {
+    // See CoUnwindAwareInvocation::scopeOutcome for details.
+
+    if (isCanceling()) return CoScopeOutcome::CANCELED;
+    if (isUnwinding()) return CoScopeOutcome::FAILURE;
+    return CoScopeOutcome::SUCCESS;
+  }
+
 protected:
   void fire() override;
 
@@ -2648,6 +2656,10 @@ inline bool CoUnwindAwareInvocation::isCanceling() const { return coroutine.isCa
 inline bool CoUnwindAwareInvocation::isUnwinding() const {
   return coroutine.isUnwinding();
 }
+inline CoScopeOutcome CoUnwindAwareInvocation::scopeOutcome() const {
+  return coroutine.scopeOutcome();
+}
+
 // ---------------------------------------------------------
 // Coroutine Magic
 //

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -2332,6 +2332,9 @@ public:
     return hasSuspendedAtLeastOnce && isNext();
   }
 
+  bool isCanceling() const { return maybeDisposalResults != kj::none && !isDone(); }
+  // See CoInvocation::isCanceling for details.
+
 protected:
   inline void scheduleResumption() { onReadyEvent.arm(); }
 
@@ -2387,6 +2390,16 @@ private:
   // coroutine.destroy() has returned. Our disposer then rethrows as needed.
 };
 
+class CurrentInvocationAccessor {
+public:
+  explicit CurrentInvocationAccessor(CoroutineBase& coroutine): coroutine(coroutine) {}
+  bool await_ready() const { return true; }
+  void await_suspend(stdcoro::coroutine_handle<>) const {}
+  CoInvocation await_resume() const { return CoInvocation(coroutine); }
+private:
+  CoroutineBase& coroutine;
+};
+
 template <typename Self, typename T>
 class CoroutineMixin;
 // CRTP mixin, covered later.
@@ -2436,6 +2449,10 @@ public:
   template <typename U>
   ForkedPromiseAwaiter<U> await_transform(ForkedPromise<U>& promise) {
     return ForkedPromiseAwaiter<U>(*this, promise);
+  }
+
+  CurrentInvocationAccessor yield_value(CurrentInvocationConstant) {
+    return CurrentInvocationAccessor(*this);
   }
 
   void fulfill(FixVoid<T>&& value) {
@@ -2581,7 +2598,9 @@ private:
 
 }  // namespace kj::_
 
-namespace kj::_ {
+namespace kj {
+
+inline bool CoInvocation::isCanceling() const { return coroutine.isCanceling(); }
 
 // ---------------------------------------------------------
 // Coroutine Magic
@@ -2590,8 +2609,8 @@ namespace kj::_ {
 // implementations. To invoke this functionality, coroutines use the `KJ_CO_MAGIC` operator on a
 // "magic" object which the coroutine adapter implementation knows about.
 //
-// As of this writing, `kj::_::Coroutine<T>` does not itself provide any such magic functionality,
-// but soon will.
+// Use `KJ_CO_MAGIC kj::CURRENT_INVOCATION` to obtain information about the current coroutine
+// invocation without suspending.
 
 #define KJ_CO_MAGIC co_yield
 // To invoke a coroutine's magic functionality `FOO`, use `KJ_CO_MAGIC FOO`. What `FOO` is, what the
@@ -2602,6 +2621,6 @@ namespace kj::_ {
 // `co_yield`. The purpose of the macro is primarily as a visual signal that the code is not
 // actually yielding a value, but rather something different is going on.
 
-}  // namespace kj::_ (private)
+}  // namespace kj
 
 KJ_END_HEADER

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -3063,6 +3063,10 @@ CoroutineBase::~CoroutineBase() noexcept(false) {
   readMaybe(maybeDisposalResults)->destructorRan = true;
 }
 
+bool UnwindAwareCoroutineBase::isUnwinding() const {
+  return UnwindDetector::uncaughtExceptionCount() > uncaughtCountAtEntry;
+}
+
 void CoroutineBase::unhandledExceptionImpl(ExceptionOrValue& resultRef) {
   // Pretty self-explanatory, we propagate the exception to the promise which owns us, unless
   // we're being destroyed, in which case we propagate it back to our disposer. Note that all
@@ -3119,6 +3123,11 @@ void CoroutineBase::fire() {
   // try-catch block, so we have no choice but to resume and throw later.
 
   coroutine.resume();
+}
+
+void UnwindAwareCoroutineBase::fire() {
+  uncaughtCountAtEntry = UnwindDetector::uncaughtExceptionCount();
+  CoroutineBase::fire();
 }
 
 void CoroutineBase::traceEvent(TraceBuilder& builder) {

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -695,8 +695,14 @@ auto coCapture(Functor&& f) {
   return _::CaptureForCoroutine(kj::mv(f));
 }
 
+struct CoUnwindAware {};
+// Opts a coroutine in to tracking whether its current invocation is unwinding. Add a defaulted
+// parameter of this type to coroutines which use CoUnwindAwareInvocation::isUnwinding().
+
 namespace _ {
 class CoroutineBase;
+class UnwindAwareCoroutineBase;
+template <bool unwindAware>
 class CurrentInvocationAccessor;
 }  // namespace _
 
@@ -718,11 +724,39 @@ public:
   // false before destruction. Calling this method after the coroutine is destroyed is undefined
   // behavior.
 
+  bool isUnwinding() const KJ_UNAVAILABLE("requires a defaulted kj::CoUnwindAware parameter");
+
 private:
   explicit CoInvocation(_::CoroutineBase& coroutine): coroutine(coroutine) {}
 
   _::CoroutineBase& coroutine;
 
+  template <bool>
+  friend class _::CurrentInvocationAccessor;
+};
+
+class CoUnwindAwareInvocation {
+  // The unwind-aware form of CoInvocation, returned in coroutines with a defaulted CoUnwindAware
+  // parameter.
+
+public:
+
+  bool isCanceling() const;
+  // See CoInvocation::isCanceling for details.
+
+  bool isUnwinding() const;
+  // Returns whether this coroutine is currently unwinding based on the current
+  // stack invocation. A problem with using UnwindDetector directly is that a coroutine might be
+  // entered from many different stacks, with different uncaught exception counts at each point.
+  // This approach correctly measures against the uncaught count at coroutine (re)entry. Like
+  // CoInvocation::isCanceling, this is undefined behavior after destruction.
+
+private:
+  explicit CoUnwindAwareInvocation(_::UnwindAwareCoroutineBase& coroutine);
+
+  _::UnwindAwareCoroutineBase& coroutine;
+
+  template <bool>
   friend class _::CurrentInvocationAccessor;
 };
 

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -695,9 +695,22 @@ auto coCapture(Functor&& f) {
   return _::CaptureForCoroutine(kj::mv(f));
 }
 
+// An enum of the three different exit scenarios for a coroutine.
+enum class CoScopeOutcome {
+  SUCCESS,
+  // execution ended without an exception.
+
+  FAILURE,
+  // execution ended with an exception.
+
+  CANCELED,
+  // the coroutine was destroyed before execution ended.
+};
+
 struct CoUnwindAware {};
 // Opts a coroutine in to tracking whether its current invocation is unwinding. Add a defaulted
-// parameter of this type to coroutines which use CoUnwindAwareInvocation::isUnwinding().
+// parameter of this type to coroutines which use CoUnwindAwareInvocation::isUnwinding() or
+// scopeOutcome().
 
 namespace _ {
 class CoroutineBase;
@@ -725,6 +738,8 @@ public:
   // behavior.
 
   bool isUnwinding() const KJ_UNAVAILABLE("requires a defaulted kj::CoUnwindAware parameter");
+  CoScopeOutcome scopeOutcome() const
+      KJ_UNAVAILABLE("requires a defaulted kj::CoUnwindAware parameter");
 
 private:
   explicit CoInvocation(_::CoroutineBase& coroutine): coroutine(coroutine) {}
@@ -750,6 +765,15 @@ public:
   // entered from many different stacks, with different uncaught exception counts at each point.
   // This approach correctly measures against the uncaught count at coroutine (re)entry. Like
   // CoInvocation::isCanceling, this is undefined behavior after destruction.
+
+  CoScopeOutcome scopeOutcome() const;
+  // Correctly differentiates between the three exit scenarios a
+  // coroutine might find itself in:
+  //  * SUCCESS: execution ended without an exception.
+  //  * FAILURE: execution ended with an exception.
+  //  * CANCELED: execution didn't end due to coroutine destruction.
+  // Note that like isCanceling and isUnwinding, this method is undefined behavior after
+  // destruction.
 
 private:
   explicit CoUnwindAwareInvocation(_::UnwindAwareCoroutineBase& coroutine);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -695,6 +695,40 @@ auto coCapture(Functor&& f) {
   return _::CaptureForCoroutine(kj::mv(f));
 }
 
+namespace _ {
+class CoroutineBase;
+class CurrentInvocationAccessor;
+}  // namespace _
+
+class CoInvocation {
+  // Information about the current invocation of a coroutine. Obtain this with:
+  //
+  //     auto invocation = KJ_CO_MAGIC kj::CURRENT_INVOCATION;
+  //
+  // This interface describes the current invocation, relative to the coroutine's last resumption.
+  // It borrows the coroutine frame and must not outlive the coroutine's returned promise.
+
+public:
+
+  bool isCanceling() const;
+  // Coroutines might end in one of three ways - running successfully to the end, throwing
+  // an exception, or getting destructed while parked.
+  // isCanceling can be used when a coroutine is being destructed to determine if the cause
+  // of the destruction is the third case - getting destructed while parked. It always returns
+  // false before destruction. Calling this method after the coroutine is destroyed is undefined
+  // behavior.
+
+private:
+  explicit CoInvocation(_::CoroutineBase& coroutine): coroutine(coroutine) {}
+
+  _::CoroutineBase& coroutine;
+
+  friend class _::CurrentInvocationAccessor;
+};
+
+class CurrentInvocationConstant final {};
+inline constexpr CurrentInvocationConstant CURRENT_INVOCATION{};
+
 // =======================================================================================
 // Advanced promise construction
 


### PR DESCRIPTION
This change defines a new operation for KJ_CO_MAGIC that allows you to get a handle to the current coroutine invocation. E.g., you can do

    auto inv = KJ_CO_MAGIC kj::CURRENT_INVOCATION;

and inv will have methods defined on it for determining things about the invocation.

The current three helpers available are isCanceling() (always available), isUnwinding(), and scopeOutcome() (only available for "CoUnwindAware" coroutines). These features allow for coroutine-specific teardown handling that discriminates on *why* the coroutine is tearing down. Was it due to a successful completion? An exception? Or, harder to determine, due to a cancelation?

Why don't existing features already help? 
 * KJ_DEFER runs in all three cases, but cannot easily tell you which case you are in or why. 
 * KJ_ON_SCOPE_SUCCESS fires when a coroutine scope is canceled! If a coroutine scope is canceled and thus destructed without further execution, no exception is thrown, so KJ_ON_SCOPE_FAILURE doesn't fire, and since KJ_ON_SCOPE_SUCCESS is defined with the opposite condition, KJ_ON_SCOPE_SUCCESS does.
 * KJ_ON_SCOPE_FAILURE has edge cases with regard to coroutine resumption on differing stacks and exception handling. It is possible for a coroutine to be resumed with different uncaught exception counters. As a result, UnwindDetector (and thus KJ_ON_SCOPE_FAILURE (and thus KJ_ON_SCOPE_SUCCESS)) have critical corner cases that may misidentify failure in coroutines depending on how they are resumed and reentered.
 
Example use:

```
Promise<void> unwindAwareFoo(CoUnwindAware = {}) {
  auto inv = KJ_CO_MAGIC CURRENT_INVOCATION;
  KJ_DEFER({
    switch (inv.scopeOutcome()) {
    case kj::CoScopeOutcome::SUCCESS:
      // coroutine exited successfully
    case kj::CoScopeOutcome::FAILURE:
      // coroutine exited with exception thrown
    case kj::CoScopeOutcome::CANCELED:
      // coroutine destruction before execution completed.
    }
  });
  co_await stuff();
}
```