### PR TITLE
tightening some lifetimes

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -143,11 +143,11 @@ struct JsonCodec::Impl {
     size_t maxChildSize = 0;
     for (auto& e: elements) maxChildSize = kj::max(maxChildSize, e.size());
 
+    kj::String ownPrefix;
+    kj::String ownDelim;
     kj::StringPtr prefix;
     kj::StringPtr delim;
     kj::StringPtr suffix;
-    kj::String ownPrefix;
-    kj::String ownDelim;
     if (!prettyPrint) {
       // No whitespace.
       delim = ",";
@@ -1058,8 +1058,8 @@ public:
       KJ_IF_SOME(fh, info.flattenHandler) {
         // Set up fieldsByName for each of the child's fields.
         for (auto& entry: fh.fieldsByName) {
-          kj::StringPtr flattenedName;
           kj::String ownName;
+          kj::StringPtr flattenedName;
           if (info.prefix.size() > 0) {
             ownName = kj::str(info.prefix, entry.key);
             flattenedName = ownName;

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -391,8 +391,8 @@ private:
 
       // Figure out what name to use.
       Schema parent = schemaLoader.get(node.getScopeId());
-      kj::StringPtr unqualifiedName;
       kj::String ownUnqualifiedName;
+      kj::StringPtr unqualifiedName;
       KJ_IF_SOME(annotatedName, annotationValue(node, NAME_ANNOTATION_ID)) {
         // The node's name has been overridden for C++ by an annotation.
         unqualifiedName = annotatedName.getText();

--- a/c++/src/capnp/rpc.c++
+++ b/c++/src/capnp/rpc.c++
@@ -148,6 +148,7 @@ kj::Exception toException(const rpc::Exception::Reader& exception) {
 
 void fromException(const kj::Exception& exception, rpc::Exception::Builder builder,
                    kj::Maybe<kj::Function<kj::String(const kj::Exception&)>&> traceEncoder) {
+  kj::String scratch;
   kj::StringPtr description = exception.getDescription();
 
   // Include context, if any.
@@ -160,7 +161,6 @@ void fromException(const kj::Exception& exception, rpc::Exception::Builder build
       break;
     }
   }
-  kj::String scratch;
   if (contextLines.size() > 0) {
     scratch = kj::str(description, '\n', kj::strArray(contextLines, "\n"));
     description = scratch;

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -185,10 +185,12 @@ struct SchemaParser::DiskFileCompat {
 struct SchemaParser::Impl {
   typedef std::unordered_map<
       const SchemaFile*, kj::Own<ModuleImpl>, SchemaFileHash, SchemaFileEq> FileMap;
+
+  // Modules can retain views into translated import paths, so the compatibility cache must be
+  // declared first and therefore destroyed after both the compiler and the modules.
+  kj::MutexGuarded<kj::Maybe<DiskFileCompat>> compat;
   kj::MutexGuarded<FileMap> fileMap;
   compiler::Compiler compiler;
-
-  kj::MutexGuarded<kj::Maybe<DiskFileCompat>> compat;
 };
 
 SchemaParser::SchemaParser(): impl(kj::heap<Impl>()) {}

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -70,12 +70,14 @@ public:
   // get at it.
 
 private:
+  // Declared before the views so it is destroyed after them. This owns their backing storage when
+  // the byte-array constructor has to copy misaligned input.
+  kj::Array<word> alignedCopy;
+
   // Optimize for single-segment case.
   kj::ArrayPtr<const word> segment0;
   kj::Array<kj::ArrayPtr<const word>> moreSegments;
   const word* end;
-
-  kj::Array<word> alignedCopy;
 
   void init(kj::ArrayPtr<const word> array);
 };

--- a/c++/src/kj/compat/http.h
+++ b/c++/src/kj/compat/http.h
@@ -485,6 +485,9 @@ public:
 private:
   const HttpHeaderTable* table;
 
+  // Backing storage must be destroyed after all header views.
+  kj::Vector<kj::Array<char>> ownedStrings;
+
   kj::Array<kj::StringPtr> indexedHeaders;
   // Size is always table->idCount().
 
@@ -493,8 +496,6 @@ private:
     kj::StringPtr value;
   };
   kj::Vector<Header> unindexedHeaders;
-
-  kj::Vector<kj::Array<char>> ownedStrings;
 
   void addNoCheck(kj::StringPtr name, kj::StringPtr value);
 


### PR DESCRIPTION
Don't know if I will land Ptr-style checks for StringPtr and ArrayPtr, but these are some trivial fixes.