### PR TITLE
docs: list HaoZeke C, Fortran, and Janet implementations

### DIFF
--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -16,6 +16,7 @@ project's documentation for details.
 * [C++](cxx.html) by [@kentonv](https://github.com/kentonv)
 * [C#](https://github.com/c80k/capnproto-dotnetcore) by [@c80k](https://github.com/c80k)
 * [Erlang](http://ecapnp.astekk.se/) by [@kaos](https://github.com/kaos)
+* [Fortran](https://github.com/HaoZeke/capnp-fortran) by [@HaoZeke](https://github.com/HaoZeke) ([docs](https://capnp-fortran.rgoswami.me/))
 * [Go](https://github.com/capnproto/go-capnp) currently maintained by [@zenhack](https://github.com/zenhack) and [@lthibault](https://github.com/lthibault)
 * [Haskell](https://github.com/zenhack/haskell-capnp) by [@zenhack](https://github.com/zenhack)
 * [JavaScript (Node.js only)](https://github.com/capnproto/node-capnp) by [@kentonv](https://github.com/kentonv)
@@ -27,8 +28,10 @@ project's documentation for details.
 
 * [C](https://github.com/opensourcerouting/c-capnproto) by [OpenSourceRouting](https://www.opensourcerouting.org/) / [@eqvinox](https://github.com/eqvinox) (originally by [@jmckaskill](https://github.com/jmckaskill)) (no longer maintained)
     * [Forked and maintained](https://gitlab.com/dkml/ext/c-capnproto) by [@jonahbeckford](https://github.com/jonahbeckford)
+    * [Forked and maintained](https://github.com/HaoZeke/c-capnproto) by [@HaoZeke](https://github.com/HaoZeke) ([docs](https://c-capnproto.rgoswami.me/))
 * [D](https://github.com/capnproto/capnproto-dlang) by [@ThomasBrixLarsen](https://github.com/ThomasBrixLarsen)
 * [Java](https://github.com/capnproto/capnproto-java/) by [@dwrensha](https://github.com/dwrensha)
+* [Janet](https://github.com/HaoZeke/capnp-janet) by [@HaoZeke](https://github.com/HaoZeke) ([docs](https://capnp-janet.rgoswami.me/))
 * [JavaScript](https://github.com/capnp-js/plugin/) by [@popham](https://github.com/popham)
 * [JavaScript](https://github.com/jscheid/capnproto-js) (older, abandoned) by [@jscheid](https://github.com/jscheid)
 * [Lua](https://github.com/cloudflare/lua-capnproto) by [CloudFlare](http://www.cloudflare.com/) / [@calio](https://github.com/calio)

--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -23,6 +23,7 @@ project's documentation for details.
 * [OCaml](https://github.com/capnproto/capnp-ocaml) by [@pelzlpj](https://github.com/pelzlpj) with [RPC](https://github.com/mirage/capnp-rpc) by [@talex5](https://github.com/talex5)
 * [Python](http://capnproto.github.io/pycapnp/) by [@jparyani](https://github.com/jparyani)
 * [Rust](https://github.com/dwrensha/capnproto-rust) by [@dwrensha](https://github.com/dwrensha)
+* [TypeScript](https://github.com/HaoZeke/capnp-ts) by [@HaoZeke](https://github.com/HaoZeke)
 
 ##### Serialization only
 


### PR DESCRIPTION
Corrected rework of #2776: same listing in `doc/otherlang.md`, now branched from `master` (the file `push-site.sh` publishes from `release-*`, which tracks this copy).

- **C:** [HaoZeke/c-capnproto](https://github.com/HaoZeke/c-capnproto) living fork of the unmaintained opensourcerouting tree. Docs: https://c-capnproto.rgoswami.me/
- **Fortran:** [HaoZeke/capnp-fortran](https://github.com/HaoZeke/capnp-fortran) native F2018 runtime (wire, packed, canonical, `capnpc-fortran`, two-party RPC). Serialization + RPC. Docs: https://capnp-fortran.rgoswami.me/
- **Janet:** [HaoZeke/capnp-janet](https://github.com/HaoZeke/capnp-janet) native wire runtime plus embed C API and `capnpc-janet`. Serialization only. Docs: https://capnp-janet.rgoswami.me/
- **TypeScript:** [HaoZeke/capnp-ts](https://github.com/HaoZeke/capnp-ts) wire runtime + `capnpc-ts`; RPC is `@haozeke/capnp-rpc` in the same repo (L1–L4). Serialization + RPC.

Sorry about the earlier v2-into-master PR.