### PR TITLE
Experimental assert_arrayptr_counters mode

### DIFF
--- a/c++/src/capnp/BUILD.bazel
+++ b/c++/src/capnp/BUILD.bazel
@@ -240,6 +240,15 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "message-arena-test",
+    srcs = ["message-arena-test.c++"],
+    deps = [
+        ":capnp",
+        "//src/kj:kj-test",
+    ],
+)
+
 [cc_test(
     name = f.removesuffix(".c++"),
     srcs = [f],

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -45,21 +45,21 @@ struct FileKey {
   // This is probably over-engineered.
 
   const kj::ReadableDirectory& baseDir;
-  kj::PathPtr path;
+  kj::Path path;
   kj::Maybe<const kj::ReadableFile&> file;
   uint64_t hashCode;
   uint64_t size;
   kj::Date lastModified;
 
   FileKey(const kj::ReadableDirectory& baseDir, kj::PathPtr path)
-      : baseDir(baseDir), path(path), file(kj::none),
+      : baseDir(baseDir), path(path.clone()), file(kj::none),
         hashCode(0), size(0), lastModified(kj::UNIX_EPOCH) {}
   FileKey(const kj::ReadableDirectory& baseDir, kj::PathPtr path, const kj::ReadableFile& file)
       : FileKey(baseDir, path, file, file.stat()) {}
 
   FileKey(const kj::ReadableDirectory& baseDir, kj::PathPtr path, const kj::ReadableFile& file,
           kj::FsNode::Metadata meta)
-      : baseDir(baseDir), path(path), file(&file),
+      : baseDir(baseDir), path(path.clone()), file(&file),
         hashCode(meta.hashCode), size(meta.size), lastModified(meta.lastModified) {}
 
   bool operator==(const FileKey& other) const {
@@ -244,7 +244,7 @@ kj::Maybe<Module&> ModuleLoader::Impl::loadModule(
     auto key = FileKey(dir, pathCopy, *file);
     auto module = kj::heap<ModuleImpl>(*this, kj::mv(file), dir, kj::mv(pathCopy));
     auto& result = *module;
-    auto insertResult = modules.insert(std::make_pair(key, kj::mv(module)));
+    auto insertResult = modules.insert(std::make_pair(kj::mv(key), kj::mv(module)));
     if (insertResult.second) {
       return result;
     } else {

--- a/c++/src/capnp/dynamic-test.c++
+++ b/c++/src/capnp/dynamic-test.c++
@@ -44,6 +44,39 @@ void checkList(T reader, std::initializer_list<ReaderFor<Element>> expected) {
   }
 }
 
+template <typename Value, typename Check>
+void checkDynamicValueCopyAndMove(Value& original, DynamicValue::Type type, Check&& check) {
+  EXPECT_EQ(type, original.getType());
+  check(original);
+
+  Value copy(original);
+  EXPECT_EQ(type, copy.getType());
+  check(copy);
+
+  Value moved(kj::mv(copy));
+  EXPECT_EQ(type, moved.getType());
+  check(moved);
+
+  Value copyAssigned(original);
+  copyAssigned = original;
+  EXPECT_EQ(type, copyAssigned.getType());
+  check(copyAssigned);
+
+  Value moveAssigned(original);
+  moveAssigned = kj::mv(copyAssigned);
+  EXPECT_EQ(type, moveAssigned.getType());
+  check(moveAssigned);
+
+  auto* self = &original;
+  original = *self;
+  EXPECT_EQ(type, original.getType());
+  check(original);
+
+  original = kj::mv(*self);
+  EXPECT_EQ(type, original.getType());
+  check(original);
+}
+
 TEST(DynamicApi, Build) {
   MallocMessageBuilder builder;
   auto root = builder.initRoot<DynamicStruct>(Schema::from<TestAllTypes>());
@@ -471,6 +504,192 @@ TEST(DynamicApi, SetDataFromText) {
 
   root.set("dataField", "foo");
   EXPECT_EQ(data("foo"), root.get("dataField").as<Data>());
+}
+
+TEST(DynamicApi, DynamicValueReaderCopyAndMove) {
+  MallocMessageBuilder message;
+  auto root = message.initRoot<TestAllTypes>();
+  root.setTextField("foo");
+  root.setDataField(data("bar"));
+  root.initInt32List(1).set(0, 123);
+  root.initStructField().setInt32Field(456);
+
+  MallocMessageBuilder anyMessage;
+  auto anyRoot = anyMessage.initRoot<test::TestAnyPointer>();
+  anyRoot.getAnyPointerField().setAs<Text>("qux");
+
+  {
+    DynamicValue::Reader value;
+    checkDynamicValueCopyAndMove(value, DynamicValue::UNKNOWN, [](auto&) {});
+  }
+  {
+    DynamicValue::Reader value = capnp::VOID;
+    checkDynamicValueCopyAndMove(value, DynamicValue::VOID, [](auto& value) {
+      value.template as<Void>();
+    });
+  }
+  {
+    DynamicValue::Reader value = true;
+    checkDynamicValueCopyAndMove(value, DynamicValue::BOOL, [](auto& value) {
+      EXPECT_TRUE(value.template as<bool>());
+    });
+  }
+  {
+    DynamicValue::Reader value = int64_t(-123);
+    checkDynamicValueCopyAndMove(value, DynamicValue::INT, [](auto& value) {
+      EXPECT_EQ(-123, value.template as<int64_t>());
+    });
+  }
+  {
+    DynamicValue::Reader value = uint64_t(123);
+    checkDynamicValueCopyAndMove(value, DynamicValue::UINT, [](auto& value) {
+      EXPECT_EQ(123u, value.template as<uint64_t>());
+    });
+  }
+  {
+    DynamicValue::Reader value = 12.5;
+    checkDynamicValueCopyAndMove(value, DynamicValue::FLOAT, [](auto& value) {
+      EXPECT_EQ(12.5, value.template as<double>());
+    });
+  }
+  {
+    DynamicValue::Reader value = root.asReader().getTextField();
+    checkDynamicValueCopyAndMove(value, DynamicValue::TEXT, [](auto& value) {
+      EXPECT_EQ("foo", value.template as<Text>());
+    });
+  }
+  {
+    DynamicValue::Reader value = root.asReader().getDataField();
+    checkDynamicValueCopyAndMove(value, DynamicValue::DATA, [](auto& value) {
+      EXPECT_EQ(data("bar"), value.template as<Data>());
+    });
+  }
+  {
+    DynamicValue::Reader value = toDynamic(root.asReader()).get("int32List");
+    checkDynamicValueCopyAndMove(value, DynamicValue::LIST, [](auto& value) {
+      auto list = value.template as<DynamicList>();
+      ASSERT_EQ(1u, list.size());
+      EXPECT_EQ(123, list[0].template as<int32_t>());
+    });
+  }
+  {
+    DynamicValue::Reader value = DynamicEnum(Schema::from<TestEnum>(), 2);
+    checkDynamicValueCopyAndMove(value, DynamicValue::ENUM, [](auto& value) {
+      EXPECT_EQ(TestEnum::BAZ, value.template as<TestEnum>());
+    });
+  }
+  {
+    DynamicValue::Reader value = toDynamic(root.asReader()).get("structField");
+    checkDynamicValueCopyAndMove(value, DynamicValue::STRUCT, [](auto& value) {
+      EXPECT_EQ(456, value.template as<DynamicStruct>().get("int32Field").template as<int32_t>());
+    });
+  }
+  {
+    DynamicValue::Reader value = anyRoot.asReader().getAnyPointerField();
+    checkDynamicValueCopyAndMove(value, DynamicValue::ANY_POINTER, [](auto& value) {
+      EXPECT_EQ("qux", value.template as<AnyPointer>().template getAs<Text>());
+    });
+  }
+  {
+    DynamicCapability::Client capability = test::TestInterface::Client(nullptr);
+    DynamicValue::Reader value(capability);
+    checkDynamicValueCopyAndMove(value, DynamicValue::CAPABILITY, [](auto& value) {
+      value.template as<DynamicCapability>();
+    });
+  }
+}
+
+TEST(DynamicApi, DynamicValueBuilderCopyAndMove) {
+  MallocMessageBuilder message;
+  auto root = message.initRoot<TestAllTypes>();
+  root.setTextField("foo");
+  root.setDataField(data("bar"));
+  root.initInt32List(1).set(0, 123);
+  root.initStructField().setInt32Field(456);
+
+  MallocMessageBuilder anyMessage;
+  auto anyRoot = anyMessage.initRoot<test::TestAnyPointer>();
+  anyRoot.getAnyPointerField().setAs<Text>("qux");
+
+  {
+    DynamicValue::Builder value;
+    checkDynamicValueCopyAndMove(value, DynamicValue::UNKNOWN, [](auto&) {});
+  }
+  {
+    DynamicValue::Builder value = capnp::VOID;
+    checkDynamicValueCopyAndMove(value, DynamicValue::VOID, [](auto& value) {
+      value.template as<Void>();
+    });
+  }
+  {
+    DynamicValue::Builder value = true;
+    checkDynamicValueCopyAndMove(value, DynamicValue::BOOL, [](auto& value) {
+      EXPECT_TRUE(value.template as<bool>());
+    });
+  }
+  {
+    DynamicValue::Builder value = int64_t(-123);
+    checkDynamicValueCopyAndMove(value, DynamicValue::INT, [](auto& value) {
+      EXPECT_EQ(-123, value.template as<int64_t>());
+    });
+  }
+  {
+    DynamicValue::Builder value = uint64_t(123);
+    checkDynamicValueCopyAndMove(value, DynamicValue::UINT, [](auto& value) {
+      EXPECT_EQ(123u, value.template as<uint64_t>());
+    });
+  }
+  {
+    DynamicValue::Builder value = 12.5;
+    checkDynamicValueCopyAndMove(value, DynamicValue::FLOAT, [](auto& value) {
+      EXPECT_EQ(12.5, value.template as<double>());
+    });
+  }
+  {
+    DynamicValue::Builder value = root.getTextField();
+    checkDynamicValueCopyAndMove(value, DynamicValue::TEXT, [](auto& value) {
+      EXPECT_EQ("foo", value.template as<Text>());
+    });
+  }
+  {
+    DynamicValue::Builder value = root.getDataField();
+    checkDynamicValueCopyAndMove(value, DynamicValue::DATA, [](auto& value) {
+      EXPECT_EQ(data("bar"), value.template as<Data>());
+    });
+  }
+  {
+    DynamicValue::Builder value = toDynamic(root).get("int32List");
+    checkDynamicValueCopyAndMove(value, DynamicValue::LIST, [](auto& value) {
+      auto list = value.template as<DynamicList>();
+      ASSERT_EQ(1u, list.size());
+      EXPECT_EQ(123, list[0].template as<int32_t>());
+    });
+  }
+  {
+    DynamicValue::Builder value = DynamicEnum(Schema::from<TestEnum>(), 2);
+    checkDynamicValueCopyAndMove(value, DynamicValue::ENUM, [](auto& value) {
+      EXPECT_EQ(TestEnum::BAZ, value.template as<TestEnum>());
+    });
+  }
+  {
+    DynamicValue::Builder value = toDynamic(root).get("structField");
+    checkDynamicValueCopyAndMove(value, DynamicValue::STRUCT, [](auto& value) {
+      EXPECT_EQ(456, value.template as<DynamicStruct>().get("int32Field").template as<int32_t>());
+    });
+  }
+  {
+    DynamicValue::Builder value = anyRoot.getAnyPointerField();
+    checkDynamicValueCopyAndMove(value, DynamicValue::ANY_POINTER, [](auto& value) {
+      EXPECT_EQ("qux", value.template as<AnyPointer>().template getAs<Text>());
+    });
+  }
+  {
+    DynamicCapability::Client capability = test::TestInterface::Client(nullptr);
+    DynamicValue::Builder value(capability);
+    checkDynamicValueCopyAndMove(value, DynamicValue::CAPABILITY, [](auto& value) {
+      value.template as<DynamicCapability>();
+    });
+  }
 }
 
 TEST(DynamicApi, BuilderAssign) {

--- a/c++/src/capnp/dynamic.c++
+++ b/c++/src/capnp/dynamic.c++
@@ -1465,181 +1465,137 @@ DynamicValue::Reader::Reader(ConstSchema constant): type(VOID) {
   }
 }
 
-#if __GNUC__ && !__clang__ && __GNUC__ >= 9
-// In the copy constructors below, we use memcpy() to copy only after verifying that it is safe.
-// But GCC 9 doesn't know we've checked, and whines. I suppose GCC is probably right: our checks
-// probably don't technically make memcpy safe according to the standard. But it works in practice,
-// and if it ever stops working, the tests will catch it.
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-
-DynamicValue::Reader::Reader(const Reader& other) {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      KJ_ASSERT_CAN_MEMCPY(Text::Reader);
-      KJ_ASSERT_CAN_MEMCPY(Data::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicList::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicEnum);
-      KJ_ASSERT_CAN_MEMCPY(DynamicStruct::Reader);
-      KJ_ASSERT_CAN_MEMCPY(AnyPointer::Reader);
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, other.capabilityValue);
-      return;
+DynamicValue::Reader::Reader(const Reader& other): type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: kj::ctor(voidValue, other.voidValue); break;
+    case BOOL: kj::ctor(boolValue, other.boolValue); break;
+    case INT: kj::ctor(intValue, other.intValue); break;
+    case UINT: kj::ctor(uintValue, other.uintValue); break;
+    case FLOAT: kj::ctor(floatValue, other.floatValue); break;
+    case TEXT: kj::ctor(textValue, other.textValue); break;
+    case DATA: kj::ctor(dataValue, other.dataValue); break;
+    case LIST: kj::ctor(listValue, other.listValue); break;
+    case ENUM: kj::ctor(enumValue, other.enumValue); break;
+    case STRUCT: kj::ctor(structValue, other.structValue); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, other.anyPointerValue); break;
+    case CAPABILITY: kj::ctor(capabilityValue, other.capabilityValue); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
-DynamicValue::Reader::Reader(Reader&& other) noexcept {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      KJ_ASSERT_CAN_MEMCPY(Text::Reader);
-      KJ_ASSERT_CAN_MEMCPY(Data::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicList::Reader);
-      KJ_ASSERT_CAN_MEMCPY(DynamicEnum);
-      KJ_ASSERT_CAN_MEMCPY(DynamicStruct::Reader);
-      KJ_ASSERT_CAN_MEMCPY(AnyPointer::Reader);
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, kj::mv(other.capabilityValue));
-      return;
+DynamicValue::Reader::Reader(Reader&& other) noexcept: type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: kj::ctor(voidValue, kj::mv(other.voidValue)); break;
+    case BOOL: kj::ctor(boolValue, kj::mv(other.boolValue)); break;
+    case INT: kj::ctor(intValue, kj::mv(other.intValue)); break;
+    case UINT: kj::ctor(uintValue, kj::mv(other.uintValue)); break;
+    case FLOAT: kj::ctor(floatValue, kj::mv(other.floatValue)); break;
+    case TEXT: kj::ctor(textValue, kj::mv(other.textValue)); break;
+    case DATA: kj::ctor(dataValue, kj::mv(other.dataValue)); break;
+    case LIST: kj::ctor(listValue, kj::mv(other.listValue)); break;
+    case ENUM: kj::ctor(enumValue, kj::mv(other.enumValue)); break;
+    case STRUCT: kj::ctor(structValue, kj::mv(other.structValue)); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, kj::mv(other.anyPointerValue)); break;
+    case CAPABILITY: kj::ctor(capabilityValue, kj::mv(other.capabilityValue)); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
 DynamicValue::Reader::~Reader() noexcept(false) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: kj::dtor(voidValue); break;
+    case BOOL: kj::dtor(boolValue); break;
+    case INT: kj::dtor(intValue); break;
+    case UINT: kj::dtor(uintValue); break;
+    case FLOAT: kj::dtor(floatValue); break;
+    case TEXT: kj::dtor(textValue); break;
+    case DATA: kj::dtor(dataValue); break;
+    case LIST: kj::dtor(listValue); break;
+    case ENUM: kj::dtor(enumValue); break;
+    case STRUCT: kj::dtor(structValue); break;
+    case ANY_POINTER: kj::dtor(anyPointerValue); break;
+    case CAPABILITY: kj::dtor(capabilityValue); break;
   }
 }
 
 DynamicValue::Reader& DynamicValue::Reader::operator=(const Reader& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  if (this != &other) {
+    kj::dtor(*this);
+    kj::ctor(*this, other);
   }
-  kj::ctor(*this, other);
   return *this;
 }
 DynamicValue::Reader& DynamicValue::Reader::operator=(Reader&& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  if (this != &other) {
+    kj::dtor(*this);
+    kj::ctor(*this, kj::mv(other));
   }
-  kj::ctor(*this, kj::mv(other));
   return *this;
 }
 
-DynamicValue::Builder::Builder(Builder& other) {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      // Unfortunately canMemcpy() doesn't work on these types due to the use of
-      // DisallowConstCopy, but __has_trivial_destructor should detect if any of these types
-      // become non-trivial.
-      static_assert(KJ_HAS_TRIVIAL_DESTRUCTOR(Text::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(Data::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicList::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicEnum) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicStruct::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(AnyPointer::Builder),
-                    "Assumptions here don't hold.");
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, other.capabilityValue);
-      return;
+DynamicValue::Builder::Builder(Builder& other): type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: kj::ctor(voidValue, other.voidValue); break;
+    case BOOL: kj::ctor(boolValue, other.boolValue); break;
+    case INT: kj::ctor(intValue, other.intValue); break;
+    case UINT: kj::ctor(uintValue, other.uintValue); break;
+    case FLOAT: kj::ctor(floatValue, other.floatValue); break;
+    case TEXT: kj::ctor(textValue, other.textValue); break;
+    case DATA: kj::ctor(dataValue, other.dataValue); break;
+    case LIST: kj::ctor(listValue, other.listValue); break;
+    case ENUM: kj::ctor(enumValue, other.enumValue); break;
+    case STRUCT: kj::ctor(structValue, other.structValue); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, other.anyPointerValue); break;
+    case CAPABILITY: kj::ctor(capabilityValue, other.capabilityValue); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
-DynamicValue::Builder::Builder(Builder&& other) noexcept {
-  switch (other.type) {
-    case UNKNOWN:
-    case VOID:
-    case BOOL:
-    case INT:
-    case UINT:
-    case FLOAT:
-    case TEXT:
-    case DATA:
-    case LIST:
-    case ENUM:
-    case STRUCT:
-    case ANY_POINTER:
-      // Unfortunately __has_trivial_copy doesn't work on these types due to the use of
-      // DisallowConstCopy, but __has_trivial_destructor should detect if any of these types
-      // become non-trivial.
-      static_assert(KJ_HAS_TRIVIAL_DESTRUCTOR(Text::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(Data::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicList::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicEnum) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(DynamicStruct::Builder) &&
-                    KJ_HAS_TRIVIAL_DESTRUCTOR(AnyPointer::Builder),
-                    "Assumptions here don't hold.");
-      break;
-
-    case CAPABILITY:
-      type = CAPABILITY;
-      kj::ctor(capabilityValue, kj::mv(other.capabilityValue));
-      return;
+DynamicValue::Builder::Builder(Builder&& other) noexcept: type(other.type) {
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: kj::ctor(voidValue, kj::mv(other.voidValue)); break;
+    case BOOL: kj::ctor(boolValue, kj::mv(other.boolValue)); break;
+    case INT: kj::ctor(intValue, kj::mv(other.intValue)); break;
+    case UINT: kj::ctor(uintValue, kj::mv(other.uintValue)); break;
+    case FLOAT: kj::ctor(floatValue, kj::mv(other.floatValue)); break;
+    case TEXT: kj::ctor(textValue, kj::mv(other.textValue)); break;
+    case DATA: kj::ctor(dataValue, kj::mv(other.dataValue)); break;
+    case LIST: kj::ctor(listValue, kj::mv(other.listValue)); break;
+    case ENUM: kj::ctor(enumValue, kj::mv(other.enumValue)); break;
+    case STRUCT: kj::ctor(structValue, kj::mv(other.structValue)); break;
+    case ANY_POINTER: kj::ctor(anyPointerValue, kj::mv(other.anyPointerValue)); break;
+    case CAPABILITY: kj::ctor(capabilityValue, kj::mv(other.capabilityValue)); break;
   }
-
-  memcpy((void*)this, &other, sizeof(*this));
 }
 DynamicValue::Builder::~Builder() noexcept(false) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  switch (type) {
+    case UNKNOWN: break;
+    case VOID: kj::dtor(voidValue); break;
+    case BOOL: kj::dtor(boolValue); break;
+    case INT: kj::dtor(intValue); break;
+    case UINT: kj::dtor(uintValue); break;
+    case FLOAT: kj::dtor(floatValue); break;
+    case TEXT: kj::dtor(textValue); break;
+    case DATA: kj::dtor(dataValue); break;
+    case LIST: kj::dtor(listValue); break;
+    case ENUM: kj::dtor(enumValue); break;
+    case STRUCT: kj::dtor(structValue); break;
+    case ANY_POINTER: kj::dtor(anyPointerValue); break;
+    case CAPABILITY: kj::dtor(capabilityValue); break;
   }
 }
 
 DynamicValue::Builder& DynamicValue::Builder::operator=(Builder& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  if (this != &other) {
+    kj::dtor(*this);
+    kj::ctor(*this, other);
   }
-  kj::ctor(*this, other);
   return *this;
 }
 DynamicValue::Builder& DynamicValue::Builder::operator=(Builder&& other) {
-  if (type == CAPABILITY) {
-    kj::dtor(capabilityValue);
+  if (this != &other) {
+    kj::dtor(*this);
+    kj::ctor(*this, kj::mv(other));
   }
-  kj::ctor(*this, kj::mv(other));
   return *this;
 }
 

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -717,8 +717,8 @@ private:
     mutable DynamicCapability::Client capabilityValue;
     // Declared mutable because `Client`s normally cannot be const.
 
-    // Warning:  Copy/move constructors assume all these types are trivially copyable except
-    //   Capability.
+    // Copy/move constructors explicitly construct the active member because some reader types
+    // are non-trivial when KJ_ASSERT_ARRAYPTR_COUNTERS is enabled.
   };
 
   template <typename T, Kind kind = kind<T>()> struct AsImpl;

--- a/c++/src/capnp/message-arena-test.c++
+++ b/c++/src/capnp/message-arena-test.c++
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Cap'n Proto contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "message.h"
+#include <kj/test.h>
+#include <string.h>
+
+namespace capnp {
+namespace {
+
+class ArenaTestMessageReader final: public MessageReader {
+public:
+  ArenaTestMessageReader(): MessageReader(ReaderOptions()) {}
+
+  kj::ArrayPtr<const word> getSegment(uint id) override {
+    return id == 0 ? kj::arrayPtr(segment) : nullptr;
+  }
+
+private:
+  word segment[1] = {};
+};
+
+class ArenaTestMessageBuilder final: public MessageBuilder {
+public:
+  kj::ArrayPtr<word> allocateSegment(uint minimumSize) override {
+    KJ_REQUIRE(minimumSize <= kj::size(segment));
+    return kj::arrayPtr(segment);
+  }
+
+private:
+  word segment[8] = {};
+};
+
+template <typename T, typename Func>
+void withPoisonedStorage(Func&& func) {
+  alignas(T) byte storage[sizeof(T)];
+  memset(storage, 0xff, sizeof(storage));
+
+  T* object = reinterpret_cast<T*>(storage);
+  kj::ctor(*object);
+  func(*object);
+  kj::dtor(*object);
+}
+
+KJ_TEST("message arenas initialize objects constructed in arenaSpace") {
+  // MessageReader and MessageBuilder intentionally leave arenaSpace uninitialized until an arena
+  // is needed. Poison the storage first so that this test catches arena members which placement
+  // construction fails to initialize, including ArrayPtr's counter when it is enabled.
+  withPoisonedStorage<ArenaTestMessageReader>([](auto& reader) {
+    KJ_EXPECT(reader.isCanonical());
+  });
+  withPoisonedStorage<ArenaTestMessageBuilder>([](auto& builder) {
+    KJ_EXPECT(builder.isCanonical());
+    KJ_EXPECT(builder.getSegmentsForOutput().size() == 1);
+  });
+}
+
+}  // namespace
+}  // namespace capnp

--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -129,16 +129,20 @@ private:
   ReaderOptions options;
 
 #if defined(__EMSCRIPTEN__) || (defined(__APPLE__) && (defined(__ppc__) || defined(__i386__)))
-  static constexpr size_t arenaSpacePadding = 19;
+  static constexpr size_t arenaSpacePadding = 15;
 #else
-  static constexpr size_t arenaSpacePadding = 18;
+  static constexpr size_t arenaSpacePadding = 14;
 #endif
 
   // Space in which we can construct a ReaderArena.  We don't use ReaderArena directly here
   // because we don't want clients to have to #include arena.h, which itself includes a bunch of
   // other headers.  We don't use a pointer to a ReaderArena because that would require an
   // extra malloc on every message which could be expensive when processing small messages.
-  alignas(8) void* arenaSpace[arenaSpacePadding + sizeof(kj::MutexGuarded<void*>) / sizeof(void*)];
+  // ReaderArena contains two ArrayPtrs: one in its segment0 member (a SegmentReader), and one
+  // within the SegmentMap stored in moreSegments.
+  alignas(8) void* arenaSpace[arenaSpacePadding +
+      sizeof(kj::MutexGuarded<void*>) / sizeof(void*) +
+      2 * sizeof(kj::ArrayPtr<const word>) / sizeof(void*)];
   bool allocatedArena;
 
   _::ReaderArena* arena() { return reinterpret_cast<_::ReaderArena*>(arenaSpace); }
@@ -242,7 +246,10 @@ public:
   // Add up the allocated space from all segments.
 
 private:
-  alignas(8) void* arenaSpace[22];
+  // BuilderArena contains two ArrayPtrs in its inline layout: one in its SegmentBuilder member
+  // (inherited from SegmentReader), and one for segment0ForOutput.
+  alignas(8) void* arenaSpace[18 +
+      2 * sizeof(kj::ArrayPtr<const word>) / sizeof(void*)];
   // Space in which we can construct a BuilderArena.  We don't use BuilderArena directly here
   // because we don't want clients to have to #include arena.h, which itself includes a bunch of
   // big STL headers.  We don't use a pointer to a BuilderArena because that would require an

--- a/c++/src/capnp/serialize.h
+++ b/c++/src/capnp/serialize.h
@@ -154,12 +154,13 @@ private:
   kj::InputStream& inputStream;
   byte* readPos;
 
+  kj::Array<word> ownedSpace;
+  // Only if scratchSpace wasn't big enough. Declared before the segment pointers so that it is
+  // destroyed after them.
+
   // Optimize for single-segment case.
   kj::ArrayPtr<const word> segment0;
   kj::Array<kj::ArrayPtr<const word>> moreSegments;
-
-  kj::Array<word> ownedSpace;
-  // Only if scratchSpace wasn't big enough.
 
   kj::UnwindDetector unwindDetector;
 };

--- a/c++/src/kj/array-test.c++
+++ b/c++/src/kj/array-test.c++
@@ -21,6 +21,9 @@
 
 #include "array.h"
 #include "debug.h"
+#include "test.h"
+#include "function.h"
+#include <signal.h>
 #include <string>
 #include <list>
 #include <kj/compat/gtest.h>
@@ -28,6 +31,16 @@
 
 namespace kj {
 namespace {
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+KJ_TEST("Array rejects destruction with an active ArrayPtr") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    auto array = heapArray<int>(4);
+    auto ptr = new ArrayPtr<int>(array.asPtr().slice(1));
+    (void)ptr;
+  });
+}
+#endif
 
 struct CloneableElement {
   int clone() const { return 123; }
@@ -121,6 +134,20 @@ struct TestNoexceptObject {
 
 int TestNoexceptObject::count = 0;
 int TestNoexceptObject::copiedCount = 0;
+
+KJ_TEST("swp Array") {
+  auto a = heapArray<int>({1, 2});
+  auto b = heapArray<int>({3, 4, 5});
+  auto aBegin = a.begin();
+  auto bBegin = b.begin();
+
+  kj::swp(a, b);
+
+  KJ_EXPECT(a.begin() == bBegin, a.size(), a[0], a[1], a[2]);
+  KJ_EXPECT(b.begin() == aBegin, b.size(), b[0], b[1]);
+  KJ_EXPECT(a.size() == 3 && a[0] == 3 && a[1] == 4 && a[2] == 5);
+  KJ_EXPECT(b.size() == 2 && b[0] == 1 && b[1] == 2);
+}
 
 TEST(Array, TrivialConstructor) {
 //  char* ptr;
@@ -265,6 +292,26 @@ TEST(Array, ThrowingDestructor) {
   EXPECT_ANY_THROW(array = nullptr);
   EXPECT_EQ(0, TestObject::count);
 }
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+TEST(Array, ThrowingDestructorDoesNotLeakArrayPtrCounter) {
+  TestObject::count = 0;
+  TestObject::throwAt = -1;
+
+  auto destroyArray = []() {
+    auto array = heapArray<TestObject>(32);
+    EXPECT_EQ(32, TestObject::count);
+
+    // The Array destructor must release its separately-allocated pointer counter even when
+    // disposing the elements throws. ASAN's leak detector verifies the counter was released.
+    TestObject::throwAt = 16;
+  };
+
+  EXPECT_ANY_THROW(destroyArray());
+  EXPECT_EQ(0, TestObject::count);
+  TestObject::throwAt = -1;
+}
+#endif
 
 TEST(SmallArray, ThrowingDestructor) {
   TestObject::count = 0;

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -122,6 +122,9 @@ public:
 // Array
 
 template <typename T>
+void swp(Array<T>& a, Array<T>& b) noexcept;
+
+template <typename T>
 class Array {
   // An owned array which will automatically be disposed of (using an ArrayDisposer) in the
   // destructor.  Can be moved, but not copied.  Much like Own<T>, but for arrays rather than
@@ -132,31 +135,34 @@ public:
   inline Array(decltype(nullptr)): ptr(nullptr), size_(0), disposer(nullptr) {}
   inline Array(Array&& other) noexcept
       : ptr(other.ptr), size_(other.size_), disposer(other.disposer) {
+    moveCounterFrom(other);
     other.ptr = nullptr;
     other.size_ = 0;
   }
   inline Array(Array<RemoveConstOrDisable<T>>&& other) noexcept
       : ptr(other.ptr), size_(other.size_), disposer(other.disposer) {
+    moveCounterFrom(other);
     other.ptr = nullptr;
     other.size_ = 0;
   }
   inline Array(T* firstElement KJ_LIFETIMEBOUND, size_t size, const ArrayDisposer& disposer)
-      : ptr(firstElement), size_(size), disposer(&disposer) {}
+      : ptr(firstElement), size_(size), disposer(&disposer) {
+    initializeCounter();
+  }
 
   KJ_DISALLOW_COPY(Array);
-  inline ~Array() noexcept(false) { dispose(); }
+  inline ~Array() noexcept(false) {
+    KJ_DEFER(deleteCounter());
+    dispose();
+  }
 
-  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
-  }
+  inline operator ArrayPtr<T>() KJ_LIFETIMEBOUND { return makePtr<T>(ptr, size_); }
   inline operator ArrayPtr<const T>() const KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
+    return makePtr<const T>(ptr, size_);
   }
-  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
-  }
+  inline ArrayPtr<T> asPtr() KJ_LIFETIMEBOUND { return makePtr<T>(ptr, size_); }
   inline ArrayPtr<const T> asPtr() const KJ_LIFETIMEBOUND {
-    return ArrayPtr<T>(ptr, size_);
+    return makePtr<const T>(ptr, size_);
   }
 
   inline constexpr size_t size() const { return size_; }
@@ -183,19 +189,19 @@ public:
 
   inline ArrayPtr<T> slice(size_t start, size_t end) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().", start, end, size_);
-    return ArrayPtr<T>(ptr + start, end - start);
+    return makePtr<T>(ptr + start, end - start);
   }
   inline ArrayPtr<const T> slice(size_t start, size_t end) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds Array::slice().", start, end, size_);
-    return ArrayPtr<const T>(ptr + start, end - start);
+    return makePtr<const T>(ptr + start, end - start);
   }
   inline ArrayPtr<T> slice(size_t start) KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
-    return ArrayPtr<T>(ptr + start, size_ - start);
+    return makePtr<T>(ptr + start, size_ - start);
   }
   inline ArrayPtr<const T> slice(size_t start) const KJ_LIFETIMEBOUND {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
-    return ArrayPtr<const T>(ptr + start, size_ - start);
+    return makePtr<const T>(ptr + start, size_ - start);
   }
 
   inline ArrayPtr<T> first(size_t count) KJ_LIFETIMEBOUND { return slice(0, count); }
@@ -225,6 +231,7 @@ public:
     if (disposer == nullptr) return nullptr;
     Array<PropagateConst<T, byte>> result(
         reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_, *disposer);
+    result.moveCounterFrom(*this);
     ptr = nullptr;
     size_ = 0;
     return result;
@@ -236,6 +243,7 @@ public:
     if (disposer == nullptr) return nullptr;
     Array<PropagateConst<T, char>> result(
         reinterpret_cast<PropagateConst<T, char>*>(ptr), size_, *disposer);
+    result.moveCounterFrom(*this);
     ptr = nullptr;
     size_ = 0;
     return result;
@@ -250,6 +258,7 @@ public:
 
   inline Array& operator=(Array&& other) {
     dispose();
+    moveCounterFrom(other);
     ptr = other.ptr;
     size_ = other.size_;
     disposer = other.disposer;
@@ -284,8 +293,45 @@ private:
   T* ptr;
   size_t size_;
   const ArrayDisposer* disposer;
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  _::AtomicPtrCounter* counter = nullptr;
+
+  inline void initializeCounter() { counter = new _::AtomicPtrCounter; }
+  inline void deleteCounter() { delete counter; }
+
+  template <typename U>
+  inline void moveCounterFrom(Array<U>& other) {
+    delete counter;
+    counter = other.counter;
+    other.counter = nullptr;
+  }
+
+  template <typename U>
+  inline ArrayPtr<U> makePtr(U* ptr, size_t size) const {
+    return counter == nullptr ? ArrayPtr<U>(ptr, size)
+                              : ArrayPtr<U>(ptr, size, *counter);
+  }
+
+  inline void assertNoRefs() const {
+    if (counter != nullptr) counter->assertEmpty();
+  }
+#else
+  inline void initializeCounter() {}
+  inline void deleteCounter() {}
+
+  template <typename U>
+  inline void moveCounterFrom(Array<U>&) {}
+
+  template <typename U>
+  inline ArrayPtr<U> makePtr(U* ptr, size_t size) const {
+    return ArrayPtr<U>(ptr, size);
+  }
+
+  inline void assertNoRefs() const {}
+#endif
 
   inline void dispose() {
+    assertNoRefs();
     // Make sure that if an exception is thrown, we are left with a null ptr, so we won't possibly
     // dispose again.
     T* ptrCopy = ptr;
@@ -301,7 +347,22 @@ private:
   friend class Array;
   template <typename U>
   friend class ArrayBuilder;
+  template <typename U>
+  friend void swp(Array<U>& a, Array<U>& b) noexcept;
+  friend class String;
+  friend class StringPtr;
+  friend class ConstString;
 };
+
+template <typename T>
+inline void swp(Array<T>& a, Array<T>& b) noexcept {
+  kj::swp(a.ptr, b.ptr);
+  kj::swp(a.size_, b.size_);
+  kj::swp(a.disposer, b.disposer);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  kj::swp(a.counter, b.counter);
+#endif
+}
 
 static_assert(!canMemcpy<Array<char>>(), "canMemcpy<>() is broken");
 

--- a/c++/src/kj/atomic.h
+++ b/c++/src/kj/atomic.h
@@ -184,6 +184,37 @@ inline void atomicThreadFence(
 #endif
 }
 
+namespace _ {  // private
+
+void atomicPtrCounterAssertionFailed(const char* reason);
+
+class AtomicPtrCounter {
+  // Only the counter itself is observed, so relaxed ordering is sufficient.
+public:
+  inline void inc() { atomicAddFetch(&count, size_t(1), AtomicMemoryOrder::RELAXED); }
+
+  inline void dec() {
+    size_t remaining = atomicSubFetch(&count, size_t(1), AtomicMemoryOrder::RELAXED);
+    if (KJ_UNLIKELY(remaining == size_t(-1))) {
+      atomicPtrCounterAssertionFailed("unbalanced inc/dec");
+    }
+  }
+
+  inline bool isEmpty() const {
+    return atomicLoad(&count, AtomicMemoryOrder::RELAXED) == 0;
+  }
+
+  inline void assertEmpty() const {
+    if (KJ_UNLIKELY(!isEmpty())) {
+      atomicPtrCounterAssertionFailed("active pointers exist");
+    }
+  }
+
+private:
+  size_t count = 0;
+};
+
+}  // namespace _ (private)
 }  // namespace kj
 
 KJ_END_HEADER

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -30,6 +30,11 @@
 namespace kj {
 namespace {
 
+#if !KJ_ASSERT_ARRAYPTR_COUNTERS
+static_assert(sizeof(ArrayPtr<byte>) == 2 * sizeof(void*),
+    "Disabled ArrayPtr tracking must not change ArrayPtr's ABI.");
+#endif
+
 struct ClonesToInt { int clone() const { return 123; } };
 struct ClonesToStringPtr { StringPtr clone() const { return "foo"; } };
 struct NoClone {};

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -175,6 +175,15 @@ typedef unsigned char byte;
 #endif
 #endif
 
+// KJ_DEBUG_MEMORY == 1 enables checks designed to catch memory usage errors.
+#ifndef KJ_DEBUG_MEMORY
+#define KJ_DEBUG_MEMORY 0
+#endif
+
+#ifndef KJ_ASSERT_ARRAYPTR_COUNTERS
+#define KJ_ASSERT_ARRAYPTR_COUNTERS 0
+#endif
+
 #define KJ_DISALLOW_COPY(classname) \
   classname(const classname&) = delete; \
   classname& operator=(const classname&) = delete
@@ -290,7 +299,13 @@ typedef unsigned char byte;
 #define KJ_UNUSED_MEMBER
 #endif
 
+#if defined(_MSC_VER)
+// MSVC intentionally ignores the standard spelling to preserve ABI compatibility with older
+// toolsets. The vendor spelling opts in to empty-member optimization; clang-cl supports it too.
+#define KJ_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#else
 #define KJ_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#endif
 
 #if KJ_HAS_COMPILER_FEATURE(thread_sanitizer) || defined(__SANITIZE_THREAD__)
 #define KJ_DISABLE_TSAN __attribute__((no_sanitize("thread"), noinline))
@@ -2529,8 +2544,19 @@ struct Mapper<Maybe<T>> {
 //
 // So common that we put it in common.h rather than array.h.
 
+}  // namespace kj
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+#include "atomic.h"
+#endif
+
+namespace kj {
+
 template <typename T>
 class Array;
+class String;
+class StringPtr;
+class ConstString;
 
 namespace _ {  // private
 class SplitIteratorEnd;
@@ -2540,6 +2566,53 @@ class SplitIterator;
 
 template <typename T>
 class SplitIterable;
+}  // namespace _ (private)
+
+namespace _ {  // private
+
+class ArrayPtrCounterTracker {
+  // Registers one live ArrayPtr with an optional AtomicPtrCounter. Copying or moving an ArrayPtr
+  // creates another live ArrayPtr without clearing the source, so both operations increment the
+  // counter. When counters are disabled this class is empty, and [[no_unique_address]] makes it
+  // take no space in ArrayPtr.
+public:
+  ArrayPtrCounterTracker() = default;
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  inline constexpr ArrayPtrCounterTracker(const Maybe<AtomicPtrCounter&>& source)
+      : counter(const_cast<Maybe<AtomicPtrCounter&>&>(source)) { inc(); }
+  inline constexpr ArrayPtrCounterTracker(const ArrayPtrCounterTracker& other)
+      : counter(const_cast<Maybe<AtomicPtrCounter&>&>(other.counter)) { inc(); }
+  inline constexpr ArrayPtrCounterTracker(ArrayPtrCounterTracker&& other)
+      : counter(other.counter) { inc(); }
+  inline constexpr ~ArrayPtrCounterTracker() { dec(); }
+
+  inline constexpr ArrayPtrCounterTracker& operator=(const ArrayPtrCounterTracker& other) {
+    setCounter(other.counter);
+    return *this;
+  }
+  inline constexpr ArrayPtrCounterTracker& operator=(ArrayPtrCounterTracker&& other) {
+    setCounter(other.counter);
+    return *this;
+  }
+
+  inline constexpr void clear() { setCounter(kj::none); }
+
+private:
+  Maybe<AtomicPtrCounter&> counter;
+
+  inline constexpr void setCounter(const Maybe<AtomicPtrCounter&>& newCounter) {
+    dec();
+    counter = const_cast<Maybe<AtomicPtrCounter&>&>(newCounter);
+    inc();
+  }
+
+  inline constexpr void inc() { KJ_IF_SOME(c, counter) { c.inc(); } }
+  inline constexpr void dec() { KJ_IF_SOME(c, counter) { c.dec(); } }
+#else
+  inline constexpr void clear() {}
+#endif
+};
+
 }  // namespace _ (private)
 
 template <typename T>
@@ -2555,6 +2628,7 @@ public:
       : ptr(begin), size_(end - begin) {}
   ArrayPtr<T>& operator=(Array<T>&&) = delete;
   ArrayPtr<T>& operator=(decltype(nullptr)) {
+    counterTracker.clear();
     ptr = nullptr;
     size_ = 0;
     return *this;
@@ -2617,10 +2691,10 @@ public:
   }
 
   inline operator ArrayPtr<const T>() const {
-    return ArrayPtr<const T>(ptr, size_);
+    return ArrayPtr<const T>(ptr, size_, counterTracker);
   }
   inline ArrayPtr<const T> asConst() const {
-    return ArrayPtr<const T>(ptr, size_);
+    return operator ArrayPtr<const T>();
   }
 
   inline constexpr size_t size() const { return size_; }
@@ -2645,20 +2719,20 @@ public:
   inline constexpr ArrayPtr<const T> slice(size_t start, size_t end) const {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds ArrayPtr::slice().",
         start, end, size_);
-    return ArrayPtr<const T>(ptr + start, end - start);
+    return ArrayPtr<const T>(ptr + start, end - start, counterTracker);
   }
   inline constexpr ArrayPtr slice(size_t start, size_t end) {
     KJ_IREQUIRE(start <= end && end <= size_, "Out-of-bounds ArrayPtr::slice().",
         start, end, size_);
-    return ArrayPtr(ptr + start, end - start);
+    return ArrayPtr(ptr + start, end - start, counterTracker);
   }
   inline constexpr ArrayPtr<const T> slice(size_t start) const {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
-    return ArrayPtr<const T>(ptr + start, size_ - start);
+    return ArrayPtr<const T>(ptr + start, size_ - start, counterTracker);
   }
   inline constexpr ArrayPtr slice(size_t start) {
     KJ_IREQUIRE(start <= size_, "Out-of-bounds ArrayPtr::slice().", start, size_);
-    return ArrayPtr(ptr + start, size_ - start);
+    return ArrayPtr(ptr + start, size_ - start, counterTracker);
   }
   inline constexpr bool startsWith(const ArrayPtr<const T>& other) const {
     return other.size() <= size_ && first(other.size()) == other;
@@ -2697,13 +2771,15 @@ public:
     // Reinterpret the array as a byte array. This is explicitly legal under C++ aliasing
     // rules.
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
-    return { reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_ * sizeof(T) };
+    return ArrayPtr<PropagateConst<T, byte>>(
+        reinterpret_cast<PropagateConst<T, byte>*>(ptr), size_ * sizeof(T), counterTracker);
   }
   inline ArrayPtr<PropagateConst<T, char>> asChars() const {
     // Reinterpret the array as a char array. This is explicitly legal under C++ aliasing
     // rules.
     KJ_ASSERT_CAN_MEMCPY(RemoveConst<T>);
-    return { reinterpret_cast<PropagateConst<T, char>*>(ptr), size_ * sizeof(T) };
+    return ArrayPtr<PropagateConst<T, char>>(
+        reinterpret_cast<PropagateConst<T, char>*>(ptr), size_ * sizeof(T), counterTracker);
   }
 
   inline constexpr bool operator==(decltype(nullptr)) const { return size_ == 0; }
@@ -2835,6 +2911,16 @@ public:
 private:
   T* ptr;
   size_t size_;
+  KJ_NO_UNIQUE_ADDRESS _::ArrayPtrCounterTracker counterTracker;
+
+  inline constexpr ArrayPtr(
+      T* ptr, size_t size, const _::ArrayPtrCounterTracker& sourceCounter)
+      : ptr(ptr), size_(size), counterTracker(sourceCounter) {}
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  inline constexpr ArrayPtr(
+      T* ptr, size_t size, const Maybe<_::AtomicPtrCounter&>& sourceCounter)
+      : ptr(ptr), size_(size), counterTracker(sourceCounter) {}
+#endif
 
   inline bool intersects(kj::ArrayPtr<const T> other) const {
     // Checks if memory area intersects with another pointer.
@@ -2844,6 +2930,14 @@ private:
     // Negating the expression gets the result:
     return begin() < other.end() && other.begin() < end();
   }
+
+  template <typename>
+  friend class ArrayPtr;
+  template <typename>
+  friend class Array;
+  friend class String;
+  friend class StringPtr;
+  friend class ConstString;
 };
 
 namespace _ {  // private

--- a/c++/src/kj/configure.bzl
+++ b/c++/src/kj/configure.bzl
@@ -44,6 +44,11 @@ def kj_configure():
     )
 
     bool_flag(
+        name = "assert_arrayptr_counters",
+        build_setting_default = False,
+    )
+
+    bool_flag(
         name = "kj_enable_irequire",
         build_setting_default = False,
     )
@@ -86,6 +91,11 @@ def kj_configure():
     )
 
     native.config_setting(
+        name = "use_assert_arrayptr_counters",
+        flag_values = {"assert_arrayptr_counters": "True"},
+    )
+
+    native.config_setting(
         name = "use_kj_enable_irequire",
         flag_values = {"kj_enable_irequire": "True"},
     )
@@ -111,6 +121,9 @@ def kj_configure():
             "//conditions:default": ["KJ_DEPRECATE_EMPTY_MAYBE_FROM_NULLPTR=0"],
         }) + select({
             "//src/kj:use_debug_memory": ["KJ_DEBUG_MEMORY=1"],
+            "//conditions:default": [],
+        }) + select({
+            "//src/kj:use_assert_arrayptr_counters": ["KJ_ASSERT_ARRAYPTR_COUNTERS=1"],
             "//conditions:default": [],
         }) + select({
             "//src/kj:use_kj_enable_irequire": ["KJ_ENABLE_IREQUIRE=1"],

--- a/c++/src/kj/memory.c++
+++ b/c++/src/kj/memory.c++
@@ -29,7 +29,7 @@ const NullDisposer NullDisposer::instance = NullDisposer();
 
 namespace _ {
 
-#if KJ_ASSERT_PTR_COUNTERS
+#if KJ_ASSERT_PTR_COUNTERS || KJ_ASSERT_ARRAYPTR_COUNTERS
 
 void atomicPtrCounterAssertionFailed(char const* reason) {
   KJ_FAIL_ASSERT("ptr counter contract violated", reason);
@@ -38,7 +38,7 @@ void atomicPtrCounterAssertionFailed(char const* reason) {
   KJ_KNOWN_UNREACHABLE(abort());
 }
 
-#endif // KJ_ASSERT_PTR_COUNTERS
+#endif  // Any pointer counters.
 
 void throwWrongDisposerError() {
   KJ_FAIL_REQUIRE("When disowning an object, disposer must be equal to Own's disposer");

--- a/c++/src/kj/memory.h
+++ b/c++/src/kj/memory.h
@@ -23,10 +23,11 @@
 
 #include "common.h"
 
-// KJ_DEBUG_MEMORY == 1 enables variety of checks designed to catch memory usage errors.
-// KJ_DEBUG_MEMORY undefined or KJ_DEBUG_MEMORY == 0 disables all such checks.
-#if !defined(KJ_DEBUG_MEMORY)
-#define KJ_DEBUG_MEMORY 0
+#ifndef KJ_ASSERT_PTR_COUNTERS
+#define KJ_ASSERT_PTR_COUNTERS KJ_DEBUG_MEMORY
+#endif
+#if KJ_ASSERT_PTR_COUNTERS
+#include "atomic.h"
 #endif
 
 // KJ_WARN_REFCOUNTED_ATTACH == 1 enables deprecation warnings when using kj::Own<T>::attach() on
@@ -34,18 +35,6 @@
 #if !defined(KJ_WARN_REFCOUNTED_ATTACH)
 #define KJ_WARN_REFCOUNTED_ATTACH 0
 #endif
-
-// KJ_ASSERT_PTR_COUNTERS == 1 keeps track of active Ptr<T> instances and asserts validity
-// of their ownership.
-// Matches KJ_DEBUG_MEMORY by default.
-#if !defined(KJ_ASSERT_PTR_COUNTERS)
-#define KJ_ASSERT_PTR_COUNTERS KJ_DEBUG_MEMORY
-#endif // KJ_ASSERT_PTR_COUNTERS
-
-#if KJ_ASSERT_PTR_COUNTERS
-#include <atomic>
-#endif // KJ_ASSERT_PTR_COUNTERS
-
 
 KJ_BEGIN_HEADER
 
@@ -223,8 +212,6 @@ private:
   size_t refcount = 1;
 };
 
-void atomicPtrCounterAssertionFailed(const char* const);
-
 }  // namespace _ (private)
 
 class PtrTarget {
@@ -270,35 +257,6 @@ private:
     return const_cast<PtrTarget*>(static_cast<const PtrTarget*>(&self));
   }
 
-#if KJ_ASSERT_PTR_COUNTERS
-  class AtomicPtrCounter {
-    // AtomicPtrCounter uses atomic operations to keep track of active pointers.
-    // Since no other memory location is observed, memory_order_relaxed is used.
-
-  public:
-    inline void dec() {
-      size_t prevCount = count.fetch_sub(1, std::memory_order_relaxed);
-      if (KJ_UNLIKELY(prevCount == 0)) {
-        _::atomicPtrCounterAssertionFailed("unbalanced inc/dec");
-      }
-    }
-
-    inline void inc() {
-      count.fetch_add(1, std::memory_order_relaxed);
-    }
-
-    inline void assertEmpty() {
-      size_t c = count.load(std::memory_order_relaxed);
-      if (KJ_UNLIKELY(c != 0)) {
-        _::atomicPtrCounterAssertionFailed("active pointers exist");
-      }
-    }
-
-  private:
-    std::atomic<size_t> count = 0;
-  };
-#endif // KJ_ASSERT_PTR_COUNTERS
-
   inline _::WeakCell* getWeakCell(const void* ptr) {
     if (weakCell == nullptr) {
       weakCell = new _::WeakCell(ptr, this);
@@ -337,7 +295,7 @@ private:
 
   _::WeakCell* weakCell = nullptr;
 #if KJ_ASSERT_PTR_COUNTERS
-  AtomicPtrCounter ptrCounter;
+  _::AtomicPtrCounter ptrCounter;
 #endif // KJ_ASSERT_PTR_COUNTERS
 
   template <typename>

--- a/c++/src/kj/string-test.c++
+++ b/c++/src/kj/string-test.c++
@@ -20,6 +20,9 @@
 // THE SOFTWARE.
 
 #include "string.h"
+#include "test.h"
+#include "function.h"
+#include <signal.h>
 #include <kj/compat/gtest.h>
 #include <string>
 #include <string_view>
@@ -34,6 +37,16 @@ namespace {
 static_assert(Cloneable<String>);
 static_assert(Cloneable<ConstString>);
 static_assert(Cloneable<StringPtr>);
+
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+KJ_TEST("String rejects destruction with an active StringPtr") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    auto string = heapString("tracked");
+    auto ptr = new StringPtr(string);
+    (void)ptr;
+  });
+}
+#endif
 
 TEST(String, Str) {
   EXPECT_EQ("foobar", str("foo", "bar"));

--- a/c++/src/kj/string.h
+++ b/c++/src/kj/string.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "common.h"
+
 #include <initializer_list>
 #include "array.h"
 #include <string.h>
@@ -322,6 +324,8 @@ public:
 
 private:
   Array<char> content;
+
+  friend class StringPtr;
 };
 
 // =======================================================================================
@@ -433,6 +437,8 @@ public:
 
 private:
   Array<const char> content;
+
+  friend class StringPtr;
 };
 
 String heapString(size_t size);
@@ -704,15 +710,35 @@ inline _::Delimited<ArrayPtr<const T>> operator*(const _::Stringifier&, const Ar
 // =======================================================================================
 // Inline implementation details.
 
-inline constexpr StringPtr::StringPtr(const String& value): content(value.cStr(), value.size() + 1) {}
-inline constexpr StringPtr::StringPtr(const ConstString& value): content(value.cStr(), value.size() + 1) {}
+inline constexpr StringPtr::StringPtr(const String& value)
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    : content(value.content.counter == nullptr
+          ? ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_)
+          : ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_,
+                                 *value.content.counter)) {}
+#else
+    : content(value.cStr(), value.size() + 1) {}
+#endif
+inline constexpr StringPtr::StringPtr(const ConstString& value)
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+    : content(value.content.counter == nullptr
+          ? ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_)
+          : ArrayPtr<const char>(value.content.ptr == nullptr ? "" : value.content.ptr,
+                                 value.content.size_ == 0 ? 1 : value.content.size_,
+                                 *value.content.counter)) {}
+#else
+    : content(value.cStr(), value.size() + 1) {}
+#endif
 
 inline constexpr StringPtr::operator ArrayPtr<const char>() const {
-  return ArrayPtr<const char>(content.begin(), content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline constexpr ArrayPtr<const char> StringPtr::asArray() const {
-  return ArrayPtr<const char>(content.begin(), content.size() - 1);
+  return content.first(content.size() - 1);
 }
 
 inline constexpr bool StringPtr::operator==(const StringPtr& other) const {
@@ -735,24 +761,41 @@ inline LiteralStringConst::operator ConstString() const {
   return ConstString(begin(), size(), NullArrayDisposer::instance);
 }
 
-inline constexpr String::operator ArrayPtr<char>() {
-  return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
-}
-inline constexpr String::operator ArrayPtr<const char>() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
-}
-inline constexpr ConstString::operator ArrayPtr<const char>() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
-}
+inline constexpr String::operator ArrayPtr<char>() { return asArray(); }
+inline constexpr String::operator ArrayPtr<const char>() const { return asArray(); }
+inline constexpr ConstString::operator ArrayPtr<const char>() const { return asArray(); }
 
 inline constexpr ArrayPtr<char> String::asArray() {
-  return content == nullptr ? ArrayPtr<char>(nullptr) : content.first(content.size() - 1);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  return content.counter == nullptr
+      ? ArrayPtr<char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1)
+      : ArrayPtr<char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1, *content.counter);
+#else
+  return content == nullptr ? ArrayPtr<char>(nullptr)
+                            : ArrayPtr<char>(content.begin(), content.size() - 1);
+#endif
 }
 inline constexpr ArrayPtr<const char> String::asArray() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  return content.counter == nullptr
+      ? ArrayPtr<const char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1)
+      : ArrayPtr<const char>(
+          content.ptr, content.size_ == 0 ? 0 : content.size_ - 1, *content.counter);
+#else
+  return content == nullptr ? ArrayPtr<const char>(nullptr)
+                            : ArrayPtr<const char>(content.begin(), content.size() - 1);
+#endif
 }
 inline constexpr ArrayPtr<const char> ConstString::asArray() const {
-  return content == nullptr ? ArrayPtr<const char>(nullptr) : content.first(content.size() - 1);
+#if KJ_ASSERT_ARRAYPTR_COUNTERS
+  return content.counter == nullptr
+      ? ArrayPtr<const char>(content.ptr, content.size_ == 0 ? 0 : content.size_ - 1)
+      : ArrayPtr<const char>(
+          content.ptr, content.size_ == 0 ? 0 : content.size_ - 1, *content.counter);
+#else
+  return content == nullptr ? ArrayPtr<const char>(nullptr)
+                            : ArrayPtr<const char>(content.begin(), content.size() - 1);
+#endif
 }
 
 inline constexpr const char* String::cStr() const { return content == nullptr ? "" : content.begin(); }


### PR DESCRIPTION
Changes `kj::Array` to keep track of its `ArrayPtrs` when `--//src/kj:assert_arrayptr_counters=True` is set (`KJ_ASSERT_ARRAYPTR_COUNTERS`). Asserts there are no active pointers when array goes away.

Currently this flag is off, but the intention is to work towards enabling it in debug mode.

This PR doesn't contain violation changes, but fixes compilation in this new mode related to the fact that `ArrayPtr` is no longer mem-copiable and its `sizeof` changes.

My experiment show that the scope of changes to clean up everything is reasonable.