### PR TITLE
KJ_EXPECT uaf fix

### DIFF
--- a/c++/src/kj/compat/gtest.h
+++ b/c++/src/kj/compat/gtest.h
@@ -53,12 +53,14 @@ inline bool doubleAlmostEqual(double a, double b) {
 
 #define EXPECT_FALSE(x) KJ_EXPECT(!(x))
 #define EXPECT_TRUE(x) KJ_EXPECT(x)
-#define EXPECT_EQ(x, y) KJ_EXPECT((x) == (y), x, y)
-#define EXPECT_NE(x, y) KJ_EXPECT((x) != (y), x, y)
-#define EXPECT_LE(x, y) KJ_EXPECT((x) <= (y), x, y)
-#define EXPECT_GE(x, y) KJ_EXPECT((x) >= (y), x, y)
-#define EXPECT_LT(x, y) KJ_EXPECT((x) <  (y), x, y)
-#define EXPECT_GT(x, y) KJ_EXPECT((x) >  (y), x, y)
+// KJ_EXPECT's comparison wrapper already retains both operands for failure diagnostics. Avoid
+// passing them again as log arguments, which would require capturing them in its logging lambda.
+#define EXPECT_EQ(x, y) KJ_EXPECT((x) == (y))
+#define EXPECT_NE(x, y) KJ_EXPECT((x) != (y))
+#define EXPECT_LE(x, y) KJ_EXPECT((x) <= (y))
+#define EXPECT_GE(x, y) KJ_EXPECT((x) >= (y))
+#define EXPECT_LT(x, y) KJ_EXPECT((x) <  (y))
+#define EXPECT_GT(x, y) KJ_EXPECT((x) >  (y))
 #define EXPECT_STREQ(x, y) KJ_EXPECT(::strcmp(x, y) == 0, x, y)
 #define EXPECT_FLOAT_EQ(x, y) KJ_EXPECT(::kj::_::floatAlmostEqual(y, x), y, x);
 #define EXPECT_DOUBLE_EQ(x, y) KJ_EXPECT(::kj::_::doubleAlmostEqual(y, x), y, x);

--- a/c++/src/kj/test-helpers.c++
+++ b/c++/src/kj/test-helpers.c++
@@ -39,7 +39,7 @@ namespace kj {
 namespace _ {  // private
 
 LogExpectation::LogExpectation(LogSeverity severity, StringPtr substring)
-    : severity(severity), substring(substring), seen(false) {}
+    : severity(severity), substring(heapString(substring)), seen(false) {}
 LogExpectation::~LogExpectation() {
   if (!unwindDetector.isUnwinding()) {
     KJ_ASSERT(seen, "expected log message not seen", severity, substring);

--- a/c++/src/kj/test-test.c++
+++ b/c++/src/kj/test-test.c++
@@ -21,6 +21,7 @@
 
 #include "common.h"
 #include "function.h"
+#include "string.h"
 #include "test.h"
 #include <cstdlib>
 #include <stdexcept>
@@ -33,6 +34,18 @@
 namespace kj {
 namespace _ {
 namespace {
+
+KJ_TEST("KJ_EXPECT keeps temporary assertion operands alive") {
+  KJ_EXPECT(heapString("foo").asBytes() == "foo"_kjb);
+
+  KJ_EXPECT_LOG(ERROR, "failed: expected");
+  KJ_EXPECT(heapString("foo").asBytes() == "bar"_kjb);
+}
+
+KJ_TEST("KJ_EXPECT_LOG keeps a temporary substring alive") {
+  KJ_EXPECT_LOG(ERROR, heapString("temporary expected log"));
+  KJ_LOG(ERROR, "temporary expected log");
+}
 
 KJ_TEST("expect exit from exit") {
   KJ_EXPECT_EXIT(42, _exit(42));

--- a/c++/src/kj/test.h
+++ b/c++/src/kj/test.h
@@ -80,19 +80,32 @@ private:
   } KJ_UNIQUE_NAME(testCase); \
   void KJ_UNIQUE_NAME(TestCase)::run()
 
+// Check and log the condition inside one function call so that temporaries backing captured
+// assertion operands remain alive until after any failure message has been rendered.
 #if KJ_MSVC_TRADITIONAL_CPP
 #define KJ_INDIRECT_EXPAND(m, vargs) m vargs
 #define KJ_FAIL_EXPECT(...) \
   KJ_INDIRECT_EXPAND(KJ_LOG, (ERROR , __VA_ARGS__));
 #define KJ_EXPECT(cond, ...) \
-  if (auto _kjCondition = ::kj::_::MAGIC_ASSERT << cond); \
-  else KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, ("failed: expected " #cond , _kjCondition, __VA_ARGS__))
+  do { \
+    [&](auto&& _kjCondition) { \
+      if (!_kjCondition) { \
+        KJ_INDIRECT_EXPAND(KJ_FAIL_EXPECT, \
+            ("failed: expected " #cond , _kjCondition, __VA_ARGS__)) \
+      } \
+    }(::kj::_::MAGIC_ASSERT << cond); \
+  } while (false);
 #else
 #define KJ_FAIL_EXPECT(...) \
   KJ_LOG(ERROR, ##__VA_ARGS__);
 #define KJ_EXPECT(cond, ...) \
-  if (auto _kjCondition = ::kj::_::MAGIC_ASSERT << cond); \
-  else KJ_FAIL_EXPECT("failed: expected " #cond, _kjCondition, ##__VA_ARGS__)
+  do { \
+    [&](auto&& _kjCondition) { \
+      if (!_kjCondition) { \
+        KJ_FAIL_EXPECT("failed: expected " #cond, _kjCondition, ##__VA_ARGS__) \
+      } \
+    }(::kj::_::MAGIC_ASSERT << cond); \
+  } while (false);
 #endif
 
 // TODO(msvc): cast results to void like non-MSVC versions do
@@ -184,7 +197,7 @@ public:
 
 private:
   LogSeverity severity;
-  StringPtr substring;
+  String substring;
   bool seen;
   UnwindDetector unwindDetector;
 };


### PR DESCRIPTION
The pattern in test.h succesfully crashes under ASAN. We do this quite a lot in our tests (e.g. io-test.c++) so it is worth fixing

uaf: https://gist.github.com/mikea/c2723d17174e9fff62074ce47051878a

pattern example: https://github.com/capnproto/capnproto/blob/v2/c%2B%2B/src/kj/io-test.c%2B%2B#L171


courtesy of experimental array ptr tracking
