### PR TITLE
KJ: Clear BlockedPumpTo state after output errors

### DIFF
--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1602,6 +1602,146 @@ KJ_TEST("Userland pipe pumpTo") {
   KJ_EXPECT(pumpPromise.wait(ws) == 3);
 }
 
+class ControlledErrorOutput final: public AsyncOutputStream {
+public:
+  Promise<void> write(ArrayPtr<const byte>) override {
+    ++writeCount;
+    auto paf = newPromiseAndFulfiller<void>();
+    pendingWrite = kj::mv(paf.fulfiller);
+    return kj::mv(paf.promise);
+  }
+
+  Promise<void> write(ArrayPtr<const ArrayPtr<const byte>>) override {
+    ++writeCount;
+    auto paf = newPromiseAndFulfiller<void>();
+    pendingWrite = kj::mv(paf.fulfiller);
+    return kj::mv(paf.promise);
+  }
+
+  Maybe<Promise<uint64_t>> tryPumpFrom(AsyncInputStream&, uint64_t) override {
+    ++pumpCount;
+    auto paf = newPromiseAndFulfiller<uint64_t>();
+    pendingPump = kj::mv(paf.fulfiller);
+    return kj::mv(paf.promise);
+  }
+
+  Promise<void> whenWriteDisconnected() override {
+    return NEVER_DONE;
+  }
+
+  void rejectWrite() {
+    auto fulfiller = kj::mv(KJ_ASSERT_NONNULL(pendingWrite));
+    pendingWrite = kj::none;
+    fulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "simulated disconnect"));
+  }
+
+  void fulfillWrite() {
+    auto fulfiller = kj::mv(KJ_ASSERT_NONNULL(pendingWrite));
+    pendingWrite = kj::none;
+    fulfiller->fulfill();
+  }
+
+  void rejectPump() {
+    auto fulfiller = kj::mv(KJ_ASSERT_NONNULL(pendingPump));
+    pendingPump = kj::none;
+    fulfiller->reject(KJ_EXCEPTION(DISCONNECTED, "simulated disconnect"));
+  }
+
+  uint writeCount = 0;
+  uint pumpCount = 0;
+  Maybe<Own<PromiseFulfiller<void>>> pendingWrite;
+  Maybe<Own<PromiseFulfiller<uint64_t>>> pendingPump;
+};
+
+KJ_TEST("Userland pipe pumpTo output exception stops scalar forwarding") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  ControlledErrorOutput output;
+  auto pumpPromise = pipe.in->pumpTo(output, 3);
+
+  auto firstWrite = pipe.out->write("foo"_kjb);
+  KJ_EXPECT(output.writeCount == 1);
+  output.rejectWrite();
+  KJ_EXPECT(firstWrite.poll(ws));
+
+  auto secondWrite = pipe.out->write("bar"_kjb);
+  auto incorrectlyForwarded = output.writeCount != 1;
+  KJ_EXPECT(!incorrectlyForwarded, "second write reached failed output");
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("simulated disconnect", firstWrite.wait(ws));
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("simulated disconnect", pumpPromise.wait(ws));
+  if (incorrectlyForwarded) {
+    output.fulfillWrite();
+    secondWrite.wait(ws);
+  } else {
+    expectRead(*pipe.in, "bar").wait(ws);
+    secondWrite.wait(ws);
+  }
+}
+
+KJ_TEST("Userland pipe pumpTo output exception stops gather forwarding") {
+  auto run = [](uint64_t amount) {
+    kj::EventLoop loop;
+    WaitScope ws(loop);
+
+    auto pipe = newOneWayPipe();
+    ControlledErrorOutput output;
+    auto pumpPromise = pipe.in->pumpTo(output, amount);
+
+    ArrayPtr<const byte> parts[] = { "foo"_kjb, "bar"_kjb };
+    auto firstWrite = pipe.out->write(parts);
+    KJ_EXPECT(output.writeCount == 1);
+    output.rejectWrite();
+    KJ_EXPECT(firstWrite.poll(ws));
+
+    auto secondWrite = pipe.out->write("baz"_kjb);
+    auto incorrectlyForwarded = output.writeCount != 1;
+    KJ_EXPECT(!incorrectlyForwarded, "second write reached failed output", amount);
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("simulated disconnect", firstWrite.wait(ws));
+    KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("simulated disconnect", pumpPromise.wait(ws));
+    if (incorrectlyForwarded) {
+      output.fulfillWrite();
+      secondWrite.wait(ws);
+    } else {
+      expectRead(*pipe.in, "baz").wait(ws);
+      secondWrite.wait(ws);
+    }
+  };
+
+  run(4);  // Pump ends part-way through the second piece.
+  run(3);  // Pump ends exactly between pieces.
+  run(6);  // The complete gather write is forwarded by the pump.
+}
+
+KJ_TEST("Userland pipe pumpTo output exception stops tryPumpFrom forwarding") {
+  kj::EventLoop loop;
+  WaitScope ws(loop);
+
+  auto pipe = newOneWayPipe();
+  auto source = newOneWayPipe();
+  ControlledErrorOutput output;
+  auto pumpPromise = pipe.in->pumpTo(output, 3);
+
+  auto subPump = KJ_ASSERT_NONNULL(pipe.out->tryPumpFrom(*source.in, 3));
+  KJ_EXPECT(output.pumpCount == 1);
+  output.rejectPump();
+  KJ_EXPECT(subPump.poll(ws));
+
+  auto secondWrite = pipe.out->write("bar"_kjb);
+  auto incorrectlyForwarded = output.writeCount != 0;
+  KJ_EXPECT(!incorrectlyForwarded, "write reached failed output after tryPumpFrom error");
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("simulated disconnect", subPump.wait(ws));
+  KJ_EXPECT_THROW_RECOVERABLE_MESSAGE("simulated disconnect", pumpPromise.wait(ws));
+  if (incorrectlyForwarded) {
+    output.fulfillWrite();
+    secondWrite.wait(ws);
+  } else {
+    expectRead(*pipe.in, "bar").wait(ws);
+    secondWrite.wait(ws);
+  }
+}
+
 KJ_TEST("Userland pipe tryPumpFrom") {
   kj::EventLoop loop;
   WaitScope ws(loop);

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -1214,6 +1214,26 @@ private:
   class BlockedPumpTo final: public AsyncCapabilityStream {
     // AsyncPipe state when a pumpTo() is currently waiting for a corresponding write().
 
+  private:
+    auto teePumpExceptionVoid() {
+      return [this](kj::Exception&& e) {
+        canceler.release();
+        pipe.endState(*this);
+        fulfiller.reject(e.clone());
+        kj::throwRecoverableException(kj::mv(e));
+      };
+    }
+
+    template <typename T>
+    auto teePumpExceptionPromise() {
+      return [this](kj::Exception&& e) -> kj::Promise<T> {
+        canceler.release();
+        pipe.endState(*this);
+        fulfiller.reject(e.clone());
+        return kj::mv(e);
+      };
+    }
+
   public:
     BlockedPumpTo(PromiseFulfiller<uint64_t>& fulfiller, AsyncPipe& pipe,
                   AsyncOutputStream& output, uint64_t amount)
@@ -1273,7 +1293,7 @@ private:
           KJ_ASSERT(pumpedSoFar == amount);
           return pipe.write(writeBuffer.slice(actual));
         }
-      }, teeExceptionPromise<void>(fulfiller, canceler)));
+      }, teePumpExceptionPromise<void>()));
     }
 
     Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
@@ -1300,7 +1320,7 @@ private:
               fulfiller.fulfill(kj::cp(amount));
               pipe.endState(*this);
               return pipe.write(partial2);
-            }, teeExceptionPromise<void>(fulfiller, canceler)));
+            }, teePumpExceptionPromise<void>()));
             ++i;
           } else {
             // The pump ends exactly at the end of a piece, how nice.
@@ -1308,7 +1328,7 @@ private:
               canceler.release();
               fulfiller.fulfill(kj::cp(amount));
               pipe.endState(*this);
-            }, teeExceptionVoid(fulfiller, canceler)));
+            }, teePumpExceptionVoid()));
           }
 
           auto remainder = pieces.slice(i, pieces.size());
@@ -1337,7 +1357,7 @@ private:
           fulfiller.fulfill(kj::cp(amount));
           pipe.endState(*this);
         }
-      }, teeExceptionVoid(fulfiller, canceler)));
+      }, teePumpExceptionVoid()));
     }
 
     Promise<void> writeWithFds(ArrayPtr<const byte> data,
@@ -1402,7 +1422,7 @@ private:
             KJ_ASSERT(pumpedSoFar == amount);
             return input.pumpTo(pipe, amount2 - actual);
           }
-        }, teeExceptionPromise<uint64_t>(fulfiller, canceler)));
+        }, teePumpExceptionPromise<uint64_t>()));
       });
     }
 


### PR DESCRIPTION
Fixes #2579.

When a downstream write or optimized sub-pump failed, `BlockedPumpTo` released its canceler and rejected the outer pump promise but left `AsyncPipe::state` pointing at the failed pump state. A subsequent write could therefore be forwarded to an output stream that was already unusable.

This change adds `BlockedPumpTo`-specific exception handlers that:

- release the canceler before propagating the error;
- clear the pipe state before invoking promise rejection observers;
- preserve the original downstream exception for both operations;
- cover scalar writes, gather-write partial/exact/full paths, and `tryPumpFrom()`.

The regression tests verify that the failed output receives no subsequent writes, both promise paths retain the original exception, and the pipe remains usable with a new reader.

Validation:

- Debug full CTest: 5/5 passed
- Debug regression tests: 100 consecutive runs passed
- Release full build and regression tests passed
- ASan + UBSan regression tests: 100 consecutive runs passed
- TSan regression tests: 100 consecutive runs passed