### PR TITLE
KJ_DROP_TEMPS macro

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -2617,9 +2617,7 @@ uint64_t AsyncTee::Buffer::consume(ArrayPtr<byte>& readBuffer, size_t& minBytes)
     if (amount == bytes.size()) {
       bufferList.pop_front();
     } else {
-      // Finish reading from `bytes` before replacing its backing array.
-      auto remainder = heapArray(bytes.slice(amount, bytes.size()));
-      bytes = kj::mv(remainder);
+      bytes = KJ_DROP_TEMPS(heapArray(bytes.slice(amount, bytes.size())));
       break;
     }
   }

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -59,6 +59,33 @@ static_assert(!Copyable<NoCopy>);
 static_assert(Copyable<NonConstCopy>);
 static_assert(!Copyable<const NonConstCopy>);
 
+struct DropTempsTemporary {
+  explicit DropTempsTemporary(bool& alive): alive(alive) { alive = true; }
+  KJ_DISALLOW_COPY_AND_MOVE(DropTempsTemporary);
+  ~DropTempsTemporary() { alive = false; }
+
+  bool& alive;
+};
+
+struct DropTempsResult {
+  explicit DropTempsResult(const DropTempsTemporary& temporary)
+      : value(temporary.alive ? 123 : 456) {}
+  KJ_DISALLOW_COPY_AND_MOVE(DropTempsResult);
+
+  int value;
+};
+
+KJ_TEST("KJ_DROP_TEMPS drops intermediate temporaries before result is used") {
+  bool temporaryAlive = false;
+
+  auto checkResult = [&](DropTempsResult result) {
+    KJ_EXPECT(!temporaryAlive);
+    KJ_EXPECT(result.value == 123);
+  };
+
+  checkResult(KJ_DROP_TEMPS(DropTempsResult(DropTempsTemporary(temporaryAlive))));
+}
+
 constexpr bool maybeReferenceOperationsAreConstexpr() {
   int first = 1;
   int second = 2;

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -451,6 +451,21 @@ KJ_NORETURN(void unreachable());
 // Create a unique identifier name.  We use concatenate __LINE__ rather than __COUNTER__ so that
 // the name can be used multiple times in the same macro.
 
+#define KJ_DROP_TEMPS(...) ([&]() { return (__VA_ARGS__); }())
+// Evaluates the expression in a nested full-expression and returns its result by value. This
+// destroys temporary values created while evaluating the expression before the result is used by
+// the enclosing expression.
+//
+// This is useful when the enclosing operation may invalidate storage viewed by an intermediate
+// temporary. For example:
+//
+//     object.replace(KJ_DROP_TEMPS(makeReplacement(object.asPtr())));
+//
+// Without KJ_DROP_TEMPS(), a temporary view returned by object.asPtr() would live until after
+// replace() returned, even if makeReplacement() had already finished reading it. The immediately-
+// invoked lambda gives that temporary a shorter full-expression while returning the replacement
+// itself to the caller.
+
 #if _MSC_VER && !defined(__clang__)
 
 #define KJ_CONSTEXPR(...) __VA_ARGS__

--- a/c++/src/kj/compat/tls.c++
+++ b/c++/src/kj/compat/tls.c++
@@ -982,7 +982,7 @@ kj::Promise<kj::AuthenticatedStream> TlsContext::wrapServer(kj::AuthenticatedStr
     auto id = conn->getIdentity(kj::mv(innerId));
     return kj::AuthenticatedStream { kj::mv(conn), kj::mv(id) };
   }).catch_([peerId=kj::mv(peerId)](kj::Exception&& e) -> kj::Promise<kj::AuthenticatedStream> {
-    e.setDescription(kj::str(e.getDescription(), "; clientId = ", peerId));
+    e.setDescription(KJ_DROP_TEMPS(kj::str(e.getDescription(), "; clientId = ", peerId)));
     kj::throwFatalException(kj::mv(e));
   });
 }

--- a/c++/src/kj/debug-test.c++
+++ b/c++/src/kj/debug-test.c++
@@ -386,8 +386,7 @@ TEST(Debug, Catch) {
     KJ_IF_SOME(e, exception) {
       String what = str(e);
       KJ_IF_SOME(eol, what.findFirst('\n')) {
-        auto firstLine = kj::str(what.first(eol));
-        what = kj::mv(firstLine);
+        what = KJ_DROP_TEMPS(kj::str(what.first(eol)));
       }
       kj::StringPtr text = what;
       EXPECT_EQ(kj::str(fileLine(__FILE__, line), ": failed: foo"), text);
@@ -405,8 +404,7 @@ TEST(Debug, Catch) {
     KJ_IF_SOME(e, exception) {
       String what = str(e);
       KJ_IF_SOME(eol, what.findFirst('\n')) {
-        auto firstLine = kj::str(what.first(eol));
-        what = kj::mv(firstLine);
+        what = KJ_DROP_TEMPS(kj::str(what.first(eol)));
       }
       kj::StringPtr text = what;
       EXPECT_EQ(kj::str(fileLine(__FILE__, line), ": failed: foo"), text);

--- a/c++/src/kj/table.h
+++ b/c++/src/kj/table.h
@@ -1025,10 +1025,7 @@ private:
   Array<_::HashBucket> buckets;
 
   void rehash(size_t targetSize) {
-    // Materialize the result before assigning it so that the temporary ArrayPtr passed to
-    // _::rehash() no longer refers to the old buckets when assignment disposes them.
-    auto newBuckets = _::rehash(buckets, targetSize);
-    buckets = kj::mv(newBuckets);
+    buckets = KJ_DROP_TEMPS(_::rehash(buckets, targetSize));
     erasedCount = 0;
   }
 };


### PR DESCRIPTION
When re-assigning arrays, it is often common to compute new arrays based on the views of the old ones. Due to C++ rules these temporaries live to the end of the expression and outlive the original object they referred to.

Rather than introduce temporaries:

    auto newValue = computeNewValue(value);
    value = kj::mv(newValue)

KJ_DROP_TEMPS let's you write it in single line:

   value = KJ_DROP_TEMPS(computeNewValue(value));

This also makes lifetime intention more obvious. 

