### PR TITLE
Fix ASAN fiber stack bounds

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -28,6 +28,12 @@
 #include <kj/compat/gtest.h>
 #include <signal.h>
 
+#if KJ_HAS_COMPILER_FEATURE(address_sanitizer) && __linux__
+#include <sanitizer/asan_interface.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
 #if !_WIN32
 #include <errno.h>
 #include <limits.h>
@@ -1544,6 +1550,60 @@ KJ_TEST("start a fiber") {
   KJ_ASSERT(fiber.poll(waitScope));
   KJ_EXPECT(fiber.wait(waitScope) == "foo");
 }
+
+#if KJ_HAS_COMPILER_FEATURE(address_sanitizer) && __linux__
+KJ_TEST("fiber switch preserves ASAN poison outside the stack") {
+  if (isLibcContextHandlingKnownBroken()) return;
+
+  constexpr size_t stackSize = 8 << 20;
+  const size_t pageSize = sysconf(_SC_PAGESIZE);
+  EventLoop loop;
+  WaitScope waitScope(loop);
+  auto paf = newPromiseAndFulfiller<void>();
+
+  // Leave a stack-sized hole immediately below a mapped sentinel page. mmap() normally reuses the
+  // hole for the fiber stack, putting the sentinel inside the incorrectly-shifted ASAN stack range
+  // that this test guards against.
+  const size_t stackMappingSize = stackSize + pageSize;
+  void* reservation = mmap(nullptr, stackMappingSize + pageSize,
+      PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  // mmap placement is only a hint, so skip the test if we cannot arrange the
+  // required layout.  We verified during development that this early return
+  // was not taken, but we don't want a flaky test.
+  if (reservation == MAP_FAILED) return;
+  if (munmap(reservation, stackMappingSize) < 0) {
+    munmap(reservation, stackMappingSize + pageSize);
+    return;
+  }
+  void* sentinel = reinterpret_cast<byte*>(reservation) + stackMappingSize;
+  KJ_DEFER({
+    ASAN_UNPOISON_MEMORY_REGION(sentinel, pageSize);
+    KJ_SYSCALL(munmap(sentinel, pageSize));
+  });
+
+  bool stackReusedHole = false;
+
+  auto fiber = startFiber(stackSize,
+      [&, promise = kj::mv(paf.promise)](WaitScope& fiberScope) mutable {
+    void* frame = __builtin_frame_address(0);
+    stackReusedHole = frame >= reinterpret_cast<byte*>(reservation) + pageSize &&
+        frame < sentinel;
+    if (!stackReusedHole) return;
+    promise.wait(fiberScope);
+  });
+
+  ASAN_POISON_MEMORY_REGION(sentinel, pageSize);
+  if (fiber.poll(waitScope)) {
+    fiber.wait(waitScope);
+    return;
+  }
+  KJ_ASSERT(stackReusedHole);
+  KJ_EXPECT(__asan_address_is_poisoned(sentinel));
+
+  paf.fulfiller->fulfill();
+  fiber.wait(waitScope);
+}
+#endif
 
 KJ_TEST("fiber promise chaining") {
   if (isLibcContextHandlingKnownBroken()) return;

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1533,7 +1533,8 @@ FiberStack::FiberStack(size_t stackSizeParam)
 
   makecontext(&context, reinterpret_cast<void(*)()>(&StartRoutine::run), 2, arg1, arg2);
 
-  __sanitizer_start_switch_fiber(&impl->originalFakeStack, impl, stackSize - sizeof(Impl));
+  __sanitizer_start_switch_fiber(&impl->originalFakeStack,
+      reinterpret_cast<byte*>(impl + 1) - stackSize, stackSize - sizeof(Impl));
   if (_setjmp(impl->originalJmpBuf) == 0) {
     setcontext(&context);
   }
@@ -1630,7 +1631,8 @@ void FiberStack::switchToFiber() {
 #if _WIN32 || __CYGWIN__
   SwitchToFiber(osFiber);
 #else
-  __sanitizer_start_switch_fiber(&impl->originalFakeStack, impl, stackSize - sizeof(Impl));
+  __sanitizer_start_switch_fiber(&impl->originalFakeStack,
+      reinterpret_cast<byte*>(impl + 1) - stackSize, stackSize - sizeof(Impl));
   if (_setjmp(impl->originalJmpBuf) == 0) {
     _longjmp(impl->fiberJmpBuf, 1);
   }


### PR DESCRIPTION
Pass the low address of the fiber stack to ASAN rather than the address of the metadata stored at its high end. The incorrect range could overlap unrelated mappings, causing ASAN to unpoison memory outside the fiber stack during context switches.