### PR TITLE
[build] Start using clang 23

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   Linux-musl:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     # We depend on both clang and libc++. We use Alpine Linux 3.23 which supports LLVM 21.
     container: alpine:3.23
     steps:
@@ -42,7 +42,7 @@ jobs:
   Linux-gcc:
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: install dependencies
         run: eval "$INSTALL_DEPS" && install_deps 20 && sudo apt-get install --no-upgrade --no-install-recommends -y gcc-15
       - name: test
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang: [18, 20, 22]
+        clang: [19, 21, 23]
         driver: [bazel-dbg, super-test]
         include:
           - driver: bazel-dbg
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang: [22]
+        clang: [23]
     steps:
       - uses: actions/checkout@v7
       - name: install dependencies
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang: [20]
+        clang: [23]
         driver: [bazel-dbg]
         include:
           - driver: bazel-dbg
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang: [22]
+        clang: [23]
         config: [asan, ubsan, tsan]
     steps:
       - uses: actions/checkout@v7
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang: [22]
+        clang: [23]
     steps:
       - uses: actions/checkout@v7
       - name: install dependencies
@@ -134,7 +134,7 @@ jobs:
         run: |
             export CC=clang-${{ matrix.clang }}
             export CLANG_TIDY=clang-tidy-${{ matrix.clang }}
-            cd c++ 
+            cd c++
             bazel build --config=ci //...
             find src/kj src/capnp -name "*.c++" | parallel $CLANG_TIDY --quiet --experimental-custom-checks {}
   MacOS:

--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -329,7 +329,7 @@ typename kj::ArrayPtr<const word> writeDataStruct(BuilderType builder);
 // Note that you may call `.toBytes()` on the returned value to convert to `ArrayPtr<const byte>`.
 
 template <typename Type>
-static typename Type::Reader defaultValue();
+typename Type::Reader defaultValue();
 // Get a default instance of the given struct or list type.
 //
 // TODO(cleanup):  Find a better home for this function?
@@ -525,7 +525,7 @@ typename kj::ArrayPtr<const word> writeDataStruct(BuilderType builder) {
 }
 
 template <typename Type>
-static typename Type::Reader defaultValue() {
+typename Type::Reader defaultValue() {
   return typename Type::Reader(_::StructReader());
 }
 

--- a/c++/src/kj/arena-test.c++
+++ b/c++/src/kj/arena-test.c++
@@ -36,11 +36,9 @@ struct TestObject {
   TestObject(const TestObject& other) {
     KJ_ASSERT(other.index != throwAt);
     index = -1;
-    copiedCount++;
   }
   ~TestObject() noexcept(false) {
     if (index == -1) {
-      --copiedCount;
     } else {
       --count;
       EXPECT_EQ(index, count);
@@ -51,12 +49,10 @@ struct TestObject {
   int index;
 
   static int count;
-  static int copiedCount;
   static int throwAt;
 };
 
 int TestObject::count = 0;
-int TestObject::copiedCount = 0;
 int TestObject::throwAt = -1;
 
 TEST(Arena, Object) {

--- a/c++/src/kj/async-coroutine-alloc-test.c++
+++ b/c++/src/kj/async-coroutine-alloc-test.c++
@@ -177,7 +177,7 @@ KJ_TEST("Coroutine Frame sizes") {
     DebugCoroutineAllocator allocator;
     auto promise = immediateCoroutine(allocator);
     KJ_EXPECT(allocator.totalAllocCount == 1);
-    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 152);
+    KJ_EXPECT_CORO_SIZE(allocator.totalAllocSize == 160);
   }
 
   {

--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -354,14 +354,14 @@ public:
 };
 
 template <typename T, typename... Params>
-static kj::Own<T, PromiseDisposer> allocPromise(Params&&... params) {
+kj::Own<T, PromiseDisposer> allocPromise(Params&&... params) {
   // Allocate a PromiseNode without appending it to any existing promise arena. Space for a new
   // arena will be allocated.
   return PromiseDisposer::alloc<T>(kj::fwd<Params>(params)...);
 }
 
 template <typename T>
-static void freePromise(T* ptr) {
+void freePromise(T* ptr) {
   // Free a PromiseNode originally allocated using `allocPromise<T>()`. The implementation of
   // PromiseNode::destroy() must call this for any type that is allocated using allocPromise().
 

--- a/c++/src/kj/maybe-test.c++
+++ b/c++/src/kj/maybe-test.c++
@@ -1691,11 +1691,8 @@ struct ThrowingNiche {
 
   static bool throwOnConstruct;
   static bool throwOnMovedFromDestroy;  // Throw when destroying moved-from value (value == -1)
-  static int constructCount;
-  static int destroyCount;
 
   explicit ThrowingNiche(int v): value(v) {
-    ++constructCount;
     if (throwOnConstruct && v != 0) {  // Don't throw for none value (v == 0)
       throw std::runtime_error("constructor throw");
     }
@@ -1706,14 +1703,12 @@ struct ThrowingNiche {
     // This means the moved-from object still needs destruction.
     other.value = -1;
     other.throwOnDestroy = false;
-    ++constructCount;
     if (throwOnConstruct && value != 0) {
       throw std::runtime_error("move constructor throw");
     }
   }
 
   ~ThrowingNiche() noexcept(false) {
-    ++destroyCount;
     if (throwOnDestroy) {
       throwOnDestroy = false;
       throw std::runtime_error("destructor throw");
@@ -1731,8 +1726,6 @@ struct ThrowingNiche {
 
 bool ThrowingNiche::throwOnConstruct = false;
 bool ThrowingNiche::throwOnMovedFromDestroy = false;
-int ThrowingNiche::constructCount = 0;
-int ThrowingNiche::destroyCount = 0;
 
 }  // namespace (anonymous)
 
@@ -1752,8 +1745,6 @@ KJ_TEST("Maybe<ThrowingNiche> exception safety - constructor throws in emplace")
       "Should be niche-optimized");
 
   ThrowingNiche::throwOnConstruct = false;
-  ThrowingNiche::constructCount = 0;
-  ThrowingNiche::destroyCount = 0;
 
   Maybe<ThrowingNiche> m;
   m.emplace(42);
@@ -1779,8 +1770,6 @@ KJ_TEST("Maybe<ThrowingNiche> exception safety - constructor throws in emplace")
 KJ_TEST("Maybe<ThrowingNiche> exception safety - destructor throws in emplace") {
   // Verify that if dtor throws during emplace, the Maybe is left in none state.
   ThrowingNiche::throwOnConstruct = false;
-  ThrowingNiche::constructCount = 0;
-  ThrowingNiche::destroyCount = 0;
 
   Maybe<ThrowingNiche> m;
   m.emplace(42);
@@ -1806,8 +1795,6 @@ KJ_TEST("Maybe<ThrowingNiche> exception safety - constructor throws in assignmen
   // guarantee). The assignment operator extracts from `other` first into a temp, so if that
   // extraction throws, `this` is unchanged.
   ThrowingNiche::throwOnConstruct = false;
-  ThrowingNiche::constructCount = 0;
-  ThrowingNiche::destroyCount = 0;
 
   Maybe<ThrowingNiche> m;
   m.emplace(42);
@@ -1840,8 +1827,6 @@ KJ_TEST("Maybe<ThrowingNiche> exception safety - constructor throws in assignmen
 KJ_TEST("Maybe<ThrowingNiche> exception safety - destructor throws in assignment") {
   // Verify that if dtor throws during assignment, the Maybe is left in none state.
   ThrowingNiche::throwOnConstruct = false;
-  ThrowingNiche::constructCount = 0;
-  ThrowingNiche::destroyCount = 0;
 
   Maybe<ThrowingNiche> m;
   m.emplace(42);
@@ -1869,8 +1854,6 @@ KJ_TEST("Maybe<ThrowingNiche> exception safety - destructor throws in assignment
 KJ_TEST("Maybe<ThrowingNiche> exception safety - destructor throws in assign-to-none") {
   // Verify that if dtor throws when assigning to none, the Maybe is left in none state.
   ThrowingNiche::throwOnConstruct = false;
-  ThrowingNiche::constructCount = 0;
-  ThrowingNiche::destroyCount = 0;
 
   Maybe<ThrowingNiche> m;
   m.emplace(42);
@@ -1906,8 +1889,6 @@ KJ_TEST("Maybe<ThrowingNiche> exception safety - source destructor throws in mov
   // - src may be in an indeterminate state (but shouldn't be double-destroyed)
   ThrowingNiche::throwOnConstruct = false;
   ThrowingNiche::throwOnMovedFromDestroy = false;
-  ThrowingNiche::constructCount = 0;
-  ThrowingNiche::destroyCount = 0;
 
   Maybe<ThrowingNiche> src;
   src.emplace(42);

--- a/c++/src/kj/tuple.h
+++ b/c++/src/kj/tuple.h
@@ -44,6 +44,14 @@ KJ_BEGIN_HEADER
 namespace kj {
 namespace _ {  // private
 
+// Use __type_pack_element for TypeByIndex instead of implementing it directly when available. Once
+// we require C++26, we could also do this portably using https://en.cppreference.com/cpp/language/pack_indexing.
+#if __has_builtin(__type_pack_element)
+template <size_t index, typename... T>
+struct TypeByIndex_ {
+  using Type = __type_pack_element<index, T...>;
+};
+#else
 template <size_t index, typename... T>
 struct TypeByIndex_;
 template <typename First, typename... Rest>
@@ -65,6 +73,8 @@ struct TypeByIndex_<index> {
 #pragma GCC diagnostic pop
 #endif
 };
+#endif
+
 template <size_t index, typename... T>
 using TypeByIndex = typename TypeByIndex_<index, T...>::Type;
 // Chose a particular type out of a list of types, by index.


### PR DESCRIPTION
Fix clang-23 warnings
Clang 23 warns about unused templates (including static templates in headers) and variables that are never being read.

[build] Start using clang 23
- Update to clang-23. The minimum tested version moves to 19.
- Test with gcc-16, which is now available for Ubuntu 26.04
- Use __type_pack_element when available – this is supported by clang 20 and GCC 14 and can be used to implement TypeByIndex. Having a non-recursive implementation for this should speed up compiling tuples.
- Update coroutine alloc size to value expected with clang-23.

type_pack_element has been used in V8 for a while, we can benefit from it too.