### PR TITLE
async-io: fix accidental blocking in SocketAddress::lookupHost()

### DIFF
--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -256,6 +256,17 @@ endif()
 
 # Tests ========================================================================
 
+# TODO(someday): maybe also build/run these tests?:
+#   exception-override-symbolizer-test.c++
+#   filesystem-disk-generic-test.c++
+#   filesystem-disk-old-kernel-test.c++
+#   compat/brotli-test.c++
+#   compat/readiness-io-test.c++
+#   compat/http-socketpair-test.c++
+
+# TODO(someday): add a way to detect when a test file is present but missing from
+# cmake build instructions?
+
 if(BUILD_TESTING)
   add_executable(kj-tests
     common-test.c++
@@ -304,6 +315,7 @@ if(BUILD_TESTING)
       function-test.c++
       filesystem-test.c++
       filesystem-disk-test.c++
+      thread-test.c++
       parse/common-test.c++
       parse/char-test.c++
       compat/url-test.c++

--- a/c++/src/kj/async-io-unix.c++
+++ b/c++/src/kj/async-io-unix.c++
@@ -1215,8 +1215,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
   auto paf = newPromiseAndCrossThreadFulfiller<Array<SocketAddress>>();
   LookupParams params = { kj::mv(host), kj::mv(service) };
 
-  auto thread = heap<Thread>(
-      [fulfiller=kj::mv(paf.fulfiller),params=kj::mv(params),portHint]() mutable {
+  kj::Thread([fulfiller=kj::mv(paf.fulfiller),params=kj::mv(params),portHint]() mutable {
     // getaddrinfo() can return multiple copies of the same address for several reasons.
     // A major one is that we don't give it a socket type (SOCK_STREAM vs. SOCK_DGRAM), so
     // it may return two copies of the same address, one for each type, unless it explicitly
@@ -1299,7 +1298,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
     } else {
       fulfiller->fulfill(KJ_MAP(addr, result) { return addr; });
     }
-  });
+  }).detach();
 
   return kj::mv(paf.promise);
 }

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -739,8 +739,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
   auto paf = newPromiseAndCrossThreadFulfiller<Array<SocketAddress>>();
   LookupParams params = { kj::mv(host), kj::mv(service) };
 
-  auto thread = heap<Thread>(
-      [fulfiller=kj::mv(paf.fulfiller),params=kj::mv(params),portHint]() mutable {
+  kj::Thread([fulfiller=kj::mv(paf.fulfiller),params=kj::mv(params),portHint]() mutable {
     // getaddrinfo() can return multiple copies of the same address for several reasons.
     // A major one is that we don't give it a socket type (SOCK_STREAM vs. SOCK_DGRAM), so
     // it may return two copies of the same address, one for each type, unless it explicitly
@@ -811,7 +810,7 @@ Promise<Array<SocketAddress>> SocketAddress::lookupHost(
     } else {
       fulfiller->fulfill(KJ_MAP(addr, result) { return addr; });
     }
-  });
+  }).detach();
 
   return kj::mv(paf.promise);
 }

--- a/c++/src/kj/thread-test.c++
+++ b/c++/src/kj/thread-test.c++
@@ -176,5 +176,32 @@ KJ_TEST("Thread::getCpuTime()") {
 }
 #endif  // !__APPLE__
 
+#if _WIN32
+uint getHandleCount() {
+  DWORD count;
+  KJ_WIN32(GetProcessHandleCount(GetCurrentProcess(), &count));
+  return static_cast<int>(count);
+}
+
+KJ_TEST("joining a thread closes its handle") {
+  auto before = getHandleCount();
+  {
+    kj::Thread([]() {});
+  }
+  auto after = getHandleCount();
+  KJ_EXPECT(after == before);
+}
+
+KJ_TEST("detaching a thread closes its handle") {
+  auto before = getHandleCount();
+  {
+    kj::Thread([]() {}).detach();
+  }
+  delay();
+  auto after = getHandleCount();
+  KJ_EXPECT(after == before);
+}
+#endif
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/thread.c++
+++ b/c++/src/kj/thread.c++
@@ -39,6 +39,8 @@ namespace kj {
 Thread::Thread(Function<void()> func): state(new ThreadState(kj::mv(func))) {
   threadHandle = CreateThread(nullptr, 0, &runThread, state, 0, nullptr);
   if (threadHandle == nullptr) {
+    // Free both references, since the destructor won't run after throwing here.
+    state->unref();
     state->unref();
     KJ_FAIL_ASSERT("CreateThread failed.");
   }
@@ -47,6 +49,7 @@ Thread::Thread(Function<void()> func): state(new ThreadState(kj::mv(func))) {
 Thread::~Thread() noexcept(false) {
   if (!detached) {
     KJ_DEFER(state->unref());
+    KJ_DEFER(KJ_ASSERT(CloseHandle(threadHandle)));
 
     KJ_ASSERT(WaitForSingleObject(threadHandle, INFINITE) != WAIT_FAILED);
 
@@ -59,8 +62,11 @@ Thread::~Thread() noexcept(false) {
 }
 
 void Thread::detach() {
+  KJ_ASSERT(!detached);
   KJ_ASSERT(CloseHandle(threadHandle));
+  threadHandle = nullptr;
   detached = true;
+  state->unref();
 }
 
 kj::Duration Thread::getCpuTime() const {
@@ -86,6 +92,8 @@ Thread::Thread(Function<void()> func): state(new ThreadState(kj::mv(func))) {
   int pthreadResult = pthread_create(reinterpret_cast<pthread_t*>(&threadId),
                                      nullptr, &runThread, state);
   if (pthreadResult != 0) {
+    // Free both references, since the destructor won't run after throwing here.
+    state->unref();
     state->unref();
     KJ_FAIL_SYSCALL("pthread_create", pthreadResult);
   }
@@ -116,6 +124,7 @@ void Thread::sendSignal(int signo) {
 }
 
 void Thread::detach() {
+  KJ_ASSERT(!detached);
   int pthreadResult = pthread_detach(*reinterpret_cast<pthread_t*>(&threadId));
   if (pthreadResult != 0) {
     KJ_FAIL_SYSCALL("pthread_detach", pthreadResult) { break; }


### PR DESCRIPTION
To perform asynchronous address lookup, SocketAddress::lookupHost() runs a blocking getaddrinfo() API call in a separate thread.  However, following a refactoring to use cross-thread fulfillers in a4ae5896, the kj::Thread was no longer moved into the return value, so it was destroyed at the end of the function.  Because kj::Thread's destructor joins the thread, calls to lookupHost() have effectively been synchronous since then.

This commit attaches the kj::Thread to the returned promise, which should allow lookup to proceed without blocking the caller.