### PR TITLE
kj/async: add Executor::isCurrent() and tryGetCurrentThreadExecutor()

### DIFF
--- a/c++/src/kj/async-xthread-test.c++
+++ b/c++/src/kj/async-xthread-test.c++
@@ -52,6 +52,37 @@ inline void delay() { usleep(10000); }
 namespace kj {
 namespace {
 
+KJ_TEST("Executor::isCurrent() and tryGetCurrentThreadExecutor()") {
+  KJ_XTHREAD_TEST_SETUP_LOOP;
+  const Executor& executor = getCurrentThreadExecutor();
+
+  KJ_EXPECT(executor.isCurrent());
+  KJ_IF_SOME(current, tryGetCurrentThreadExecutor()) {
+    KJ_EXPECT(&current == &executor);
+  } else {
+    KJ_FAIL_EXPECT("expected a current executor");
+  }
+
+  Thread([&]() noexcept {
+    // This thread has no event loop at all.
+    KJ_EXPECT(!executor.isCurrent());
+    KJ_EXPECT(tryGetCurrentThreadExecutor() == kj::none);
+
+    Own<const Executor> otherExecutor;
+    {
+      // A thread running a *different* event loop still isn't `executor`'s.
+      EventLoop otherLoop;
+      WaitScope otherWaitScope(otherLoop);
+      KJ_EXPECT(!executor.isCurrent());
+      KJ_EXPECT(getCurrentThreadExecutor().isCurrent());
+      otherExecutor = getCurrentThreadExecutor().addRef();
+    }
+
+    // An executor whose loop has been destroyed is no longer anyone's current executor.
+    KJ_EXPECT(!otherExecutor->isCurrent());
+  });
+}
+
 KJ_TEST("synchronous simple cross-thread events") {
   MutexGuarded<kj::Maybe<const Executor&>> executor;  // to get the Executor from the other thread
   Own<PromiseFulfiller<uint>> fulfiller;  // accessed only from the subthread

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1244,6 +1244,17 @@ bool Executor::isLive() const {
   return impl->state.lockShared()->loop != kj::none;
 }
 
+bool Executor::isCurrent() const {
+  EventLoop* current = threadLocalEventLoop;
+  if (current == nullptr) return false;
+  KJ_IF_SOME(loop, impl->state.lockShared()->loop) {
+    return &loop == current;
+  } else {
+    // Loop already destroyed; it can't be anyone's current loop.
+    return false;
+  }
+}
+
 void Executor::send(_::XThreadEvent& event, bool sync) const {
   KJ_ASSERT(event.state == _::XThreadEvent::UNUSED);
 
@@ -1328,6 +1339,12 @@ EventLoop& Executor::getLoop() const {
 
 const Executor& getCurrentThreadExecutor() {
   return currentEventLoop().getExecutor();
+}
+
+Maybe<const Executor&> tryGetCurrentThreadExecutor() {
+  EventLoop* loop = threadLocalEventLoop;
+  if (loop == nullptr) return kj::none;
+  return loop->getExecutor();
 }
 
 // =======================================================================================

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1133,6 +1133,15 @@ public:
   //   philosophy, but right now I'm not excited about the extra template metaprogramming needed
   //   for "try" versions...
 
+  bool isCurrent() const;
+  // Returns true if this Executor belongs to the event loop currently running on this thread --
+  // i.e. this is the executor `getCurrentThreadExecutor()` would return. Never throws; a thread
+  // with no current event loop (including one whose loop has already been destroyed) returns
+  // false. Useful for code reachable from both the owning event-loop thread and foreign threads
+  // that wants to take a fast path in the former case, e.g. a `std::task::Waker`-style callback
+  // that arms an event directly when on the loop's thread and falls back to a cross-thread
+  // fulfiller otherwise.
+
   template <typename Func>
   PromiseForResult<Func, void> executeAsync(Func&& func, SourceLocation location = {}) const;
   // Call from any thread to request that the given function be executed on the executor's thread,
@@ -1219,6 +1228,11 @@ private:
 const Executor& getCurrentThreadExecutor();
 // Get the executor for the current thread's event loop. This reference can then be passed to other
 // threads.
+
+Maybe<const Executor&> tryGetCurrentThreadExecutor();
+// Like getCurrentThreadExecutor(), but returns none if the thread has no current event loop,
+// rather than throwing. Intended for code that can run on threads with no event loop at all, e.g.
+// teardown paths and foreign-runtime callbacks.
 
 // =======================================================================================
 // The EventLoop class


### PR DESCRIPTION
Code that can be reached both from the owning event-loop thread and from foreign threads (e.g. a `std::task::Waker`-style callback bridging KJ to another runtime) needs a non-throwing way to ask "is this executor's loop current on this thread?". Until now the only options were `getCurrentThreadExecutor()`, which throws when the thread has no event loop, or catching that exception as a probe — which is what workerd's kj-rs currently does.

This adds:

- `Executor::isCurrent()` — true iff this executor belongs to the event loop currently running on this thread. Never throws; returns false on threads with no loop and for executors whose loop has been destroyed. (Suggested by @mikea in [workerd#7010 review](https://github.com/cloudflare/workerd/pull/7010).)
- `kj::tryGetCurrentThreadExecutor()` — like `getCurrentThreadExecutor()`, but returns none instead of throwing when there is no current loop. kj-rs needs this to distinguish "no loop at all" (legal during teardown) from "a different live loop" (contract violation) without exception-catching.

First user: workerd's `kj-rs` executor guard, which currently probes via `kj::runCatchingExceptions(getCurrentThreadExecutor)` on every cross-thread wake check.

Tested with a new case in `async-xthread-test.c++` covering: current on own loop thread, false + none on a loop-less thread, false under a different loop, and false after the owning loop is destroyed (via a retained `addRef()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)