### PR TITLE
kj/async: lock-free Executor::isCurrent(); report setRunnable(false) before EventPort::wait()

### DIFF
--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -1432,6 +1432,59 @@ TEST(Async, SetRunnable) {
   }
 }
 
+KJ_TEST("setRunnable(false) is reported before EventPort::wait(), and an arm during wait() "
+        "reports setRunnable(true)") {
+  // A port that, while "sleeping", does some work that arms a KJ event -- the shape of an
+  // integration that drives a foreign event loop inside wait(). The loop must tell it the queue
+  // was empty going in (so it may sleep) and must report the arm (so it can stop sleeping),
+  // rather than leaving `lastRunnableState` stale-true from the events that ran earlier in the
+  // same wait loop.
+  class WorkingEventPort: public EventPort {
+  public:
+    bool runnable = false;
+    int callCount = 0;
+    int waitCount = 0;
+    bool runnableAtWait = true;
+    int callCountAfterArm = 0;
+    kj::Maybe<kj::Own<PromiseFulfiller<void>>> fulfiller;
+
+    bool wait() override {
+      ++waitCount;
+      runnableAtWait = runnable;
+      KJ_IF_SOME(f, fulfiller) {
+        // Work done while sleeping that arms a KJ event.
+        f->fulfill();
+        fulfiller = kj::none;
+        callCountAfterArm = callCount;
+        KJ_EXPECT(runnable);
+      }
+      return false;
+    }
+    bool poll() override { return false; }
+    void setRunnable(bool runnable) override {
+      this->runnable = runnable;
+      ++callCount;
+    }
+  };
+
+  WorkingEventPort port;
+  EventLoop loop(port);
+  WaitScope waitScope(loop);
+
+  auto paf = newPromiseAndFulfiller<void>();
+  port.fulfiller = kj::mv(paf.fulfiller);
+
+  // An event runs first (making the loop runnable), then the wait drains the queue and has to
+  // sleep on the pending fulfiller.
+  kj::evalLater([]() {}).then([&]() { return kj::mv(paf.promise); }).wait(waitScope);
+
+  KJ_EXPECT(port.waitCount == 1);
+  KJ_EXPECT(!port.runnableAtWait);
+  // The arm inside wait() produced a fresh setRunnable(true) edge.
+  KJ_EXPECT(port.callCountAfterArm > 0);
+  KJ_EXPECT(!port.runnable);
+}
+
 TEST(Async, Poll) {
   EventLoop loop;
   WaitScope waitScope(loop);

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1921,6 +1921,14 @@ void EventLoop::wait() {
   KJ_SILENCE_DANGLING_ELSE_END
 
   KJ_IF_SOME(p, port) {
+    // We only get here when the queue is empty, but `lastRunnableState` may still be true: the
+    // wait loop (waitImpl) only reports the runnable -> empty transition once the whole wait is
+    // over. Report it now, so that the port sees the true state while it sleeps and so that an
+    // event armed *during* `p.wait()` -- by work the port runs while sleeping, e.g. an
+    // integrated foreign event loop -- produces a `setRunnable(true)` edge the port can act on
+    // (e.g. stop sleeping). Without this the edge is lost and the arm sits unserviced until
+    // something else wakes the port.
+    setRunnable(false);
     if (p.wait()) {
       // Another thread called wake(). Check for cross-thread events.
       KJ_IF_SOME(e, executor) {

--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -1245,12 +1245,17 @@ bool Executor::isLive() const {
 }
 
 bool Executor::isCurrent() const {
+  // Answer from the calling thread's side: are we the current loop's executor? This touches only
+  // the current thread's own EventLoop (whose `executor` member is only ever accessed from that
+  // thread), so no lock is needed -- unlike reading `impl->state.loop`, which the owning thread
+  // nulls at loop destruction while other threads may be asking. If the current loop has never
+  // created an executor, `this` (which exists) cannot be it. A destroyed loop is not anyone's
+  // current loop, so that case is covered too.
   EventLoop* current = threadLocalEventLoop;
   if (current == nullptr) return false;
-  KJ_IF_SOME(loop, impl->state.lockShared()->loop) {
-    return &loop == current;
+  KJ_IF_SOME(e, current->executor) {
+    return e.get() == this;
   } else {
-    // Loop already destroyed; it can't be anyone's current loop.
     return false;
   }
 }

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -1276,6 +1276,11 @@ public:
   // transitions from empty -> runnable or runnable -> empty.  This is typically useful when
   // integrating with an external event loop; if the loop is currently runnable then you should
   // arrange to call run() on it soon.  The default implementation does nothing.
+  //
+  // `setRunnable(false)` is guaranteed to have been called before `wait()` is invoked (the queue
+  // is empty then), so if an event is armed while `wait()` is in progress -- e.g. by work the
+  // port itself runs while sleeping -- the port will observe `setRunnable(true)` and can use it
+  // to stop sleeping.
 
   virtual void wake() const;
   // Wake up the EventPort's thread from another thread.


### PR DESCRIPTION
Two small KJ event-loop changes motivated by integrating a foreign event loop (tokio) *inside* `EventPort::wait()`, where the port keeps running other work while KJ sleeps. Each is its own commit.

## 1. `Executor::isCurrent()` without the lock

`isCurrent()` took a shared lock on the executor's state to read `loop`, since the owning thread nulls that field at loop destruction while other threads may be asking. Answering from the caller's side removes the lock: compare `this` against the *current* thread's loop's own `executor` member, which is only ever touched by its own thread. If the current loop never created an executor, `this` cannot be it; a destroyed loop is not anyone's current loop. Behavior is unchanged; the existing cases in `async-xthread-test.c++` (no loop, other loop, no executor yet, destroyed loop) all still pass.

This is on a hot path for us: it decides per wake whether an event can be armed directly or must go cross-thread.

## 2. `setRunnable(false)` before `port.wait()`

`EventLoop::wait()` is only reached with an empty queue, but `waitImpl` reports the runnable → empty transition only once the whole wait is over, so `lastRunnableState` is typically still true when `port.wait()` runs. Because `setRunnable()` is edge-triggered on that stale state, an event armed *during* `wait()` produces no `setRunnable(true)` call. For a port that drives other work while sleeping, that work can arm KJ events (fulfill a `PromiseFulfiller`, add to a `TaskSet`), and the arm then sits unserviced until something unrelated wakes the port; under a timer-less wait, forever.

Calling `setRunnable(false)` right before `port.wait()` gives the port the true state going in and guarantees the arm is reported. `UnixEventPort` and `Win32EventPort` ignore `setRunnable`, so they are unaffected; a port that already tracks it now simply gets the false edge slightly earlier than it did after `run()`.

Added a test with a port that arms an event from inside `wait()` and checks both the state observed on entry and the edge received (it fails without the fix), and documented the guarantee on `EventPort::setRunnable()`.

Tested: `bazel test //src/kj:async-test //src/kj:async-xthread-test` (macOS arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)